### PR TITLE
Cache clear

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -76,12 +76,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/JetBrains/phpstorm-stubs.git",
-                "reference": "3f4891a7df1ba335cfbda521f4f4eaa0724b7e10"
+                "reference": "bcc073a39ef194cd80945667886952d000ea614c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/3f4891a7df1ba335cfbda521f4f4eaa0724b7e10",
-                "reference": "3f4891a7df1ba335cfbda521f4f4eaa0724b7e10",
+                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/bcc073a39ef194cd80945667886952d000ea614c",
+                "reference": "bcc073a39ef194cd80945667886952d000ea614c",
                 "shasum": ""
             },
             "type": "library",
@@ -101,7 +101,7 @@
                 "stubs",
                 "type"
             ],
-            "time": "2017-12-29T13:54:16+00:00"
+            "time": "2018-01-10T15:52:40+00:00"
         },
         {
             "name": "microsoft/tolerant-php-parser",
@@ -1058,12 +1058,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "0b9a64d842bf7f15c9f3964909100a6663e97db2"
+                "reference": "d4482c9ab98d71171f2b27423b0891f67c9ed44e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/0b9a64d842bf7f15c9f3964909100a6663e97db2",
-                "reference": "0b9a64d842bf7f15c9f3964909100a6663e97db2",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/d4482c9ab98d71171f2b27423b0891f67c9ed44e",
+                "reference": "d4482c9ab98d71171f2b27423b0891f67c9ed44e",
                 "shasum": ""
             },
             "require": {
@@ -1116,7 +1116,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2017-11-12T18:48:08+00:00"
+            "time": "2018-01-07T17:54:41+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -1496,16 +1496,16 @@
         },
         {
             "name": "lstrojny/functional-php",
-            "version": "1.6.0",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lstrojny/functional-php.git",
-                "reference": "c0c15f048355d0a7ab17914022ec1f901fe5144a"
+                "reference": "7c2091ddea572e012aa980e5d19d242d3a06ad5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lstrojny/functional-php/zipball/c0c15f048355d0a7ab17914022ec1f901fe5144a",
-                "reference": "c0c15f048355d0a7ab17914022ec1f901fe5144a",
+                "url": "https://api.github.com/repos/lstrojny/functional-php/zipball/7c2091ddea572e012aa980e5d19d242d3a06ad5b",
+                "reference": "7c2091ddea572e012aa980e5d19d242d3a06ad5b",
                 "shasum": ""
             },
             "require": {
@@ -1592,6 +1592,7 @@
                     "src/Functional/Reject.php",
                     "src/Functional/Retry.php",
                     "src/Functional/Select.php",
+                    "src/Functional/SelectKeys.php",
                     "src/Functional/SequenceConstant.php",
                     "src/Functional/SequenceExponential.php",
                     "src/Functional/SequenceLinear.php",
@@ -1599,6 +1600,7 @@
                     "src/Functional/Sort.php",
                     "src/Functional/Sum.php",
                     "src/Functional/SuppressError.php",
+                    "src/Functional/Tap.php",
                     "src/Functional/Tail.php",
                     "src/Functional/TailRecursion.php",
                     "src/Functional/True.php",
@@ -1628,7 +1630,7 @@
             "keywords": [
                 "functional"
             ],
-            "time": "2017-05-08T10:17:44+00:00"
+            "time": "2018-01-03T10:08:50+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1783,12 +1785,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/test-utils.git",
-                "reference": "dc1d2780ee553d2d7ebed3cce89e41377b7226d9"
+                "reference": "19af66eb2eb94e95646d29062619e12fe8330347"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/test-utils/zipball/dc1d2780ee553d2d7ebed3cce89e41377b7226d9",
-                "reference": "dc1d2780ee553d2d7ebed3cce89e41377b7226d9",
+                "url": "https://api.github.com/repos/phpactor/test-utils/zipball/19af66eb2eb94e95646d29062619e12fe8330347",
+                "reference": "19af66eb2eb94e95646d29062619e12fe8330347",
                 "shasum": ""
             },
             "require-dev": {
@@ -1816,7 +1818,7 @@
                 }
             ],
             "description": "Utilities for managing the test environment",
