### PR TITLE
Added Phpversoin resolver extension

### DIFF
--- a/lib/Extension/CodeTransformExtra/CodeTransformExtraExtension.php
+++ b/lib/Extension/CodeTransformExtra/CodeTransformExtraExtension.php
@@ -32,6 +32,7 @@ use Phpactor\Extension\CodeTransformExtra\Rpc\ImportMissingClassesHandler;
 use Phpactor\Extension\CodeTransform\CodeTransformExtension;
 use Phpactor\Extension\Core\CoreExtension;
 use Phpactor\Extension\Logger\LoggingExtension;
+use Phpactor\Extension\Php\Model\PhpVersionResolver;
 use Phpactor\Extension\Rpc\RpcExtension;
 use Phpactor\Extension\Console\ConsoleExtension;
 use Phpactor\Extension\SourceCodeFilesystem\SourceCodeFilesystemExtension;
@@ -194,7 +195,7 @@ class CodeTransformExtraExtension implements Extension
                 return $resolver->resolve($path);
             }, $templatePaths);
 
-            $phpVersion = $container->getParameter(CoreExtension::PARAM_PHP_VERSION);
+            $phpVersion = $container->get(PhpVersionResolver::class)->resolve();
             $paths = (new PhpVersionPathResolver($phpVersion))->resolve($resolvedTemplatePaths);
 
             foreach ($paths as $path) {

--- a/lib/Extension/Core/Application/Status.php
+++ b/lib/Extension/Core/Application/Status.php
@@ -3,6 +3,7 @@
 namespace Phpactor\Extension\Core\Application;
 
 use Phpactor\ConfigLoader\Core\PathCandidates;
+use Phpactor\Extension\Php\Model\PhpVersionResolver;
 use Phpactor\Extension\SourceCodeFilesystem\SourceCodeFilesystemExtension;
 use Phpactor\Filesystem\Domain\FilesystemRegistry;
 use Symfony\Component\Process\ExecutableFinder;
@@ -30,16 +31,23 @@ class Status
      */
     private $workingDirectory;
 
+    /**
+     * @var PhpVersionResolver
+     */
+    private $phpVersionResolver;
+
     public function __construct(
         FilesystemRegistry $registry,
         PathCandidates $paths,
         string $workingDirectory,
+        PhpVersionResolver $phpVersionResolver,
         ExecutableFinder $executableFinder = null
     ) {
         $this->registry = $registry;
         $this->executableFinder = $executableFinder ?: new ExecutableFinder();
         $this->paths = $paths;
         $this->workingDirectory = $workingDirectory;
+        $this->phpVersionResolver = $phpVersionResolver;
     }
 
     public function check(): array
@@ -48,6 +56,7 @@ class Status
         $diagnostics = [
             'filesystems' => $filesystems,
             'cwd' => $this->workingDirectory,
+            'php_version' => $this->phpVersionResolver->resolve(),
             'config_files' => [],
             'good' => [],
             'bad' => [],

--- a/lib/Extension/Core/CoreExtension.php
+++ b/lib/Extension/Core/CoreExtension.php
@@ -7,6 +7,7 @@ use Phpactor\Extension\Core\Application\Helper\ClassFileNormalizer;
 use Phpactor\Extension\Core\Rpc\CacheClearHandler;
 use Phpactor\Extension\Core\Rpc\ConfigHandler;
 use Phpactor\Extension\Core\Rpc\StatusHandler;
+use Phpactor\Extension\Php\Model\PhpVersionResolver;
 use Phpactor\Extension\Rpc\RpcExtension;
 use Phpactor\FilePathResolverExtension\FilePathResolverExtension;
 use Phpactor\Extension\Core\Console\Dumper\DumperRegistry;
@@ -34,7 +35,6 @@ class CoreExtension implements Extension
     const PARAM_DUMPER = 'console_dumper_default';
     const PARAM_XDEBUG_DISABLE = 'xdebug_disable';
     const PARAM_COMMAND = 'command';
-    const PARAM_PHP_VERSION = 'core.php_version';
 
     public function configure(Resolver $schema)
     {
@@ -42,7 +42,6 @@ class CoreExtension implements Extension
             self::PARAM_DUMPER => 'indented',
             self::PARAM_XDEBUG_DISABLE => true,
             self::PARAM_COMMAND => null,
-            self::PARAM_PHP_VERSION => phpversion(),
         ]);
     }
 
