### PR TITLE
Check if vim plugin is already loaded and exit early.

### DIFF
--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -6,6 +6,11 @@
 " | _|      |__|  |__| | _|    /__/     \__\ \______|    |__|      \______/  | _| `._____|
 "                                                                                         
 
+if exists('g:phpactorLoaded')
+  finish
+endif
+
+let g:phpactorLoaded = 1
 let g:phpactorpath = expand('<sfile>:p:h') . '/..'
 let g:phpactorbinpath = g:phpactorpath. '/bin/phpactor'
 let g:phpactorInitialCwd = getcwd()


### PR DESCRIPTION
I'm using native `packages` feature and adding phpactor only for `php` filetype:

```vimL
autocmd FileType php packadd phpactor
```

When i try to jump to definition, vim does packadd again, and it fails with these errors:

```vimL
E127: Cannot redefine function phpactor#GotoDefinition: It is in use                                                                                                                                                                                                              
line  316:                                                                                                                                                                                                                                                                        
E127: Cannot redefine function phpactor#_switchToBufferOrEdit: It is in use                                                                                                                                                                                                       
line  423:                                                                                                                                                                                                                                                                        
E127: Cannot redefine function phpactor#rpc: It is in use                                                                                                                                                                                                                         
line  667:                                                                                                                                                                                                                                                                        
E127: Cannot redefine function phpactor#_rpc_dispatch: It is in use   
```

This PR prevents that from happening. It is also generally a good practice when writing a vim plugin to have this check, just to avoid constant loading of the same code.

