### PR TITLE
Soft implementation of macros

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "phpactor/class-mover": "dev-master",
         "phpactor/source-code-filesystem": "dev-master",
         "phpactor/class-to-file": "dev-master",
-        "phpactor/code-transform": "dev-master",
+        "phpactor/code-transform": "dev-reflection_macro",
         "phpactor/worse-reflection": "dev-master",
         "phpactor/path-finder": "dev-master",
         "symfony/filesystem": "^3.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "2a5ba0bab5ce366befabebe7509be4e3",
+    "content-hash": "8cba6ef586281b0ecfdc11ac8c5b659d",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -104,6 +104,48 @@
                 "performance"
             ],
             "time": "2018-04-11T15:42:36+00:00"
+        },
+        {
+            "name": "dantleech/argument-resolver",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://gitlab.com/dantleech/argument-resolver.git",
+                "reference": "852f995ee469647d9996e120fc71546b264f9ac7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://gitlab.com/api/v4/projects/dantleech%2Fargument-resolver/repository/archive.zip?sha=852f995ee469647d9996e120fc71546b264f9ac7",
+                "reference": "852f995ee469647d9996e120fc71546b264f9ac7",
+                "shasum": ""
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.10.1",
+                "phpunit/phpunit": "^7.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DTL\\ArgumentResolver\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Leech",
+                    "email": "daniel@dantleech.com"
+                }
+            ],
+            "description": "Resolve method arguments from an associative array",
+            "time": "2018-07-02T08:30:07+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -751,19 +793,20 @@
         },
         {
             "name": "phpactor/code-transform",
-            "version": "dev-master",
+            "version": "dev-reflection_macro",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/code-transform.git",
-                "reference": "520f7a99d4c3aca45eef4df1b257bd3c5d9a99a5"
+                "reference": "3738f4c87e48b25a2338df203fed94d245cee285"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/code-transform/zipball/520f7a99d4c3aca45eef4df1b257bd3c5d9a99a5",
-                "reference": "520f7a99d4c3aca45eef4df1b257bd3c5d9a99a5",
+                "url": "https://api.github.com/repos/phpactor/code-transform/zipball/3738f4c87e48b25a2338df203fed94d245cee285",
+                "reference": "3738f4c87e48b25a2338df203fed94d245cee285",
                 "shasum": ""
             },
             "require": {
+                "dantleech/argument-resolver": "^1.0@dev",
                 "phpactor/class-to-file": "^1.0@dev",
                 "phpactor/code-builder": "dev-master",
                 "webmozart/path-util": "^2.3@dev"
@@ -795,7 +838,7 @@
                 }
             ],
             "description": "Applies introspective transformations on source code",
