### PR TITLE
[VIM Plugin] Disable the omni-complete errors by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Improvements:
    - [WorseReflection] [problem with name import](https://github.com/phpactor/worse-reflection/pull/37) (thanks @adeslade)
    - [WorseReflection] All class members implement common interface, fixes
      #283
+   - [VIM Plugin] Disable the omni-complete errors by default, as this breaks
+     the assumptions of some auto-complete managers (set
+     `g:phpactorOmniError` to `v:true` to enable again), fixes #370.
 
 Bugfixes:
 

--- a/doc/phpactor.txt
+++ b/doc/phpactor.txt
@@ -1,13 +1,24 @@
-*phpactor* *phpactor.txt* PHP introspection tools
+*phpactor* *phpactor.txt* PHP completion and refactoring tool
 
                           PHPACTOR REFERENCE MANUAL~
 
-1. Installation                 |phpactor-installation|
-2. Updating                     |phpactor-updating|
-3. Mappings                     |phpactor-mappings|
-4. Requirements                 |phpactor-requirements|
-5. Completion                   |phpactor-completion|
-6. Context Menu                 |phpactor-context-menu|
+
+1. Introduction                 phpactor-introduction
+2. Installation                 |phpactor-installation|
+3. Updating                     |phpactor-updating|
+4. Mappings                     |phpactor-mappings|
+5. Configuration                phpactor-configuration
+6. Requirements                 |phpactor-requirements|
+7. Completion                   |phpactor-completion|
+8. Context Menu                 |phpactor-context-menu|
+
+================================================================================
+                                                            *phpactor-introduction*
+Phpactor is a completion and refactoring tool for PHP. This help file
+documents the VIM plugin. To see _all_ of the documentation, visit the
+website:
+
+    https://phpactor.github.io/phpactor/
 
 ================================================================================
                                                             *phpactor-installation*
@@ -76,6 +87,17 @@ copy the following configuration into your .vimrc:
 `vmap <silent><Leader>em :<C-U>call phpactor#ExtractMethod()<CR>`
 
 See the Refactorings chapter for more functions you can map shortcuts to.
+
+================================================================================
+CONFIGURATION                                            *phpactor-configuration*
+
+The plugin has some configuration options:
+
+- `g:phpactorPhpBin`: PHP executable to use.
+- `g:phpactorBranch`: Phpactor branch (default is `master`, use `develop` for
+  bleeding edge).
+- `g:phpactorOmniError`: Set to `v:true` to enable useful error messages when
+  completion is invoked.
 
 ================================================================================
 REQUIREMENTS                                               *phpactor-requirements*

--- a/doc/vim-plugin.md
+++ b/doc/vim-plugin.md
@@ -76,10 +76,6 @@ need to either re-source (`:source ~/path/to/phpactor/plugin/phpactor.vim`) the 
 If you are feeling dangerous, you may choose to track the `develop` branch,
 by specifying a branch name in your `.vimrc`:
 
-```vim
-let g:phpactorBranch = "develop"
-```
-
 Keyboard Mappings
 -----------------
 
@@ -116,6 +112,23 @@ your `.vimrc` to change the PHP binary:
 ```
 let g:phpactorPhpBin = "/usr/bin/local/php6.0"
 ```
+
+Configuration
+-------------
+
+The plugin has some configuration options:
+
+```
+let g:phpactorPhpBin = 'php'
+let g:phpactorBranch = 'master'
+let g:phpactorOmniError = v:false
+```
+
+- `g:phpactorPhpBin`: PHP executable to use.
+- `g:phpactorBranch`: Phpactor branch (default is `master`, use `develop` for
+  bleeding edge).
+- `g:phpactorOmniError`: Set to `v:true` to enable useful error messages when
+  completion is invoked.
 
 Completion
 ----------

--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -11,6 +11,7 @@ let g:phpactorbinpath = g:phpactorpath. '/bin/phpactor'
 let g:phpactorPhpBin = 'php'
 let g:phpactorInitialCwd = getcwd()
 let g:phpactorBranch = 'master'
+let g:phpactorOmniError = v:false
 
 """""""""""""""""
 " Update Phpactor
@@ -69,7 +70,9 @@ function! phpactor#Complete(findstart, base)
     endif
 
     if !empty(issues)
-        echoe join(issues, ', ')
+        if g:phpactorOmniError
+            echoe join(issues, ', ')
+        endif
     endif
 
     return completions


### PR DESCRIPTION
As this breaks the assumptions of some auto-complete managers (set
`g:phpactorOmniError` to `v:true` to enable again), fixes #370.