### PR TITLE
Add PHP open tag in template example

### DIFF
--- a/doc/templates.md
+++ b/doc/templates.md
@@ -25,6 +25,8 @@ In order to create the above variant we need to create a template locally in
 directories, in a `templates` folder):
 
 ```twig
+<?php
+
 {# /path/to/project/.phpactor/templates/phpunit_test/SourceCode.php.twig #}
 namespace {{ prototype.namespace }};
 


### PR DESCRIPTION
Hi Dan (and other contributors): thanks for this awesome tool :pray: 

This PR just fixes a thing in the [templates documentation](https://phpactor.github.io/phpactor/templates.html):
The example could let the user think that phpactor will automatically prepend `<?php\n` to the file, but it is not.