### PR TITLE
Allow case insensitive search in vim autocompletion

### DIFF
--- a/doc/vim-plugin.md
+++ b/doc/vim-plugin.md
@@ -162,6 +162,7 @@ The plugin has some configuration options:
 let g:phpactorPhpBin = 'php'
 let g:phpactorBranch = 'master'
 let g:phpactorOmniAutoClassImport = v:true
+let g:phpactorCompletionIgnoreCase = 0
 ```
 
 - `g:phpactorPhpBin`: PHP executable to use.
@@ -169,6 +170,9 @@ let g:phpactorOmniAutoClassImport = v:true
   bleeding edge).
 - `g:phpactorOmniAutoClassImport`: Automatically import classes when
   completing class names with OmniComplete.
+- `g:phpactorCompletionIgnoreCase`: Ignore case when searching completion
+  candidates.
+
 
 Extensions
 ----------

--- a/doc/vim-plugin.md
+++ b/doc/vim-plugin.md
@@ -162,7 +162,6 @@ The plugin has some configuration options:
 let g:phpactorPhpBin = 'php'
 let g:phpactorBranch = 'master'
 let g:phpactorOmniAutoClassImport = v:true
-let g:phpactorCompletionIgnoreCase = 0
 ```
 
 - `g:phpactorPhpBin`: PHP executable to use.
@@ -170,8 +169,6 @@ let g:phpactorCompletionIgnoreCase = 0
   bleeding edge).
 - `g:phpactorOmniAutoClassImport`: Automatically import classes when
   completing class names with OmniComplete.
-- `g:phpactorCompletionIgnoreCase`: Ignore case when searching completion
-  candidates.
 
 
 Extensions
@@ -207,12 +204,18 @@ autocmd FileType php setlocal omnifunc=phpactor#Complete
 To invoke omni complete in insert mode `<C-x><C-o>` (`ctrl-x` then `ctrl-o`).
 See `:help compl-omni`.
 
+For case sensitive searching, set
+```vimscript
+let g:phpactorCompletionIgnoreCase = 0
+```
+
 Omni complete can also provide feedback when something fails to complete, this
 can be useful, enable it with:
 
 ```
 let g:phpactorOmniError = v:true
 ```
+
 
 Completion plugins
 ------------------

--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -25,7 +25,7 @@ if !exists('g:phpactorOmniAutoClassImport')
 endif
 
 if !exists('g:phpactorCompletionIgnoreCase')
-    let g:phpactorCompletionIgnoreCase = 0
+    let g:phpactorCompletionIgnoreCase = 1
 endif
 
 if g:phpactorOmniAutoClassImport == v:true

--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -24,6 +24,10 @@ if !exists('g:phpactorOmniAutoClassImport')
     let g:phpactorOmniAutoClassImport = v:true
 endif
 
+if !exists('g:phpactorCompletionIgnoreCase')
+    let g:phpactorCompletionIgnoreCase = 0
+endif
+
 if g:phpactorOmniAutoClassImport == v:true
     autocmd CompleteDone *.php call phpactor#_completeImportClass(v:completed_item)
 endif
@@ -85,7 +89,8 @@ function! phpactor#Complete(findstart, base)
                         \ 'abbr': phpactor#_completeTruncateLabel(suggestion['label'], g:phpactorCompleteLabelTruncateLength),
                         \ 'menu': suggestion['short_description'],
                         \ 'kind': suggestion['type'],
-                        \ 'dup': 1
+                        \ 'dup': 1,
+                        \ 'icase': g:phpactorCompletionIgnoreCase
                         \ }
             call add(completions, completion)
             let g:_phpactorCompletionMeta[phpactor#_completionItemHash(completion)] = suggestion


### PR DESCRIPTION
Introduces global variable g:phpactorCompletionIgnoreCase (0 by default),
which if set to 1, allows case insensitive search for completion.