### PR TITLE
Optimise replace private / protected members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,39 +1,48 @@
 Changelog
 =========
 
-## develop
+## Develop
 
 Improvements:
 
+  - [ClassMover] Find/replace references will only traverse possible classes
+    when givn a known class member #349 (also it will no longer ask the scope,
+    instead defaulting to either composer or full-filesystem search depending
+    on env).
+  - [ClassMover] (RPC) Will update current (unsaved) source.
   - [vim-plugin] Correctly handle expanding class when at beginning of word, #438 thanks @greg0ire 
+
+API:
+
+  - [WorseReflection] (API) All member collections extend common interface,
+    class-likes have a `members(): ReflectionMemberCollection` method.
 
 ## 0.3.0
 
 Features:
 
-    - [Application] Disable XDebug by default, very much improve performance.
+  - [Application] Disable XDebug by default, very much improve performance.
       Fixes #317
 
 Improvements:
 
-    - [Completion] Do not evaluate left operand when completing expression,
-      #380
-    - [RPC] Request validation (no more undefined index errors).
-    - [WorseReflection] Classes inherit constants from interfaces.
-    - [CodeBuilder] Use statements added after the first
-      lexigraphically inferior existing use-statement, fixes #176. Thanks
-      @greg0ire.
+  - [Completion] Do not evaluate left operand when completing expression,
+    #380
+  - [RPC] Request validation (no more undefined index errors).
+  - [WorseReflection] Classes inherit constants from interfaces.
+  - [CodeBuilder] Use statements added after the first lexigraphically
+    inferior existing use-statement, fixes #176. Thanks @greg0ire.
 
 Bug fixes:
 
-    - [WorseReflection] Associated class for trait methods is the trait
-      itself, not the class it's used in, #412
-    - [WorseReflection] Do not evaluate assignments with missing tokens.
-    - [SourceCodeFilesystem] Non-existing paths not ignored.
-    - [CodeTransform] Indentation not being taken into account for code
-      updates (fixes #423).
-    - [WorseReflection] Tolerate incomplete if statements, fixes #424
-    - [WorseReflection] Tolerate missing token in expression evaluator #430
+  - [WorseReflection] Associated class for trait methods is the trait
+    itself, not the class it's used in, #412
+  - [WorseReflection] Do not evaluate assignments with missing tokens.
+  - [SourceCodeFilesystem] Non-existing paths not ignored.
+  - [CodeTransform] Indentation not being taken into account for code
+    updates (fixes #423).
+  - [WorseReflection] Tolerate incomplete if statements, fixes #424
+  - [WorseReflection] Tolerate missing token in expression evaluator #430
 
 ## 0.2.0
 

--- a/composer.lock
+++ b/composer.lock
@@ -269,12 +269,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/JetBrains/phpstorm-stubs.git",
-                "reference": "c42e3e304597b22e705bc966213490342f5b9f58"
+                "reference": "07a712def7205d8921e6ff93c9ee12119def463e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/c42e3e304597b22e705bc966213490342f5b9f58",
-                "reference": "c42e3e304597b22e705bc966213490342f5b9f58",
+                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/07a712def7205d8921e6ff93c9ee12119def463e",
+                "reference": "07a712def7205d8921e6ff93c9ee12119def463e",
                 "shasum": ""
             },
             "type": "library",
@@ -294,7 +294,7 @@
                 "stubs",
                 "type"
             ],
-            "time": "2018-04-19T20:37:42+00:00"
+            "time": "2018-04-20T16:19:58+00:00"
         },
         {
             "name": "lstrojny/functional-php",
@@ -921,12 +921,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/worse-reflection.git",
-                "reference": "ed8dbf735bc7af117b1ea64f1ead9887c949ac37"
+                "reference": "8f3b5e7531cd303841c028c5bff1cf373c96ab4c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/worse-reflection/zipball/ed8dbf735bc7af117b1ea64f1ead9887c949ac37",
-                "reference": "ed8dbf735bc7af117b1ea64f1ead9887c949ac37",
+                "url": "https://api.github.com/repos/phpactor/worse-reflection/zipball/8f3b5e7531cd303841c028c5bff1cf373c96ab4c",
+                "reference": "8f3b5e7531cd303841c028c5bff1cf373c96ab4c",
                 "shasum": ""
             },
             "require": {
@@ -965,7 +965,7 @@
                 }
             ],
             "description": "Lazy AST reflector that is much worse than better",
