### PR TITLE
Parse cwd path until find .git repository

### DIFF
--- a/lib/Container/CoreExtension.php
+++ b/lib/Container/CoreExtension.php
@@ -80,7 +80,7 @@ class CoreExtension implements ExtensionInterface
         }
 
         // Return base CWD where .git directory is present
-        if (!is_dir($path . '/' . '.git') and $path !== '/') {
+        if (!is_dir(sprintf('%s/.git', $path)) && $path !== '/') {
             return $this->getBaseCwd(dirname($path));
         }
 

--- a/lib/Container/CoreExtension.php
+++ b/lib/Container/CoreExtension.php
@@ -81,7 +81,7 @@ class CoreExtension implements ExtensionInterface
 
         // Return base CWD where .git directory is present
         if (!is_dir($path . '/' . '.git') and $path !== '/') {
-            return $this->getBaseCwd($path . '/' . '..');
+            return $this->getBaseCwd(dirname($path));
         }
 
         return $path;

--- a/lib/Container/CoreExtension.php
+++ b/lib/Container/CoreExtension.php
@@ -56,8 +56,8 @@ class CoreExtension implements ExtensionInterface
     public function getDefaultConfig()
     {
         return [
-            'autoload' => 'vendor/autoload.php',
-            'cwd' => getcwd(),
+            'autoload' => $this->getBaseCwd() . '/' . 'vendor/autoload.php',
+            'cwd' => $this->getBaseCwd(),
             'console_dumper_default' => 'indented',
             'cache_dir' => __DIR__ . '/../../cache',
         ];
@@ -72,6 +72,19 @@ class CoreExtension implements ExtensionInterface
         $this->registerClassMover($container);
         $this->registerSourceCodeFilesystem($container);
         $this->registerApplicationServices($container);
+    }
+
+    private function getBaseCwd($path = null) {
+        if (is_null($path)) {
+            $path = getcwd();
+        }
+
+        // Return base CWD where .git directory is present
+        if (!is_dir($path . '/' . '.git') and $path !== '/') {
+            return $this->getBaseCwd($path . '/' . '..');
+        }
+
+        return $path;
     }
 
     private function registerMonolog(Container $container)

--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -120,7 +120,7 @@ function! phpactor#ClassExpand()
     let namespace_prefix = classInfo['class_namespace'] . "\\"
 
     " If this is the start of the word
-    if (col('.') == 1 || ' ' == char)
+    if (col('.') == 1 || ' ' == char || '(' == char)
         execute "normal! i" . namespace_prefix
         return
     endif


### PR DESCRIPTION
I'm currently using this plugin with `vim` but my configuration handles a `autochdir`. So, when I opened a file, the `cwd` changed. This feature implements a simple way to parse the sub-directory and find the related `.git` directory (base root). It allows to use the base `.git` directory and load easily the `vendor/autoload.php` file