### PR TITLE
Completion: hide private/protected methods/properties

### DIFF
--- a/lib/Application/Complete.php
+++ b/lib/Application/Complete.php
@@ -160,13 +160,13 @@ class Complete
             return $symbolInformation->withIssue(sprintf('Could not find class "%s"', (string) $type));
         }
 
-        $needsPublicAccess = !in_array($symbolInformation->symbol()->name(), ['this', 'self']);
+        $publicOnly = !in_array($symbolInformation->symbol()->name(), ['this', 'self'], true);
         /** @var $method ReflectionMethod */
         foreach ($classReflection->methods() as $method) {
             if ($method->name() === '__construct') {
                 continue;
             }
-            if ($needsPublicAccess && !$method->visibility()->isPublic()) {
+            if ($publicOnly && false === $method->visibility()->isPublic()) {
                 continue;
             }
             $info = $this->getMethodInfo($method);
@@ -179,7 +179,7 @@ class Complete
 
         if ($classReflection instanceof ReflectionClass) {
             foreach ($classReflection->properties() as $property) {
-                if ($needsPublicAccess && !$property->visibility()->isPublic()) {
+                if ($publicOnly && false === $property->visibility()->isPublic()) {
                     continue;
                 }
                 $suggestions[] = [

--- a/lib/Application/Complete.php
+++ b/lib/Application/Complete.php
@@ -160,9 +160,13 @@ class Complete
             return $symbolInformation->withIssue(sprintf('Could not find class "%s"', (string) $type));
         }
 
+        $needsPublicAccess = !in_array($symbolInformation->symbol()->name(), ['this', 'self']);
         /** @var $method ReflectionMethod */
         foreach ($classReflection->methods() as $method) {
             if ($method->name() === '__construct') {
+                continue;
+            }
+            if ($needsPublicAccess && !$method->visibility()->isPublic()) {
                 continue;
             }
             $info = $this->getMethodInfo($method);
@@ -175,6 +179,9 @@ class Complete
 
         if ($classReflection instanceof ReflectionClass) {
             foreach ($classReflection->properties() as $property) {
+                if ($needsPublicAccess && !$property->visibility()->isPublic()) {
+                    continue;
+                }
                 $suggestions[] = [
                     'type' => 'm',
                     'name' => $property->name(),

--- a/tests/System/Application/CompleteTest.php
+++ b/tests/System/Application/CompleteTest.php
@@ -46,6 +46,22 @@ EOT
                     ]
                 ]
             ],
+            'Private property' => [
+                <<<'EOT'
+<?php
+
+class Foobar
+{
+    private $foo;
+}
+
+$foobar = new Foobar();
+$foobar->
+
+EOT
+        , 76,
+            [ ]
+            ],
             'Public property access' => [
                 <<<'EOT'
 <?php
@@ -122,6 +138,24 @@ EOT
                         'name' => 'foo',
                         'info' => 'pub foo(): Foobar|Barbar',
                     ]
+                ]
+            ],
+            'Private method' => [
+                <<<'EOT'
+<?php
+
+class Foobar
+{
+    private function foo(): Barbar
+    {
+    }
+}
+
+$foobar = new Foobar();
+$foobar->
+
+EOT
+                , 105, [
                 ]
             ],
             'Static method' => [


### PR DESCRIPTION
Just a naive quick fix for hiding private/protected methods & properties, as you mentioned rewriting a new completion engine in #109 and #214 