### PR TITLE
FEATURE: Allow to configure non existing autoloader paths

### DIFF
--- a/lib/Container/CoreExtension.php
+++ b/lib/Container/CoreExtension.php
@@ -204,10 +204,7 @@ class CoreExtension implements ExtensionInterface
 
             foreach ($autoloaderPaths as $autoloaderPath) {
                 if (!file_exists($autoloaderPath)) {
-                    throw new \InvalidArgumentException(sprintf(
-                        'Could not locate autoloaderPath file "%s"',
-                        $autoloaderPath
-                    ));
+                    continue;
                 }
 
                 $autoloader = require $autoloaderPath;
@@ -217,6 +214,13 @@ class CoreExtension implements ExtensionInterface
                 }
 
                 $autoloaders[] = $autoloader;
+            }
+
+            if ($autoloaders === []) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Could not locate autoloaderPath file "%s"',
+                    $autoloaderPath
+                ));
             }
 
             foreach (spl_autoload_functions() as $autoloadFunction) {


### PR DESCRIPTION
Do not break if one of the configured autoloaders does not exist, but
only if none exists.

This way it's possible to configure all possible locations in your home
folder for the whole machine.