@@ -123,7 +122,8 @@ class CoreExtension implements Extension
             return new Status(
                 $container->get('source_code_filesystem.registry'),
                 $container->get('config_loader.candidates'),
-                $container->get(FilePathResolverExtension::SERVICE_FILE_PATH_RESOLVER)->resolve('%project_root%')
+                $container->get(FilePathResolverExtension::SERVICE_FILE_PATH_RESOLVER)->resolve('%project_root%'),
+                $container->get(PhpVersionResolver::class)
             );
         });
     }

--- a/lib/Extension/Core/Rpc/StatusHandler.php
+++ b/lib/Extension/Core/Rpc/StatusHandler.php
@@ -48,6 +48,8 @@ class StatusHandler implements Handler
                 'Info',
                 '----',
                 'Version: ' . $diagnostics['phpactor_version'],
+                'PHP: ' . sprintf('%s (supporting %s)', phpversion(), $diagnostics['php_version']),
+                'Phpactor dir: ' . realpath(__DIR__ . '/../../../../'),
                 'Work dir: ' . $diagnostics['cwd'] . PHP_EOL,
                 'Diagnostics',
                 '-----------',

--- a/lib/Extension/Php/Model/ChainResolver.php
+++ b/lib/Extension/Php/Model/ChainResolver.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Phpactor\Extension\Php\Model;
+
+use RuntimeException;
+
+class ChainResolver implements PhpVersionResolver
+{
+    /**
+     * @var PhpVersionResolver[]
+     */
+    private $versionResolvers;
+
+    public function __construct(PhpVersionResolver ...$versionResolvers)
+    {
+        $this->versionResolvers = $versionResolvers;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function resolve(): ?string
+    {
+        foreach ($this->versionResolvers as $versionResolver) {
+            if (!$version = $versionResolver->resolve()) {
+                continue;
+            }
+
+            return $version;
+        }
+
+        throw new RuntimeException(sprintf(
+            '%s resolvers could not resolve PHP version',
+            count($this->versionResolvers)
+        ));
+    }
+}

--- a/lib/Extension/Php/Model/ComposerPhpVersionResolver.php
+++ b/lib/Extension/Php/Model/ComposerPhpVersionResolver.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Phpactor\Extension\Php\Model;
+
+class ComposerPhpVersionResolver implements PhpVersionResolver
+{
+    /**
+     * @var string
+     */
+    private $composerJsonPath;
+
+    public function __construct(string $composerJsonPath)
+    {
+        $this->composerJsonPath = $composerJsonPath;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function resolve(): ?string
+    {
+        if (!file_exists($this->composerJsonPath)) {
+            return null;
+        }
+
+        if (!$contents = file_get_contents($this->composerJsonPath)) {
+            return null;
+        }
+
+        if (!$json = json_decode($contents, true)) {
+            return null;
+        }
+
+        if (isset($json['config']['platform']['php'])) {
+            return $json['config']['platform']['php'];
+        }
+
+        if (isset($json['require']['php'])) {
+            return preg_replace('/[^0-9.]/', '', $json['require']['php']);
+        }
+
+        return null;
+    }
+}

--- a/lib/Extension/Php/Model/ConstantPhpVersionResolver.php
+++ b/lib/Extension/Php/Model/ConstantPhpVersionResolver.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Phpactor\Extension\Php\Model;
+
+class ConstantPhpVersionResolver implements PhpVersionResolver
+{
+    /**
+     * @var string|null
+     */
+    private $version;
+
+    public function __construct(?string $version)
+    {
+        $this->version = $version;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function resolve(): ?string
+    {
+        return $this->version;
+    }
+}

--- a/lib/Extension/Php/Model/PhpVersionResolver.php
+++ b/lib/Extension/Php/Model/PhpVersionResolver.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Phpactor\Extension\Php\Model;
+
+interface PhpVersionResolver
+{
+    /**
+     * @return string
+     */
+    public function resolve(): ?string;
+}

--- a/lib/Extension/Php/Model/RuntimePhpVersionResolver.php
+++ b/lib/Extension/Php/Model/RuntimePhpVersionResolver.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Phpactor\Extension\Php\Model;
+
+use Phpactor\Extension\Php\Model\PhpVersionResolver;
+
+class RuntimePhpVersionResolver implements PhpVersionResolver
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function resolve(): ?string
+    {
+        return phpversion();
+    }
+}

--- a/lib/Extension/Php/PhpExtension.php
+++ b/lib/Extension/Php/PhpExtension.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Phpactor\Extension\Php;
+
+use Phpactor\Container\Container;
+use Phpactor\Container\ContainerBuilder;
+use Phpactor\Container\Extension;
+use Phpactor\Extension\Php\Model\ChainResolver;
+use Phpactor\Extension\Php\Model\ComposerPhpVersionResolver;
+use Phpactor\Extension\Php\Model\ConstantPhpVersionResolver;
+use Phpactor\Extension\Php\Model\PhpVersionResolver;
+use Phpactor\Extension\Php\Model\RuntimePhpVersionResolver;
+use Phpactor\FilePathResolverExtension\FilePathResolverExtension;
+use Phpactor\MapResolver\Resolver;
+
+class PhpExtension implements Extension
+{
+    const PARAM_VERSION = 'php.version';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function load(ContainerBuilder $container)
+    {
+        $container->register(PhpVersionResolver::class, function (Container $container) {
+            $pathResolver = $container->get(FilePathResolverExtension::SERVICE_FILE_PATH_RESOLVER);
+            $composerPath = $pathResolver->resolve('%project_root%/composer.json');
+
+            return new ChainResolver(
+                new ConstantPhpVersionResolver($container->getParameter(self::PARAM_VERSION)),
+                new ComposerPhpVersionResolver($composerPath),
+                new RuntimePhpVersionResolver()
+            );
+        });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function configure(Resolver $schema)
+    {
+        $schema->setDefaults([
+            self::PARAM_VERSION => null
+        ]);
+    }
+}

--- a/lib/Phpactor.php
+++ b/lib/Phpactor.php
@@ -26,6 +26,7 @@ use Phpactor\Extension\Rpc\RpcExtension;
 use Phpactor\Extension\Console\ConsoleExtension;
 use Phpactor\Extension\ClassToFile\ClassToFileExtension;
 use Phpactor\Extension\Logger\LoggingExtension;
+use Phpactor\Extension\Php\PhpExtension;
 use Phpactor\Extension\ComposerAutoloader\ComposerAutoloaderExtension;
 use Phpactor\MapResolver\Resolver;
 use Phpactor\Container\Extension;
@@ -94,6 +95,7 @@ class Phpactor
             WorseReferenceFinderExtension::class,
             ReferenceFinderRpcExtension::class,
             ReferenceFinderExtension::class,
+            PhpExtension::class,
         ];
 
         if (file_exists($config[ExtensionManagerExtension::PARAM_INSTALLED_EXTENSIONS_FILE])) {

--- a/tests/Unit/Extension/Core/Application/StatusTest.php
+++ b/tests/Unit/Extension/Core/Application/StatusTest.php
@@ -4,6 +4,7 @@ namespace Phpactor\Tests\Unit\Extension\Core\Application;
 
 use PHPUnit\Framework\TestCase;
 use Phpactor\ConfigLoader\Core\PathCandidates;
+use Phpactor\Extension\Php\Model\PhpVersionResolver;
 use Phpactor\Extension\SourceCodeFilesystem\SourceCodeFilesystemExtension;
 use Phpactor\Filesystem\Domain\FilesystemRegistry;
 use Phpactor\Extension\Core\Application\Status;
@@ -15,11 +16,23 @@ class StatusTest extends TestCase
      */
     private $registry;
 
+    /**
+     * @var ObjectProphecy
+     */
+    private $resolver;
+
+    /**
+     * @var PathCandidates
+     */
+    private $paths;
+
+
     public function setUp()
     {
         $this->registry = $this->prophesize(FilesystemRegistry::class);
+        $this->resolver = $this->prophesize(PhpVersionResolver::class);
         $this->paths = new PathCandidates([]);
-        $this->status = new Status($this->registry->reveal(), $this->paths, '/path/to/here');
+        $this->status = new Status($this->registry->reveal(), $this->paths, '/path/to/here', $this->resolver->reveal());
     }
 
     public function testStatusNoComposerOrGit()

--- a/tests/Unit/Extension/Core/Rpc/StatusHandlerTest.php
+++ b/tests/Unit/Extension/Core/Rpc/StatusHandlerTest.php
@@ -40,6 +40,7 @@ class StatusHandlerTest extends HandlerTestCase
     public function testStatus()
     {
         $this->status->check()->willReturn([
+            'php_version' => '7.1',
             'phpactor_version' => 'version one',
             'cwd' => '/path/to/here',
             'good' => [ 'i am good' ],

--- a/tests/Unit/Extension/PhpVersionResolver/Model/ChainResolverTest.php
+++ b/tests/Unit/Extension/PhpVersionResolver/Model/ChainResolverTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Phpactor\Tests\Unit\Extension\PhpVersionResolver\Model;
+
+use PHPUnit\Framework\TestCase;
+use Phpactor\Extension\Php\Model\ChainResolver;
+use Phpactor\Extension\Php\Model\PhpVersionResolver;
+use RuntimeException;
+
+class ChainResolverTest extends TestCase
+{
+    public function testThrowsExceptionIfNoVeresionCanBeResolved()
+    {
+        $this->expectException(RuntimeException::class);
+        (new ChainResolver())->resolve();
+    }
+
+    public function testResolvesVersion()
+    {
+        $resolver = $this->prophesize(PhpVersionResolver::class);
+        $resolver->resolve()->willReturn('7.1');
+        self::assertEquals('7.1', (new ChainResolver($resolver->reveal()))->resolve());
+    }
+}

--- a/tests/Unit/Extension/PhpVersionResolver/Model/ComposerPhpVersionResolverTest.php
+++ b/tests/Unit/Extension/PhpVersionResolver/Model/ComposerPhpVersionResolverTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Phpactor\Tests\Unit\Extension\PhpVersionResolver\Model;
+
+use PHPUnit\Framework\TestCase;
+use Phpactor\Extension\Php\Model\ComposerPhpVersionResolver;
+use Phpactor\Tests\IntegrationTestCase;
+
+class ComposerPhpVersionResolverTest extends IntegrationTestCase
+{
+    public function testReturnsPlatform()
+    {
+        $this->workspace()->reset();
+        $this->workspace()->loadManifest(<<<'EOT'
+// File: composer.json
+{
+    "require": {
+        "php": "^7.1"
+    }
+}
+EOT
+        );
+        $resolver = new ComposerPhpVersionResolver($this->workspace()->path('/composer.json'));
+        self::assertEquals('7.1', $resolver->resolve());
+    }
+
+    public function testReturnsPlatformWithHigherPrio()
+    {
+        $this->workspace()->reset();
+        $this->workspace()->loadManifest(<<<'EOT'
+// File: composer.json
+{
+    "require": {
+        "php": "^7.1"
+    },
+    "config": {
+        "platform": {
+            "php": "7.3"
+        }
+    }
+}
+EOT
+        );
+        $resolver = new ComposerPhpVersionResolver($this->workspace()->path('/composer.json'));
+        self::assertEquals('7.3', $resolver->resolve());
+    }
+}


### PR DESCRIPTION
Automatically detect PHP version to support based on:

- Explicitly configured version (`php.version`)
- Composer platform
- Composer PHP requirement
- Runtime PHP version