### PR TITLE
"composer install" did not symlink binary

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,9 @@
         "phpactor/test-utils": "dev-master",
         "friendsofphp/php-cs-fixer": "^2.12@dev"
     },
+    "bin": [
+        "phpactor"
+    ],
     "autoload": {
         "psr-4": {
             "Phpactor\\": "lib/"


### PR DESCRIPTION
my ~/.composer/composer.json
```json
{
    "minimum-stability": "dev",
    "require": {
        "phpunit/phpunit": "*",
        "friendsofphp/php-cs-fixer": "*",
        "phpactor/phpactor": "*"
    }
}
```
osx
composer version: 1.6.3