### PR TITLE
Search for class import candidates using full name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Features:
   - [completion] Use declared classes as completion source
   - [import-class] Import declared classes (as long as they can be statically
     resolved).
+  - [rpc] Class import uses offset to determine type to import
 
 Bug fixes:
 
@@ -25,6 +26,8 @@ Bug fixes:
 
 BC Break:
 
+  - [rpc] Import class no longer requires name parameter. RPC version changed
+    to version 2.
   - [code-transform] Generate accessors is now a class action and allows
     generation of multiple accessors.
 

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "symfony/filesystem": "^3.3",
         "symfony/yaml": "^3.3",
         "webmozart/glob": "^4.1",
+        "phpactor/text-document": "~1.1",
         "phpactor/config-loader": "~0.1",
         "phpactor/code-transform-extension": "^0.1",
         "phpactor/worse-reference-finder-extension": "~0.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2f0881f4360e733aade6f295142e0eea",
+    "content-hash": "0cb687d65581898c8965df507487fbe7",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -1903,16 +1903,16 @@
         },
         {
             "name": "phpactor/text-document",
-            "version": "1.0.0",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/text-document.git",
-                "reference": "b525a96a536cbd37fa44e05f388c6e8b7e32db5d"
+                "reference": "1a174bc1879e958210dcc9f47db113f1803d0375"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/text-document/zipball/b525a96a536cbd37fa44e05f388c6e8b7e32db5d",
-                "reference": "b525a96a536cbd37fa44e05f388c6e8b7e32db5d",
+                "url": "https://api.github.com/repos/phpactor/text-document/zipball/1a174bc1879e958210dcc9f47db113f1803d0375",
+                "reference": "1a174bc1879e958210dcc9f47db113f1803d0375",
                 "shasum": ""
             },
             "require": {
@@ -1920,10 +1920,11 @@
                 "webmozart/path-util": "^2.3"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.13",
+                "friendsofphp/php-cs-fixer": "~2.15.0",
                 "infection/infection": "^0.11.4",
-                "phpstan/phpstan": "^0.10.7",
-                "phpunit/phpunit": "^7.5"
+                "phpactor/test-utils": "^1.0",
+                "phpstan/phpstan": "~0.11.0",
+                "phpunit/phpunit": "~7.0"
             },
             "type": "library",
             "extra": {
@@ -1947,7 +1948,7 @@
                 }
             ],
             "description": "Collection of value objects for representing and referencing text documents",
-            "time": "2019-03-03T11:51:38+00:00"
+            "time": "2019-06-29T07:38:03+00:00"
         },
         {
             "name": "phpactor/worse-reference-finder-extension",

--- a/lib/Extension/CodeTransformExtra/Rpc/ImportClassHandler.php
+++ b/lib/Extension/CodeTransformExtra/Rpc/ImportClassHandler.php
@@ -153,6 +153,7 @@ class ImportClassHandler extends AbstractHandler
             $this->filesystem,
             $name
         );
+
         return array_map(function (array $suggestion) {
             return $suggestion['class'];
         }, $suggestions);

