### PR TITLE
Update Slack invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,4 @@ Community
 ---------
 
 - Follow [@phpactor](https://twitter.com/phpactor) for the latest news.
-- Join the `#phpactor` channel on the Slack [Symfony
-  Devs](https://symfony-devs.slack.com/join/shared_invite/enQtMzM3NDA1NzEyMzg0LTgyNGYwYjFjMjY5YjllYWZkYTY2OWM4MDQzZTgzMmNjNGI3ZDJhYzE2Yjc4NmFmM2JiOTZjODg2MGJlM2RjMDU)
-  channel.
+- Join the `#phpactor` channel on the Slack [Symfony Devs](https://symfony.com/slack-invite) channel.


### PR DESCRIPTION
The Slack invite link in README had expired. Updates to use one that redirects which should avoid future expiry.