### PR TITLE
Disable XDebug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Changelog
 
 ## Unreleased
 
+Features:
+
+    - [Application] Disable XDebug by default, very much improve performance.
+      Fixes #317
+
 Improvements:
 
     - [Completion] Do not evaluate left operand when completing expression,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## Unreleased
+
+Improvements:
+
+    - [Completion] Do not evaluate left operand when completing expression,
+      #380
+
 ## 0.2.0
 
 Features:

--- a/bin/phpactor
+++ b/bin/phpactor
@@ -5,6 +5,7 @@ use Symfony\Component\Debug\Debug;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Phpactor\Application;
+use Composer\XdebugHandler\XdebugHandler;
 
 foreach ([
     __DIR__ . '/../../../autoload.php',
@@ -32,6 +33,10 @@ if (version_compare(PHP_VERSION, $minVersion) < 0) {
 }
 
 require_once $autoloadFile;
+
+$xdebug = new XdebugHandler('PHPACTOR', '--ansi');
+$xdebug->check();
+unset($xdebug);
 
 Debug::enable();
 

--- a/bin/phpactor
+++ b/bin/phpactor
@@ -34,10 +34,6 @@ if (version_compare(PHP_VERSION, $minVersion) < 0) {
 
 require_once $autoloadFile;
 
-$xdebug = new XdebugHandler('PHPACTOR', '--ansi');
-$xdebug->check();
-unset($xdebug);
-
 Debug::enable();
 
 $application = new Application();

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "symfony/yaml": "^3.3",
         "microsoft/tolerant-php-parser": "dev-master",
         "monolog/monolog": "^2.0@dev",
-        "phpactor/completion": "^1.0@dev"
+        "phpactor/completion": "^1.0@dev",
+        "composer/xdebug-handler": "dev-master"
     },
     "config": {
         "platform": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "microsoft/tolerant-php-parser": "dev-master",
         "monolog/monolog": "^2.0@dev",
         "phpactor/completion": "^1.0@dev",
-        "composer/xdebug-handler": "dev-master"
+        "composer/xdebug-handler": "^1.1"
     },
     "config": {
         "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -701,12 +701,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/completion.git",
-                "reference": "25a69cf42a7044a18d2089437658bc71f694034d"
+                "reference": "8d1447abe0d89705de0c21aceea724af4735b263"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/completion/zipball/25a69cf42a7044a18d2089437658bc71f694034d",
-                "reference": "25a69cf42a7044a18d2089437658bc71f694034d",
+                "url": "https://api.github.com/repos/phpactor/completion/zipball/8d1447abe0d89705de0c21aceea724af4735b263",
+                "reference": "8d1447abe0d89705de0c21aceea724af4735b263",
                 "shasum": ""
             },
             "require": {
@@ -740,7 +740,7 @@
                 }
             ],
             "description": "Completion library for Worse Reflection",
-            "time": "2018-04-06T11:39:29+00:00"
+            "time": "2018-04-14T10:48:14+00:00"
         },
         {
             "name": "phpactor/docblock",
@@ -874,12 +874,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/worse-reflection.git",
-                "reference": "b61d63b1856e708492b0ac83e6e3a010f9448a21"
+                "reference": "6c95ef90144fd43eaca9b38a5637170f05ad0243"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/worse-reflection/zipball/b61d63b1856e708492b0ac83e6e3a010f9448a21",
-                "reference": "b61d63b1856e708492b0ac83e6e3a010f9448a21",
+                "url": "https://api.github.com/repos/phpactor/worse-reflection/zipball/6c95ef90144fd43eaca9b38a5637170f05ad0243",
+                "reference": "6c95ef90144fd43eaca9b38a5637170f05ad0243",
                 "shasum": ""
             },
             "require": {
@@ -918,7 +918,7 @@
                 }
             ],
             "description": "Lazy AST reflector that is much worse than better",
