### PR TITLE
[Completion] Class member completion on variable which is the right ...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Bug fixes:
 
     - [WorseReflection] Associated class for trait methods is the trait
       itself, not the class it's used in, #412
+    - [Completion] Class member completion on variable which is the right
+      operand in an assignment to a variable with the same name has no type.
 
 ## 0.2.0
 

--- a/composer.lock
+++ b/composer.lock
@@ -745,12 +745,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/completion.git",
-                "reference": "8d1447abe0d89705de0c21aceea724af4735b263"
+                "reference": "1b65a6a59f59918be71c59e34428c18c20b9e72d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/completion/zipball/8d1447abe0d89705de0c21aceea724af4735b263",
-                "reference": "8d1447abe0d89705de0c21aceea724af4735b263",
+                "url": "https://api.github.com/repos/phpactor/completion/zipball/1b65a6a59f59918be71c59e34428c18c20b9e72d",
+                "reference": "1b65a6a59f59918be71c59e34428c18c20b9e72d",
                 "shasum": ""
             },
             "require": {
@@ -784,7 +784,7 @@
                 }
             ],
             "description": "Completion library for Worse Reflection",
-            "time": "2018-04-14T10:48:14+00:00"
+            "time": "2018-04-15T09:25:36+00:00"
         },
         {
             "name": "phpactor/docblock",

--- a/lib/Extension/SourceCodeFilesystem/SourceCodeFilestem/Application/ClassSearch.php
+++ b/lib/Extension/SourceCodeFilesystem/SourceCodeFilestem/Application/ClassSearch.php
@@ -7,6 +7,7 @@ use Phpactor\ClassFileConverter\Domain\FilePath;
 use Phpactor\Filesystem\Domain\FilesystemRegistry;
 use Phpactor\WorseReflection\Reflector;
 use Phpactor\WorseReflection\Core\Exception\NotFound;
+use SplFileInfo;
 
 class ClassSearch
 {


### PR DESCRIPTION
... operand in an assignment to a variable with the same name has no type causes the type to be unassigned and no completion is therefore possible.