### PR TITLE
Adds fzf support for list input

### DIFF
--- a/autoload/phpactor/input.vim
+++ b/autoload/phpactor/input.vim
@@ -1,0 +1,68 @@
+function! phpactor#input#text(label, default, completionType, ResultHandler)
+    if v:null != a:completionType
+        let text = input(a:label, a:default, a:completionType)
+    else
+        let text = input(a:label, a:default)
+    endif
+
+    call a:ResultHandler(text)
+endfunction
+
+function! phpactor#input#confirm(label, default, completionType, ResultHandler)
+    let choice = confirm(inputParameters["label"], "&Yes\n&No\n")
+
+    if choice == 1
+        let response = v:true
+    else
+        let response = v:false
+    endif
+
+    call a:ResultHandler(response)
+endfunction
+
+function! phpactor#input#choice(label, choices, ResultHandler)
+    let list = []
+    let choices = []
+    let usedShortcuts = []
+
+    if empty(a:choices)
+        call confirm("No choices available")
+        throw "cancelled"
+    endif
+
+    for choiceLabel in keys(a:choices)
+        let buffer = []
+        let foundShortcut = v:false
+
+        for char in split(choiceLabel, '\zs')
+            if v:false == foundShortcut && -1 == index(usedShortcuts, tolower(char))
+                call add(buffer, '&')
+                let foundShortcut = v:true
+                call add(usedShortcuts, tolower(char))
+            endif
+
+            call add(buffer, char)
+        endfor
+
+        let confirmLabel = join(buffer, "")
+
+        call add(list, confirmLabel)
+        call add(choices, choiceLabel)
+    endfor
+
+    let choice = confirm(a:label, join(list, "\n"))
+
+    if (choice == 0)
+        " this is an exception, not a message!
+        throw "cancelled"
+    endif
+
+    call a:ResultHandler(choices[choice - 1])
+endfunction
+
+function! phpactor#input#list(label, choices, ResultHandler)
+    let choices = sort(keys(a:choices))
+
+    let strategy = phpactor#input#list#strategy()
+    call call('phpactor#input#list#'. strategy, [a:label, choices, a:ResultHandler])
+endfunction

--- a/autoload/phpactor/input.vim
+++ b/autoload/phpactor/input.vim
@@ -8,8 +8,8 @@ function! phpactor#input#text(label, default, completionType, ResultHandler)
     call a:ResultHandler(text)
 endfunction
 
-function! phpactor#input#confirm(label, default, completionType, ResultHandler)
-    let choice = confirm(inputParameters["label"], "&Yes\n&No\n")
+function! phpactor#input#confirm(label, ResultHandler)
+    let choice = confirm(a:label, "&Yes\n&No\n")
 
     if choice == 1
         let response = v:true

--- a/autoload/phpactor/input.vim
+++ b/autoload/phpactor/input.vim
@@ -63,6 +63,11 @@ endfunction
 function! phpactor#input#list(label, choices, ResultHandler)
     let choices = sort(keys(a:choices))
 
-    let strategy = phpactor#input#list#strategy()
-    call call('phpactor#input#list#'. strategy, [a:label, choices, a:ResultHandler])
+    try
+      let strategy = phpactor#input#list#strategy()
+      call call(strategy, [a:label, choices, a:ResultHandler])
+    catch /E117/
+      redraw!
+      echo 'The strategy "'. strategy .'" is unknown, check the value of "g:phpactorInputListStrategy".'
+    endtry
 endfunction