-            "time": "2018-01-05T08:55:54+00:00"
+            "time": "2018-01-13T10:21:32+00:00"
         },
         {
             "name": "phpbench/dom",
@@ -1941,7 +1943,7 @@
         },
         {
             "name": "phpdocumentor/reflection-common",
-            "version": "dev-master",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
@@ -2493,12 +2495,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "33fd41a76e746b8fa96d00b49a23dadfa8334cdf"
+                "reference": "e244c19aec6a1f0a2ff9e498b9b4bed22537730a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/33fd41a76e746b8fa96d00b49a23dadfa8334cdf",
-                "reference": "33fd41a76e746b8fa96d00b49a23dadfa8334cdf",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/e244c19aec6a1f0a2ff9e498b9b4bed22537730a",
+                "reference": "e244c19aec6a1f0a2ff9e498b9b4bed22537730a",
                 "shasum": ""
             },
             "require": {
@@ -2544,7 +2546,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2018-01-06T05:45:45+00:00"
+            "time": "2018-01-07T17:10:51+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -2597,12 +2599,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "b11c729f95109b56a0fe9650c6a63a0fcd8c439f"
+                "reference": "c2019a4d1d15b86fc3da1139c99f6ed16a1fe517"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/b11c729f95109b56a0fe9650c6a63a0fcd8c439f",
-                "reference": "b11c729f95109b56a0fe9650c6a63a0fcd8c439f",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/c2019a4d1d15b86fc3da1139c99f6ed16a1fe517",
+                "reference": "c2019a4d1d15b86fc3da1139c99f6ed16a1fe517",
                 "shasum": ""
             },
             "require": {
@@ -2653,7 +2655,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2017-12-22T14:50:35+00:00"
+            "time": "2018-01-12T08:56:06+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -2928,12 +2930,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "e1b86d7bde734bd7d05454ea964eb8283a3259b6"
+                "reference": "ff755086ff55902772e3fae5dd5f29bcbae68285"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/e1b86d7bde734bd7d05454ea964eb8283a3259b6",
-                "reference": "e1b86d7bde734bd7d05454ea964eb8283a3259b6",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/ff755086ff55902772e3fae5dd5f29bcbae68285",
+                "reference": "ff755086ff55902772e3fae5dd5f29bcbae68285",
                 "shasum": ""
             },
             "require": {
@@ -2965,7 +2967,7 @@
             ],
             "description": "Allows reflection of object attributes, including inherited and non-public ones",
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
-            "time": "2017-11-16T09:51:26+00:00"
+            "time": "2018-01-07T16:00:13+00:00"
         },
         {
             "name": "sebastian/recursion-context",

--- a/lib/Application/CacheClear.php
+++ b/lib/Application/CacheClear.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Phpactor\Application;
+
+use Symfony\Component\Filesystem\Filesystem;
+use Webmozart\PathUtil\Path;
+
+class CacheClear
+{
+    /**
+     * @var string
+     */
+    private $cachePath;
+
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    public function __construct(string $cachePath)
+    {
+        $this->cachePath = Path::canonicalize($cachePath);
+        $this->filesystem = new Filesystem();
+    }
+
+    public function clearCache()
+    {
+        $this->filesystem->remove($this->cachePath);
+    }
+
+    public function cachePath()
+    {
+        return $this->cachePath;
+    }
+}

--- a/lib/Console/Command/CacheClearCommand.php
+++ b/lib/Console/Command/CacheClearCommand.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Phpactor\Console\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Phpactor\Application\CacheClear;
+
+class CacheClearCommand extends Command
+{
+    /**
+     * @var CacheClear
+     */
+    private $cache;
+
+    public function __construct(CacheClear $cache)
+    {
+        parent::__construct();
+        $this->cache = $cache;
+    }
+
+    protected function configure()
+    {
+        $this->setName('cache:clear');
+        $this->setDescription('Clear the cache');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->cache->clearCache();
+        $output->writeln(sprintf('<info>Cache cleared: </>%s', $this->cache->cachePath()));
+    }
+}

--- a/lib/Container/CoreExtension.php
+++ b/lib/Container/CoreExtension.php
@@ -45,6 +45,8 @@ use Psr\Log\LogLevel;
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\FingersCrossedHandler;
 use Phpactor\ClassFileConverter\PathFinder;
+use Phpactor\Application\CacheClear;
+use Phpactor\Console\Command\CacheClearCommand;
 
 class CoreExtension implements ExtensionInterface
 {
@@ -184,6 +186,12 @@ class CoreExtension implements ExtensionInterface
             return new ReferencesMemberCommand(
                 $container->get('application.method_references'),
                 $container->get('console.dumper_registry')
+            );
+        }, [ 'ui.console.command' => []]);
+
+        $container->register('command.cache_clear', function (Container $container) {
+            return new CacheClearCommand(
+                $container->get('application.cache_clear')
             );
         }, [ 'ui.console.command' => []]);
 
