### PR TITLE
Completion generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Other:
 
   - [Completion] Completors now `yield` suggestions and problems are no longer
     returned. The `issues` key returned from suggestions is now deprecated.
+  - [Vim Plugin] The "omni error" feature has been removed (as completion no
+    longer returns them).
 
 ## 2018-08-04 0.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ Improvements:
   - [Completion] Completion qualifiers to allow reusable way to determine
     candidate completors.
 
+Other:
+
+  - [Completion] Completors now `yield` suggestions and problems are no longer
+    returned. The `issues` key returned from suggestions is now deprecated.
+
 ## 2018-08-04 0.9.0
 
 BC Breaks:

--- a/composer.lock
+++ b/composer.lock
@@ -362,12 +362,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/JetBrains/phpstorm-stubs.git",
-                "reference": "7c563fb4fe2c671419b0937445df1dc563e95ab5"
+                "reference": "7faeb15c4dae254e3aadc1176463ca1b6e098b80"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/7c563fb4fe2c671419b0937445df1dc563e95ab5",
-                "reference": "7c563fb4fe2c671419b0937445df1dc563e95ab5",
+                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/7faeb15c4dae254e3aadc1176463ca1b6e098b80",
+                "reference": "7faeb15c4dae254e3aadc1176463ca1b6e098b80",
                 "shasum": ""
             },
             "require-dev": {
@@ -392,7 +392,7 @@
                 "stubs",
                 "type"
             ],
-            "time": "2018-10-01 16:12:09"
+            "time": "2018-10-04 13:34:19"
         },
         {
             "name": "lstrojny/functional-php",
@@ -897,12 +897,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/completion.git",
-                "reference": "a526eb922d30a96887541c746cdba8007f2fde10"
+                "reference": "d0385f91b168a6800ca0788295a5fb0289eebe7b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/completion/zipball/a526eb922d30a96887541c746cdba8007f2fde10",
-                "reference": "a526eb922d30a96887541c746cdba8007f2fde10",
+                "url": "https://api.github.com/repos/phpactor/completion/zipball/d0385f91b168a6800ca0788295a5fb0289eebe7b",
+                "reference": "d0385f91b168a6800ca0788295a5fb0289eebe7b",
                 "shasum": ""
             },
             "require": {
@@ -912,6 +912,7 @@
                 "phpbench/phpbench": "^1.0@dev"
             },
             "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.13",
                 "phpactor/test-utils": "^1.0@dev",
                 "phpstan/phpstan": "^0.10.0@dev",
                 "phpunit/phpunit": "^7.0"
@@ -938,7 +939,7 @@
                 }
             ],
             "description": "Completion library for Worse Reflection",
-            "time": "2018-09-25 21:13:24"
+            "time": "2018-10-07 10:19:30"
         },
         {
             "name": "phpactor/docblock",
@@ -1262,12 +1263,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpbench/phpbench.git",
-                "reference": "7a33cea9dcb39fd14c29e69f1dea3070ebecae21"
+                "reference": "dcbe193e1696326b2f026f6d44a16637a61f8e1a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpbench/phpbench/zipball/7a33cea9dcb39fd14c29e69f1dea3070ebecae21",
-                "reference": "7a33cea9dcb39fd14c29e69f1dea3070ebecae21",
+                "url": "https://api.github.com/repos/phpbench/phpbench/zipball/dcbe193e1696326b2f026f6d44a16637a61f8e1a",
+                "reference": "dcbe193e1696326b2f026f6d44a16637a61f8e1a",
                 "shasum": ""
             },
             "require": {
@@ -1283,7 +1284,7 @@
                 "phpbench/container": "~1.2",
                 "phpbench/dom": "~0.2.0",
                 "seld/jsonlint": "^1.0",
-                "symfony/console": "^2.6|^3.0|^4.0",
+                "symfony/console": "^3.2|^4.0",
                 "symfony/debug": "^2.4|^3.0|^4.0",
                 "symfony/filesystem": "^2.4|^3.0|^4.0",
                 "symfony/finder": "^2.4|^3.0|^4.0",
@@ -1330,7 +1331,7 @@
                 }
             ],
             "description": "PHP Benchmarking Framework",