--- a/lib/Extension/CodeTransformExtra/Rpc/ImportClassHandler.php
+++ b/lib/Extension/CodeTransformExtra/Rpc/ImportClassHandler.php
@@ -74,7 +74,7 @@ class ImportClassHandler extends AbstractHandler
     public function handle(array $arguments)
     {
         if (null === $arguments[self::PARAM_QUALIFIED_NAME]) {
-            $name = (new WordAtOffset('\s|%|\(|\)|\[|\]|:|;|\r|\r\n|\n'))($arguments[self::PARAM_SOURCE], $arguments[self::PARAM_OFFSET]);
+            $name = (new WordAtOffset(WordAtOffset::SPLIT_QUALIFIED_PHP_NAME))($arguments[self::PARAM_SOURCE], $arguments[self::PARAM_OFFSET]);
             $suggestions = $this->suggestions($name);
 
             if (count($suggestions) === 0) {

--- a/lib/Extension/SourceCodeFilesystemExtra/SourceCodeFilestem/Application/ClassSearch.php
+++ b/lib/Extension/SourceCodeFilesystemExtra/SourceCodeFilestem/Application/ClassSearch.php
@@ -35,8 +35,8 @@ class ClassSearch
 
     public function classSearch(string $filesystemName, string $name)
     {
+        $name = $this->convertFqnToRelativePath($name);
         $filesystem = $this->filesystemRegistry->get($filesystemName);
-        $name = str_replace('\\', '/', $name);
 
         /** @var FileList<SplFileInfo> $files */
         $files = $filesystem->fileList('{' . $name . '}')->named($name . '.php');
@@ -122,5 +122,10 @@ class ClassSearch
         }
 
         return substr($declaredClass, $offset + 1);
+    }
+
+    private function convertFqnToRelativePath(string $name)
+    {
+        return str_replace('\\', '/', $name);
     }
 }

--- a/lib/Extension/SourceCodeFilesystemExtra/SourceCodeFilestem/Application/ClassSearch.php
+++ b/lib/Extension/SourceCodeFilesystemExtra/SourceCodeFilestem/Application/ClassSearch.php
@@ -36,6 +36,7 @@ class ClassSearch
     public function classSearch(string $filesystemName, string $name)
     {
         $filesystem = $this->filesystemRegistry->get($filesystemName);
+        $name = str_replace('\\', '/', $name);
 
         /** @var FileList<SplFileInfo> $files */
         $files = $filesystem->fileList('{' . $name . '}')->named($name . '.php');

--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -186,8 +186,7 @@ endfunction
 " Insert a use statement
 """"""""""""""""""""""""
 function! phpactor#UseAdd()
-    let word = expand("<cword>")
-    call phpactor#rpc("import_class", {"name": word, "offset": phpactor#_offset(), "source": phpactor#_source(), "path": expand('%:p')})
+    call phpactor#rpc("import_class", {"offset": phpactor#_offset(), "source": phpactor#_source(), "path": expand('%:p')})
 endfunction
 
 """""""""""""""""""""""""""

--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -133,7 +133,6 @@ function! phpactor#_completeImportClass(completedItem)
     if !empty(get(suggestion, "class_import", ""))
         call phpactor#rpc("import_class", {
                     \ "qualified_name": suggestion['class_import'], 
-                    \ "name": suggestion['name'], 
                     \ "offset": phpactor#_offset(), 
                     \ "source": phpactor#_source(), 
                     \ "path": expand('%:p')})

--- a/tests/System/Extension/SourceCodeFilesystem/Command/ClassSearchCommandTest.php
+++ b/tests/System/Extension/SourceCodeFilesystem/Command/ClassSearchCommandTest.php
@@ -32,6 +32,13 @@ class ClassSearchCommandTest extends SystemTestCase
         $this->assertContains('Badger.php"', $process->getOutput());
     }
 
+    public function testSearchByQualifiedName()
+    {
+        $process = $this->phpactor('class:search "Badger\\Carnivorous" --format=json');
+        $this->assertSuccess($process);
+        $this->assertContains('Carnivorous.php"', $process->getOutput());
+    }
+
     /**
      * @testdox It should return information baesd on a class "short" name.
      */

--- a/tests/Unit/Extension/CoreTransform/Rpc/ImportClassHandlerTest.php
+++ b/tests/Unit/Extension/CoreTransform/Rpc/ImportClassHandlerTest.php
@@ -19,9 +19,9 @@ use Phpactor\CodeTransform\Domain\Refactor\ImportClass\ClassAlreadyImportedExcep
 class ImportClassHandlerTest extends HandlerTestCase
 {
     const TEST_NAME = 'Foo';
-    const TEST_OFFSET = 1234;
+    const TEST_OFFSET = 7;
     const TEST_PATH = '/path/to';
-    const TEST_SOURCE = '<?php foo';
+    const TEST_SOURCE = '<?php Foo';
     const TEST_ALIAS = 'Alias';
 
     /**
@@ -62,7 +62,6 @@ class ImportClassHandlerTest extends HandlerTestCase
 
         /** @var InputCallbackResponse $response */
         $response = $this->handle('import_class', [
-            ImportClassHandler::PARAM_NAME => self::TEST_NAME,
             ImportClassHandler::PARAM_OFFSET => self::TEST_OFFSET,
             ImportClassHandler::PARAM_PATH => self::TEST_PATH,
             ImportClassHandler::PARAM_SOURCE => self::TEST_SOURCE
@@ -81,7 +80,6 @@ class ImportClassHandlerTest extends HandlerTestCase
 
         /** @var EchoResponse $response */
         $response = $this->handle('import_class', [
-            ImportClassHandler::PARAM_NAME => self::TEST_NAME,
             ImportClassHandler::PARAM_OFFSET => self::TEST_OFFSET,
             ImportClassHandler::PARAM_PATH => self::TEST_PATH,
             ImportClassHandler::PARAM_SOURCE => self::TEST_SOURCE
@@ -106,7 +104,6 @@ class ImportClassHandlerTest extends HandlerTestCase
 
         /** @var EchoResponse $response */
         $response = $this->handle('import_class', [
-            ImportClassHandler::PARAM_NAME => self::TEST_NAME,
             ImportClassHandler::PARAM_OFFSET => self::TEST_OFFSET,
             ImportClassHandler::PARAM_PATH => self::TEST_PATH,
             ImportClassHandler::PARAM_SOURCE => self::TEST_SOURCE
@@ -127,7 +124,6 @@ class ImportClassHandlerTest extends HandlerTestCase
         /** @var EchoResponse $response */
         $response = $this->handle('import_class', [
             ImportClassHandler::PARAM_QUALIFIED_NAME => self::TEST_NAME,
-            ImportClassHandler::PARAM_NAME => self::TEST_NAME,
             ImportClassHandler::PARAM_OFFSET => self::TEST_OFFSET,
             ImportClassHandler::PARAM_PATH => self::TEST_PATH,
             ImportClassHandler::PARAM_SOURCE => self::TEST_SOURCE
@@ -155,7 +151,6 @@ class ImportClassHandlerTest extends HandlerTestCase
         $response = $this->handle('import_class', [
             ImportClassHandler::PARAM_ALIAS => self::TEST_ALIAS,
             ImportClassHandler::PARAM_QUALIFIED_NAME => self::TEST_NAME,
-            ImportClassHandler::PARAM_NAME => self::TEST_NAME,
             ImportClassHandler::PARAM_OFFSET => self::TEST_OFFSET,
             ImportClassHandler::PARAM_PATH => self::TEST_PATH,
             ImportClassHandler::PARAM_SOURCE => self::TEST_SOURCE
@@ -176,7 +171,6 @@ class ImportClassHandlerTest extends HandlerTestCase
         /** @var EchoResponse $response */
         $response = $this->handle('import_class', [
             ImportClassHandler::PARAM_QUALIFIED_NAME => self::TEST_NAME,
-            ImportClassHandler::PARAM_NAME => self::TEST_NAME,
             ImportClassHandler::PARAM_OFFSET => self::TEST_OFFSET,
             ImportClassHandler::PARAM_PATH => self::TEST_PATH,
             ImportClassHandler::PARAM_SOURCE => self::TEST_SOURCE


### PR DESCRIPTION

- the `name` is not passed from the VIM plugin, only the offset.
- Phpactor then determines the "word" under the cursor
- Word boundary chars do not include `\`