### PR TITLE
Preserve original path if available when generating new class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Bug fix:
   - [text-document] Word splitting includes commas, and other non-word chars
     (#851) - @einenlum
   - [worse-reflection] Functions wrongly memonized as classes - @dantleech
+  - [class-new-cli] response shows source code instead of path (#792)
+  - [class-new] Wrong file path when destination shares the same namespace as source (#795).
 
 ## 2019-10-23 0.13.5
 

--- a/lib/Extension/CodeTransformExtra/Application/ClassNew.php
+++ b/lib/Extension/CodeTransformExtra/Application/ClassNew.php
@@ -4,6 +4,7 @@ namespace Phpactor\Extension\CodeTransformExtra\Application;
 
 use Phpactor\CodeTransform\Domain\ClassName;
 use Phpactor\CodeTransform\Domain\SourceCode;
+use Phpactor\Phpactor;
 
 class ClassNew extends AbstractClassGenerator
 {
@@ -12,7 +13,8 @@ class ClassNew extends AbstractClassGenerator
         $className = $this->normalizer->normalizeToClass($src);
 
         $code = $this->generators->get($variant)->generateNew(ClassName::fromString((string) $className));
-        $filePath = $this->normalizer->normalizeToFile($className);
+
+        $filePath = Phpactor::isFile($src) ? Phpactor::normalizePath($src) : $this->normalizer->normalizeToFile($className);
 
         $code = $code->withPath($filePath);
 


### PR DESCRIPTION
Note, this is lacking any test. Will see if I get time to add an integration test here.

---
The ClassNew class can accept either an FQN or a file path, prior to
this fix if it was given a file path, it converted it to a class name,
but then used the class name to convert it back to the file path - which
is not 100% reliable, as it's possible for a class to exist at multiple
locations.

This fix preserves the file location if given.