### PR TITLE
Vim extract functions handles motions

### DIFF
--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -165,6 +165,10 @@ function! phpactor#ExtractExpression(isSelection)
     call phpactor#rpc("extract_expression", { "path": phpactor#_path(), "offset_start": selectionStart, "offset_end": selectionEnd, "source": phpactor#_source()})
 endfunction
 
+function! phpactor#ExtractConstant()
+    call phpactor#rpc("extract_constant", { "offset": phpactor#_offset(), "source": phpactor#_source(), "path": phpactor#_path()})
+endfunction
+
 function! phpactor#ClassExpand()
     let word = expand("<cword>")
     let classInfo = phpactor#rpc("class_search", { "short_name": word })

--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -145,11 +145,24 @@ endfunction
 """"""""""""""""""""""""
 " Extract method
 """"""""""""""""""""""""
-function! phpactor#ExtractMethod()
-    let selectionStart = phpactor#_selectionStart()
-    let selectionEnd = phpactor#_selectionEnd()
 
-    call phpactor#rpc("extract_method", { "path": phpactor#_path(), "offset_start": selectionStart, "offset_end": selectionEnd, "source": phpactor#_source()})
+function! phpactor#ExtractMethod(...)
+    let positions = {}
+
+    if 0 == a:0 " Visual mode - backward compatibility
+        let positions.start = phpactor#_selectionStart()
+        let positions.end = phpactor#_selectionEnd()
+    elseif a:1 ==? 'v' " Visual mode
+        let positions.start = phpactor#_selectionStart()
+        let positions.end = phpactor#_selectionEnd()
+    else " Linewise or characterwise motion
+        let linewise = 'line' == a:1
+
+        let positions.start = s:getStartOffsetFromMark("'[", linewise)
+        let positions.end = s:getEndOffsetFromMark("']", linewise)
+    endif
+
+    call phpactor#rpc("extract_method", { "path": phpactor#_path(), "offset_start": positions.start, "offset_end": positions.end, "source": phpactor#_source()})
 endfunction
 
 function! phpactor#ExtractExpression(type)

--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -152,17 +152,26 @@ function! phpactor#ExtractMethod()
     call phpactor#rpc("extract_method", { "path": phpactor#_path(), "offset_start": selectionStart, "offset_end": selectionEnd, "source": phpactor#_source()})
 endfunction
 
-function! phpactor#ExtractExpression(isSelection)
+function! phpactor#ExtractExpression(type)
+    let positions = {}
 
-    if a:isSelection 
-        let selectionStart = phpactor#_selectionStart()
-        let selectionEnd = phpactor#_selectionEnd()
-    else
-        let selectionStart = phpactor#_offset()
-        let selectionEnd = v:null
+    if v:true == a:type  " Invoked from Visual mode - backward compatibility
+        let positions.start = phpactor#_selectionStart()
+        let positions.end = phpactor#_selectionEnd()
+    elseif v:false == a:type " Invoked from an offset - backward compatibility
+        let positions.start = phpactor#_offset()
+        let positions.end = v:null
+    elseif a:type ==? 'v' " Visual mode
+        let positions.start = phpactor#_selectionStart()
+        let positions.end = phpactor#_selectionEnd()
+    else " Linewise or characterwise motion
+        let linewise = 'line' == a:type
+
+        let positions.start = s:getStartOffsetFromMark("'[", linewise)
+        let positions.end = s:getEndOffsetFromMark("']", linewise)
     endif
 
-    call phpactor#rpc("extract_expression", { "path": phpactor#_path(), "offset_start": selectionStart, "offset_end": selectionEnd, "source": phpactor#_source()})
+    call phpactor#rpc("extract_expression", { "path": phpactor#_path(), "offset_start": positions.start, "offset_end": positions.end, "source": phpactor#_source()})
 endfunction
 
 function! phpactor#ExtractConstant()


### PR DESCRIPTION
This PR allow the function of the vim plugin allowing to extract some code to a method or an expression to also handle motions in order to provide a better user experience.

It's from my previous idea about idea default mappings.
Since it's not something you want here I made another plugin just to add the mappings on my side.
But I would still need this part to be merged in order to user motions.

For those who where interested in the default mappings you can get them from:
http://github.com/elythyr/phpactor-mappings