@@ -398,6 +406,12 @@ class CoreExtension implements ExtensionInterface
                 $container->get('path_finder.path_finder'),
                 $container->get('application.class_new'),
                 $container->getParameter(self::NAVIGATOR_AUTOCREATE)
+            );
+        });
+
+        $container->register('application.cache_clear', function (Container $container) {
+            return new CacheClear(
+                $container->getParameter(self::CACHE_DIR)
             );
         });
 

--- a/lib/Container/RpcExtension.php
+++ b/lib/Container/RpcExtension.php
@@ -27,6 +27,7 @@ use Phpactor\Rpc\RequestHandler\ExceptionCatchingHandler;
 use Phpactor\Rpc\RequestHandler\LoggingHandler;
 use Phpactor\Rpc\Handler\NavigateHandler;
 use Phpactor\Rpc\Handler\OverrideMethodHandler;
+use Phpactor\Rpc\Handler\CacheClearHandler;
 
 class RpcExtension implements ExtensionInterface
 {
@@ -175,6 +176,12 @@ class RpcExtension implements ExtensionInterface
             return new OverrideMethodHandler(
                 $container->get('reflection.reflector'),
                 $container->get('code_transform.refactor.override_method')
+            );
+        }, [ 'rpc.handler' => [] ]);
+
+        $container->register('rpc.handler.cache_clear', function (Container $container) {
+            return new CacheClearHandler(
+                $container->get('application.cache_clear')
             );
         }, [ 'rpc.handler' => [] ]);
     }

--- a/lib/Rpc/Handler/CacheClearHandler.php
+++ b/lib/Rpc/Handler/CacheClearHandler.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Phpactor\Rpc\Handler;
+
+use Phpactor\Rpc\Handler;
+use Phpactor\Application\CacheClear;
+use Phpactor\Rpc\Response\EchoResponse;
+
+class CacheClearHandler implements Handler
+{
+    const CACHE_CLEAR = 'cache_clear';
+
+    /**
+     * @var CacheClear
+     */
+    private $cacheClear;
+
+    public function __construct(CacheClear $cacheClear)
+    {
+        $this->cacheClear = $cacheClear;
+    }
+
+    public function name(): string
+    {
+        return self::CACHE_CLEAR;
+    }
+
+    public function defaultParameters(): array
+    {
+        return [];
+    }
+
+    public function handle(array $arguments)
+    {
+        $this->cacheClear->clearCache();
+
+        return EchoResponse::fromMessage(sprintf('Cache cleared: %s', $this->cacheClear->cachePath()));
+    }
+}

--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -222,6 +222,11 @@ function! phpactor#Navigate()
     call phpactor#rpc("navigate", { "source_path": currentPath })
 endfunction
 
+function! phpactor#CacheClear()
+    let currentPath = expand('%')
+    call phpactor#rpc("cache_clear", {})
+endfunction
+
 """""""""""""""""""""""
 " Utility functions
 """""""""""""""""""""""

--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -223,7 +223,6 @@ function! phpactor#Navigate()
 endfunction
 
 function! phpactor#CacheClear()
-    let currentPath = expand('%')
     call phpactor#rpc("cache_clear", {})
 endfunction
 

