### PR TITLE
Add license information to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "PHP refactoring and intellisense tool for text editors",
     "minimum-stability": "dev",
     "prefer-stable": true,
+    "license": "MIT",
     "require": {
         "composer/xdebug-handler": "^1.1",
         "monolog/monolog": "^1.0",


### PR DESCRIPTION
The lack of "license" is warned by the `composer validate` command.
This change must be applied to composer.lock before release.