-            "time": "2018-04-20T11:02:53+00:00"
+            "time": "2018-04-21T11:59:48+00:00"
         },
         {
             "name": "phpbench/container",

--- a/doc/refactorings.md
+++ b/doc/refactorings.md
@@ -884,7 +884,7 @@ Rename a class member.
 Having an API which is expressive of the intent of the class is important, and
 contributes to making your code more consistent and maintainable.
 
-When renaming methods global search and replace can be used, but is a shotgun approach and
+When renaming members global search and replace can be used, but is a shotgun approach and
 you may end up replacing many things you did not mean to replace (e.g. imagine renaming the method `name()`).
 
 This refactoring will:
@@ -894,8 +894,12 @@ This refactoring will:
 3. Identify the members, and try and identify the containing class.
 4. Replace only the members which certainly belong to the target class.
 
-Due to the loosely typed nature of PHP this refactoring may not find all of the member accesses for the given class. Run
-your tests before and after applying this refactoring.
+When replacing _private_ and _protected_ members, only the related classes
+will be updated.
+
+Due to the loosely typed nature of PHP this refactoring may not find all of
+the member accesses for the given class. Run your tests before and after
+applying this refactoring.
 
 <div class="alert alert-info">
 <b>Hint</b>: Use the CLI command to list all of the <b>risky</b> references. Risky references are those member accesses which match

--- a/lib/Extension/ClassMover/Application/ClassMemberReferences.php
+++ b/lib/Extension/ClassMover/Application/ClassMemberReferences.php
@@ -89,6 +89,24 @@ class ClassMemberReferences
         ];
     }
 