--- a/autoload/phpactor/input/list.vim
+++ b/autoload/phpactor/input/list.vim
@@ -1,0 +1,40 @@
+function! phpactor#input#list#strategy()
+    if !has_key(g:, 'phpactor#input#list#strategy')
+        let g:phpactor#input#list#strategy = s:auto_detect_strategy()
+    endif
+
+    return g:phpactor#input#list#strategy
+endfunction
+
+function! phpactor#input#list#inputlist(label, choices, ResultHandler)
+    echo a:label
+    let choice = inputlist(s:add_number_to_choices(a:choices))
+
+    if (choice == 0)
+        throw "cancelled"
+    endif
+
+    call a:ResultHandler(a:choices[choice - 1])
+endfunction
+
+function! phpactor#input#list#fzf(label, choices, ResultHandler)
+    " sink works because "key" is converted to integer, so only the number is kept
+    call fzf#run({
+        \ 'source': s:add_number_to_choices(a:choices),
+        \ 'sink': {key -> a:ResultHandler(a:choices[key - 1])},
+        \ 'down': '30%',
+        \ 'options': ['--tiebreak=index', '--layout=reverse-list']
+    \ })
+endfunction
+
+function! s:auto_detect_strategy()
+    if get(g:, 'loaded_fzf', 0)
+        return 'fzf'
+    endif
+
+    return 'inputlist'
+endfunction
+
+function! s:add_number_to_choices(choices)
+    return map(copy(a:choices), {key, value -> key + 1 .') '. value})
+endfunction

--- a/autoload/phpactor/input/list.vim
+++ b/autoload/phpactor/input/list.vim
@@ -1,9 +1,9 @@
 function! phpactor#input#list#strategy()
-    if !has_key(g:, 'phpactor#input#list#strategy')
-        let g:phpactor#input#list#strategy = s:auto_detect_strategy()
+    if !has_key(g:, 'phpactorInputListStrategy')
+        let g:phpactorInputListStrategy = s:auto_detect_strategy()
     endif
 
-    return g:phpactor#input#list#strategy
+    return g:phpactorInputListStrategy
 endfunction
 
 function! phpactor#input#list#inputlist(label, choices, ResultHandler)

--- a/autoload/phpactor/input/list.vim
+++ b/autoload/phpactor/input/list.vim
@@ -1,5 +1,11 @@
 function! phpactor#input#list#strategy()
-    if !has_key(g:, 'phpactorInputListStrategy')
+    if has_key(g:, 'phpactorInputListStrategy')
+        return g:phpactorInputListStrategy
+    endif
+
+    if has_key(g:, 'phpactorCustomInputListStrategy')
+        let g:phpactorInputListStrategy = g:phpactorCustomInputListStrategy
+    else
         let g:phpactorInputListStrategy = s:auto_detect_strategy()
     endif
 
@@ -28,11 +34,13 @@ function! phpactor#input#list#fzf(label, choices, ResultHandler)
 endfunction
 
 function! s:auto_detect_strategy()
+    let strategy = 'inputlist'
+
     if get(g:, 'loaded_fzf', 0)
-        return 'fzf'
+        let strategy = 'fzf'
     endif
 
-    return 'inputlist'
+    return 'phpactor#input#list#'. strategy
 endfunction
 
 function! s:add_number_to_choices(choices)

--- a/doc/vim-plugin.md
+++ b/doc/vim-plugin.md
@@ -161,10 +161,25 @@ Configuration
 
 The plugin has some configuration options:
 
-```
+```vim
 let g:phpactorPhpBin = 'php'
 let g:phpactorBranch = 'master'
 let g:phpactorOmniAutoClassImport = v:true
+let g:phpactorInputListStrategy = 'inputlist|fzf'
+
+" Example of implementation with vim's inputlist() function
+function! InputListCustomStrategy(label, choices, ResultHandler)
+    echo a:label
+    let choice = inputlist(s:add_number_to_choices(a:choices))
+
+    if (choice == 0)
+        throw "cancelled"
+    endif
+
+    call a:ResultHandler(a:choices[choice - 1])
+endfunction
+
+let g:phpactorCustomInputListStrategy = 'InputListCustomStrategy'
 ```
 
 - `g:phpactorPhpBin`: PHP executable to use.
@@ -172,7 +187,9 @@ let g:phpactorOmniAutoClassImport = v:true
   bleeding edge).
 - `g:phpactorOmniAutoClassImport`: Automatically import classes when
   completing class names with OmniComplete.
-
+- `g:phpactorInputListStrategy`: Select a strategy for the [Input
+  List](#input-list).
+- `g:phpactorCustomInputListStrategy`: Specify your own strategy.
 
 Extensions
 ----------
@@ -272,3 +289,23 @@ should see something like the following:
 Method "execute":
 [r]eplace_references, (f)ind_references, (g)enerate_method, g(o)to_definition:
 ```
