### PR TITLE
Use actual vendor dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ Improvements:
   - [vim-plugin] Completion - trigger on any word-like, fixes #443
   - [WorseReflection] Support for `@property` type override (but doesn't
     create a "pretend" property).
+  - [Application] Pass the Phpactor vendor directory as an argument to the
+    Application and include vendor files (e.g. stubs) relative to that, fixes
+    #460
+  - [Application] Use XDG data directory for cache.
 
 Bug fixes:
 

--- a/bin/phpactor
+++ b/bin/phpactor
@@ -36,7 +36,7 @@ require_once $autoloadFile;
 
 Debug::enable();
 
-$application = new Application();
+$application = new Application(realpath(dirname($autoloadFile)));
 $output = new ConsoleOutput();
 
 try {

--- a/lib/Application.php
+++ b/lib/Application.php
@@ -18,9 +18,15 @@ class Application extends SymfonyApplication
      */
     private $container;
 
-    public function __construct($name = 'UNKNOWN', $version = 'UNKNOWN')
+    /**
+     * @var string
+     */
+    private $vendorDir;
+
+    public function __construct(string $vendorDir)
     {
         parent::__construct('Phpactor', '0.1');
+        $this->vendorDir = $vendorDir;
     }
 
     public function doRun(InputInterface $input, OutputInterface $output)
@@ -89,7 +95,7 @@ class Application extends SymfonyApplication
 
     private function initialize(InputInterface $input)
     {
-        $this->container = Phpactor::boot($input);
+        $this->container = Phpactor::boot($input, $this->vendorDir);
 
         foreach ($this->container->getServiceIdsForTag('ui.console.command') as $commandId => $attrs) {
             $this->add($this->container->get($commandId));

--- a/lib/Config/Paths.php
+++ b/lib/Config/Paths.php
@@ -16,8 +16,8 @@ class Paths
      * @var string
      */
     private $cwd;
-
     public function __construct(Xdg $xdg = null, string $cwd = null)
+
     {
         $this->xdg = $xdg ?: new Xdg();
         $this->cwd = $cwd ?: getcwd();
@@ -66,5 +66,10 @@ class Paths
         }
 
         return $path;
+    }
+
+    public function userCacheDir(): string
+    {
+        return $this->userData('cache');
     }
 }

--- a/lib/Config/Paths.php
+++ b/lib/Config/Paths.php
@@ -67,9 +67,4 @@ class Paths
 
         return $path;
     }
-
-    public function userCacheDir(): string
-    {
-        return $this->userData('cache');
-    }
 }

--- a/lib/Container/PhpactorContainer.php
+++ b/lib/Container/PhpactorContainer.php
@@ -58,7 +58,7 @@ class PhpactorContainer implements Container, ContainerBuilder
      */
     public function has($id)
     {
-        return isset($this->factories[$id]);
+        return array_key_exists($id, $this->factories);
     }
 
     public function getServiceIdsForTag(string $tag): array

