### PR TITLE
include symfony debug as dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,4 +52,3 @@ jobs:
         - curl -OS http://couscous.io/couscous.phar
       script:
         - php couscous.phar travis-auto-deploy
-

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "phpactor/rpc-extension": "dev-master",
         "phpactor/source-code-filesystem-extension": "dev-master",
         "phpactor/worse-reflection-extension": "dev-master",
-        "phpactor/console-extension": "dev-master"
+        "phpactor/console-extension": "dev-master",
+        "symfony/debug": "^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "52911fd43097aa04713972824e343b64",
+    "content-hash": "1f1aea76f2bb07c30a98ca53dd069480",
     "packages": [
         {
             "name": "composer/xdebug-handler",
@@ -1849,6 +1849,62 @@
                 "standards"
             ],
             "time": "2018-10-31 08:00:32"
+        },
+        {
+            "name": "symfony/debug",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/debug.git",
+                "reference": "0aae90af4e1e7fc5b14928ca424056f9e7046cf4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/0aae90af4e1e7fc5b14928ca424056f9e7046cf4",
+                "reference": "0aae90af4e1e7fc5b14928ca424056f9e7046cf4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "psr/log": "~1.0"
+            },
+            "conflict": {
+                "symfony/http-kernel": "<3.4"
+            },
+            "require-dev": {
+                "symfony/http-kernel": "~3.4|~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Debug\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Debug Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-11-11 19:52:12"
         },
         {
             "name": "symfony/filesystem",
@@ -4349,62 +4405,6 @@
                 "validator"
             ],
             "time": "2018-01-24T12:46:19+00:00"
-        },
-        {
-            "name": "symfony/debug",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/debug.git",
-                "reference": "85c1365d7a07678aac602a02d5b01278efc7b634"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/85c1365d7a07678aac602a02d5b01278efc7b634",
-                "reference": "85c1365d7a07678aac602a02d5b01278efc7b634",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1.3",
-                "psr/log": "~1.0"
-            },
-            "conflict": {
-                "symfony/http-kernel": "<3.4"
-            },
-            "require-dev": {
-                "symfony/http-kernel": "~3.4|~4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.2-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Debug\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Debug Component",
-            "homepage": "https://symfony.com",
-            "time": "2018-10-31 09:23:02"
         },
         {
             "name": "symfony/event-dispatcher",


### PR DESCRIPTION
It was noticed that Phpactor didn't run with `composer install --no-dev` as the main `bin/phpactor` file enables the symfony Debug error handler.

Having this enabled is useful in development (ensuring that errors are always presented as exceptions), and presents no security risk or performance penalty in the context of the tool that I'm aware of.

So adding as a regular dependency for now.



