### PR TITLE
dantleech/what-changed: 3 updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Improvements:
   - [code-transform] Support extracting expressions to methods #666
   - [code-transform] Extract method adds return statement to calling code if
     extracted code contained a return #704
+  - [worse-reflection] Support union catch #711
 
 Bug fixes:
 
@@ -39,6 +40,8 @@ Bug fixes:
   - [completion] Include `$` on static properties #677
   - [extension-manager] Do not install dev dependencies for extensions #674
   - [class-to-file] sort candidates by path length #712 thanks @greg0ire
+  - [code-transform] Rename variable includes anonumous function use #713
+  - [worse-reflection] Do not downcast union types in named docblocks #711
 
 ## 2018-12-02 0.11.0
 

--- a/composer.lock
+++ b/composer.lock
@@ -766,12 +766,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/code-builder.git",
-                "reference": "f3364cbc4d5ddfa10ff5058b23d9a96647bd006b"
+                "reference": "4269d94e76413a98359e9e9ec792f91134871268"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/code-builder/zipball/f3364cbc4d5ddfa10ff5058b23d9a96647bd006b",
-                "reference": "f3364cbc4d5ddfa10ff5058b23d9a96647bd006b",
+                "url": "https://api.github.com/repos/phpactor/code-builder/zipball/4269d94e76413a98359e9e9ec792f91134871268",
+                "reference": "4269d94e76413a98359e9e9ec792f91134871268",
                 "shasum": ""
             },
             "require": {
@@ -806,7 +806,7 @@
                 }
             ],
             "description": "Generating and modifying source code",
-            "time": "2019-01-06T17:46:32+00:00"
+            "time": "2019-01-19T12:28:05+00:00"
         },
         {
             "name": "phpactor/code-transform",
@@ -814,12 +814,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/code-transform.git",
-                "reference": "d1981454cac55dfcc3500a0eb298bf92f2557525"
+                "reference": "cba700d93f485042d212a3a8325b423f20dccfb4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/code-transform/zipball/d1981454cac55dfcc3500a0eb298bf92f2557525",
-                "reference": "d1981454cac55dfcc3500a0eb298bf92f2557525",
+                "url": "https://api.github.com/repos/phpactor/code-transform/zipball/cba700d93f485042d212a3a8325b423f20dccfb4",
+                "reference": "cba700d93f485042d212a3a8325b423f20dccfb4",
                 "shasum": ""
             },
             "require": {
@@ -856,7 +856,7 @@
                 }
             ],
             "description": "Applies introspective transformations on source code",
-            "time": "2019-01-13T09:03:32+00:00"
+            "time": "2019-01-19T12:32:52+00:00"
         },
         {
             "name": "phpactor/code-transform-extension",
@@ -2052,12 +2052,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/worse-reflection.git",
-                "reference": "07ea6dd7231fee10f62b5c986b72f30dde857c1e"
+                "reference": "4892ffd1d575ecb106c5ee69fc40d9673d1b293f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/worse-reflection/zipball/07ea6dd7231fee10f62b5c986b72f30dde857c1e",
-                "reference": "07ea6dd7231fee10f62b5c986b72f30dde857c1e",
+                "url": "https://api.github.com/repos/phpactor/worse-reflection/zipball/4892ffd1d575ecb106c5ee69fc40d9673d1b293f",
+                "reference": "4892ffd1d575ecb106c5ee69fc40d9673d1b293f",
                 "shasum": ""
             },
             "require": {
@@ -2099,7 +2099,7 @@
                 }
             ],
             "description": "Lazy AST reflector that is much worse than better",
-            "time": "2019-01-13T08:52:14+00:00"
+            "time": "2019-01-19T12:15:46+00:00"
         },
         {
             "name": "phpactor/worse-reflection-extension",


### PR DESCRIPTION
Fixes #715, #713 and #711 
```
phpactor/code-builder f3364cbc..4269d94e

    [2019-01-19 12:27:36] 4269d94e dantleech do not include virtual methods in prototype

  phpactor/code-transform d1981454..cba700d9

    [2019-01-19 12:32:52] cba700d9 dantleech support use variable name in rename

  phpactor/worse-reflection 07ea6dd7..4892ffd1

    [2019-01-19 12:06:40] 5b2bb567 dantleech support injected named union types
    [2019-01-19 12:15:19] 4892ffd1 dantleech support catch type hint union
```