### PR TITLE
Allow to reuse open window when go to definition

### DIFF
--- a/autoload/phpactor.vim
+++ b/autoload/phpactor.vim
@@ -319,7 +319,7 @@ function! s:isOpenInCurrentWindow(filePath)
 endfunction
 
 function! phpactor#_switchToBufferOrEdit(filePath)
-    if <SID>isOpenInCurrentWindow(a:filePath)
+    if s:isOpenInCurrentWindow(a:filePath)
         return v:false
     endif
 
@@ -509,7 +509,7 @@ function! phpactor#_rpc_dispatch(actionName, parameters)
     if a:actionName == "open_file"
         let changedFileOrWindow = v:true
 
-        call <SID>openFileInSelectedTarget(
+        call s:openFileInSelectedTarget(
               \ a:parameters["path"],
               \ a:parameters["target"],
               \ get(a:parameters, "use_open_window", g:phpactorUseOpenWindows),
@@ -517,7 +517,7 @@ function! phpactor#_rpc_dispatch(actionName, parameters)
               \ )
 
         if a:parameters["target"] == 'focused_window'
-            let changedFileOrWindow = !<SID>isOpenInCurrentWindow(a:parameters["path"])
+            let changedFileOrWindow = !s:isOpenInCurrentWindow(a:parameters["path"])
         endif
 
         if (a:parameters['offset'])

--- a/doc/phpactor.txt
+++ b/doc/phpactor.txt
@@ -44,6 +44,11 @@ use the VIM quick-fix list.
 Function to use when presenting a user with a choice of options. The default
 is to use the VIM inputlist.
 
+                                                    *g:phpactorUseOpenWindows*
+When jump to the line of a file displayed in any existing window reuse this
+window to avoid have more than one view of the same file. The default is
+false.
+
 ==============================================================================
 COMPLETION                                               *phpactor-completion*
 

--- a/ftplugin/php.vim
+++ b/ftplugin/php.vim
@@ -47,6 +47,8 @@ if !exists('g:phpactorInputListStrategy')
     let g:phpactorInputListStrategy = 'phpactor#input#list#inputlist'
 endif
 
+let g:phpactorUseOpenWindows = get(g:, 'phpactorUseOpenWindows', v:false)
+
 if g:phpactorOmniAutoClassImport == v:true
     autocmd CompleteDone *.php call phpactor#_completeImportClass(v:completed_item)
 endif

--- a/ftplugin/php.vim
+++ b/ftplugin/php.vim
@@ -9,44 +9,36 @@ let g:phpactorInitialCwd = getcwd()
 let g:phpactorCompleteLabelTruncateLength=50
 let g:_phpactorCompletionMeta = {}
 
-if !exists('g:phpactorPhpBin')
-    ""
-    " Path to the PHP binary used by Phpactor
-    let g:phpactorPhpBin = 'php'
-endif
+""
+" Path to the PHP binary used by Phpactor
+let g:phpactorPhpBin = get(g:, 'phpactorPhpBin', 'php')
 
-if !exists('g:phpactorBranch')
-    ""
-    " The Phpactor branch to use when calling @command(PhpactorUpdate)
-    let g:phpactorBranch = 'master'
-endif
+""
+" The Phpactor branch to use when calling @command(PhpactorUpdate)
+let g:phpactorBranch = get(g:, 'phpactorBranch', 'master')
 
-if !exists('g:phpactorOmniAutoClassImport')
-    ""
-    " Automatically import classes when using VIM native omni-completion
-    let g:phpactorOmniAutoClassImport = v:true
-endif
+""
+" Automatically import classes when using VIM native omni-completion
+let g:phpactorOmniAutoClassImport = get(g:, 'phpactorOmniAutoClassImport', v:true)
 
-if !exists('g:phpactorCompletionIgnoreCase')
-    ""
-    " Ignore case when suggestion completion results
-    let g:phpactorCompletionIgnoreCase = 1
-endif
+""
+" Ignore case when suggestion completion results
+let g:phpactorCompletionIgnoreCase = get(g:, 'phpactorCompletionIgnoreCase', 1)
 
-if !exists('g:phpactorQuickfixStrategy')
-    ""
-    " Function to use when populating a list of code references. The default
-    " is to use the VIM quick-fix list.
-    let g:phpactorQuickfixStrategy = 'phpactor#quickfix#vim'
-endif
+""
+" Function to use when populating a list of code references. The default
+" is to use the VIM quick-fix list.
+let g:phpactorQuickfixStrategy = get(g:, 'phpactorQuickfixStrategy', 'phpactor#quickfix#vim')
 
-if !exists('g:phpactorInputListStrategy')
-    ""
-    " Function to use when presenting a user with a choice of options. The default
-    " is to use the VIM inputlist.
-    let g:phpactorInputListStrategy = 'phpactor#input#list#inputlist'
-endif
+""
+" Function to use when presenting a user with a choice of options. The default
+" is to use the VIM inputlist.
+let g:phpactorInputListStrategy = get(g:, 'phpactorInputListStrategy', 'phpactor#input#list#inputlist')
 
+""
+" When jump to the line of a file displayed in any existing window
+" reuse this window to avoid have more than one view of the same file.
+" The default is false.
 let g:phpactorUseOpenWindows = get(g:, 'phpactorUseOpenWindows', v:false)
 
 if g:phpactorOmniAutoClassImport == v:true
@@ -55,4 +47,3 @@ endif
 
 
 " vim: et ts=4 sw=4 fdm=marker
-


### PR DESCRIPTION
In this minimal proposition we can enable this behavior by setting `g:phpactorUseOpenWindows` to `v:true` only (excluding calling `phpactor#_rpc_dispatch(actionName, parameters)` manually with the custom "use_open_window" parameter value). 

Closes #894 