### PR TITLE
changes scoped vim variables to global

### DIFF
--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -6,16 +6,16 @@
 " | _|      |__|  |__| | _|    /__/     \__\ \______|    |__|      \______/  | _| `._____|
 "                                                                                         
 
-let s:phpactorpath = expand('<sfile>:p:h') . '/..'
-let s:phpactorbinpath = s:phpactorpath. '/bin/phpactor'
-let s:phpactorInitialCwd = getcwd()
+let g:phpactorpath = expand('<sfile>:p:h') . '/..'
+let g:phpactorbinpath = g:phpactorpath. '/bin/phpactor'
+let g:phpactorInitialCwd = getcwd()
 
 """""""""""""""""
 " Update Phpactor
 """""""""""""""""
 function! phpactor#Update()
     let current = getcwd()
-    execute 'cd ' . s:phpactorpath
+    execute 'cd ' . g:phpactorpath
     echo system('git pull origin master')
     echo system('composer install')
     execute 'cd ' .  current
@@ -239,7 +239,7 @@ function! phpactor#rpc(action, arguments)
 
     let request = {"actions": [ { "action": a:action, "parameters": a:arguments } ] }
 
-    let cmd = 'php ' . s:phpactorbinpath . ' rpc --working-dir=' . s:phpactorInitialCwd
+    let cmd = 'php ' . g:phpactorbinpath . ' rpc --working-dir=' . g:phpactorInitialCwd
     let result = system(cmd, json_encode(request))
 
     if (v:shell_error == 0)


### PR DESCRIPTION
In order to make thing like following works : 

```vim
" Update PHPActor cwd each time a new buffer is accessed
function! UpdatePHPActorPath()
	" Change working dir to the current file
	cd %:p:h

	" Set 'gitdir' to be the folder containing .git
	let gitdir = system("git rev-parse --show-toplevel")

	" See if the command output starts with 'fatal' (if it does, not in a git repo)
	if empty(matchstr(gitdir, '^fatal:.*'))
		let g:phpactorInitialCwd = gitdir
	endif
endfunction

autocmd BufEnter *.php call UpdatePHPActorPath()
```