### PR TITLE
Adds vim and neovim paths to default `code_transform.template_paths`

### DIFF
--- a/lib/Config/ConfigLoader.php
+++ b/lib/Config/ConfigLoader.php
@@ -41,7 +41,9 @@ class ConfigLoader
     public function configDirs(): array
     {
         $configDirs = $this->xdg->getConfigDirs();
-        array_unshift($configDirs, Path::join(getcwd(), '/.phpactor'));
+        array_unshift($configDirs, Path::join(getenv('HOME'), '/.vim'));
+        array_unshift($configDirs, Path::join(getenv('HOME'), '/.config/nvim'));
+		array_unshift($configDirs, Path::join(getcwd(), '/.phpactor'));
 
         return $configDirs;
     }

--- a/lib/Config/ConfigLoader.php
+++ b/lib/Config/ConfigLoader.php
@@ -43,7 +43,7 @@ class ConfigLoader
         $configDirs = $this->xdg->getConfigDirs();
         array_unshift($configDirs, Path::join(getenv('HOME'), '/.vim'));
         array_unshift($configDirs, Path::join(getenv('HOME'), '/.config/nvim'));
-		array_unshift($configDirs, Path::join(getcwd(), '/.phpactor'));
+        array_unshift($configDirs, Path::join(getcwd(), '/.phpactor'));
 
         return $configDirs;
     }


### PR DESCRIPTION
By default, only the current project is checked. Now, it there's no `.phpactor/phpactor/template` directory, fallback on `$HOME/.vim/phpactor/template` and `$HOME/.nvim/phpactor/template` directories to load custom transformation templates