### PR TITLE
.git in submodules are not dirs but normal files

### DIFF
--- a/lib/Container/CoreExtension.php
+++ b/lib/Container/CoreExtension.php
@@ -80,7 +80,7 @@ class CoreExtension implements ExtensionInterface
         }
 
         // Return base CWD where .git directory is present
-        if (!is_dir(sprintf('%s/.git', $path)) && $path !== '/') {
+        if (!file_exists(sprintf('%s/.git', $path)) && $path !== '/') {
             return $this->getBaseCwd(dirname($path));
         }
 


### PR DESCRIPTION
This allows to detect the cwd even when working in submodules