### PR TITLE
Add troubleshooting to vim-plugin doc

### DIFF
--- a/doc/vim-plugin.md
+++ b/doc/vim-plugin.md
@@ -73,8 +73,15 @@ auto-completion can still work (sometimes slowly depending on project size).
 
 **E117: Unknown function: phpactor#Status**:
 
-When using vim-plug, you will need to open a PHP file before Phpactor is registered.
-For best results, `cd` to a project that uses Git and Composer before starting Vim.
+Vim-plug and most other package managers for Vim will lazy-load Phpactor when it's
+needed, i.e. when opening a PHP file. If you get this error, open a PHP file and
+run the command again.
+
+**Composer not found** or **Git not detected**:
+
+The Git and Composer checks are referring to the current "workspace" (i.e. where you
+started Vim from). If you've already setup Git and Composer for your project, ensure
+you are starting Vim from the project directory to enable detection.
 
 Updating
 --------

--- a/doc/vim-plugin.md
+++ b/doc/vim-plugin.md
@@ -69,6 +69,13 @@ Config files
 Phpactor works best with Composer - but much functionality including
 auto-completion can still work (sometimes slowly depending on project size).
 
+### Troubleshooting
+
+**E117: Unknown function: phpactor#Status**:
+
+When using vim-plug, you will need to open a PHP file before Phpactor is registered.
+For best results, `cd` to a project that uses Git and Composer before starting Vim.
+
 Updating
 --------
 


### PR DESCRIPTION
I've been bitten by #507 on more than one occasion: setting up Phpactor yields the dreaded **E117: Unknown function: phpactor#Status** as I'm attempting to do it from my vim config and not a PHP file.

This adds some text to the doc to hopefully workaround the confusion for new users or those like me with the memory of a goldfish.