### PR TITLE
Fix vim bundles dir

### DIFF
--- a/doc/vim-plugin.md
+++ b/doc/vim-plugin.md
@@ -29,7 +29,7 @@ Then in VIM:
 Now you will need to install the Phpactor dependencies with composer:
 
 ```
-$ cd ~/.vim/bundles/phpactor
+$ cd ~/.vim/bundle/phpactor
 $ composer install
 ```
 


### PR DESCRIPTION
For me, the bundle directory is on singular `~/.vim/bundle/phpactor`.