### PR TITLE
Class completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Changelog
 
 ## Develop
 
+Functions:
+
+  - [Completion] _Experimental_ class completion: complete use, new and
+    extends. Class names inferred from file names.
+
 Improvements:
 
   - [ClassMover] Find/replace references will only traverse possible classes
@@ -18,6 +23,9 @@ Non-functional:
     class-likes have a `members(): ReflectionMemberCollection` method.
   - [Completion] Refactored to make interface more efficient, decoupled
     formatting from completion.
+  - [Completion] Made existing completors a subset of tolerant-parser
+    completors (means there is one "chain" tolerant completor which delegates
+    to the other completors and we only have to parse once).
 
 ## 0.3.0
 

--- a/composer.lock
+++ b/composer.lock
@@ -748,15 +748,17 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/completion.git",
-                "reference": "b375106a5296f1a90827712646a33c7588ada119"
+                "reference": "9380a870d0eb48ae8b272083755f61dea145788c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/completion/zipball/b375106a5296f1a90827712646a33c7588ada119",
-                "reference": "b375106a5296f1a90827712646a33c7588ada119",
+                "url": "https://api.github.com/repos/phpactor/completion/zipball/9380a870d0eb48ae8b272083755f61dea145788c",
+                "reference": "9380a870d0eb48ae8b272083755f61dea145788c",
                 "shasum": ""
             },
             "require": {
+                "phpactor/class-to-file": "^1.0@dev",
+                "phpactor/source-code-filesystem": "^1.0@dev",
                 "phpactor/worse-reflection": "^1.0@dev",
                 "phpbench/phpbench": "^1.0@dev"
             },
@@ -787,7 +789,7 @@
                 }
             ],
             "description": "Completion library for Worse Reflection",
-            "time": "2018-04-22T11:26:44+00:00"
+            "time": "2018-04-22T16:48:00+00:00"
         },
         {
             "name": "phpactor/docblock",

--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -43,16 +43,24 @@ function! phpactor#Complete(findstart, base)
         let line = getline('.')
         let start = col('.')
         let originalStart = start
-        let triggers = [ "->", "::" ]
+        let triggers = [ "$", "->", "::", "extends", "use", "implements", "new" ]
+        let buffer = []
 
         while start -1 >= 0
 
-            if line[start-1:start-1] == "$"
-                return start
-            endif
+            let char = line[start-1:start-1]
 
-            if index(triggers, line[start-2:start-1]) >= 0
-                return start
+            if char != " " && char != "\n" && char != ""
+                call add(buffer, char)
+                for trigger in triggers
+                    if len(buffer) >= len(trigger)
+                        let toCompare = join(reverse(copy(buffer)), '')
+                        let toCompare = toCompare[0:strlen(trigger) - 1]
+                        if trigger == toCompare
+                            return start + strlen(trigger) - 1
+                        endif
+                    endif
+                endfor
             endif
 
             let start -= 1


### PR DESCRIPTION
Experimental class completion. Currently supports `extends`, `new` and `use` (doesn't support `implements` at the moment or other lists (e.g. trait use statements).

Technically it also supports any partially completed qualified name, but currently the VIM plugin only lets triggers on the above set of keywords.

Works in the same way as the Class Search feature - by traversing the composer filesystem and inferring class names.

Track progress on #368 