-            "time": "2018-04-14T07:18:27+00:00"
+            "time": "2018-04-14T11:14:43+00:00"
         },
         {
             "name": "phpbench/container",
@@ -2002,12 +2002,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "6b728c018f8cc44d384ca81ca447aa48657473e2"
+                "reference": "2729f42b9a89ba0074fc0cdba56d6843a1e69741"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/6b728c018f8cc44d384ca81ca447aa48657473e2",
-                "reference": "6b728c018f8cc44d384ca81ca447aa48657473e2",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/2729f42b9a89ba0074fc0cdba56d6843a1e69741",
+                "reference": "2729f42b9a89ba0074fc0cdba56d6843a1e69741",
                 "shasum": ""
             },
             "require": {
@@ -2090,7 +2090,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2018-04-13T22:58:32+00:00"
+            "time": "2018-04-14T11:10:05+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "3d1492b05fd0525de1986b25a9f09aed",
+    "content-hash": "a494b517034431f17cca75e3312ff59e",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -63,7 +63,7 @@
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "dev-master",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
@@ -3869,7 +3869,6 @@
         "microsoft/tolerant-php-parser": 20,
         "monolog/monolog": 20,
         "phpactor/completion": 20,
-        "composer/xdebug-handler": 20,
         "phpbench/phpbench": 20,
         "phpactor/test-utils": 20,
         "friendsofphp/php-cs-fixer": 20

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "4c60b9bf9ebb32e1424bf0a886efb3e6",
+    "content-hash": "3d1492b05fd0525de1986b25a9f09aed",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -60,6 +60,50 @@
                 "validation"
             ],
             "time": "2018-04-09T14:40:28+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "c919dc6c62e221fc6406f861ea13433c0aa24f08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/c919dc6c62e221fc6406f861ea13433c0aa24f08",
+                "reference": "c919dc6c62e221fc6406f861ea13433c0aa24f08",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0",
+                "psr/log": "^1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "time": "2018-04-11T15:42:36+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -3825,6 +3869,7 @@
         "microsoft/tolerant-php-parser": 20,
         "monolog/monolog": 20,
         "phpactor/completion": 20,
+        "composer/xdebug-handler": 20,
         "phpbench/phpbench": 20,
         "phpactor/test-utils": 20,
         "friendsofphp/php-cs-fixer": 20

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -47,6 +47,13 @@ Phpactor will automatically look to see if it can use the
 [composer](https://getcomposer.org) autoloader at this
 path. The autoloader helps Phpactor locate classes.
 
+#### xdebug_disable
+
+*Default*: `true`
+
+Experimental: Disable XDebug if it's enabled. This can (likely will) have a
+very positive effect on performance.
+
 #### autoload.deregister
 
 *Default*: `true`

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -47,19 +47,12 @@ Phpactor will automatically look to see if it can use the
 [composer](https://getcomposer.org) autoloader at this
 path. The autoloader helps Phpactor locate classes.
 
-#### xdebug_disable
-
-*Default*: `true`
-
-Experimental: Disable XDebug if it's enabled. This can (likely will) have a
-very positive effect on performance.
-
 #### autoload.deregister
 
 *Default*: `true`
 
-By default Phpactor will deregister the included autoloader to prevent
 any potential conflicts. However, some autoloaders may add global dependencies
+By default Phpactor will deregister the included autoloader to prevent
 on the code available through that autoloader (e.g. Drupal). In such cases
 set this to `false` and hope that everything is *fine*.
 
@@ -92,6 +85,13 @@ The default logging level.
 *Default*: `phpactor.log`
 
 Where the log file is
+
+#### xdebug_disable
+
+*Default*: `true`
+
+Disable XDebug if it's enabled. This can (likely will) have a very positive
+effect on performance.
 
 ### Code Transform Extension
 

--- a/lib/Extension/Completion/CompletionExtension.php
+++ b/lib/Extension/Completion/CompletionExtension.php
@@ -42,11 +42,17 @@ class CompletionExtension implements Extension
         });
         
         $container->register('completion.completor.class_member', function (Container $container) {
-            return new WorseClassMemberCompletor($container->get('reflection.reflector'));
+            return new WorseClassMemberCompletor(
+                $container->get('reflection.reflector'),
+                $container->get('reflection.tolerant_parser')
+            );
         }, [ 'completion.completor' => []]);
         
         $container->register('completion.completor.local_variable', function (Container $container) {
-            return new WorseLocalVariableCompletor($container->get('reflection.reflector'));
+            return new WorseLocalVariableCompletor(
+                $container->get('reflection.reflector'),
+                $container->get('reflection.tolerant_parser')
+            );
         }, [ 'completion.completor' => []]);
     }
 

--- a/lib/Extension/Core/Application/Status.php
+++ b/lib/Extension/Core/Application/Status.php
@@ -39,6 +39,12 @@ class Status
             $diagnostics['bad'][] = 'Git not detected. Some operations which would have been better scoped to your project repository will now include vendor paths.';
         }
 
