### PR TITLE
Update integrations to include alternate Drupal option.

### DIFF
--- a/doc/integrations.md
+++ b/doc/integrations.md
@@ -79,7 +79,7 @@ Full details are available in the README for this plugin, however, the short ver
 ```json
 {
     "require": {
-        "fenetikm/autoload-drupal": "dev-master"
+        "fenetikm/autoload-drupal": "0.1"
     },
     "extra": {
         "autoload-drupal": {

--- a/doc/integrations.md
+++ b/doc/integrations.md
@@ -11,8 +11,12 @@ Drupal 8
 --------
 
 Drupal automatically adds its modules to the autoloader during the kernel
-boot process. It is therefore necessary to boot the kernel to have a fully
-useful autoloader.
+boot process. It is therefore necessary to either 1) boot the kernel to have a fully
+useful autoloader *or* 2) to use a different mechanism to add the modules to the Composer autoloader.
+
+Depending on your setup option 1 or 2 will be preferable.
+
+### Option 1: Bootstrap Drupal on the fly to generate the autoloader
 
 Create the following bootstrap file `autoload_phpactor.php`, in (for example)
 `web/`:
@@ -51,7 +55,7 @@ return $autoload;
 
 Then edit `.phpactor.yml` to use that:
 
-```
+```yaml
 # Use the special autoloader above
 autoload: web/phpactor_autoload.php
 
@@ -63,3 +67,36 @@ code_transform.indentation: 2
 # registered and hope for the best.
 autoload.deregister: false
 ```
+
+The downside to this option is that it requires access to the DB from your current environment which may be tricky if you are running Drupal inside a VM.
+
+### Option 2: Add the modules into the Composer autoloader
+
+This option requires merging in any modules (Drupal, contrib, custom) into the Composer autoloader via a discovery mechanism offered by the [Drupal Autoloader](https://github.com/fenetikm/autoload-drupal) composer plugin.
+
+Full details are available in the README for this plugin, however, the short version is that you will need to put the following into your `composer.json` file:
+
+```json
+{
+    "require": {
+        "fenetikm/autoload-drupal": "dev-master"
+    },
+    "extra": {
+        "autoload-drupal": {
+            "modules": [
+              "app/modules/contrib/",
+              "app/modules/custom/",
+              "app/core/modules/"
+            ]
+        }
+    }
+}
+```
+
+and then rebuild your Composer autoloader e.g.
+
+```sh
+composer autoload-dump
+```
+
+The upside to this option is that it won't require the relatively slow Drupal bootstrap (which will hit the DB) but the downside is that you will have to regenerate the autoloader every time you add / remove a module.


### PR DESCRIPTION
This provides an alternate option for integrating Drupal and phpactor. Any questions, let me know.