--- a/lib/Container/PhpactorContainer.php
+++ b/lib/Container/PhpactorContainer.php
@@ -85,7 +85,7 @@ class PhpactorContainer implements Container, ContainerBuilder
 
     public function getParameter(string $name)
     {
-        if (!isset($this->parameters[$name])) {
+        if (!array_key_exists($name, $this->parameters)) {
             throw new RuntimeException(sprintf(
                 'Unknown parameter "%s", known parameters "%s"',
                 $name,

--- a/lib/Container/Schema.php
+++ b/lib/Container/Schema.php
@@ -41,7 +41,7 @@ class Schema
         if ($diff = array_diff(array_keys($config), $allowedKeys)) {
             throw new InvalidConfig(sprintf(
                 'Keys "%s" are not known, known keys: "%s"',
-                implode('", "', array_keys($config)),
+                implode('", "', ($diff)),
                 implode('", "', $allowedKeys)
             ));
         }

--- a/lib/Extension/CodeTransform/CodeTransformExtension.php
+++ b/lib/Extension/CodeTransform/CodeTransformExtension.php
@@ -189,7 +189,7 @@ class CodeTransformExtension implements Extension
     {
         $container->register('code_transform.twig_loader', function (Container $container) {
             $loaders = [];
-            $loaders[] = new FilesystemLoader(__DIR__ . '/../../../vendor/phpactor/code-builder/templates');
+            $loaders[] = new FilesystemLoader($contaier->getParameter('vendor_dir') . '/'. 'phpactor/code-builder/templates');
 
             foreach ($container->getParameter(self::TEMPLATE_PATHS) as $templatePath) {
                 $loaders[] = new FilesystemLoader($templatePath);

--- a/lib/Extension/CodeTransform/CodeTransformExtension.php
+++ b/lib/Extension/CodeTransform/CodeTransformExtension.php
@@ -189,7 +189,7 @@ class CodeTransformExtension implements Extension
     {
         $container->register('code_transform.twig_loader', function (Container $container) {
             $loaders = [];
-            $loaders[] = new FilesystemLoader($contaier->getParameter('vendor_dir') . '/'. 'phpactor/code-builder/templates');
+            $loaders[] = new FilesystemLoader($container->getParameter('vendor_dir') . '/'. 'phpactor/code-builder/templates');
 
             foreach ($container->getParameter(self::TEMPLATE_PATHS) as $templatePath) {
                 $loaders[] = new FilesystemLoader($templatePath);

--- a/lib/Extension/Core/CoreExtension.php
+++ b/lib/Extension/Core/CoreExtension.php
@@ -51,7 +51,7 @@ class CoreExtension implements Extension
             self::AUTOLOAD_DEREGISTER => true,
             self::WORKING_DIRECTORY => getcwd(),
             self::DUMPER => 'indented',
-            self::CACHE_DIR => __DIR__ . '/../../../cache',
+            self::CACHE_DIR => null,
             self::LOGGING_ENABLED => false,
             self::LOGGING_FINGERS_CROSSED => true,
             self::LOGGING_PATH => 'phpactor.log',

--- a/lib/Extension/Core/CoreExtension.php
+++ b/lib/Extension/Core/CoreExtension.php
@@ -40,6 +40,7 @@ class CoreExtension implements Extension
     const LOGGING_FINGERS_CROSSED = 'logging.fingers_crossed';
     const AUTOLOAD_DEREGISTER = 'autoload.deregister';
     const XDEBUG_DISABLE = 'xdebug_disable';
+    const VENDOR_DIRECTORY = 'vendor_dir';
 
     public static $autoloader;
 
@@ -56,6 +57,7 @@ class CoreExtension implements Extension
             self::LOGGING_PATH => 'phpactor.log',
             self::LOGGING_LEVEL => LogLevel::WARNING,
             self::XDEBUG_DISABLE => true,
+            self::VENDOR_DIRECTORY => null,
         ]);
     }
 

--- a/lib/Extension/WorseReflection/WorseReflectionExtension.php
+++ b/lib/Extension/WorseReflection/WorseReflectionExtension.php
@@ -27,7 +27,7 @@ class WorseReflectionExtension implements Extension
     public function configure(Schema $schema)
     {
         $schema->setDefaults([
-            'reflection.stub_directory' => __DIR__ . '/../../../vendor/jetbrains/phpstorm-stubs',
+            'reflection.stub_directory' => 'jetbrains/phpstorm-stubs',
         ]);
     }
 
@@ -63,7 +63,7 @@ class WorseReflectionExtension implements Extension
         $container->register('reflection.locator.stub', function (Container $container) {
             return new StubSourceLocator(
                 ReflectorBuilder::create()->build(),
-                $container->getParameter('reflection.stub_directory'),
+                $container->getParameter('vendor_dir') . '/' . $container->getParameter('reflection.stub_directory'),
                 $container->getParameter('cache_dir')
             );
         }, [ 'reflection.source_locator' => []]);

--- a/lib/Phpactor.php
+++ b/lib/Phpactor.php
@@ -60,7 +60,7 @@ class Phpactor
         });
 
         if (!isset($config['cache_dir'])) {
-            $config['cache_dir'] = $paths->userCacheDir();
+            $config['cache_dir'] = $paths->userData('cache');
         }
 
         // > method resolve config

--- a/lib/Phpactor.php
+++ b/lib/Phpactor.php
@@ -54,9 +54,14 @@ class Phpactor
 
         $container = new PhpactorContainer();
 
-        $container->register('config.paths', function () {
-            return new Paths();
+        $paths = new Paths();
+        $container->register('config.paths', function () use ($paths) {
+            return $paths;
         });
+
+        if (!isset($config['cache_dir'])) {
+            $config['cache_dir'] = $paths->userCacheDir();
+        }
 
         // > method resolve config
         $masterSchema = new Schema();

--- a/lib/Phpactor.php
+++ b/lib/Phpactor.php
@@ -22,16 +22,16 @@ use Composer\XdebugHandler\XdebugHandler;
 
 class Phpactor
 {
-    public static function boot(InputInterface $input): PhpactorContainer
+    public static function boot(InputInterface $input, string $vendorDir): PhpactorContainer
     {
-
         $config = [];
 
         $configLoader = new ConfigLoader();
         $config = $configLoader->loadConfig();
+        $config[CoreExtension::VENDOR_DIRECTORY] = $vendorDir;
 
         if ($input->hasParameterOption([ '--working-dir', '-d' ])) {
-            $config['cwd'] = $input->getParameterOption([ '--working-dir', '-d' ]);
+            $config[CoreExtension::WORKING_DIRECTORY] = $input->getParameterOption([ '--working-dir', '-d' ]);
         }
 
         if (!isset($config[CoreExtension::XDEBUG_DISABLE]) || $config[CoreExtension::XDEBUG_DISABLE]) {
@@ -53,7 +53,6 @@ class Phpactor
         ];
 
         $container = new PhpactorContainer();
-        // TODO: Put this in core ext??
 
         $container->register('config.paths', function () {
             return new Paths();

--- a/lib/Phpactor.php
+++ b/lib/Phpactor.php
@@ -59,8 +59,8 @@ class Phpactor
             return $paths;
         });
 
-        if (!isset($config['cache_dir'])) {
-            $config['cache_dir'] = $paths->userData('cache');
+        if (false === isset($config[CoreExtension::CACHE_DIR])) {
+            $config[CoreExtension::CACHE_DIR] = $paths->userData('cache');
         }
 
         // > method resolve config

--- a/tests/Integration/ApplicationTest.php
+++ b/tests/Integration/ApplicationTest.php
@@ -16,9 +16,14 @@ class ApplicationTest extends IntegrationTestCase
         $this->workspace()->reset();
     }
 
-    public function application()
+    public function tearDown()
     {
-        return Bootstrap::createApplication();
+        $this->workspace()->reset();
+    }
+
+    public function application(): Application
+    {
+        return new Application(__DIR__ . '/../../vendor');
     }
 
     public function testConfig()
@@ -34,7 +39,7 @@ EOT
 
         chdir($this->workspaceDir());
         $output = new BufferedOutput();
-        $application = new Application();
+        $application = $this->application();
         $application->setAutoExit(false);
         $application->setCatchExceptions(false);
         $application->run(new ArrayInput([
@@ -48,7 +53,7 @@ EOT
     {
         $output = new BufferedOutput();
 
-        $application = new Application();
+        $application = $this->application();
         $application->setAutoExit(false);
         $application->run(new ArrayInput([
             'command' => 'class:reflect',
@@ -65,7 +70,7 @@ EOT
         $this->loadProject('Animals');
         $output = new BufferedOutput();
 
-        $application = new Application();
+        $application = $this->application();
         $application->setAutoExit(false);
         $application->setCatchExceptions(false);
         $exitCode = $application->run(new ArrayInput([

--- a/tests/IntegrationTestCase.php
+++ b/tests/IntegrationTestCase.php
@@ -88,6 +88,6 @@ abstract class IntegrationTestCase extends TestCase
 
     protected function container(): Container
     {
-        return Phpactor::boot(new ArrayInput([]));
+        return Phpactor::boot(new ArrayInput([]), __DIR__ . '/../vendor');
     }
 }

--- a/tests/System/SystemTestCase.php
+++ b/tests/System/SystemTestCase.php
@@ -21,7 +21,6 @@ abstract class SystemTestCase extends IntegrationTestCase
             $process->setInput($stdin);
         }
 
-
         $process->run();
 
         return $process;

--- a/tests/Unit/Container/PhpactorContainerTest.php
+++ b/tests/Unit/Container/PhpactorContainerTest.php
@@ -19,6 +19,7 @@ class PhpactorContainerTest extends TestCase
     {
         $this->container = new PhpactorContainer([
             'configKey1' => 'value1',
+            'nullKey' => null,
         ]);
     }
 
@@ -86,6 +87,12 @@ class PhpactorContainerTest extends TestCase
     {
         $result = $this->container->getParameter('configKey1');
         $this->assertEquals('value1', $result);
+    }
+
+    public function testReturnsNullParameter()
+    {
+        $result = $this->container->getParameter('nullKey');
+        $this->assertEquals(null, $result);
     }
 
     public function testBuildReturnsAConfiguredContainer()


### PR DESCRIPTION
This is another approach to #460 which avoids the global state dependency.

To be honest, the whole bootstrapping process needs to be refactored and probably migrated to use the Symfony DI container and Configuration, as with #405 