+
+Input List
+----------
+
+The input list is the window shown to let you choose an item among a list.
+
+### Strategies
+
+This plugin provides two strategy to handle input lists:
+- `inputlist`: Vim's internal `inputlist()` function.
+- `fzf`: Fuzzy finder using [Fzf](https://github.com/junegunn/fzf) plugin.
+
+You can choose between those strategies by specifying the option
+[g:phpactorInputListStrategy](#configuration).
+
+### Input list strategies auto-detection
+
+When no strategy is defined the plugin will default to the `fzf` strategy if
+the [Fzf](https://github.com/junegunn/fzf) plugin is loaded or to `inputlist`
+if it's not.

--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -441,69 +441,6 @@ function! phpactor#rpc(action, arguments)
     endif
 endfunction
 
-function! phpactor#_input_choice(label, choices)
-    let list = []
-    let choices = []
-    let usedShortcuts = []
-
-    if empty(a:choices)
-        call confirm("No choices available")
-        throw "cancelled"
-    endif
-
-    for choiceLabel in keys(a:choices)
-        let buffer = []
-        let foundShortcut = v:false
-
-        for char in split(choiceLabel, '\zs')
-            if v:false == foundShortcut && -1 == index(usedShortcuts, tolower(char))
-                call add(buffer, '&')
-                let foundShortcut = v:true
-                call add(usedShortcuts, tolower(char))
-            endif
-
-            call add(buffer, char)
-        endfor
-
-        let confirmLabel = join(buffer, "")
-
-        call add(list, confirmLabel)
-        call add(choices, choiceLabel)
-    endfor
-
-    let choice = confirm(a:label, join(list, "\n"))
-
-    if (choice == 0)
-        " this is an exception, not a message!
-        throw "cancelled"
-    endif
-
-    let choice = choice - 1
-    return a:choices[get(choices, choice)]
-endfunction
-
-function! phpactor#_input_list(label, choices)
-    let list = []
-    let choices = []
-
-    let c = 1
-    for choiceLabel in keys(a:choices)
-        call add(list, c . ") " . choiceLabel)
-        call add(choices, choiceLabel)
-        let c = c + 1
-    endfor
-
-    echo a:label
-    let choice = inputlist(list)
-
-    if (choice == 0)
-        throw "cancelled"
-    endif
-
-    let choice = choice - 1
-    return a:choices[choices[choice]]
-endfunction
-
 function! phpactor#_rpc_dispatch(actionName, parameters)
 
     " >> return_choice
@@ -633,21 +570,11 @@ function! phpactor#_rpc_dispatch(actionName, parameters)
 
     " >> input_callback
     if a:actionName == "input_callback"
+        let inputs = a:parameters['inputs']
+        let action = a:parameters['callback']['action']
         let parameters = a:parameters['callback']['parameters']
-        for input in a:parameters['inputs']
 
-            try 
-                let value = phpactor#_rpc_dispatch_input(input['type'], input['parameters'])
-            catch /cancelled/
-                execute ':redraw'
-                echo "Cancelled"
-                return
-            endtry
-
-            let parameters[input['name']] = value
-        endfor
-        call phpactor#rpc(a:parameters['callback']['action'], parameters)
-        return
+        return phpactor#_rpc_dispatch_input(inputs, action, parameters)
     endif
 
     " >> information
@@ -708,38 +635,53 @@ function! phpactor#_rpc_dispatch(actionName, parameters)
     throw "Do not know how to handle action '" . a:actionName . "'"
 endfunction
 
-function! phpactor#_rpc_dispatch_input(type, parameters)
+function! phpactor#_rpc_dispatch_input_handler(Next, parameters, parameterName, result)
+    let a:parameters[a:parameterName] = a:result
+
+    call a:Next(a:parameters)
+endfunction
+
+function! phpactor#_rpc_dispatch_input(inputs, action, parameters)
+    let input = remove(a:inputs, 0)
+    let inputParameters = input['parameters']
+
+    let Next = empty(a:inputs)
+        \ ? function('phpactor#rpc', [a:action])
+        \ : function('phpactor#_rpc_dispatch_input', [a:inputs, a:action])
+
+    let ResultHandler = function('phpactor#_rpc_dispatch_input_handler', [
+        \ Next,
+        \ a:parameters,
+        \ input['name'],
+    \ ])
+
     " Remove any existing output in the message window
     execute ':redraw'
 
-    " >> text
-    if a:type == 'text'
-        if v:null != a:parameters['type']
-            return input(a:parameters['label'], a:parameters['default'], a:parameters['type'])
-        endif
-        return input(a:parameters['label'], a:parameters['default'])
+    if 'text' == input['type']
+        let TypeHandler = function('phpactor#input#text', [
+            \ inputParameters['label'],
+            \ inputParameters['default'],
+            \ inputParameters['type']
+        \ ])
+    elseif 'choice' == input['type']
+        let TypeHandler = function('phpactor#input#choice', [
+            \ inputParameters['label'],
+            \ inputParameters['choices']
+        \ ])
+    elseif 'list' == input['type']
+        let TypeHandler = function('phpactor#input#list', [
+            \ inputParameters['label'],
+            \ inputParameters['choices']
+        \ ])
+    elseif 'confirm' == input['type']
+        let TypeHandler = function('phpactor#input#confirm', [
+            \ inputParameters['label'],
+            \ '&Yes\n&No\n'
+        \ ])
+    else
+        throw "Do not know how to handle input '" . input['type'] . "'"
     endif
 
-    " >> choice
-    if a:type == 'choice'
-        return phpactor#_input_choice(a:parameters['label'], a:parameters['choices'])
-    endif
-
-    if a:type == 'list'
-        return phpactor#_input_list(a:parameters['label'], a:parameters['choices'])
-    endif
-
-    " >> confirm
-    if a:type == 'confirm'
-        let choice = confirm(a:parameters["label"], "&Yes\n&No\n")
-
-        if choice == 1
-            return v:true
-        endif
-
-        return v:false
-    endif
-
-
-    throw "Do not know how to handle input '" . a:type . "'"
+    call TypeHandler(ResultHandler)
 endfunction

--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -574,7 +574,13 @@ function! phpactor#_rpc_dispatch(actionName, parameters)
         let action = a:parameters['callback']['action']
         let parameters = a:parameters['callback']['parameters']
 
-        return phpactor#_rpc_dispatch_input(inputs, action, parameters)
+        try
+          return phpactor#_rpc_dispatch_input(inputs, action, parameters)
+        catch /cancelled/
+          redraw
+          echo 'Cancelled'
+          return
+        endtry
     endif
 
     " >> information

--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -682,8 +682,7 @@ function! phpactor#_rpc_dispatch_input(inputs, action, parameters)
         \ ])
     elseif 'confirm' == input['type']
         let TypeHandler = function('phpactor#input#confirm', [
-            \ inputParameters['label'],
-            \ '&Yes\n&No\n'
+            \ inputParameters['label']
         \ ])
     else
         throw "Do not know how to handle input '" . input['type'] . "'"


### PR DESCRIPTION
There is the PR.

After checking there is already a fallback to the standard vim `inputlist()`.
It's in the `autoload/phpactor/input/list.vim` file.
It's possible to define a strategy for the inputlist with the global variable `phpactor#input#list#strategy`.
The value must be a valid function inside the namespace `phpactor#input#list`.
The corresponding function will be used.

If the global variable does not exist, then the strategy is automatically detected beetween fzf and vim's `inputlist()` depending on is the fzf plugin is loaded or not.