### PR TITLE
[Vim Plugin] Goto reference in a modified file causes warning fixes #477

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## develop
+
+Bug fixes:
+
+  - [Vim Plugin] Goto reference in a modified file causes warning #477.
+
 ## 2018-05-20 0.5.0
 
 Features:

--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -376,7 +376,6 @@ function! phpactor#_rpc_dispatch(actionName, parameters)
     " >> open_file
     if a:actionName == "open_file"
         call phpactor#_switchToBufferOrEdit(a:parameters['path'])
-        exec ":edit"
 
         if (a:parameters['offset'])
             exec ":goto " .  (a:parameters['offset'] + 1)

--- a/plugin/tests/goto_reference.vader
+++ b/plugin/tests/goto_reference.vader
@@ -10,4 +10,4 @@ Do:
   :call phpactor#GotoDefinition()\<Enter>
 
 Then:
-  AssertEqual "lib/Phpactor.php", expand('%')
+  AssertEqual "Phpactor.php", expand('%:t')

--- a/plugin/tests/goto_reference.vader
+++ b/plugin/tests/goto_reference.vader
@@ -1,0 +1,13 @@
+Given php:
+  <?php 
+
+  use Phpactor\Phpactor;
+
+  new Phpactor();
+
+Do:
+  /Phpactor\<Enter>nn
+  :call phpactor#GotoDefinition()\<Enter>
+
+Then:
+  AssertEqual "lib/Phpactor.php", expand('%')


### PR DESCRIPTION
- [x] Fixes #477 :crossed_fingers: 
- [x] Adds regression to test for goto definition, because why not.