### PR TITLE
Bugfix 770

### DIFF
--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -379,20 +379,17 @@ function! phpactor#_applyTextEdits(path, edits)
         " end = { line: 1234, character: 0 }
         let end = edit['end']
 
-        " move the cursor into the start position
-        call setpos('.', [ 0, start['line'] + 1, start['character'] + 1 ])
-
         if start['character'] != 0 || end['character'] != 0
             throw "Non-zero character offsets not supported in text edits, got " . json_encode(edit)
         endif
 
         " to delete
-        let linesToDelete = end['line'] - start['line']
-        if linesToDelete > 0
-            call execute('normal ' . linesToDelete . 'dd')
+        let numberOfDeletedLines = end['line'] - start['line']
+        if numberOfDeletedLines > 0
+            silent execute printf('keepjumps %d,%dd _', start['line'] + 1, end['line'])
 
             if end['line'] < curLine " Delete above the cursor
-                let curLine -= linesToDelete " Move the cursor up
+                let curLine -= numberOfDeletedLines " Move the cursor up
             elseif start['line'] < curLine " Delte the cursor line
                 let curLineBeforeDeletion = curLine " Memorize it
             endif
@@ -400,12 +397,12 @@ function! phpactor#_applyTextEdits(path, edits)
 
         if edit['text'] == "\n"
             " if this is just a new line, add a new line
-            call append(start['line'], '')
+            keepjumps call append(start['line'], '')
             let newLines = 1
         else
             " insert characters after the current line
             let appendLines = split(edit['text'], "\n")
-            call append(start['line'], appendLines)
+            keepjumps call append(start['line'], appendLines)
             let newLines = len(appendLines)
         endif
 

--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -395,19 +395,12 @@ function! phpactor#_applyTextEdits(path, edits)
             endif
         endif
 
-        if edit['text'] == "\n"
-            " if this is just a new line, add a new line
-            keepjumps call append(start['line'], '')
-            let newLines = 1
-        else
-            " insert characters after the current line
-            let appendLines = split(edit['text'], "\n")
-            keepjumps call append(start['line'], appendLines)
-            let newLines = len(appendLines)
-        endif
+        let newLines = edit['text'] == "\n" ? [''] : split(edit['text'], "\n")
+        keepjumps call append(start['line'], newLines)
+        let numberOfNewLines = len(newLines)
 
         " If lines have been inserted where the cursor was before its line got deleted
-        if 0 < newLines && v:null != curLineBeforeDeletion
+        if 0 < numberOfNewLines && v:null != curLineBeforeDeletion
             \ && start['line'] < curLineBeforeDeletion
             \ && curLineBeforeDeletion <= end['line'] + 1
             " Reposition the cursor to this line and reset the position before deletion
@@ -415,7 +408,7 @@ function! phpactor#_applyTextEdits(path, edits)
             let curLineBeforeDeletion = v:null
         elseif curLine > start['line']
             " Otherwise simply move the cursor down
-            let curLine += newLines
+            let curLine += numberOfNewLines
         endif
 
     endfor

--- a/plugin/tests/apply_text_edits/replace_a_line.vader
+++ b/plugin/tests/apply_text_edits/replace_a_line.vader
@@ -1,0 +1,43 @@
+Include: utils.vader
+
+Given php (Original source):
+  <?php
+
+  class Foo
+  {
+      /**
+       * @var string
+       */
+      private $foo:
+
+      private function foo()
+      {
+          return $this->foo();
+      }
+  }
+
+Execute (Goes to the method line and changes the visibility):
+  10
+  call Apply(
+    \ Delete(10),
+    \ Insert(10, '    public function foo()')
+  \ )
+
+Then (The cursor should not have moved):
+  call AssertCursorDidntMove()
+
+Expect php (The visibility shoud have changed):
+  <?php
+
+  class Foo
+  {
+      /**
+       * @var string
+       */
+      private $foo:
+
+      public function foo()
+      {
+          return $this->foo();
+      }
+  }

--- a/plugin/tests/apply_text_edits/replace_line_which_move.vader
+++ b/plugin/tests/apply_text_edits/replace_line_which_move.vader
@@ -1,0 +1,49 @@
+Include: utils.vader
+
+Given php (Original source):
+  <?php
+
+  class Foo
+  {
+      /**
+       * @var string
+       */
+      private $foo:
+
+      private function foo()
+      {
+          return $this->foo();
+      }
+  }
+
+Execute (Goes to the method line and changes the visibility):
+  10
+  call Apply(
+    \ Delete(10),
+    \ Insert(10, '    /**'),
+    \ Insert(11, '     * @var int $i'),
+    \ Insert(12, '     */'),
+    \ Insert(13, '    private function foo(int $i)')
+  \ )
+
+Then (Then cursor should still be on the method signature):
+  call AssertCursorOnLine(13)
+
+Expect php (The docblock should be added and the signature changed):
+  <?php
+
+  class Foo
+  {
+      /**
+       * @var string
+       */
+      private $foo:
+
+      /**
+       * @var int $i
+       */
+      private function foo(int $i)
+      {
+          return $this->foo();
+      }
+  }

--- a/plugin/tests/apply_text_edits/utils.vader
+++ b/plugin/tests/apply_text_edits/utils.vader
@@ -31,5 +31,9 @@ Before:
     AssertEqual g:applyTextEditsPosBefore, getpos('.')
   endfunction
 
+  function! AssertCursorOnLine(line)
+    AssertEqual a:line, line('.')
+  endfunction
+
 After:
   Restore

--- a/plugin/tests/apply_text_edits/utils.vader
+++ b/plugin/tests/apply_text_edits/utils.vader
@@ -1,0 +1,35 @@
+Before:
+  Save g:applyTextEditsPosBefore
+
+  set nofoldenable
+
+  function! Apply(...)
+    let g:applyTextEditsPosBefore = getpos('.')
+    let ApplyTextEdits = function('phpactor#_applyTextEdits', [expand('%:p')])
+
+    call ApplyTextEdits(a:000)
+  endfunction
+
+  function! Position(line)
+    return { 'line': a:line, 'character': 0 }
+  endfunction
+
+  function! Delete(startLine, ...)
+    let startLine = a:startLine - 1
+    let endLine = 0 < a:0 ? a:1 : a:startLine
+
+    return { 'start': Position(startLine), 'end': Position(endLine), 'text': '' }
+  endfunction
+
+  function! Insert(line, text)
+    let line = a:line - 1
+
+    return { 'start': Position(line), 'end': Position(line), 'text': a:text }
+  endfunction
+
+  function! AssertCursorDidntMove()
+    AssertEqual g:applyTextEditsPosBefore, getpos('.')
+  endfunction
+
+After:
+  Restore


### PR DESCRIPTION
Fixes #770

Or at least an attempt :)
We would need some tests to check more scenarios.
I'm not familiar with vim tests, I saw there is some in the `plugin` directory.
Are they still up to date ?
Is it possible to check the cursor position within a test ?

If yes I might try to create some so we could add every failing scenario and keep being sure everything works correctly.

As I explain in my last commit, I decided a totally different approach.
I realize that if I struggle so much it was mainly because I was trying to figure out a way to localize and move a "virtual" cursor which would have represented the line that was deleted.
It's event hard to explain so I guess it was indeed a bad idea!

Then I got a new idea, what I instead of focusing on the deleted line I focus on the remaining one.
The one where the cursor ends up after the deletion.
If we memorize the difference of lines between this one and the deleted one, then we just have to "reposition" the cursor relatively to it's current position.

Does it make sense to you ?
Once the transformation is done the cursor should still be X lines above the first unchanged one.