### PR TITLE
Update to include latest code-transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Bug fixes:
   - [worse-reflection] Do not downcast union types in named docblocks #711
   - [code-transform] Extract method sometimes creates method in new class in
     same file #730
+  - [code-transform] Add Missing Properties added trait props in new class #726
 
 ## 2018-12-02 0.11.0
 

--- a/composer.lock
+++ b/composer.lock
@@ -814,12 +814,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/code-transform.git",
-                "reference": "111409cab6b03d8908c5717dbb0b786582224080"
+                "reference": "c75b56e12cbc56a9d0cd0b8c172a8dd6020e78ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/code-transform/zipball/111409cab6b03d8908c5717dbb0b786582224080",
-                "reference": "111409cab6b03d8908c5717dbb0b786582224080",
+                "url": "https://api.github.com/repos/phpactor/code-transform/zipball/c75b56e12cbc56a9d0cd0b8c172a8dd6020e78ad",
+                "reference": "c75b56e12cbc56a9d0cd0b8c172a8dd6020e78ad",
                 "shasum": ""
             },
             "require": {
@@ -856,7 +856,7 @@
                 }
             ],
             "description": "Applies introspective transformations on source code",
-            "time": "2019-02-03T11:50:31+00:00"
+            "time": "2019-02-03T19:02:29+00:00"
         },
         {
             "name": "phpactor/code-transform-extension",


### PR DESCRIPTION
Last night's `composer.lock` commit (#734) brought `code-builder` up to date but missed the PR merge in `code-transform`. Without that, #726 is still an issue so this pulls in the latest changes to resolve it.