### PR TITLE
Allow transform command to act on globs and changed behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Changelog
 Features:
 
   - [CodeTransforn] Extract expression
+  - [Application] Changed behavior of Transform command: accepts globs, shows
+    diffs and writes to files (rather than just dumping them to stdout if they
+    changed).
   - [Completion] Support constant completion
 
 Improvements:

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "microsoft/tolerant-php-parser": "dev-master",
         "monolog/monolog": "^2.0@dev",
         "phpactor/completion": "^1.0@dev",
-        "composer/xdebug-handler": "^1.1"
+        "composer/xdebug-handler": "^1.1",
+        "sebastian/diff": "2.0.x-dev"
     },
     "config": {
         "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "a494b517034431f17cca75e3312ff59e",
+    "content-hash": "20afb65e0f0209054ad2a278b7592f08",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -1237,6 +1237,58 @@
                 "psr-3"
             ],
             "time": "2018-04-03T15:59:15+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "2.0.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "abcc70409ddfb310a8cb41ef0c2e857425438cf4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/abcc70409ddfb310a8cb41ef0c2e857425438cf4",
+                "reference": "abcc70409ddfb310a8cb41ef0c2e857425438cf4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff"
+            ],
+            "time": "2017-12-14T11:32:19+00:00"
         },
         {
             "name": "seld/jsonlint",
@@ -3215,58 +3267,6 @@
             "time": "2018-02-01T13:46:46+00:00"
         },
         {
-            "name": "sebastian/diff",
-            "version": "2.0.x-dev",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "abcc70409ddfb310a8cb41ef0c2e857425438cf4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/abcc70409ddfb310a8cb41ef0c2e857425438cf4",
-                "reference": "abcc70409ddfb310a8cb41ef0c2e857425438cf4",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.2"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Diff implementation",
-            "homepage": "https://github.com/sebastianbergmann/diff",
-            "keywords": [
-                "diff"
-            ],
-            "time": "2017-12-14T11:32:19+00:00"
-        },
-        {
             "name": "sebastian/environment",
             "version": "dev-master",
             "source": {
@@ -3944,6 +3944,7 @@
         "microsoft/tolerant-php-parser": 20,
         "monolog/monolog": 20,
         "phpactor/completion": 20,
+        "sebastian/diff": 20,
         "phpbench/phpbench": 20,
         "phpactor/test-utils": 20,
         "friendsofphp/php-cs-fixer": 20

--- a/lib/Extension/CodeTransform/Application/Transformer.php
+++ b/lib/Extension/CodeTransform/Application/Transformer.php
@@ -40,10 +40,6 @@ class Transformer
 
         $transformedCode = $this->transform->transform($source, $transformations);
 
-        if ($source == $transformedCode) {
-            return null;
-        }
-
         return $transformedCode;
     }
 }

--- a/lib/Extension/CodeTransform/Command/ClassInflectCommand.php
+++ b/lib/Extension/CodeTransform/Command/ClassInflectCommand.php
@@ -24,7 +24,7 @@ class ClassInflectCommand extends Command
     private $dumperRegistry;
 
     /**
-     * @var ClassNew
+     * @var ClassInflect
      */
     private $classInflect;
 

--- a/lib/Extension/CodeTransform/Command/ClassTransformCommand.php
+++ b/lib/Extension/CodeTransform/Command/ClassTransformCommand.php
@@ -2,12 +2,17 @@
 
 namespace Phpactor\Extension\CodeTransform\Command;
 
+use Phpactor\CodeTransform\Domain\SourceCode;
+use Phpactor\Extension\Core\Application\Helper\FilesystemHelper;
+use Phpactor\Phpactor;
+use SebastianBergmann\Diff\Differ;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Phpactor\Extension\CodeTransform\Application\Transformer;
+use Webmozart\Glob\Glob;
 
 class ClassTransformCommand extends Command
 {
@@ -16,11 +21,17 @@ class ClassTransformCommand extends Command
      */
     private $transformer;
 
+    /**
+     * @var Differ
+     */
+    private $differ;
+
     public function __construct(
         Transformer $transformer
     ) {
         parent::__construct();
         $this->transformer = $transformer;
+        $this->differ = new Differ();
     }
 
     public function configure()
@@ -29,13 +40,61 @@ class ClassTransformCommand extends Command
         $this->setDescription('Apply a transformation to an existing class (path or FQN)');
         $this->addArgument('src', InputArgument::REQUIRED, 'Source path or FQN');
         $this->addOption('transform', 't', InputOption::VALUE_REQUIRED|InputOption::VALUE_IS_ARRAY, 'Tranformations to apply', []);
+        $this->addOption('dry-run', null, InputOption::VALUE_NONE, 'Do not make any changes');
+        $this->addOption('diff', null, InputOption::VALUE_NONE, 'Output diff');
     }
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        $src = $input->getArgument('src');
+        $pattern = $input->getArgument('src');
+        $dryRun = $input->getOption('dry-run');
+        $diff = $input->getOption('diff');
+        /** @var array $transformations */
         $transformations = $input->getOption('transform');
 
-        $output->writeln($this->transformer->transform($src, $transformations));
+        $pattern = Phpactor::normalizePath($pattern);
+
+        if (false === Glob::isDynamic($pattern) && false === file_exists($pattern)) {
+            throw new \RuntimeException(sprintf(
+                'File "%s" does not exist',
+                $pattern
+            ));
+        }
+
+        $paths = array_filter(Glob::glob($pattern), function ($path) {
+            return is_file($path);
+        });
+
+        if (empty($paths)) {
+            $output->writeln(sprintf('No files found for pattern "%s"', $pattern));
+            return 0;
+        }
+
+        $affected = 0;
+        foreach ($paths as $path) {
+            $existing = SourceCode::fromStringAndPath(file_get_contents($path), $path);
+            $transformed = $this->transformer->transform($existing, $transformations);
+
+            $changed = trim($existing->__toString()) != trim($transformed);
+
+            if ($changed) {
+              $affected++;
+            }
+
+            if ($changed && $diff) {
+                $output->writeln($this->differ->diff($existing, $transformed));
+            }
+
+            if ($dryRun === false && $changed) {
+                $output->writeln($path);
+                file_put_contents($path, $transformed);
+            }
+        }
+
+        $output->writeln(sprintf(
+            '%s files affected%s',
+            $affected,
+            $dryRun ? ' (dry run)' : ''
+        ));
     }
 }


### PR DESCRIPTION
- Transform command accepts globs
- Writes to files (unless in dry-run mode)
- Shows diffs if requested

This allows, for example, recursively fixing namespaces after updating a project namespace:

```
$ phpactor code:transform "lib/**/*.php" --transform=fix_namespace_class_name
```