### PR TITLE
Define application root path according to location of vendor folder

### DIFF
--- a/lib/Phpactor.php
+++ b/lib/Phpactor.php
@@ -51,7 +51,7 @@ class Phpactor
 
         $config = $loader->load();
         $config[CoreExtension::COMMAND] = $input->getFirstArgument();
-        $config[FilePathResolverExtension::PARAM_APPLICATION_ROOT] = realpath(__DIR__ . '/..');
+        $config[FilePathResolverExtension::PARAM_APPLICATION_ROOT] = self::resolveApplicationRoot();
         $config = self::configureExtensionManager($config, $vendorDir);
 
         if ($input->hasParameterOption([ '--working-dir', '-d' ])) {
@@ -185,5 +185,18 @@ class Phpactor
         }
 
         return $config;
+    }
+
+    private static function resolveApplicationRoot(): string
+    {
+        $paths = [ __DIR__ . '/..', __DIR__ .'/../../../..' ];
+
+        foreach ($paths as $path) {
+            if (is_dir(realpath($path.'/vendor'))) {
+                return realpath($path);
+            }
+        }
+
+        throw new RuntimeException(sprintf('Could not resolve application root, tried "%s"', implode('", "', $paths)));
     }
 }


### PR DESCRIPTION
Application path is defined differently when phpactor is installed through composer (as a required package)