### PR TITLE
Prevents `cwd` to be took from vendor directory

### DIFF
--- a/lib/Container/CoreExtension.php
+++ b/lib/Container/CoreExtension.php
@@ -80,7 +80,7 @@ class CoreExtension implements ExtensionInterface
         }
 
         // Return base CWD where .git directory is present
-        if (!file_exists(sprintf('%s/.git', $path)) && $path !== '/') {
+        if (!file_exists(sprintf('%s/.git', $path)) && $path !== '/' || strpos($path, 'vendor')) {
             return $this->getBaseCwd(dirname($path));
         }
 


### PR DESCRIPTION
If we go to definition, the file has potentiel chance to be placed into the `vendor` directory. But, Composer doesn't install dependencies into the dependency project folder. So, we can't next go to definition within the dependency project. This patch prevents for getting `cwd` within the `vendor` directory, always parent one.

```
./project
./project/vendor
./project/vendor/toto/Alias.php
./project/vendor/phpactor/Definition.php -> refers to ./project/vendor/toto/Alias.php.

Cannot be found because the cwd is in the project/vendor/phpactor directory. That's
wrong because there's no vendor directory within
```