### PR TITLE
Use confirm menu for context menu

### DIFF
--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -273,7 +273,6 @@ function! phpactor#_input_confirm_choice(label, choices)
     let choices = []
     let usedShortcuts = []
 
-
     for choiceLabel in keys(a:choices)
         let buffer = []
         let foundShortcut = v:false
@@ -303,28 +302,6 @@ function! phpactor#_input_confirm_choice(label, choices)
 
     let choice = choice - 1
     return a:choices[get(choices, choice)]
-endfunction
-
-function! phpactor#_input_numeric_choice(label, choices)
-    let list = []
-    let choices = []
-
-    let c = 1
-    for choiceLabel in keys(a:choices)
-        call add(list, c . ") " . choiceLabel)
-        call add(choices, choiceLabel)
-        let c = c + 1
-    endfor
-
-    echo a:label
-    let choice = inputlist(list)
-
-    if (choice == 0)
-        throw "Cancelled"
-    endif
-
-    let choice = choice - 1
-    return a:choices[choices[choice]]
 endfunction
 
 function! phpactor#_rpc_dispatch(actionName, parameters)


### PR DESCRIPTION
Replaces the numeric context menu with a shortcut based one (using VIMs builtin `confirm` menu).

![asd](https://user-images.githubusercontent.com/530801/32408520-5e5810c2-c199-11e7-83d1-50f44d55da2b.png)

By default the first character of the menu option is used, in order to prevent colisions, we automatically advance the short-cut character if a shortcut is already used -  this reduces the chance of collision, but we are limited by the range of charcters in the label (and overall by the 26 chars in the alphabet).

However - this works at the moment, and is much more intuitive than the numeric selection. In the future we could build on this without breaking BC too much (and I can probably start writing some documentation...).