+    public function replaceInSource(
+        string $source,
+        string $class,
+        string $memberName,
+        string $memberType,
+        string $replacement
+    )
+    {
+        $className = $class ? $this->classFileNormalizer->normalizeToClass($class) : null;
+        $query = $this->createQuery($className, $memberName, $memberType);
+
+        $referenceList = $this->memberFinder->findMembers(
+            SourceCode::fromString($source),
+            $query
+        );
+        return (string) $this->replaceReferencesInCode($source, $referenceList->withClasses(), $replacement);
+    }
+
     private function referencesInFile(
         Filesystem $filesystem,
         $filePath,

--- a/lib/Extension/ClassMover/Application/ClassMemberReferences.php
+++ b/lib/Extension/ClassMover/Application/ClassMemberReferences.php
@@ -15,7 +15,6 @@ use Phpactor\ClassMover\Domain\Model\ClassMemberQuery;
 use Phpactor\Filesystem\Domain\FilesystemRegistry;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionClassLike;
 use Phpactor\WorseReflection\Reflector;
-use Phpactor\WorseReflection\Core\ClassName;
 use \SplFileInfo;
 
 class ClassMemberReferences
@@ -68,12 +67,12 @@ class ClassMemberReferences
         bool $dryRun = false
     ) {
         $className = $class ? $this->classFileNormalizer->normalizeToClass($class) : null;
-        $reflection = $this->reflector->reflectClassLike(ClassName::fromString($className));
+        $reflection = $this->reflector->reflectClassLike($className);
         $filesystem = $this->filesystemRegistry->get($scope);
-        $results = [];
 
         $filePaths = (new FileFinder())->filesFor($filesystem, $reflection, $memberName, $memberType);
 
+        $results = [];
         foreach ($filePaths as $filePath) {
             $references = $this->referencesInFile($filesystem, $filePath, $className, $memberName, $memberType, $replace, $dryRun);
 

--- a/lib/Extension/ClassMover/Application/ClassMemberReferences.php
+++ b/lib/Extension/ClassMover/Application/ClassMemberReferences.php
@@ -70,7 +70,7 @@ class ClassMemberReferences
         $reflection = $className ? $this->reflector->reflectClassLike($className) : null;
         $filesystem = $this->filesystemRegistry->get($scope);
 
-        $filePaths = (new FileFinder())->filesFor($filesystem, $reflection, $memberName, $memberType);
+        $filePaths = (new FileFinder())->filesFor($filesystem, $reflection, $memberName);
 
         $results = [];
         foreach ($filePaths as $filePath) {
@@ -159,7 +159,7 @@ class ClassMemberReferences
     private function serializeReferenceList(string $code, MemberReferences $referenceList)
     {
         $references = [];
-        /** @var $reference ClassRef */
+        /** @var MemberReference $reference */
         foreach ($referenceList as $reference) {
             $ref = $this->serializeReference($code, $reference);
 

--- a/lib/Extension/ClassMover/Application/ClassMover.php
+++ b/lib/Extension/ClassMover/Application/ClassMover.php
@@ -16,7 +16,7 @@ use Phpactor\Extension\ClassMover\Application\Logger\ClassMoverLogger;
 class ClassMover
 {
     /**
-     * @var ClassToFileFileToClass
+     * @var ClassFileNormalizer
      */
     private $classFileNormalizer;
 

--- a/lib/Extension/ClassMover/Application/ClassReferences.php
+++ b/lib/Extension/ClassMover/Application/ClassReferences.php
@@ -29,7 +29,7 @@ class ClassReferences
     /**
      * @var ClassFileNormalizer
      */
-    private $classFileNormalizer;
+    private $classFileNormalizerasd;
 
     /**
      * @var ClassReplacer
@@ -42,7 +42,7 @@ class ClassReferences
         ClassReplacer $refReplacer,
         FilesystemRegistry $filesystemRegistry
     ) {
-        $this->classFileNormalizer = $classFileNormalizer;
+        $this->classFileNormalizerasd = $classFileNormalizer;
         $this->filesystemRegistry = $filesystemRegistry;
         $this->refFinder = $refFinder;
         $this->refReplacer = $refReplacer;
@@ -60,9 +60,9 @@ class ClassReferences
 
     public function findOrReplaceReferences(string $filesystemName, string $class, string $replace = null, bool $dryRun = false)
     {
-        $classPath = $this->classFileNormalizer->normalizeToFile($class);
+        $classPath = $this->classFileNormalizerasd->normalizeToFile($class);
         $classPath = Phpactor::normalizePath($classPath);
-        $className = $this->classFileNormalizer->normalizeToClass($class);
+        $className = $this->classFileNormalizerasd->normalizeToClass($class);
         $filesystem = $this->filesystemRegistry->get($filesystemName);
 
         $results = [];

--- a/lib/Extension/ClassMover/Application/Finder/FileFinder.php
+++ b/lib/Extension/ClassMover/Application/Finder/FileFinder.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Phpactor\Extension\ClassMover\Application\Finder;
+
+use Phpactor\Filesystem\Domain\Filesystem;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionClass;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionClassLike;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionInterface;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionMember;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionTrait;
+use Phpactor\WorseReflection\Core\Visibility;
+
+class FileFinder
+{
+    public function filesFor(Filesystem $filesystem, ReflectionClassLike $reflection, string $memberName = null, string $memberType = null)
+    {
+        // if no member name, then we are searching for all members of the
+        // class, and we can't really optimise this...
+        if (null === $memberName) {
+            return $this->allPhpFiles($filesystem);
+        }
+
+        $members = $reflection->members();
+        if ($members->count() === 0) {
+            throw new RuntimeException(sprintf(
+                'Class has no member named "%s", has the following member names: "%s"',
+                implode('", "', $members->keys())
+            ));
+        }
+
+        $members = $members->byName()->byVisibilities([
+            Visibility::public()
+        ]);
+
+        if (
+            false === $reflection instanceof ReflectionClass &&
+            $members->count() > 1
+        ) {
+            // we have public members or a non-class, we need to search the
+            // whole tree, but we can discount any files which do not contain
+            // the member name string.
+            return $this->allPhpFiles()->filter(function (SplFileInfo $file) use ($memberName) {
+                return preg_match('{' . $memberName . '}', file_get_contents($file->getPathname()));
+            });
+        }
+
+        /** @var ReflectionMember $member */
+        $private = false;
+        foreach ($members as $member) {
+            if ($member->visibility() === Visibility::private()) {
+                $private = true;
+            }
+        }
+
+        return $this->pathsFromReflectionClass($reflection, $private);
+    }
+
+    private function pathsFromReflectionClass(ReflectionClass $reflection, bool $private)
+    {
+        $filePaths = array_map(function (ReflectionTrait $trait) {
+            return $trait->sourceCode()->path();
+        }, iterator_to_array($reflection->traits()));
+        $filePaths[] = $reflection->sourceCode()->path();
+        
+        if ($private) {
+            return $filePaths;
+        }
+        
+        while ($parent = $reflection->parent()) {
+            $filePaths[] = $parent->sourceCode()->path();
+        }
+        
+        foreach ($reflection->interfaces() as $interface) {
+            $filePaths[] = $interface->sourceCode()->path();
+        }
+        
+        return $filePaths;
+    }
+
+    private function allPhpFiles(Filesystem $filesystem)
+    {
+        $filePaths = $filesystem->fileList()->existing()->phpFiles();
+        return $filePaths;
+    }
+}

--- a/lib/Extension/ClassMover/Application/Finder/FileFinder.php
+++ b/lib/Extension/ClassMover/Application/Finder/FileFinder.php
@@ -27,7 +27,7 @@ class FileFinder
         }
 
         $members = $reflection->members();
-        if ($members->byName('foobar')->count() === 0) {
+        if ($members->byName($memberName)->count() === 0) {
             throw new RuntimeException(sprintf(
                 'Class has no member named "%s", has the following member names: "%s"',
                 $memberName, implode('", "', $members->keys())
@@ -67,7 +67,13 @@ class FileFinder
             return $trait->sourceCode()->path();
         }, iterator_to_array($reflection->traits()));
 
-        $filePaths[] = $reflection->sourceCode()->path();
+        $filePaths[] = $path = $reflection->sourceCode()->path();
+
+        if (empty($path)) {
+            throw new RuntimeException(sprintf(
+                'Source has no path associated with it'
+            ));
+        }
         
         if ($private) {
             return FileList::fromFilePaths($filePaths);

--- a/lib/Extension/ClassMover/Application/Finder/FileFinder.php
+++ b/lib/Extension/ClassMover/Application/Finder/FileFinder.php
@@ -18,11 +18,11 @@ class FileFinder
     /**
      * @return FileList<SplFileInfo>
      */
-    public function filesFor(Filesystem $filesystem, ReflectionClassLike $reflection, string $memberName = null): FileList
+    public function filesFor(Filesystem $filesystem, ReflectionClassLike $reflection = null, string $memberName = null): FileList
     {
         // if no member name, then we are searching for all members of the
         // class, and we can't really optimise this...
-        if (null === $memberName) {
+        if (null === $reflection || null === $memberName) {
             return $this->allPhpFiles($filesystem);
         }
 

--- a/lib/Extension/ClassMover/Rpc/ReferencesHandler.php
+++ b/lib/Extension/ClassMover/Rpc/ReferencesHandler.php
@@ -20,6 +20,7 @@ use Phpactor\Extension\Rpc\Response\Input\ChoiceInput;
 use Phpactor\Filesystem\Domain\FilesystemRegistry;
 use Phpactor\Extension\Rpc\Response\Input\TextInput;
 use Phpactor\Extension\Rpc\Handler\AbstractHandler;
+use Phpactor\WorseReflection;
 
 /**
  * TODO: Extract and re[write|factor] the spaghetti business logic in this
@@ -197,7 +198,17 @@ class ReferencesHandler extends AbstractHandler
         $classType = (string) $symbolContext->type();
         $references = $this->classReferences->findOrReplaceReferences($filesystem, $classType, $replacement);
 
-        return [$source, $references['references']];
+        $updatedSource = null;
+        if ($source) {
+            $updatedSource = $this->classReferences->replaceInSource(
+                $source,
+                $classType,
+                $replacement
+            );
+        }
+
+
+        return [$updatedSource, $references['references']];
     }
 
     private function memberReferences(
@@ -219,7 +230,7 @@ class ReferencesHandler extends AbstractHandler
         );
 
         $updatedSource = null;
-        if ($source) {
+        if ($source && $replacement) {
             $updatedSource = $this->classMemberReferences->replaceInSource(
                 $source,
                 $classType,

--- a/lib/Extension/ClassMover/Rpc/ReferencesHandler.php
+++ b/lib/Extension/ClassMover/Rpc/ReferencesHandler.php
@@ -3,6 +3,7 @@
 namespace Phpactor\Extension\ClassMover\Rpc;
 
 use Phpactor\Extension\ClassMover\Application\ClassReferences;
+use Phpactor\Extension\Rpc\Response\OpenFileResponse;
 use Phpactor\Extension\SourceCodeFilesystem\SourceCodeFilesystemExtension;
 use Phpactor\Extension\Rpc\Response\EchoResponse;
 use Phpactor\Extension\Rpc\Response\FileReferencesResponse;
@@ -85,7 +86,7 @@ class ReferencesHandler extends AbstractHandler
             self::PARAMETER_SOURCE => null,
             self::PARAMETER_PATH => null,
             self::PARAMETER_MODE => self::MODE_FIND,
-            self::PARAMETER_FILESYSTEM => null,
+            self::PARAMETER_FILESYSTEM => $this->defaultFilesystem,
             self::PARAMETER_REPLACEMENT => null,
         ];
     }
@@ -123,7 +124,7 @@ class ReferencesHandler extends AbstractHandler
             case self::MODE_FIND:
                 return $this->findReferences($symbolContext, $arguments['filesystem']);
             case self::MODE_REPLACE:
-                return $this->replaceReferences1($symbolContext, $arguments['filesystem'], $arguments[self::PARAMETER_REPLACEMENT]);
+                return $this->replaceReferences($symbolContext, $arguments['filesystem'], $arguments[self::PARAMETER_REPLACEMENT], $arguments['path']);
         }
 
         throw new \InvalidArgumentException(sprintf(
@@ -146,7 +147,7 @@ class ReferencesHandler extends AbstractHandler
         ]);
     }
 
-    private function replaceReferences1(SymbolContext $symbolContext, string $filesystem, string $replacement)
+    private function replaceReferences(SymbolContext $symbolContext, string $filesystem, string $replacement, string $path)
     {
         $references = $this->performFindOrReplaceReferences($symbolContext, $filesystem, $replacement);
 
@@ -157,6 +158,7 @@ class ReferencesHandler extends AbstractHandler
         return CollectionResponse::fromActions([
             $this->echoMessage('Replaced', $symbolContext, $filesystem, $references),
             EchoResponse::fromMessage('You will need to refresh any open files (:e<CR>)'),
+            OpenFileResponse::fromPath($path),
             FileReferencesResponse::fromArray($references),
         ]);
     }

--- a/lib/Extension/ClassMover/Rpc/ReferencesHandler.php
+++ b/lib/Extension/ClassMover/Rpc/ReferencesHandler.php
@@ -23,8 +23,8 @@ use Phpactor\Extension\Rpc\Handler\AbstractHandler;
 use Phpactor\WorseReflection;
 
 /**
- * TODO: Extract and re[write|factor] the spaghetti business logic in this
- * class.
+ * TODO: Extract the responsiblities of this class, see
+ *       https://github.com/phpactor/phpactor/issues/440
  */
 class ReferencesHandler extends AbstractHandler
 {

--- a/lib/Extension/ClassMover/Rpc/ReferencesHandler.php
+++ b/lib/Extension/ClassMover/Rpc/ReferencesHandler.php
@@ -26,6 +26,7 @@ class ReferencesHandler extends AbstractHandler
     const PARAMETER_OFFSET = 'offset';
     const PARAMETER_SOURCE = 'source';
     const PARAMETER_MODE = 'mode';
+    const PARAMETER_PATH = 'path';
     const PARAMETER_FILESYSTEM = 'filesystem';
 
     const MODE_FIND = 'find';
@@ -82,6 +83,7 @@ class ReferencesHandler extends AbstractHandler
         return [
             self::PARAMETER_OFFSET => null,
             self::PARAMETER_SOURCE => null,
+            self::PARAMETER_PATH => null,
             self::PARAMETER_MODE => self::MODE_FIND,
             self::PARAMETER_FILESYSTEM => null,
             self::PARAMETER_REPLACEMENT => null,
@@ -91,7 +93,7 @@ class ReferencesHandler extends AbstractHandler
     public function handle(array $arguments)
     {
         $offset = $this->reflector->reflectOffset(
-            SourceCode::fromString($arguments[self::PARAMETER_SOURCE]),
+            SourceCode::fromPathAndString($arguments[self::PARAMETER_PATH], $arguments[self::PARAMETER_SOURCE]),
             Offset::fromInt($arguments[self::PARAMETER_OFFSET])
         );
         $symbolContext = $offset->symbolContext();

--- a/lib/Extension/Rpc/menu.json
+++ b/lib/Extension/Rpc/menu.json
@@ -34,7 +34,8 @@
             "action": "references",
             "parameters": {
                 "offset": "%offset%",
-                "source": "%source%"
+                "source": "%source%",
+                "path": "%path%"
             }
         },
         "goto_definition": {
@@ -50,6 +51,7 @@
             "parameters": {
                 "offset": "%offset%",
                 "source": "%source%",
+                "path": "%path%",
                 "mode": "replace"
             }
         }
@@ -71,7 +73,8 @@
             "action": "references",
             "parameters": {
                 "offset": "%offset%",
-                "source": "%source%"
+                "source": "%source%",
+                "path": "%path%"
             }
         },
         "goto_definition": {
@@ -112,7 +115,8 @@
             "parameters": {
                 "offset": "%offset%",
                 "source": "%source%",
-                "mode": "replace"
+                "mode": "replace",
+                "path": "%path%"
             }
         },
         "transform_file": {
@@ -137,7 +141,8 @@
             "action": "references",
             "parameters": {
                 "offset": "%offset%",
-                "source": "%source%"
+                "source": "%source%",
+                "path": "%path%"
             }
         },
         "generate_accessor": {
@@ -161,6 +166,7 @@
             "parameters": {
                 "offset": "%offset%",
                 "source": "%source%",
+                "path": "%path%",
                 "mode": "replace"
             }
         }
@@ -170,7 +176,8 @@
             "action": "references",
             "parameters": {
                 "offset": "%offset%",
-                "source": "%source%"
+                "source": "%source%",
+                "path": "%path%"
             }
         },
         "generate_method": {
@@ -193,6 +200,7 @@
             "action": "references",
             "parameters": {
                 "offset": "%offset%",
+                "path": "%path%",
                 "source": "%source%",
                 "mode": "replace"
             }

--- a/lib/Extension/Rpc/menu.json
+++ b/lib/Extension/Rpc/menu.json
@@ -35,7 +35,7 @@
             "parameters": {
                 "offset": "%offset%",
                 "source": "%source%",
-                "path": "%path%"
+                "path": "%current_path%"
             }
         },
         "goto_definition": {
@@ -51,7 +51,7 @@
             "parameters": {
                 "offset": "%offset%",
                 "source": "%source%",
-                "path": "%path%",
+                "path": "%current_path%",
                 "mode": "replace"
             }
         }
@@ -74,7 +74,7 @@
             "parameters": {
                 "offset": "%offset%",
                 "source": "%source%",
-                "path": "%path%"
+                "path": "%current_path%"
             }
         },
         "goto_definition": {
@@ -116,7 +116,7 @@
                 "offset": "%offset%",
                 "source": "%source%",
                 "mode": "replace",
-                "path": "%path%"
+                "path": "%current_path%"
             }
         },
         "transform_file": {
@@ -142,7 +142,7 @@
             "parameters": {
                 "offset": "%offset%",
                 "source": "%source%",
-                "path": "%path%"
+                "path": "%current_path%"
             }
         },
         "generate_accessor": {
@@ -166,7 +166,7 @@
             "parameters": {
                 "offset": "%offset%",
                 "source": "%source%",
-                "path": "%path%",
+                "path": "%current_path%",
                 "mode": "replace"
             }
         }
@@ -177,7 +177,7 @@
             "parameters": {
                 "offset": "%offset%",
                 "source": "%source%",
-                "path": "%path%"
+                "path": "%current_path%"
             }
         },
         "generate_method": {
@@ -200,7 +200,7 @@
             "action": "references",
             "parameters": {
                 "offset": "%offset%",
-                "path": "%path%",
+                "path": "%current_path%",
                 "source": "%source%",
                 "mode": "replace"
             }

--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -158,7 +158,6 @@ function! phpactor#ClassNew()
 endfunction
 
 function! phpactor#ClassInflect()
-    let currentPath = expand('%')
     call phpactor#rpc("class_inflect", { "current_path": currentPath })
 endfunction
 
@@ -168,7 +167,7 @@ function! phpactor#ClassReferences()
 endfunction
 
 function! phpactor#FindReferences()
-    call phpactor#rpc("references", { "offset": phpactor#_offset(), "source": phpactor#_source()})
+    call phpactor#rpc("references", { "offset": phpactor#_offset(), "source": phpactor#_source(), "path": phpactor#_path()})
 endfunction
 
 function! phpactor#Navigate()
@@ -208,6 +207,10 @@ endfunction
 
 function! phpactor#_source()
     return join(getline(1,'$'), "\n")
+endfunction
+
+function! phpactor#_path()
+    return expand('%')
 endfunction
 
 function! phpactor#_selectionStart()

--- a/tests/System/Extension/ClassMover/Command/ReferencesMemberCommandTest.php
+++ b/tests/System/Extension/ClassMover/Command/ReferencesMemberCommandTest.php
@@ -23,43 +23,13 @@ class ReferencesMemberCommandTest extends SystemTestCase
     }
 
     /**
-     * @testdox When non-existing member given, suggest existing mthods with exception.
+     * @testdox When non-existing member given, suggest existing members with exception.
      */
-    public function testNonExistingMethod()
+    public function testNonExistingMember()
     {
         $process = $this->phpactor('references:member "Animals\Badger" bad --type="method"');
         $this->assertEquals(255, $process->getExitCode());
-        $this->assertContains('known methods: "__construct"', $process->getErrorOutput());
-    }
-
-    /**
-     * @testdox When non-existing property given, suggest existing with exception.
-     */
-    public function testNonExistingProperties()
-    {
-        $process = $this->phpactor('references:member "Animals\Badger" bad --type="property"');
-        $this->assertEquals(255, $process->getExitCode());
-        $this->assertContains('known properties: "carnivorous"', $process->getErrorOutput());
-    }
-
-    /**
-     * @testdox When non-existing property given, suggest existing with exception.
-     */
-    public function testNonExistingConstants()
-    {
-        $process = $this->phpactor('references:member "Animals\Badger" bad --type="constant"');
-        $this->assertEquals(255, $process->getExitCode());
-        $this->assertContains('known constants: "LODGING"', $process->getErrorOutput());
-    }
-
-    /**
-     * @testdox When non-existing members given, suggest all available members.
-     */
-    public function testNonExistingMembers()
-    {
-        $process = $this->phpactor('references:member "Animals\Badger" bad');
-        $this->assertEquals(255, $process->getExitCode());
-        $this->assertContains('known members: "__construct", "badge"', $process->getErrorOutput());
+        $this->assertContains('Class has no member named "bad"', $process->getErrorOutput());
     }
 
     /**

--- a/tests/Unit/Extension/ClassMover/Application/Finder/FileFinderTest.php
+++ b/tests/Unit/Extension/ClassMover/Application/Finder/FileFinderTest.php
@@ -80,7 +80,7 @@ class FileFinderTest extends TestCase
     public function testParentsTraitsAndInterfacesIfMemberIsProtected()
     {
         $class = $this->reflectClass(
-            SourceCode::fromPathAndString('barfoo', 'interface Inter1 {} class ParentClass {} trait Barbar {} class Foobar extends ParentClass implements Inter1 { protected function foobar(){} }'), 
+            SourceCode::fromPathAndString('barfoo', 'interface Inter1 {} class ParentClass {} trait Barbar {} class Foobar extends ParentClass implements Inter1 { use Barbar; protected function foobar(){} }'), 
             'Foobar'
         );
         $files = $this->filesFor($class, 'foobar');

--- a/tests/Unit/Extension/ClassMover/Application/Finder/FileFinderTest.php
+++ b/tests/Unit/Extension/ClassMover/Application/Finder/FileFinderTest.php
@@ -27,7 +27,6 @@ class FileFinderTest extends TestCase
      */
     private $fileList;
 
-
     public function setUp()
     {
         $this->filesystem = $this->prophesize(Filesystem::class);
@@ -39,6 +38,13 @@ class FileFinderTest extends TestCase
         $this->setupAllFiles();
         $class = $this->reflectClass('class Foobar {}', 'Foobar');
         $files = $this->filesFor($class, null);
+        $this->assertEquals($this->fileList->reveal(), $files);
+    }
+
+    public function testReturnsAllPhpFilesIfNoClassReflectionGiven()
+    {
+        $this->setupAllFiles();
+        $files = $this->filesFor(null, null);
         $this->assertEquals($this->fileList->reveal(), $files);
     }
 
@@ -81,7 +87,7 @@ class FileFinderTest extends TestCase
         $this->assertEquals(FileList::fromFilePaths(['barfoo', 'barfoo', 'barfoo', 'barfoo'], $files), $files);
     }
 
-    private function filesFor(ReflectionClassLike $class, string $memberName = null)
+    private function filesFor(ReflectionClassLike $class = null, string $memberName = null)
     {
         return (new FileFinder())->filesFor($this->filesystem->reveal(), $class, $memberName);
     }
@@ -95,7 +101,7 @@ class FileFinderTest extends TestCase
 
     private function reflectClass($source, string $name)
     {
-        $builder = ReflectorBuilder::create()->addSource('<?php ' . $source);
+        $builder = ReflectorBuilder::create()->addSource(SourceCode::fromPathAndString('foobar', '<?php ' . $source));
         return $builder->build()->reflectClassLike($name);
     }
 

--- a/tests/Unit/Extension/ClassMover/Application/Finder/FileFinderTest.php
+++ b/tests/Unit/Extension/ClassMover/Application/Finder/FileFinderTest.php
@@ -2,6 +2,101 @@
 
 namespace Phpactor\Tests\Unit\Extension\ClassMover\Application\Finder;
 
-class FileFinderTest
+use Closure;
+use PHPUnit\Framework\TestCase;
+use Phpactor\Extension\ClassMover\Application\Finder\FileFinder;
+use Phpactor\Filesystem\Domain\FileList;
+use Phpactor\Filesystem\Domain\Filesystem;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionClass;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionClassLike;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionInterface;
+use Phpactor\WorseReflection\Core\SourceCode;
+use Phpactor\WorseReflection\ReflectorBuilder;
+use Prophecy\Argument;
+use RuntimeException;
+
+class FileFinderTest extends TestCase
 {
+    /**
+     * @var ObjectProphecy
+     */
+    private $filesystem;
+
+    /**
+     * @var ObjectProphecy
+     */
+    private $fileList;
+
+
+    public function setUp()
+    {
+        $this->filesystem = $this->prophesize(Filesystem::class);
+        $this->fileList = $this->prophesize(FileList::class);
+    }
+
+    public function testReturnsAllPhpFilesIfNoMemberNameGiven()
+    {
+        $this->setupAllFiles();
+        $class = $this->reflectClass('class Foobar {}', 'Foobar');
+        $files = $this->filesFor($class, null);
+        $this->assertEquals($this->fileList->reveal(), $files);
+    }
+
+    public function testThrowsExceptionIfClassHasNoMembersByName()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Class has no member named "foobar"');
+        $this->setupAllFiles();
+        $class = $this->reflectClass('class Foobar { public function bar() {} }', 'Foobar');
+        $files = $this->filesFor($class, 'foobar');
+        $this->assertEquals($this->fileList->reveal(), $files);
+    }
+
+    public function testReturnsAllPhpFilesFilteredByMemberIfMemberIsPublic()
+    {
+        $this->setupAllFiles();
+        $class = $this->reflectClass('class Foobar { public function foobar() {} }', 'Foobar');
+        $this->fileList->filter(Argument::type(Closure::class))->willReturn($this->fileList->reveal());
+        $files = $this->filesFor($class, 'foobar');
+        $this->assertEquals($this->fileList->reveal(), $files);
+    }
+
+    public function testReturnsClassAndTraitFilePathsIfMemberIsPrivate()
+    {
+        $class = $this->reflectClass(
+            SourceCode::fromPathAndString('barfoo', 'trait Barbar {} class Foobar { use Barbar; private function foobar(){} }'), 
+            'Foobar'
+        );
+        $files = $this->filesFor($class, 'foobar');
+        $this->assertEquals(FileList::fromFilePaths(['barfoo', 'barfoo'], $files), $files);
+    }
+
+    public function testParentsTraitsAndInterfacesIfMemberIsProtected()
+    {
+        $class = $this->reflectClass(
+            SourceCode::fromPathAndString('barfoo', 'interface Inter1 {} class ParentClass {} trait Barbar {} class Foobar extends ParentClass implements Inter1 { protected function foobar(){} }'), 
+            'Foobar'
+        );
+        $files = $this->filesFor($class, 'foobar');
+        $this->assertEquals(FileList::fromFilePaths(['barfoo', 'barfoo', 'barfoo', 'barfoo'], $files), $files);
+    }
+
+    private function filesFor(ReflectionClassLike $class, string $memberName = null)
+    {
+        return (new FileFinder())->filesFor($this->filesystem->reveal(), $class, $memberName);
+    }
+
+    private function setupAllFiles()
+    {
+        $this->filesystem->fileList()->willReturn($this->fileList->reveal());
+        $this->fileList->existing()->willReturn($this->fileList->reveal());
+        $this->fileList->phpFiles()->willReturn($this->fileList->reveal());
+    }
+
+    private function reflectClass($source, string $name)
+    {
+        $builder = ReflectorBuilder::create()->addSource('<?php ' . $source);
+        return $builder->build()->reflectClassLike($name);
+    }
+
 }

--- a/tests/Unit/Extension/ClassMover/Application/Finder/FileFinderTest.php
+++ b/tests/Unit/Extension/ClassMover/Application/Finder/FileFinderTest.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Phpactor\Tests\Unit\Extension\ClassMover\Application\Finder;
+
+class FileFinderTest
+{
+}

--- a/tests/Unit/Extension/ClassMover/Rpc/ReferencesHandlerTest.php
+++ b/tests/Unit/Extension/ClassMover/Rpc/ReferencesHandlerTest.php
@@ -166,6 +166,7 @@ class ReferencesHandlerTest extends HandlerTestCase
 
     public function testReplaceClassReferences()
     {
+        $source = '<?php new \stdClass();';
         $this->classReferences->findOrReplaceReferences(
             SourceCodeFilesystemExtension::FILESYSTEM_GIT,
             'stdClass',
@@ -173,8 +174,14 @@ class ReferencesHandlerTest extends HandlerTestCase
             null
         )->willReturn($this->exampleClassResponse());
 
+        $this->classReferences->replaceInSource(
+            $source,
+            'stdClass',
+            'newClass'
+        )->willReturn($source);
+
         $action = $this->handle('references', [
-            'source' => '<?php new \stdClass();',
+            'source' => $source,
             'offset' => 15,
             'filesystem' => 'git',
             'path' => self::TEST_PATH,

--- a/tests/Unit/Extension/ClassMover/Rpc/ReferencesHandlerTest.php
+++ b/tests/Unit/Extension/ClassMover/Rpc/ReferencesHandlerTest.php
@@ -21,6 +21,8 @@ use Phpactor\Tests\Unit\Extension\Rpc\Handler\HandlerTestCase;
 
 class ReferencesHandlerTest extends HandlerTestCase
 {
+    const TEST_PATH = 'test_file.php';
+
     /**
      * @var ClassReferences
      */
@@ -71,7 +73,9 @@ class ReferencesHandlerTest extends HandlerTestCase
 
         $action = $this->handle('references', [
             'source' => '<?php',
-            'offset' => 1,
+            'offset' => 2173,
+            'path' => self::TEST_PATH,
+            'filesystem' => null,
         ]);
 
         $this->assertInstanceOf(InputCallbackResponse::class, $action);
@@ -93,6 +97,7 @@ class ReferencesHandlerTest extends HandlerTestCase
             'source' => '<?php',
             'offset' => 1,
             'filesystem' => 'git',
+            'path' => self::TEST_PATH,
         ]);
     }
 
@@ -111,6 +116,7 @@ class ReferencesHandlerTest extends HandlerTestCase
             'source' => '<?php new \stdClass();',
             'offset' => 15,
             'filesystem' => 'git',
+            'path' => self::TEST_PATH,
         ]);
 
         $this->assertInstanceOf(EchoResponse::class, $action);
@@ -128,6 +134,7 @@ class ReferencesHandlerTest extends HandlerTestCase
             'source' => '<?php new \stdClass();',
             'offset' => 15,
             'filesystem' => 'git',
+            'path' => self::TEST_PATH,
         ]);
 
         $this->assertInstanceOf(CollectionResponse::class, $action);
