### PR TITLE
[Completion] Refactored to make interface more efficient, decoupled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ Improvements:
   - [ClassMover] (RPC) Will update current (unsaved) source.
   - [vim-plugin] Correctly handle expanding class when at beginning of word, #438 thanks @greg0ire 
 
-API:
+Non-functional:
 
-  - [WorseReflection] (API) All member collections extend common interface,
+  - [WorseReflection] All member collections extend common interface,
     class-likes have a `members(): ReflectionMemberCollection` method.
+  - [Completion] Refactored to make interface more efficient, decoupled
+    formatting from completion.
 
 ## 0.3.0
 

--- a/composer.lock
+++ b/composer.lock
@@ -748,12 +748,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/completion.git",
-                "reference": "50ca71e884440c42e80090352d0fe325148a0797"
+                "reference": "b375106a5296f1a90827712646a33c7588ada119"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/completion/zipball/50ca71e884440c42e80090352d0fe325148a0797",
-                "reference": "50ca71e884440c42e80090352d0fe325148a0797",
+                "url": "https://api.github.com/repos/phpactor/completion/zipball/b375106a5296f1a90827712646a33c7588ada119",
+                "reference": "b375106a5296f1a90827712646a33c7588ada119",
                 "shasum": ""
             },
             "require": {
@@ -787,7 +787,7 @@
                 }
             ],
             "description": "Completion library for Worse Reflection",
-            "time": "2018-04-15T10:13:42+00:00"
+            "time": "2018-04-22T11:26:44+00:00"
         },
         {
             "name": "phpactor/docblock",


### PR DESCRIPTION
...formatting from completion.

- [x] There is now only `public complete` instead of `couldComplete` and `complete`, `complete` should return early if it can't complete.
- [x] Extract formatting from the completors themselves.

Initially this work was an attempt to make variable completion in call expressions show some contextual oinformation, e.g.

```
$hallo = 'hallo';
$this->foobar('hello', $h<>
```

Might suggest:

```
$hallo string # (string $param1, >>string $param2<<)`
```

But became a mess, so dropped it...