### PR TITLE
Fix class new path (command)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Bug fixes:
   - [code-builder] Class import doesn't work with single element namespace
     #760
   - [code-builder] Variant is not passed to class generator (#766)
+  - [phpactor CLI] response shows source code instead of path (#792)
 
 BC Break:
 


### PR DESCRIPTION
- Add test case for variant behavior
- Do not show the "source code" in the path response.

Note that the response here is basically confusing - `src` can be either an FQN or a path, so the `path` key is returned to show the path of the resolved class if an FQN was given.