### PR TITLE
Add keepjumps when using "goto"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Features:
   - [context-menu] Invoke menu for the nearest actionable node (i.e. you can
     invoke the context menu on whitespace now) - @elythyr
   - [class-mover] Jump to interface implementation
+  - [vim-plugin] Extract functions handles motions @elythyr
+  - [vim-plugin] Jumping to another file preserves the jumplist @elythyr
 
 Bug fix:
 

--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -517,7 +517,7 @@ function! phpactor#_rpc_dispatch(actionName, parameters)
 
 
         if (a:parameters['offset'])
-            exec ":goto " .  (a:parameters['offset'] + 1)
+            exec ":keepjumps goto " .  (a:parameters['offset'] + 1)
             normal! zz
         endif
         return


### PR DESCRIPTION
Make a better user experience by preserving je jumplist

To see what I'm talking about, without the change go to a file.
Once there use the "goto" functionality to jump to a method definition in another file.
Then if you try to use `<C-O>` to go back you will stay in the file but your cursor will go to the previous position (inside this file).
By adding keepjumps, you will be take back right on the method call on which you used the "goto".