+        if (extension_loaded('xdebug')) {
+            $diagnostics['bad'][] = 'XDebug is enabled. XDebug has a negative effect on performance.';
+        } else {
+            $diagnostics['good'][] = 'XDebug is disabled. XDebug has a negative effect on performance.';
+        }
+
         return $diagnostics;
     }
 }

--- a/lib/Extension/Core/CoreExtension.php
+++ b/lib/Extension/Core/CoreExtension.php
@@ -39,6 +39,7 @@ class CoreExtension implements Extension
     const LOGGING_ENABLED = 'logging.enabled';
     const LOGGING_FINGERS_CROSSED = 'logging.fingers_crossed';
     const AUTOLOAD_DEREGISTER = 'autoload.deregister';
+    const XDEBUG_DISABLE = 'xdebug_disable';
 
     public static $autoloader;
 
@@ -54,6 +55,7 @@ class CoreExtension implements Extension
             self::LOGGING_FINGERS_CROSSED => true,
             self::LOGGING_PATH => 'phpactor.log',
             self::LOGGING_LEVEL => LogLevel::WARNING,
+            self::XDEBUG_DISABLE => true,
         ]);
     }
 

--- a/lib/Extension/WorseReflection/WorseReflectionExtension.php
+++ b/lib/Extension/WorseReflection/WorseReflectionExtension.php
@@ -16,6 +16,8 @@ use Phpactor\Extension\WorseReflection\Command\OffsetInfoCommand;
 use Phpactor\Extension\WorseReflection\Application\OffsetInfo;
 use Phpactor\Extension\WorseReflection\Application\ClassReflector;
 use Phpactor\Extension\WorseReflection\Command\ClassReflectorCommand;