@@ -168,6 +175,7 @@ class ReferencesHandlerTest extends HandlerTestCase
             'source' => '<?php new \stdClass();',
             'offset' => 15,
             'filesystem' => 'git',
+            'path' => self::TEST_PATH,
             'mode' => ReferencesHandler::MODE_REPLACE,
             'replacement' => 'newClass',
         ]);
@@ -190,6 +198,7 @@ class ReferencesHandlerTest extends HandlerTestCase
         $action = $this->handle('references', [
             'source' => $std = '<?php $foo = new ' . __CLASS__ . '(); $foo->testMemberReturnNoneFound();',
             'offset' => 104,
+            'path' => self::TEST_PATH,
             'filesystem' => 'git',
         ]);
 
@@ -223,6 +232,7 @@ class ReferencesHandlerTest extends HandlerTestCase
         $action = $this->handle('references', [
             'source' => $std = '<?php $foo = new ' . __CLASS__ . '(); $foo->testMemberReferences();',
             'offset' => 104,
+            'path' => self::TEST_PATH,
             'filesystem' => 'git',
         ]);
 
@@ -266,6 +276,7 @@ class ReferencesHandlerTest extends HandlerTestCase
         $action = $this->handle('references', [
             'source' => '<?php $foo = new ' . __CLASS__ . '(); $foo->testMemberReferences();',
             'offset' => 104,
+            'path' => self::TEST_PATH,
             'filesystem' => 'git',
             'mode' => ReferencesHandler::MODE_REPLACE,
         ]);
@@ -290,6 +301,7 @@ class ReferencesHandlerTest extends HandlerTestCase
 
         $action = $this->handle('references', [
             'source' => '<?php $foo = new ' . __CLASS__ . '(); $foo->testMemberReferences();',
+            'path' => self::TEST_PATH,
             'offset' => 104,
             'filesystem' => 'git',
             'mode' => ReferencesHandler::MODE_REPLACE,
@@ -309,6 +321,7 @@ class ReferencesHandlerTest extends HandlerTestCase
 
         $action = $this->handle('references', [
             'source' => $std = '<?php $foo = new ' . __CLASS__ . '(); $foo->testMemberReferences();',
+            'path' => self::TEST_PATH,
             'offset' => 104,
             'filesystem' => 'git',
         ]);


### PR DESCRIPTION
- [x] When a known protected / private class member is given, only traverse the possible related files,
- [x] Do not ask for the filesystem scope (default to either composer or full FS depending on env.).
- [x] Issue a reload request for the current file in the RPC response.
- [x] Replace references in current file (not just those on the disk) for clkass members.
- [x] Same for class references

**NOTE**: The application code for this is quite frightning, should extract it see #440 

Fixes #349 