### PR TITLE
Log errors in application error handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Changelog
   - [completion] Do not suggest static members on non-static calls and
     vice-versa.
 
+  - [application] Log errors in command error handler (for logging async
+    completion errors using the complete command)
+
 ## 2018-12-02 0.11.0
 
 BC Break:

--- a/lib/Application.php
+++ b/lib/Application.php
@@ -83,6 +83,8 @@ class Application extends SymfonyApplication
             ],
         ];
 
+        $this->container->get('logging.logger')->error($e->getMessage());
+
         while ($e = $e->getPrevious()) {
             $errors['previous'][] = $this->serializeException($e);
         }


### PR DESCRIPTION
When exceptions are thrown during the `complete` command, they are serialized to STDOUT, but they are not logged with the logging system, making it difficult to debug integrations (e.g. the ncm2-phpactor integration).

This PR enables logging in the application exception handler. Note that the `complete` command should be deprecated, or at least delegate to the RPC handler.