-            "time": "2018-06-27T19:45:12+00:00"
+            "time": "2018-07-02T20:23:39+00:00"
         },
         {
             "name": "phpactor/completion",

--- a/lib/Extension/CodeTransform/CodeTransformExtension.php
+++ b/lib/Extension/CodeTransform/CodeTransformExtension.php
@@ -11,14 +11,14 @@ use Phpactor\CodeBuilder\Util\TextFormat;
 use Phpactor\CodeTransform\Adapter\Native\GenerateNew\ClassGenerator;
 use Phpactor\CodeTransform\Adapter\TolerantParser\ClassToFile\Transformer\ClassNameFixerTransformer;
 use Phpactor\CodeTransform\Adapter\TolerantParser\Refactor\TolerantExtractExpression;
-use Phpactor\CodeTransform\Adapter\TolerantParser\Refactor\TolerantImportClass;
-use Phpactor\CodeTransform\Adapter\TolerantParser\Refactor\TolerantRenameVariable;
+use Phpactor\CodeTransform\Adapter\TolerantParser\Macro\TolerantImportClass;
+use Phpactor\CodeTransform\Adapter\TolerantParser\Macro\TolerantRenameVariable;
 use Phpactor\CodeTransform\Adapter\WorseReflection\GenerateFromExisting\InterfaceFromExistingGenerator;
-use Phpactor\CodeTransform\Adapter\WorseReflection\Refactor\WorseExtractConstant;
-use Phpactor\CodeTransform\Adapter\WorseReflection\Refactor\WorseExtractMethod;
-use Phpactor\CodeTransform\Adapter\WorseReflection\Refactor\WorseGenerateAccessor;
-use Phpactor\CodeTransform\Adapter\WorseReflection\Refactor\WorseGenerateMethod;
-use Phpactor\CodeTransform\Adapter\WorseReflection\Refactor\WorseOverrideMethod;
+use Phpactor\CodeTransform\Adapter\WorseReflection\Macro\WorseExtractConstant;
+use Phpactor\CodeTransform\Adapter\WorseReflection\Macro\WorseExtractMethod;
+use Phpactor\CodeTransform\Adapter\WorseReflection\Macro\WorseGenerateAccessor;
+use Phpactor\CodeTransform\Adapter\WorseReflection\Macro\WorseGenerateMethod;
+use Phpactor\CodeTransform\Adapter\WorseReflection\Macro\WorseOverrideMethod;
 use Phpactor\CodeTransform\Adapter\WorseReflection\Transformer\AddMissingProperties;
 use Phpactor\CodeTransform\Adapter\WorseReflection\Transformer\CompleteConstructor;
 use Phpactor\CodeTransform\Adapter\WorseReflection\Transformer\ImplementContracts;
@@ -50,7 +50,6 @@ use Phpactor\Extension\CodeTransform\Rpc\TransformHandler;
 use Twig\Environment;
 use Twig\Loader\ChainLoader;
 use Twig\Loader\FilesystemLoader;
-
 class CodeTransformExtension implements Extension
 {
     const CLASS_NEW_VARIANTS = 'code_transform.class_new.variants';

--- a/lib/Extension/CodeTransform/Rpc/ExtractConstantHandler.php
+++ b/lib/Extension/CodeTransform/Rpc/ExtractConstantHandler.php
@@ -56,7 +56,7 @@ class ExtractConstantHandler extends AbstractHandler
             return $this->createInputCallback($arguments);
         }
 
-        $sourceCode = $this->extractConstant->extractConstant(
+        $sourceCode = $this->extractConstant->__invoke(
             SourceCode::fromStringAndPath($arguments[self::PARAM_SOURCE], $arguments[self::PARAM_PATH]),
             $arguments[self::PARAM_OFFSET],
             $arguments[self::PARAM_CONSTANT_NAME]

--- a/lib/Extension/CodeTransform/Rpc/ExtractExpressionHandler.php
+++ b/lib/Extension/CodeTransform/Rpc/ExtractExpressionHandler.php
@@ -63,7 +63,7 @@ class ExtractExpressionHandler extends AbstractHandler
             return $this->createInputCallback($arguments);
         }
 
-        $sourceCode = $this->extractExpression->extractExpression(
+        $sourceCode = $this->extractExpression->__invoke(
             SourceCode::fromString($arguments[self::PARAM_SOURCE]),
             $arguments[self::PARAM_OFFSET_START],
             $arguments[self::PARAM_OFFSET_END],

--- a/lib/Extension/CodeTransform/Rpc/ExtractMethodHandler.php
+++ b/lib/Extension/CodeTransform/Rpc/ExtractMethodHandler.php
@@ -68,7 +68,7 @@ class ExtractMethodHandler extends AbstractHandler
             return $this->createInputCallback($arguments);
         }
 
-        $sourceCode = $this->extractMethod->extractMethod(
+        $sourceCode = $this->extractMethod->__invoke(
             SourceCode::fromString($arguments[self::PARAM_SOURCE]),
             $arguments[self::PARAM_OFFSET_START],
             $arguments[self::PARAM_OFFSET_END],

--- a/lib/Extension/CodeTransform/Rpc/GenerateAccessorHandler.php
+++ b/lib/Extension/CodeTransform/Rpc/GenerateAccessorHandler.php
@@ -41,7 +41,7 @@ class GenerateAccessorHandler extends AbstractHandler
 
     public function handle(array $arguments)
     {
-        $sourceCode = $this->generateAccessor->generateAccessor(
+        $sourceCode = $this->generateAccessor->__invoke(
             SourceCode::fromStringAndPath(
                 $arguments[self::PARAM_SOURCE],
                 $arguments[self::PARAM_PATH]

--- a/lib/Extension/CodeTransform/Rpc/GenerateMethodHandler.php
+++ b/lib/Extension/CodeTransform/Rpc/GenerateMethodHandler.php
@@ -40,7 +40,7 @@ class GenerateMethodHandler extends AbstractHandler
 
     public function handle(array $arguments)
     {
-        $sourceCode = $this->generateMethod->generateMethod(
+        $sourceCode = $this->generateMethod->__invoke(
             SourceCode::fromStringAndPath(
                 $arguments[self::PARAM_SOURCE],
                 $arguments[self::PARAM_PATH]

--- a/lib/Extension/CodeTransform/Rpc/ImportClassHandler.php
+++ b/lib/Extension/CodeTransform/Rpc/ImportClassHandler.php
@@ -96,7 +96,7 @@ class ImportClassHandler extends AbstractHandler
         }
 
         try {
-            $sourceCode = $this->classImport->importClass(
+            $sourceCode = $this->classImport->__invoke(
                 SourceCode::fromStringAndPath(
                     $arguments[self::PARAM_SOURCE],
                     $arguments[self::PARAM_PATH]

--- a/lib/Extension/CodeTransform/Rpc/OverrideMethodHandler.php
+++ b/lib/Extension/CodeTransform/Rpc/OverrideMethodHandler.php
@@ -82,7 +82,7 @@ class OverrideMethodHandler extends AbstractHandler
             return $this->createInputCallback($arguments);
         }
 
-        $transformedCode = $this->overrideMethod->overrideMethod(
+        $transformedCode = $this->overrideMethod->__invoke(
             SourceCode::fromString($arguments[self::PARAM_SOURCE]),
             (string) $class->name(),
             $arguments[self::PARAM_METHOD_NAME]

--- a/lib/Extension/CodeTransform/Rpc/RenameVariableHandler.php
+++ b/lib/Extension/CodeTransform/Rpc/RenameVariableHandler.php
@@ -68,7 +68,7 @@ class RenameVariableHandler extends AbstractHandler
             return $this->createInputCallback($arguments);
         }
 
-        $sourceCode = $this->renameVariable->renameVariable(
+        $sourceCode = $this->renameVariable->__invoke(
             SourceCode::fromStringAndPath(
                 $arguments[self::PARAM_SOURCE],
                 $arguments[self::PARAM_PATH]

--- a/tests/Unit/Extension/CoreTransform/Rpc/ExtractConstantHandlerTest.php
+++ b/tests/Unit/Extension/CoreTransform/Rpc/ExtractConstantHandlerTest.php
@@ -53,7 +53,7 @@ class ExtractConstantHandlerTest extends HandlerTestCase
 
     public function testExtractConstant()
     {
-        $this->extractConstant->extractConstant(
+        $this->extractConstant->__invoke(
             self::SOURCE,
             self::OFFSET,
             self::CONSTANT_NAME

--- a/tests/Unit/Extension/CoreTransform/Rpc/ExtractExpressionHandlerTest.php
+++ b/tests/Unit/Extension/CoreTransform/Rpc/ExtractExpressionHandlerTest.php
@@ -55,7 +55,7 @@ class ExtractExpressionHandlerTest extends HandlerTestCase
 
     public function testExtractExpression()
     {
-        $this->extractExpression->extractExpression(
+        $this->extractExpression->__invoke(
             self::SOURCE,
             self::OFFSET_START,
             self::OFFSET_END,

--- a/tests/Unit/Extension/CoreTransform/Rpc/ExtractMethodHandlerTest.php
+++ b/tests/Unit/Extension/CoreTransform/Rpc/ExtractMethodHandlerTest.php
@@ -55,7 +55,7 @@ class ExtractMethodHandlerTest extends HandlerTestCase
 
     public function testExtractMethod()
     {
-        $this->extractMethod->extractMethod(
+        $this->extractMethod->__invoke(
             self::SOURCE,
             self::OFFSET_START,
             self::OFFSET_END,

--- a/tests/Unit/Extension/CoreTransform/Rpc/GenerateAccessorHandlerTest.php
+++ b/tests/Unit/Extension/CoreTransform/Rpc/GenerateAccessorHandlerTest.php
@@ -33,7 +33,7 @@ class GenerateAccessorHandlerTest extends HandlerTestCase
 
     public function testGenerateAccessor()
     {
-        $this->generateAccessor->generateAccessor(
+        $this->generateAccessor->__invoke(
             self::SOURCE,
             self::OFFSET
         )->willReturn(SourceCode::fromStringAndPath('asd', '/path'));

--- a/tests/Unit/Extension/CoreTransform/Rpc/ImportClassHandlerTest.php
+++ b/tests/Unit/Extension/CoreTransform/Rpc/ImportClassHandlerTest.php
@@ -95,7 +95,7 @@ class ImportClassHandlerTest extends HandlerTestCase
             ],
         ]);
         $transformed = SourceCode::fromStringAndPath('hello', self::TEST_PATH);
-        $this->importClass->importClass(
+        $this->importClass->__invoke(
             SourceCode::fromStringAndPath(self::TEST_SOURCE, self::TEST_PATH),
             self::TEST_OFFSET,
             self::TEST_NAME,
@@ -115,7 +115,7 @@ class ImportClassHandlerTest extends HandlerTestCase
 
     public function testAsksForAliasIfClassAlreadyUsed()
     {
-        $this->importClass->importClass(
+        $this->importClass->__invoke(
             SourceCode::fromStringAndPath(self::TEST_SOURCE, self::TEST_PATH),
             self::TEST_OFFSET,
             self::TEST_NAME,
@@ -142,7 +142,7 @@ class ImportClassHandlerTest extends HandlerTestCase
     public function testUsesGivenAlias()
     {
         $transformed = SourceCode::fromStringAndPath('hello', self::TEST_PATH);
-        $this->importClass->importClass(
+        $this->importClass->__invoke(
             SourceCode::fromStringAndPath(self::TEST_SOURCE, self::TEST_PATH),
             self::TEST_OFFSET,
             self::TEST_NAME,
@@ -164,7 +164,7 @@ class ImportClassHandlerTest extends HandlerTestCase
 
     public function testShowsMessageIfSelectedClassIsAlreadyImported()
     {
-        $this->importClass->importClass(
+        $this->importClass->__invoke(
             SourceCode::fromStringAndPath(self::TEST_SOURCE, self::TEST_PATH),
             self::TEST_OFFSET,
             self::TEST_NAME,

--- a/tests/Unit/Extension/CoreTransform/Rpc/OverrideMethodHandlerTest.php
+++ b/tests/Unit/Extension/CoreTransform/Rpc/OverrideMethodHandlerTest.php
@@ -69,7 +69,7 @@ class ChildClass extends ParentClass
 EOT
         ;
 
-        $this->overrideMethod->overrideMethod($source, 'ChildClass', 'foobar')->willReturn(TransformSourceCode::fromString('hello'));
+        $this->overrideMethod->__invoke($source, 'ChildClass', 'foobar')->willReturn(TransformSourceCode::fromString('hello'));
 
         $action = $this->handle('override_method', [
             'class_name' => 'ChildClass',

--- a/tests/Unit/Extension/CoreTransform/Rpc/RenameVariableHandlerTest.php
+++ b/tests/Unit/Extension/CoreTransform/Rpc/RenameVariableHandlerTest.php
@@ -74,7 +74,7 @@ class RenameVariableHandlerTest extends HandlerTestCase
 
     public function testRenameVariable()
     {
-        $this->renameVariable->renameVariable(
+        $this->renameVariable->__invoke(
             self::SOURCE,
             self::OFFSET,
             self::VARIABLE_NAME,


### PR DESCRIPTION
This PR integrates the macro work in `code-transform` and just adjusts the existing RPC handlers to call `__invoke` instead of the previous methods.