### PR TITLE
Use vim-plug instead of Vundle in docs and add deoplete integration to vim docs.

### DIFF
--- a/doc/phpactor.txt
+++ b/doc/phpactor.txt
@@ -10,8 +10,8 @@
 5. Configuration                |phpactor-configuration|
 6. Requirements                 |phpactor-requirements|
 7. Completion                   |phpactor-completion|
-7. Completion plugins           |phpactor-completion-plugins|
-8. Context Menu                 |phpactor-context-menu|
+8. Completion plugins           |phpactor-completion-plugins|
+9. Context Menu                 |phpactor-context-menu|
 
 ================================================================================
                                                             *phpactor-introduction*
@@ -31,6 +31,10 @@ Add the plugin to your .vimrc:
 
 Then in VIM:
 `:PlugInstall`
+
+If you do not use vim-plug, you will need to install the Phpactor dependencies with composer manually:
+`$ cd ~/.vim/bundle/phpactor`
+`$ composer install`
 
 Now issue the following command
 `:call phpactor#Status():`
@@ -125,7 +129,7 @@ COMPLETION PLUGINS                                *phpactor-completion-plugins*
 
 Several asynchronous completion frameworks support Phpactor
 
-                                                *phpactor-deoplete*
+                                                              *phpactor-deoplete*
 To use Phpactor with deoplete.nvim add this to your vimrc/init.vim:
 `Plug 'Shougo/deoplete.nvim'`
 `Plug 'phpactor/phpactor', { 'do': 'composer install', 'for': ['php'] }`

--- a/doc/phpactor.txt
+++ b/doc/phpactor.txt
@@ -10,6 +10,7 @@
 5. Configuration                |phpactor-configuration|
 6. Requirements                 |phpactor-requirements|
 7. Completion                   |phpactor-completion|
+7. Completion plugins           |phpactor-completion-plugins|
 8. Context Menu                 |phpactor-context-menu|
 
 ================================================================================
@@ -22,17 +23,14 @@ website:
 
 ================================================================================
                                                             *phpactor-installation*
-Install Phpactor using your favorite VIM package manager, I am using Vundle.
+Install Phpactor using your favorite VIM package manager.
+If you don't use any, I recommend vim-plug.
 Add the plugin to your .vimrc:
 
-`Plugin 'phpactor/phpactor'`
+`Plug 'phpactor/phpactor', {'for': 'php', 'do': composer install'}`
 
 Then in VIM:
-`:VundleInstall`
-
-You will need to install the Phpactor dependencies with composer:
-`$ cd ~/.vim/bundle/phpactor`
-`$ composer install`
+`:PlugInstall`
 
 Now issue the following command
 `:call phpactor#Status():`
@@ -122,10 +120,26 @@ This information is useful. Other completion mehanisms may not provide this info
 Always enable omni-completion. If another mechanism is failing to complete,
 invoke omni-complete to find out why.
 
+================================================================================
+COMPLETION PLUGINS                                *phpactor-completion-plugins*
+
+Several asynchronous completion frameworks support Phpactor
+
+                                                *phpactor-deoplete*
+To use Phpactor with deoplete.nvim add this to your vimrc/init.vim:
+`Plug 'Shougo/deoplete.nvim'`
+`Plug 'phpactor/phpactor', { 'do': 'composer install', 'for': ['php'] }`
+`Plug 'kristijanhusak/deoplete-phpactor'`
+
+Run `PlugInstall` and you're good to go!
+
                                                 *phpactor-neovim-completion-manager*
-If you are using Neovim with the Neovim Completion Manager you should certainly
-install ncm-phpactor to benefit from great asynchronous complete-as-you-type
-auto-completion.
+To use Phpactor with Neovim Completion manager add this to your vimrc/init.vim:
+`Plug 'roxma/nvim-completion-manager'`
+`Plug 'phpactor/phpactor', { 'do': 'composer install', 'for': ['php'] }`
+`Plug 'roxma/ncm-phpactor'`
+
+Run `PlugInstall` and you're good to go!
 
 ================================================================================
 CONTEXT MENU                                               *phpactor-context-menu*

--- a/doc/vim-plugin.md
+++ b/doc/vim-plugin.md
@@ -28,6 +28,12 @@ Then in VIM:
 :PlugInstall
 ```
 
+If you do not use [vim-plug](https://github.com/junegunn/vim-plug), you will need to install the Phpactor dependencies with composer manually:
+```
+$ cd ~/.vim/bundle/phpactor
+$ composer install
+```
+
 or using nvim, do the above where it counts.
 
 <div class="alert alert-info">

--- a/doc/vim-plugin.md
+++ b/doc/vim-plugin.md
@@ -14,24 +14,18 @@ Phpactor VIM Plugin
 Installation
 ------------
 
-Install Phpactor using your favorite VIM package manager, I am using Vundle.
-Add the plugin to your `.vimrc`:
+Install Phpactor using your favorite VIM package manager.
+If you don't use any, I recommend [vim-plug](https://github.com/junegunn/vim-plug).
+Add the plugin to your .vimrc:
 
 ```
-Plugin 'phpactor/phpactor'
+Plug 'phpactor/phpactor', {'for': 'php', 'do': composer install'}
 ```
 
 Then in VIM:
 
 ```
-:VundleInstall
-```
-
-Now you will need to install the Phpactor dependencies with composer:
-
-```
-$ cd ~/.vim/bundle/phpactor
-$ composer install
+:PlugInstall
 ```
 
 or using nvim, do the above where it counts.


### PR DESCRIPTION
@dantleech as you said here https://github.com/phpactor/phpactor/pull/410 , docs should be consistent, so i switched all `Vundle` with `Plug`. I think nowadays most of people use vim-plug because it allows loading plugins by filetype and running additional installations, like you have `composer install` here.

Also, i updated vim doc, because i forgot to do it in last PR.