### PR TITLE
adds debug mode

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -73,6 +73,16 @@ nnoremap <silent><Leader>d :call phpactor#OffsetTypeInfo()<CR>
 **NOTE**: The above mappings are probably sub-optimal, feel free to find a
 something that works for you.
 
+Debug mode
+----------
+
+By default, no error will be thrown in your interface. If you want enable debug
+mode, feel free to dynamically call the following command
+
+```vim
+:let g:phpactorDebug = 1
+```
+
 Omni-completion
 ---------------
 

--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -10,6 +10,7 @@ let g:phpactorpath = expand('<sfile>:p:h') . '/..'
 let g:phpactorbinpath = g:phpactorpath. '/bin/phpactor'
 let g:phpactorPhpBin = 'php'
 let g:phpactorInitialCwd = getcwd()
+let g:phpactorDebug = 0
 
 """""""""""""""""
 " Update Phpactor
@@ -261,7 +262,11 @@ function! phpactor#rpc(action, arguments)
             endif
         endfor
     else
-        echo "Phpactor returned an error: " . result
+        " Only show error if debug is true
+        if (g:phpactorDebug == 1)
+            echo "Phpactor returned an error: " . result
+        endif
+
         return
     endif
 endfunction


### PR DESCRIPTION
When using PHPActor globally with `ncm-phpactor`, the completion will be tried each time `<C-o>` is pressed or when `ncm-phpactor` triggers will matches. But, if we're on a non-conform repository (no `Composer` or no `git`), an error will be thrown on each triggered events. This patch implements a debug mode that will throw error if true, or do nothing otherwise.