### PR TITLE
[vim-plugin] Adding support for async calls

### DIFF
--- a/autoload/phpactor.vim
+++ b/autoload/phpactor.vim
@@ -311,6 +311,25 @@ function! phpactor#GenerateAccessors()
     call phpactor#rpc("generate_accessor", { "source": phpactor#_source(), "path": expand('%:p'), 'offset': phpactor#_offset() })
 endfunction
 
+let s:indexerJobId = v:null
+function! phpactor#IndexStart()
+    let s:indexerJobId = phpactor#nvim#asyncCall("index", {"watch": v:true})
+    if s:indexerJobId == v:null
+        return
+    endif
+
+    echo "Indexer starated with job ID " . s:indexerJobId
+endfunction
+
+function! phpactor#IndexStop()
+    if s:indexerJobId == v:null
+        echo "Indexer not running"
+        return
+    endif
+
+    call jobstop(s:indexerJobId)
+    echo "Indexer stopped"
+endfunction
 """""""""""""""""""""""
 " Utility functions
 """""""""""""""""""""""

--- a/autoload/phpactor.vim
+++ b/autoload/phpactor.vim
@@ -434,16 +434,8 @@ function! phpactor#rpc(action, arguments)
     let result = system(cmd, json_encode(request))
 
     if (v:shell_error == 0)
-        try 
-            let response = json_decode(result)
-        catch 
-            throw "Could not parse response from Phpactor: " . v:exception
-        endtry
 
-        let actionName = response['action']
-        let parameters = response['parameters']
-
-        let response = phpactor#_rpc_dispatch(actionName, parameters)
+        let response = phpactor#rpc#handleRawResponse(result)
 
         if !empty(response)
             return response

--- a/autoload/phpactor/nvim.vim
+++ b/autoload/phpactor/nvim.vim
@@ -1,0 +1,36 @@
+func! phpactor#nvim#asyncCall(action, arguments)
+    let callbacks = {
+    \   'on_stdout': function('phpactor#nvim#asyncHandle'),
+    \   'on_stderr': function('phpactor#nvim#asyncHandle'),
+    \   'on_exit': function('phpactor#nvim#asyncHandle')
+    \ }
+    let job = jobstart([ g:phpactorPhpBin, g:phpactorbinpath, 'rpc', '--working-dir=' . g:phpactorInitialCwd ], callbacks)
+
+    let request = { "action": a:action, "parameters": a:arguments }
+
+    call chansend(job, json_encode(request))
+    call chanclose(job, 'stdin')
+endfunc
+
+let s:stdout = []
+let s:stderr = []
+
+func! phpactor#nvim#asyncHandle(jobId, data, event)
+    if a:event == 'stdout'
+        call extend(s:stdout, a:data)
+        return
+    elseif a:event == 'stderr'
+        call extend(s:stderr, a:data)
+        return
+    endif
+
+    if a:data != 0
+        echo "Phpactor returned an error: " . join(s:stderr)
+        return
+    endif
+
+    call phpactor#rpc#handleRawResponse(join(s:stdout))
+
+    let s:stdout = []
+    let s:stderr = []
+endfunc

--- a/autoload/phpactor/rpc.vim
+++ b/autoload/phpactor/rpc.vim
@@ -1,0 +1,12 @@
+func! phpactor#rpc#handleRawResponse(response)
+    try 
+        let response = json_decode(a:response)
+    catch 
+        throw "Could not parse response from Phpactor: " . v:exception
+    endtry
+
+    let actionName = response['action']
+    let parameters = response['parameters']
+
+    return phpactor#_rpc_dispatch(actionName, parameters)
+endfunc

--- a/autoload/phpactor/rpc.vim
+++ b/autoload/phpactor/rpc.vim
@@ -1,4 +1,8 @@
 func! phpactor#rpc#handleRawResponse(response)
+    if "" == a:response
+        return v:null
+    endif
+
     try 
         let response = json_decode(a:response)
     catch 

--- a/ftplugin/php.vim
+++ b/ftplugin/php.vim
@@ -50,7 +50,3 @@ endif
 if g:phpactorOmniAutoClassImport == v:true
     autocmd CompleteDone *.php call phpactor#_completeImportClass(v:completed_item)
 endif
-
-
-" vim: et ts=4 sw=4 fdm=marker
-

--- a/ftplugin/php/commands.vim
+++ b/ftplugin/php/commands.vim
@@ -120,3 +120,8 @@ command! -nargs=0 PhpactorChangeVisibility call phpactor#ChangeVisibility()
 ""
 " Generate accessors for the current class
 command! -nargs=0 PhpactorGenerateAccessors call phpactor#GenerateAccessors()
+
+""
+" Generate accessors for the current class
+command! -nargs=0 PhpactorIndexStart call phpactor#IndexStart()
+command! -nargs=0 PhpactorIndexStop call phpactor#IndexStop()


### PR DESCRIPTION
Adding support for making async calls to Phpactor (mainly to facilitate maintaining an indexer process).

Also adds:

```
:PhpactorIndexStart
:PhpactorIndexStop
```

to control the indexer provided by https://github.com/phpactor/workspace-query

TODO:

- [ ] Introduce request ID and/or original action name in RPC response (option to disallow concurrent requests to same RPC method? Ability to cancel job?)
- [ ] Support VIM 8 in addition to Nvim
- [ ] Nice to have: Support in-proces communication? (or at least the ability for the job to send notifications to the editor)
- [ ] Handle SIGTERM gracefully in Phpactor when running RPC (e.g. send termination message)
- [ ] Make asyncable commands async (e.g. find all references #747)