-            "time": "2018-09-08 09:00:14"
+            "time": "2018-10-06 15:25:58"
         },
         {
             "name": "psr/container",
@@ -2367,12 +2368,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "7136aa4e0c5f912e8af82383775460d906168a10"
+                "reference": "a06a649aae5e777094a626897e3b044b65c3a715"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/7136aa4e0c5f912e8af82383775460d906168a10",
-                "reference": "7136aa4e0c5f912e8af82383775460d906168a10",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/a06a649aae5e777094a626897e3b044b65c3a715",
+                "reference": "a06a649aae5e777094a626897e3b044b65c3a715",
                 "shasum": ""
             },
             "require": {
@@ -2455,7 +2456,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2018-08-23 13:15:44"
+            "time": "2018-10-05 09:22:44"
         },
         {
             "name": "myclabs/deep-copy",

--- a/doc/vim-plugin.md
+++ b/doc/vim-plugin.md
@@ -144,15 +144,12 @@ The plugin has some configuration options:
 ```
 let g:phpactorPhpBin = 'php'
 let g:phpactorBranch = 'master'
-let g:phpactorOmniError = v:false
 let g:phpactorOmniAutoClassImport = v:true
 ```
 
 - `g:phpactorPhpBin`: PHP executable to use.
 - `g:phpactorBranch`: Phpactor branch (default is `master`, use `develop` for
   bleeding edge).
-- `g:phpactorOmniError`: Set to `v:true` to enable useful error messages when
-  completion is invoked.
 - `g:phpactorOmniAutoClassImport`: Automatically import classes when
   completing class names with OmniComplete.
 

--- a/lib/Extension/Completion/Application/Complete.php
+++ b/lib/Extension/Completion/Application/Complete.php
@@ -3,6 +3,7 @@
 namespace Phpactor\Extension\Completion\Application;
 
 use Phpactor\Completion\Core\Completor;
+use Phpactor\Completion\Core\Suggestion;
 
 class Complete
 {
@@ -18,11 +19,14 @@ class Complete
 
     public function complete(string $source, int $offset): array
     {
-        $result = $this->competor->complete($source, $offset);
+        $suggestions = iterator_to_array($this->competor->complete($source, $offset));
+        $suggestions = array_map(function (Suggestion $suggestion) {
+            return $suggestion->toArray();
+        }, $suggestions);
 
         return [
-            'suggestions' => $result->suggestions()->sorted()->toArray(),
-            'issues' => $result->issues()->toArray(),
+            'suggestions' => $suggestions,
+            'issues' => [],
         ];
     }
 }

--- a/lib/Extension/Completion/Application/Complete.php
+++ b/lib/Extension/Completion/Application/Complete.php
@@ -26,6 +26,8 @@ class Complete
 
         return [
             'suggestions' => $suggestions,
+
+            // deprecated
             'issues' => [],
         ];
     }

