### PR TITLE
Fix context menu handler callback offset

### DIFF
--- a/lib/Extension/ContextMenu/Handler/ContextMenuHandler.php
+++ b/lib/Extension/ContextMenu/Handler/ContextMenuHandler.php
@@ -134,7 +134,7 @@ class ContextMenuHandler implements Handler
                 self::NAME,
                 [
                     self::PARAMETER_SOURCE => $arguments[self::PARAMETER_SOURCE],
-                    self::PARAMETER_OFFSET => $symbol->position()->start(),
+                    self::PARAMETER_OFFSET => $arguments[self::PARAMETER_OFFSET],
                     self::PARAMETER_CURRENT_PATH => $arguments[self::PARAMETER_CURRENT_PATH],
                 ]
             ),


### PR DESCRIPTION
The original offset should be used in the callback from the
context menu, not the resolved one.

Actually not sure why it makes a difference if the offset used
is the resolved one, and not the original.

But the actions which were initially available when the menu is invoked, are not the same as those which are resolved when the callback returns: this means that the selected action will likely not be the one you intended if it doesn't crash first.

cc @elythyr 