--- a/tests/Benchmark/ClassSearchBench.php
+++ b/tests/Benchmark/ClassSearchBench.php
@@ -15,7 +15,7 @@ class ClassSearchBench extends BaseBenchCase
 {
     public function setUp()
     {
-        $this->initWorkspace();
+        $this->workspace()->reset();
         $this->loadProject('Symfony');
     }
 

--- a/tests/Benchmark/CompleteBench.php
+++ b/tests/Benchmark/CompleteBench.php
@@ -16,7 +16,7 @@ class CompleteBench extends BaseBenchCase
 {
     public function setUp()
     {
-        $this->initWorkspace();
+        $this->workspace()->reset();
         $this->loadProject('PhpUnit');
     }
 

--- a/tests/Integration/Application/CacheClearTest.php
+++ b/tests/Integration/Application/CacheClearTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Phpactor\Tests\Integration\Application;
+
+use Phpactor\Tests\IntegrationTestCase;
+use Phpactor\Application\CacheClear;
+
+class CacheClearTest extends IntegrationTestCase
+{
+    /**
+     * @var CacheClear
+     */
+    private $cacheClear;
+
+    public function setUp()
+    {
+        $this->workspace()->reset();
+        $this->workspace()->loadManifest(<<<'EOT'
+// File: test.text
+Hello World
+// File: folder/test.text
+Hello World
+EOT
+        );
+        $this->cacheClear = new CacheClear($this->workspaceDir());
+    }
+
+    public function testCacheClear()
+    {
+        $this->assertTrue($this->workspace()->exists('/test.text'));
+        $this->assertTrue($this->workspace()->exists('/folder/test.text'));
+
+        $this->cacheClear->clearCache();
+
+        $this->assertFalse($this->workspace()->exists('/test.text'));
+        $this->assertFalse($this->workspace()->exists('/folder/test.text'));
+    }
+}

--- a/tests/Integration/Console/ApplicationTest.php
+++ b/tests/Integration/Console/ApplicationTest.php
@@ -11,7 +11,7 @@ class ApplicationTest extends IntegrationTestCase
 {
     public function setUp()
     {
-        $this->initWorkspace();
+        $this->workspace()->reset();
     }
 
     /**

--- a/tests/IntegrationTestCase.php
+++ b/tests/IntegrationTestCase.php
@@ -5,6 +5,7 @@ namespace Phpactor\Tests;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Filesystem\Filesystem;
 use PHPUnit\Framework\TestCase;
+use Phpactor\TestUtils\Workspace;
 
 abstract class IntegrationTestCase extends TestCase
 {
@@ -29,13 +30,9 @@ abstract class IntegrationTestCase extends TestCase
         $filesystem->mirror($this->workspaceDir(), $this->cacheDir($name));
     }
 
-    protected function initWorkspace()
+    protected function workspace(): Workspace
     {
-        $filesystem = new Filesystem();
-        if (file_exists($this->workspaceDir())) {
-            $filesystem->remove($this->workspaceDir());
-        }
-        $filesystem->mkdir($this->workspaceDir());
+        return Workspace::create($this->workspaceDir());
     }
 
     protected function assertSuccess(Process $process)

--- a/tests/System/Console/Command/CacheClearCommandTest.php
+++ b/tests/System/Console/Command/CacheClearCommandTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Phpactor\Tests\System\Console\Command;
+
+use Phpactor\Tests\System\SystemTestCase;
+
+class CacheClearCommandTest extends SystemTestCase
+{
+    public function setUp()
+    {
+        $this->workspace()->reset();
+        $this->loadProject('Animals');
+    }
+
+    public function testCacheClear()
+    {
+        $process = $this->phpactor('cache:clear');
+        $this->assertSuccess($process);
+        $this->assertContains('Cache cleared', $process->getOutput());
+    }
+}

--- a/tests/System/Console/Command/ClassCopyCommandTest.php
+++ b/tests/System/Console/Command/ClassCopyCommandTest.php
@@ -8,7 +8,7 @@ class ClassCopyCommandTest extends SystemTestCase
 {
     public function setUp()
     {
-        $this->initWorkspace();
+        $this->workspace()->reset();
         $this->loadProject('Animals');
     }
 

--- a/tests/System/Console/Command/ClassInflectCommandTest.php
+++ b/tests/System/Console/Command/ClassInflectCommandTest.php
@@ -8,7 +8,7 @@ class ClassInflectCommandTest extends SystemTestCase
 {
     public function setUp()
     {
-        $this->initWorkspace();
+        $this->workspace()->reset();
         $this->loadProject('Animals');
     }
 

--- a/tests/System/Console/Command/ClassMoveCommandTest.php
+++ b/tests/System/Console/Command/ClassMoveCommandTest.php
@@ -8,7 +8,7 @@ class ClassMoveCommandTest extends SystemTestCase
 {
     public function setUp()
     {
-        $this->initWorkspace();
+        $this->workspace()->reset();
         $this->loadProject('Animals');
     }
 

--- a/tests/System/Console/Command/ClassNewCommandTest.php
+++ b/tests/System/Console/Command/ClassNewCommandTest.php
@@ -8,7 +8,7 @@ class ClassNewCommandTest extends SystemTestCase
 {
     public function setUp()
     {
-        $this->initWorkspace();
+        $this->workspace()->reset();
         $this->loadProject('Animals');
     }
 

--- a/tests/System/Console/Command/ClassReflectorCommandTest.php
+++ b/tests/System/Console/Command/ClassReflectorCommandTest.php
@@ -8,7 +8,7 @@ class ClassReflectorCommandTest extends SystemTestCase
 {
     public function setUp()
     {
-        $this->initWorkspace();
+        $this->workspace()->reset();
         $this->loadProject('Animals');
     }
 

--- a/tests/System/Console/Command/ClassSearchCommandTest.php
+++ b/tests/System/Console/Command/ClassSearchCommandTest.php
@@ -8,7 +8,7 @@ class ClassSearchCommandTest extends SystemTestCase
 {
     public function setUp()
     {
-        $this->initWorkspace();
+        $this->workspace()->reset();
         $this->loadProject('Animals');
     }
 

--- a/tests/System/Console/Command/ClassTransformCommandTest.php
+++ b/tests/System/Console/Command/ClassTransformCommandTest.php
@@ -8,7 +8,7 @@ class ClassTransformCommandTest extends SystemTestCase
 {
     public function setUp()
     {
-        $this->initWorkspace();
+        $this->workspace()->reset();
         $this->loadProject('Animals');
     }
 

--- a/tests/System/Console/Command/CompleteCommandTest.php
+++ b/tests/System/Console/Command/CompleteCommandTest.php
@@ -8,7 +8,7 @@ class CompleteCommandTest extends SystemTestCase
 {
     public function setUp()
     {
-        $this->initWorkspace();
+        $this->workspace()->reset();
         $this->loadProject('Animals');
     }
 

--- a/tests/System/Console/Command/FileInfoCommandTest.php
+++ b/tests/System/Console/Command/FileInfoCommandTest.php
@@ -8,7 +8,7 @@ class FileInfoCommandTest extends SystemTestCase
 {
     public function setUp()
     {
-        $this->initWorkspace();
+        $this->workspace()->reset();
         $this->loadProject('Animals');
     }
 

--- a/tests/System/Console/Command/OffsetInfoCommandTest.php
+++ b/tests/System/Console/Command/OffsetInfoCommandTest.php
@@ -8,7 +8,7 @@ class OffsetInfoCommandTest extends SystemTestCase
 {
     public function setUp()
     {
-        $this->initWorkspace();
+        $this->workspace()->reset();
         $this->loadProject('Animals');
     }
 

--- a/tests/System/Console/Command/ReferencesClassCommandTest.php
+++ b/tests/System/Console/Command/ReferencesClassCommandTest.php
@@ -8,7 +8,7 @@ class ReferencesClassCommandTest extends SystemTestCase
 {
     public function setUp()
     {
-        $this->initWorkspace();
+        $this->workspace()->reset();
         $this->loadProject('Animals');
     }
 

--- a/tests/System/Console/Command/ReferencesMemberCommandTest.php
+++ b/tests/System/Console/Command/ReferencesMemberCommandTest.php
@@ -8,7 +8,7 @@ class ReferencesMemberCommandTest extends SystemTestCase
 {
     public function setUp()
     {
-        $this->initWorkspace();
+        $this->workspace()->reset();
         $this->loadProject('Animals');
     }
 

--- a/tests/Unit/Application/CacheClearTest.php
+++ b/tests/Unit/Application/CacheClearTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Phpactor\Tests\Unit\Application;
+
+use PHPUnit\Framework\TestCase;
+
+class CacheClearTest extends TestCase
+{
+}

--- a/tests/Unit/Application/CacheClearTest.php
+++ b/tests/Unit/Application/CacheClearTest.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace Phpactor\Tests\Unit\Application;
-
-use PHPUnit\Framework\TestCase;
-
-class CacheClearTest extends TestCase
-{
-}

--- a/tests/Unit/Rpc/Handler/CacheClearHandlerTest.php
+++ b/tests/Unit/Rpc/Handler/CacheClearHandlerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Phpactor\Tests\Unit\Rpc\Handler;
+
+use PHPUnit\Framework\TestCase;
+use Phpactor\Tests\Unit\Rpc\Handler\HandlerTestCase;
+use Phpactor\Rpc\Handler;
+use Phpactor\Rpc\Handler\CacheClearHandler;
+use Phpactor\Application\CacheClear;
+use Prophecy\Prophecy\ObjectProphecy;
+
+class CacheClearHandlerTest extends HandlerTestCase
+{
+    /**
+     * @var CacheClear|ObjectProphecy
+     */
+    private $clearCache;
+
+    public function setUp()
+    {
+        $this->clearCache = $this->prophesize(CacheClear::class);
+    }
+
+    public function createHandler(): Handler
+    {
+        return new CacheClearHandler($this->clearCache->reveal());
+    }
+
+    public function testClearCache()
+    {
+        $this->clearCache->clearCache()->shouldBeCalled();
+        $this->clearCache->cachePath()->willReturn('/path/to');
+        $this->handle('cache_clear', []);
+    }
+}


### PR DESCRIPTION
Command / Handler / VIM function for clearing the cache.

Currently the only cached information is the phpstorm stub map used for locating standard PHP classes.