--- a/lib/Extension/Completion/LanguageServer/CompletionHandler.php
+++ b/lib/Extension/Completion/LanguageServer/CompletionHandler.php
@@ -38,22 +38,23 @@ class CompletionHandler implements Handler
     public function __invoke(TextDocumentItem $textDocument, Position $position): Generator
     {
         $textDocument = $this->sessionManager->current()->workspace()->get($textDocument->uri);
-        $completionList = new CompletionList();
 
-        $response = $this->completor->complete(
+        $suggestions = $this->completor->complete(
             $textDocument->text,
             $position->toOffset($textDocument->text)
         );
 
-        /**
-         * @var Suggestion $suggestion
-         */
-        foreach ($response->suggestions() as $suggestion) {
+        $completionList = new CompletionList();
+        $completionList->isIncomplete = true;
+
+        foreach ($suggestions as $suggestion) {
+            /** @var Suggestion $suggestion */
             $completionList->items[] = new CompletionItem(
                 $suggestion->name(),
                 PhpactorToLspCompletionType::fromPhpactorType($suggestion->type()),
                 $suggestion->shortDescription()
             );
+
         }
 
         yield $completionList;

--- a/lib/Extension/Completion/LanguageServer/PhpactorToLspCompletionType.php
+++ b/lib/Extension/Completion/LanguageServer/PhpactorToLspCompletionType.php
@@ -7,7 +7,7 @@ use Phpactor\Completion\Core\Suggestion;
 
 class PhpactorToLspCompletionType
 {
-    public static function fromPhpactorType(string $suggestionType)
+    public static function fromPhpactorType(?string $suggestionType)
     {
         switch ($suggestionType):
             case Suggestion::TYPE_METHOD:

--- a/lib/Test.php
+++ b/lib/Test.php
@@ -1,6 +1,0 @@
-<?php
-
-namespace Phpactor;
-
-
-

--- a/lib/Test.php
+++ b/lib/Test.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace Phpactor;
+
+
+

--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -19,10 +19,6 @@ if !exists('g:phpactorBranch')
     let g:phpactorBranch = 'master'
 endif
 
-if !exists('g:phpactorOmniError')
-    let g:phpactorOmniError = v:false
-endif
-
 if !exists('g:phpactorOmniAutoClassImport')
     let g:phpactorOmniAutoClassImport = v:true
 endif
@@ -92,12 +88,6 @@ function! phpactor#Complete(findstart, base)
             call add(completions, completion)
             let g:_phpactorCompletionMeta[phpactor#_completionItemHash(completion)] = suggestion
         endfor
-    endif
-
-    if !empty(issues)
-        if g:phpactorOmniError
-            echoe join(issues, ', ')
-        endif
     endif
 
     return completions

--- a/tests/System/Extension/Completion/Application/CompleteTest.php
+++ b/tests/System/Extension/Completion/Application/CompleteTest.php
@@ -13,10 +13,13 @@ class CompleteTest extends SystemTestCase
      */
     public function testComplete(string $source, array $expected)
     {
-        $result = $this->complete($source);
+        $suggestions = $this->complete($source)['suggestions'];
+        usort($suggestions, function ($one, $two) {
+            return $one['name'] <=> $two['name'];
+        });
 
         foreach ($expected as $index => $expectedSuggestion) {
-            $this->assertArraySubset($expectedSuggestion, $result['suggestions'][$index]);
+            $this->assertArraySubset($expectedSuggestion, $suggestions[$index]);
         }
     }
 
@@ -289,72 +292,5 @@ EOT
         $result = $complete->complete($source, $offset);
 
         return $result;
-    }
-
-    /**
-     * @dataProvider provideErrors
-     */
-    public function testErrors(string $source, array $expected)
-    {
-        $results = $this->complete($source);
-        $this->assertEquals($expected, $results['issues']);
-    }
-
-    public function provideErrors()
-    {
-        return [
-            [
-                <<<'EOT'
-<?php
-
-$asd = 'asd';
-$asd-><>
-EOT
-                ,
-                [
-                    'Cannot complete members on scalar value (string)',
-                ]
-            ],
-            [
-                <<<'EOT'
-<?php
-
-$asd-><>
-EOT
-                ,
-                [
-                    'Variable "asd" is undefined',
-                ]
-            ],
-            [
-                <<<'EOT'
-<?php
-
-$asd = new BooBar();
-$asd-><>
-EOT
-                ,
-                [
-                    'Could not find class "BooBar"',
-                ]
-            ],
-            [
-                <<<'EOT'
-<?php
-
-class Foobar
-{
-    public $foobar;
-}
-
-$foobar = new Foobar();
-$foobar->barbar-><>;
-EOT
-                ,
-                [
-                    'Class "Foobar" has no properties named "barbar"',
-                ]
-            ]
-        ];
     }
 }

--- a/tests/Unit/Extension/Completion/LanguageServer/CompletionHandlerTest.php
+++ b/tests/Unit/Extension/Completion/LanguageServer/CompletionHandlerTest.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Phpactor\Tests\Unit\Extension\Completion\LanguageServer;
+
+class CompletionHandlerTest
+{
+}

--- a/tests/Unit/Extension/Completion/LanguageServer/CompletionHandlerTest.php
+++ b/tests/Unit/Extension/Completion/LanguageServer/CompletionHandlerTest.php
@@ -2,6 +2,87 @@
 
 namespace Phpactor\Tests\Unit\Extension\Completion\LanguageServer;
 
-class CompletionHandlerTest
+use Generator;
+use LanguageServerProtocol\CompletionItem;
+use LanguageServerProtocol\CompletionList;
+use LanguageServerProtocol\Position;
+use LanguageServerProtocol\TextDocumentItem;
+use PHPUnit\Framework\TestCase;
+use Phpactor\Completion\Core\Completor;
+use Phpactor\Completion\Core\Suggestion;
+use Phpactor\Extension\Completion\LanguageServer\CompletionHandler;
+use Phpactor\LanguageServer\Core\Handler;
+use Phpactor\LanguageServer\Core\Session\Manager;
+
+class CompletionHandlerTest extends TestCase
 {
+    /**
+     * @var Manager
+     */
+    private $manager;
+
+    /**
+     * @var TextDocumentItem
+     */
+    private $document;
+
+    /**
+     * @var Position
+     */
+    private $position;
+
+
+    public function setUp()
+    {
+        $this->manager = new Manager();
+        $this->manager->initialize('foo');
+        $this->document = new TextDocumentItem();
+        $this->document->uri = 'test';
+        $this->document->text = 'hello';
+        $this->position = new Position(1, 1);
+
+        $this->manager->current()->workspace()->open($this->document);
+    }
+
+    public function testHandleNoSuggestions()
+    {
+        $handler = $this->create([]);
+        $generator = $handler->__invoke($this->document, $this->position);
+        $this->assertInstanceOf(CompletionList::class, $generator->current());
+        $list = $generator->current();
+        $this->assertEquals([], $list->items);
+    }
+
+    public function testHandleSuggestions()
+    {
+        $handler = $this->create([
+            Suggestion::create('hello'),
+            Suggestion::create('goodbye'),
+        ]);
+        $generator = $handler->__invoke($this->document, $this->position);
+        $this->assertInstanceOf(CompletionList::class, $generator->current());
+        $list = $generator->current();
+        $this->assertEquals([
+            new CompletionItem('hello'),
+            new CompletionItem('goodbye'),
+        ], $list->items);
+    }
+
+    private function create(array $suggestions): Handler
+    {
+        return new CompletionHandler($this->manager, new class($suggestions) implements Completor {
+            private $suggestions;
+            public function __construct(array $suggestions) 
+            {
+                $this->suggestions = $suggestions;
+            }
+
+            public function complete(string $source, int $offset): Generator
+            {
+                foreach ($this->suggestions as $suggestion) {
+                    yield $suggestion;
+                }
+            }
+        });
+    }
 }


### PR DESCRIPTION
The completion `Completor` instances now return generators of `Suggestion` instances. This means it can stream results to clients rather than blocking until all completions can be resolved.

Unfortunately there was no simple way to maintain the list of issues encountred when building the completion list, so this feature has been removed. We could re-introduce the feature if it seems that it is missed, but linters should do this job anyway.