+use Phpactor\WorseReflection\Bridge\TolerantParser\Parser\CachedParser;
+use Phpactor\WorseReflection\Bridge\TolerantParser\Reflector\TolerantFactory;
 
 class WorseReflectionExtension implements Extension
 {
@@ -42,6 +44,7 @@ class WorseReflectionExtension implements Extension
         $container->register('reflection.reflector', function (Container $container) {
             $builder = ReflectorBuilder::create()
                 ->enableCache()
+                ->withSourceReflectorFactory(new TolerantFactory($container->get('reflection.tolerant_parser')))
                 ->enableContextualSourceLocation();
         
             foreach (array_keys($container->getServiceIdsForTag('reflection.source_locator')) as $locatorId) {
@@ -51,6 +54,10 @@ class WorseReflectionExtension implements Extension
             $builder->withLogger(new PsrLogger($container->get('monolog.logger')));
         
             return $builder->build();
+        });
+
+        $container->register('reflection.tolerant_parser', function (Container $container) {
+            return new CachedParser();
         });
         
         $container->register('reflection.locator.stub', function (Container $container) {

--- a/lib/Phpactor.php
+++ b/lib/Phpactor.php
@@ -18,11 +18,13 @@ use Phpactor\Container\Extension;
 use Symfony\Component\Console\Input\InputInterface;
 use Phpactor\Config\Paths;
 use Phpactor\Extension\ClassToFile\ClassToFileExtension;
+use Composer\XdebugHandler\XdebugHandler;
 
 class Phpactor
 {
     public static function boot(InputInterface $input): PhpactorContainer
     {
+
         $config = [];
 
         $configLoader = new ConfigLoader();
@@ -30,6 +32,12 @@ class Phpactor
 
         if ($input->hasParameterOption([ '--working-dir', '-d' ])) {
             $config['cwd'] = $input->getParameterOption([ '--working-dir', '-d' ]);
+        }
+
+        if (!isset($config[CoreExtension::XDEBUG_DISABLE]) || $config[CoreExtension::XDEBUG_DISABLE]) {
+            $xdebug = new XdebugHandler('PHPACTOR', '--ansi');
+            $xdebug->check();
+            unset($xdebug);
         }
 
         $extensionNames = [

--- a/tests/Benchmark/BaseBenchCase.php
+++ b/tests/Benchmark/BaseBenchCase.php
@@ -6,16 +6,17 @@ use Phpactor\Tests\IntegrationTestCase;
 use Phpactor\Application;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Process\Process;
 
 class BaseBenchCase extends IntegrationTestCase
 {
-    protected function runCommand(array $input): BufferedOutput
+    protected function runCommand(string $command): string
     {
         chdir($this->workspaceDir());
-        $application = new Application();
-        $output = new BufferedOutput();
-        $application->setAutoExit(false);
-        $application->run(new ArrayInput($input), $output);
-        return $output;
+
+        $process = new Process(__DIR__ . '/../../bin/phpactor ' . $command);
+        $process->setWorkingDirectory($this->workspaceDir());
+        $process->run();
+        return $process->getOutput();
     }
 }

--- a/tests/Benchmark/ClassSearchBench.php
+++ b/tests/Benchmark/ClassSearchBench.php
@@ -16,6 +16,6 @@ class ClassSearchBench extends BaseBenchCase
 
     public function benchClassSearch()
     {
-        $this->runCommand([ 'command' => 'class:search', 'name' => 'Request' ]);
+        $this->runCommand('class:search Request');
     }
 }

--- a/tests/Benchmark/CompleteBench.php
+++ b/tests/Benchmark/CompleteBench.php
@@ -18,11 +18,7 @@ class CompleteBench extends BaseBenchCase
 
     public function benchComplete()
     {
-        $output = $this->runCommand([
-            'command' => 'complete',
-            'path' => 'tests/FoobarTest.php',
-            'offset'=> 145
-        ]);
-        Assert::assertContains('info:pub', $output->fetch());
+        $output = $this->runCommand('complete tests/FoobarTest.php 184'); //145?
+        Assert::assertContains('info:pub', $output);
     }
 }

--- a/tests/Benchmark/CompleteBench.php
+++ b/tests/Benchmark/CompleteBench.php
@@ -18,7 +18,7 @@ class CompleteBench extends BaseBenchCase
 
     public function benchComplete()
     {
-        $output = $this->runCommand('complete tests/FoobarTest.php 184'); //145?
+        $output = $this->runCommand('complete tests/FoobarTest.php 145'); //145?
         Assert::assertContains('info:pub', $output);
     }
 }

--- a/tests/System/Extension/Completion/Application/CompleteTest.php
+++ b/tests/System/Extension/Completion/Application/CompleteTest.php
@@ -1,17 +1,19 @@
 <?php
 
-namespace Phpactor\Tests\System;
+namespace Phpactor\Tests\System\Extension\Completion\Application;
 
 use Phpactor\Extension\Completion\Application\Complete;
+use Phpactor\TestUtils\ExtractOffset;
+use Phpactor\Tests\System\SystemTestCase;
 
 class CompleteTest extends SystemTestCase
 {
     /**
      * @dataProvider provideComplete
      */
-    public function testComplete(string $source, int $offset, array $expected)
+    public function testComplete(string $source, array $expected)
     {
-        $result = $this->complete($source, $offset);
+        $result = $this->complete($source);
 
         $this->assertEquals($expected, $result['suggestions']);
         $this->assertEquals(json_encode($expected, true), json_encode($result['suggestions'], true));
@@ -30,10 +32,10 @@ class Foobar
 }
 
 $foobar = new Foobar();
-$foobar->
+$foobar-><>
 
 EOT
-        , 75, [
+        , [
                     [
                         'type' => 'm',
                         'name' => 'foo',
@@ -51,10 +53,10 @@ class Foobar
 }
 
 $foobar = new Foobar();
-$foobar->
+$foobar-><>
 
 EOT
-        , 76,
+        ,
             [ ]
             ],
             'Public property access' => [
@@ -75,10 +77,10 @@ class Foobar
 }
 
 $foobar = new Foobar();
-$foobar->foo->
+$foobar->foo-><>
 
 EOT
-                , 148, [
+               , [
                     [
                         'type' => 'm',
                         'name' => 'bar',
@@ -98,10 +100,10 @@ class Foobar
 }
 
 $foobar = new Foobar();
-$foobar->
+$foobar-><>
 
 EOT
-                , 132, [
+                , [
                     [
                         'type' => 'f',
                         'name' => 'foo',
@@ -124,10 +126,10 @@ class Foobar
 }
 
 $foobar = new Foobar();
-$foobar->
+$foobar-><>
 
 EOT
-                , 141, [
+                , [
                     [
                         'type' => 'f',
                         'name' => 'foo',
@@ -147,10 +149,10 @@ class Foobar
 }
 
 $foobar = new Foobar();
-$foobar->
+$foobar-><>
 
 EOT
-                , 105, [
+                , [
                 ]
             ],
             'Static method' => [
@@ -163,10 +165,10 @@ class Foobar
 }
 
 $foobar = new Foobar();
-$foobar::
+$foobar::<>
 
 EOT
-                , 82, [
+                , [
                     [
                         'type' => 'm',
                         'name' => 'foo',
@@ -189,10 +191,10 @@ class Foobar
 }
 
 $foobar = new Foobar();
-$foobar->me::
+$foobar->me::<>
 
 EOT
-                , 138, [
+                , [
                     [
                         'type' => 'm',
                         'name' => 'foo',
@@ -216,10 +218,10 @@ class Foobar
 }
 
 $foobar = new Foobar();
-$foobar::f
+$foobar::f<>
 
 EOT
-                , 113, [
+                , [
                     [
                         'type' => 'm',
                         'name' => 'foobar',
@@ -238,10 +240,10 @@ class Foobar
 }
 
 $foobar = new Foobar();
-$foobar::
+$foobar::<>
 
 EOT
-                , 116, [
+                , [
                     [
                         'type' => 'm',
                         'name' => 'FOOBAR',
@@ -265,10 +267,10 @@ class Foobar
 
 $foobar = new Foobar();
 $foobar
-    ->
+    -><>
 
 EOT
-                , 83, [
+                , [
                     [
                         'type' => 'm',
                         'name' => 'foobar',
@@ -279,10 +281,11 @@ EOT
         ];
     }
 
-    private function complete(string $source, $offset)
+    private function complete(string $source)
     {
+        list($source, $offset) = ExtractOffset::fromSource($source);
         $complete = $this->container()->get('application.complete');
-        $result =$complete->complete($source, $offset);
+        $result = $complete->complete($source, $offset);
 
         return $result;
     }
@@ -290,9 +293,9 @@ EOT
     /**
      * @dataProvider provideErrors
      */
-    public function testErrors(string $source, int $offset, array $expected)
+    public function testErrors(string $source, array $expected)
     {
-        $results = $this->complete($source, $offset);
+        $results = $this->complete($source);
         $this->assertEquals($expected, $results['issues']);
     }
 
@@ -304,9 +307,9 @@ EOT
 <?php
 
 $asd = 'asd';
-$asd->
+$asd-><>
 EOT
-                ,27,
+                ,
                 [
                     'Cannot complete members on scalar value (string)',
                 ]
@@ -315,9 +318,9 @@ EOT
                 <<<'EOT'
 <?php
 
-$asd->
+$asd-><>
 EOT
-                ,13,
+                ,
                 [
                     'Variable "asd" is undefined',
                 ]
@@ -327,9 +330,9 @@ EOT
 <?php
 
 $asd = new BooBar();
-$asd->
+$asd-><>
 EOT
-                ,34,
+                ,
                 [
                     'Could not find class "BooBar"',
                 ]
@@ -344,9 +347,9 @@ class Foobar
 }
 
 $foobar = new Foobar();
-$foobar->barbar->;
+$foobar->barbar-><>;
 EOT
-                ,86,
+                ,
                 [
                     'Class "Foobar" has no properties named "barbar"',
                 ]


### PR DESCRIPTION
Following from comment on #317 have tried using the composer library to disable XDebug.

Surprisingly it seems to make no performance difference at all (on my machine):

```
benchmark: ClassSearchBench, subject: benchClassSearch
+--------+--------+------+-----------------------------------------------------+-----------------------------------------------------+
| groups | params | revs | no xdebug                                           | xdebug                                              |
+--------+--------+------+-----------------------------------------------------+-----------------------------------------------------+
|        | []     | 1    | 205,910.200μs                                       | 202,725.500μs                                       |
+--------+--------+------+-----------------------------------------------------+-----------------------------------------------------+

benchmark: CompleteBench, subject: benchComplete
+--------+--------+------+-----------------------------------------------------+-----------------------------------------------------+
| groups | params | revs | no xdebug                                           | xdebug                                              |
+--------+--------+------+-----------------------------------------------------+-----------------------------------------------------+
|        | []     | 1    | 573,967.000μs                                       | 570,346.100μs                                       |
+--------+--------+------+-----------------------------------------------------+-----------------------------------------------------+
```
