### PR TITLE
Standalone usage

### DIFF
--- a/bin/phpactor
+++ b/bin/phpactor
@@ -13,7 +13,7 @@ foreach ([
 ] as $file) {
     if (file_exists($file)) {
         $autoloadFile = $file;
-        define('__VENDOR_DIR__', realpath(basename($autoloadFile)));
+        define('__VENDOR_DIR__', realpath(dirname($autoloadFile)));
         break;
     }
 }

--- a/bin/phpactor
+++ b/bin/phpactor
@@ -13,7 +13,7 @@ foreach ([
 ] as $file) {
     if (file_exists($file)) {
         $autoloadFile = $file;
-        define('VENDOR_DIR', realpath(basename($autoloadFile)));
+        define('__VENDOR_DIR__', realpath(basename($autoloadFile)));
         break;
     }
 }

--- a/bin/phpactor
+++ b/bin/phpactor
@@ -13,6 +13,7 @@ foreach ([
 ] as $file) {
     if (file_exists($file)) {
         $autoloadFile = $file;
+        define('VENDOR_DIR', realpath(basename($autoloadFile)));
         break;
     }
 }

--- a/lib/Extension/CodeTransform/CodeTransformExtension.php
+++ b/lib/Extension/CodeTransform/CodeTransformExtension.php
@@ -189,7 +189,11 @@ class CodeTransformExtension implements Extension
     {
         $container->register('code_transform.twig_loader', function (Container $container) {
             $loaders = [];
-            $loaders[] = new FilesystemLoader(__DIR__ . '/../../../vendor/phpactor/code-builder/templates');
+            
+            $userPath = __DIR__ . '/../../../vendor/phpactor/code-builder/templates';
+            $corePath = __DIR__ . '/../../../../../../vendor/phpactor/code-builder/templates';
+            
+            $loaders[] = new FilesystemLoader(is_dir($userPath) ? $userPath : $corePath);
 
             foreach ($container->getParameter(self::TEMPLATE_PATHS) as $templatePath) {
                 $loaders[] = new FilesystemLoader($templatePath);

--- a/lib/Extension/CodeTransform/CodeTransformExtension.php
+++ b/lib/Extension/CodeTransform/CodeTransformExtension.php
@@ -189,11 +189,7 @@ class CodeTransformExtension implements Extension
     {
         $container->register('code_transform.twig_loader', function (Container $container) {
             $loaders = [];
-            
-            $userPath = __DIR__ . '/../../../vendor/phpactor/code-builder/templates';
-            $corePath = __DIR__ . '/../../../../../../vendor/phpactor/code-builder/templates';
-            
-            $loaders[] = new FilesystemLoader(is_dir($userPath) ? $userPath : $corePath);
+            $loaders[] = new FilesystemLoader(__VENDOR_DIR__ . '/phpactor/code-builder/templates');
 
             foreach ($container->getParameter(self::TEMPLATE_PATHS) as $templatePath) {
                 $loaders[] = new FilesystemLoader($templatePath);

--- a/lib/Extension/WorseReflection/WorseReflectionExtension.php
+++ b/lib/Extension/WorseReflection/WorseReflectionExtension.php
@@ -26,12 +26,8 @@ class WorseReflectionExtension implements Extension
      */
     public function configure(Schema $schema)
     {
-        $userPath = __DIR__ . '/../../../vendor/jetbrains/phpstorm-stubs';
-        $corePath = __DIR__ . '/../../../../../../vendor/jetbrains/phpstorm-stubs';
-        $path = is_dir($userPath) ? $userPath : $corePath;
-
         $schema->setDefaults([
-            'reflection.stub_directory' => $path,
+            'reflection.stub_directory' => __VENDOR_DIR__ . '/jetbrains/phpstorm-stubs',
         ]);
     }
 

--- a/lib/Extension/WorseReflection/WorseReflectionExtension.php
+++ b/lib/Extension/WorseReflection/WorseReflectionExtension.php
@@ -26,8 +26,12 @@ class WorseReflectionExtension implements Extension
      */
     public function configure(Schema $schema)
     {
+        $userPath = __DIR__ . '/../../../vendor/jetbrains/phpstorm-stubs';
+        $corePath = __DIR__ . '/../../../../../../vendor/jetbrains/phpstorm-stubs';
+        $path = is_dir($userPath) ? $userPath : $corePath;
+
         $schema->setDefaults([
-            'reflection.stub_directory' => __DIR__ . '/../../../vendor/jetbrains/phpstorm-stubs',
+            'reflection.stub_directory' => $path,
         ]);
     }
 
@@ -46,20 +50,20 @@ class WorseReflectionExtension implements Extension
                 ->enableCache()
                 ->withSourceReflectorFactory(new TolerantFactory($container->get('reflection.tolerant_parser')))
                 ->enableContextualSourceLocation();
-        
+
             foreach (array_keys($container->getServiceIdsForTag('reflection.source_locator')) as $locatorId) {
                 $builder->addLocator($container->get($locatorId));
             }
-        
+
             $builder->withLogger(new PsrLogger($container->get('monolog.logger')));
-        
+
             return $builder->build();
         });
 
         $container->register('reflection.tolerant_parser', function (Container $container) {
             return new CachedParser();
         });
-        
+
         $container->register('reflection.locator.stub', function (Container $container) {
             return new StubSourceLocator(
                 ReflectorBuilder::create()->build(),
@@ -67,7 +71,7 @@ class WorseReflectionExtension implements Extension
                 $container->getParameter('cache_dir')
             );
         }, [ 'reflection.source_locator' => []]);
-        
+
         $container->register('reflection.locator.worse', function (Container $container) {
             return new ClassToFileSourceLocator($container->get('class_to_file.class_to_file'));
         }, [ 'reflection.source_locator' => []]);

--- a/tests/Integration/ApplicationTest.php
+++ b/tests/Integration/ApplicationTest.php
@@ -13,6 +13,8 @@ class ApplicationTest extends IntegrationTestCase
 {
     public function setUp()
     {
+        parent::setUp();
+
         $this->workspace()->reset();
     }
 

--- a/tests/IntegrationTestCase.php
+++ b/tests/IntegrationTestCase.php
@@ -12,6 +12,15 @@ use Phpactor\Phpactor;
 
 abstract class IntegrationTestCase extends TestCase
 {
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (!defined('__VENDOR_DIR__')) {
+            define('__VENDOR_DIR__', realpath(dirname(__FILE__) . '/../vendor'));
+        }
+    }
+
     protected function workspaceDir()
     {
         return __DIR__ . '/Assets/Workspace';


### PR DESCRIPTION
I hoped to use phpactor as standalone binary that just sits in my PATH. 

Once I do `composer global require phpactor/phpactor dev-develop`, then I can call that binary from anywhere. But when I do, I get this message:

<a href="https://cl.ly/1k040J382N2s" target="_blank"><img src="https://dzwonsemrish7.cloudfront.net/items/1o3x0C3A3W061m2H260M/Image%202018-04-30%20at%2012.00.09%20AM.png" style="display: block;height: auto;width: 100%;"/></a>

I noticed the path here tries to reach within phpactor/vendor folder that is now levels up (at standalone usage).

This may not be the best way to fix this issue, but it works.

I have to point out this problem, as I'd like to access the binary from global path so it's easily reached/wrapped by my vim commands, or any other tools.