### PR TITLE
Added hint to help determine cause of bad diagnostic

### DIFF
--- a/lib/Extension/Core/Application/Status.php
+++ b/lib/Extension/Core/Application/Status.php
@@ -56,7 +56,7 @@ class Status
         if (in_array(SourceCodeFilesystemExtension::FILESYSTEM_COMPOSER, $filesystems)) {
             $diagnostics['good'][] = 'Composer detected - faster class location and more features!';
         } else {
-            $diagnostics['bad'][] = 'Composer not found - some functionality will not be available (e.g. class creation) and class location will fallback to scanning the filesystem - this can be slow.';
+            $diagnostics['bad'][] = 'Composer not found - some functionality will not be available (e.g. class creation) and class location will fallback to scanning the filesystem - this can be slow. Make sure you\'ve run `composer install` in your project!';
         }
 
         if (in_array(SourceCodeFilesystemExtension::FILESYSTEM_GIT, $filesystems)) {


### PR DESCRIPTION
It didn't recognize composer on my (freshly check out) project.

After some digging I found it actually tried to find `vendor/autoload.php` instead of `composer.json` or something, and I hadn't yet run composer install :hankey: 

With this extra message it might help people understand better why detection might fail. Although maybe it should even be more specific about `vendor/autoload.php`?