### PR TITLE
[vim-plugin] Reload file before replacing contents, fixes #445

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Improvements:
     on env).
   - [ClassMover] (RPC) Will update current (unsaved) source.
   - [vim-plugin] Correctly handle expanding class when at beginning of word, #438 thanks @greg0ire 
+  - [vim-plugin] Reload file before replacing contents, fixes #445
+  - [vim-plugin] File references, do not show quick fix list if all references
+    are in current file.
 
 Non-functional:
 

--- a/plugin/tests/rpc_file_references.vader
+++ b/plugin/tests/rpc_file_references.vader
@@ -1,0 +1,6 @@
+Execute (populates quickfix list):
+    call setqflist([])
+    call phpactor#_rpc_dispatch("file_references", {"file_references": [ {"file": "file1", "references": [ {"line_no": 10, "col_no": 1}]}]})
+    let list = getqflist()
+    AssertEqual 10, list[0]['lnum']
+    AssertEqual 2, list[0]['col']

--- a/plugin/tests/rpc_replace_file_source.vader
+++ b/plugin/tests/rpc_replace_file_source.vader
@@ -1,0 +1,10 @@
+Given php (matches expects):
+   <?php
+
+   // hello world
+
+Execute:
+   call phpactor#_rpc_dispatch("replace_file_source", {"path": "[Vader]", "source": "<?php // goodbye world"})
+
+Expect:
+  <?php // goodbye world


### PR DESCRIPTION
Means no awkard "File modified on disk" errors when performing refactorings that replace the disk file source AND replace the source of the current file (e.g. renaming member).

Also, file-references, do not show quick-fix list if the references are only in the current file.