### PR TITLE
fixes updating source from generate method handler

### DIFF
--- a/lib/Extension/CodeTransform/Rpc/GenerateMethodHandler.php
+++ b/lib/Extension/CodeTransform/Rpc/GenerateMethodHandler.php
@@ -51,7 +51,7 @@ class GenerateMethodHandler extends AbstractHandler
 
         return UpdateFileSourceResponse::fromPathOldAndNewSource(
             $sourceCode->path(),
-            file_get_contents($sourceCode->path()),
+            $arguments[self::PARAM_SOURCE],
             (string) $sourceCode
         );
     }


### PR DESCRIPTION
Was using the saved file as a point of reference instead of the passed
source. Fixes #565