### PR TITLE
Stable Context Menu Shortcuts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,6 @@ jobs:
       script:
         # Run the VIM Plugin tests
         - config/travis/vim-plugin-test.sh
-    - php: 7.1
     - php: 7.2
     - stage: docs
       php: 7.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Improvements:
   - [vim-plugin] Better handling of `json_decode` errors
   - [vim-plugin] Add option to switch to open windows
     `g:phpactorUseOpenWindows` - @przepompownia
+  - [vim-plugin] Stable context menu shortcuts - @dantleech (#896)
 
 ## 2019-10-23 0.13.5
 

--- a/autoload/phpactor.vim
+++ b/autoload/phpactor.vim
@@ -713,7 +713,8 @@ function! phpactor#_rpc_dispatch_input(inputs, action, parameters)
     elseif 'choice' == input['type']
         let TypeHandler = function('phpactor#input#choice', [
             \ inputParameters['label'],
-            \ inputParameters['choices']
+            \ inputParameters['choices'],
+            \ inputParameters['keyMap']
         \ ])
     elseif 'list' == input['type']
         let TypeHandler = function('phpactor#input#list', [

--- a/autoload/phpactor/input.vim
+++ b/autoload/phpactor/input.vim
@@ -33,6 +33,8 @@ function! phpactor#input#choice(label, choices, keyMap, ResultHandler)
     for choiceLabel in keys(a:choices)
         let buffer = []
 
+        " note that a:keyMap can be an empty list because PHP's json_decode
+        " can't tell the difference between an empty list and an empty dict
         if !empty(a:keyMap) && has_key(a:keyMap, choiceLabel) && !empty(a:keyMap[choiceLabel])
             let confirmLabel = s:determineConfirmLabelFromPreference(choiceLabel, a:keyMap[choiceLabel])
         else

--- a/autoload/phpactor/input.vim
+++ b/autoload/phpactor/input.vim
@@ -71,7 +71,8 @@ function! s:determineConfirmLabelFromPreference(choiceLabel, preference)
     endfor
 
     if foundShortcut == v:false
-        "call add(buffer, a:preference . '&')
+        " Could not find char in the label - add the shortcut at the end
+        call add(buffer, '&' . a:preference)
     endif
 
     return join(buffer, "")

--- a/autoload/phpactor/input.vim
+++ b/autoload/phpactor/input.vim
@@ -24,7 +24,6 @@ let s:usedShortcuts = []
 function! phpactor#input#choice(label, choices, keyMap, ResultHandler)
     let s:usedShortcuts = []
     let list = []
-    let choices = []
 
     if empty(a:choices)
         call confirm("No choices available")
@@ -41,7 +40,6 @@ function! phpactor#input#choice(label, choices, keyMap, ResultHandler)
         endif
 
         call add(list, confirmLabel)
-        call add(choices, choiceLabel)
     endfor
 
     let choice = confirm(a:label, join(list, "\n"))
@@ -51,7 +49,7 @@ function! phpactor#input#choice(label, choices, keyMap, ResultHandler)
         throw "cancelled"
     endif
 
-    call a:ResultHandler(choices[choice - 1])
+    call a:ResultHandler(keys(a:choices)[choice - 1])
 endfunction
 
 function! s:determineConfirmLabelFromPreference(choiceLabel, preference)

--- a/autoload/phpactor/input.vim
+++ b/autoload/phpactor/input.vim
@@ -20,10 +20,11 @@ function! phpactor#input#confirm(label, ResultHandler)
     call a:ResultHandler(response)
 endfunction
 
-function! phpactor#input#choice(label, choices, ResultHandler)
+let s:usedShortcuts = []
+function! phpactor#input#choice(label, choices, keyMap, ResultHandler)
+    let s:usedShortcuts = []
     let list = []
     let choices = []
-    let usedShortcuts = []
 
     if empty(a:choices)
         call confirm("No choices available")
@@ -32,19 +33,12 @@ function! phpactor#input#choice(label, choices, ResultHandler)
 
     for choiceLabel in keys(a:choices)
         let buffer = []
-        let foundShortcut = v:false
 
-        for char in split(choiceLabel, '\zs')
-            if v:false == foundShortcut && -1 == index(usedShortcuts, tolower(char))
-                call add(buffer, '&')
-                let foundShortcut = v:true
-                call add(usedShortcuts, tolower(char))
-            endif
-
-            call add(buffer, char)
-        endfor
-
-        let confirmLabel = join(buffer, "")
+        if !empty(a:keyMap) && has_key(a:keyMap, choiceLabel) && !empty(a:keyMap[choiceLabel])
+            let confirmLabel = s:determineConfirmLabelFromPreference(choiceLabel, a:keyMap[choiceLabel])
+        else
+            let confirmLabel = s:determineConfirmLabel(choiceLabel)
+        endif
 
         call add(list, confirmLabel)
         call add(choices, choiceLabel)
@@ -60,15 +54,55 @@ function! phpactor#input#choice(label, choices, ResultHandler)
     call a:ResultHandler(choices[choice - 1])
 endfunction
 
+function! s:determineConfirmLabelFromPreference(choiceLabel, preference)
+    let buffer = []
+    let foundShortcut = v:false
+
+    for char in split(a:choiceLabel, '\zs')
+        if foundShortcut == v:false && tolower(char) == tolower(a:preference)
+            let foundShortcut = v:true
+
+            call add(buffer, '&' . a:preference)
+            call add(s:usedShortcuts, a:preference)
+            continue
+        endif
+
+        call add(buffer, char)
+    endfor
+
+    if foundShortcut == v:false
+        "call add(buffer, a:preference . '&')
+    endif
+
+    return join(buffer, "")
+endfunction
+
+function! s:determineConfirmLabel(choiceLabel)
+    let foundShortcut = v:false
+    let buffer = []
+    for char in split(a:choiceLabel, '\zs')
+        if v:false == foundShortcut && -1 == index(s:usedShortcuts, tolower(char))
+            let foundShortcut = v:true
+
+            call add(buffer, '&')
+            call add(s:usedShortcuts, tolower(char))
+        endif
+
+        call add(buffer, char)
+    endfor
+
+    return join(buffer, "")
+endfunction
+
 function! phpactor#input#list(label, choices, multi, ResultHandler)
     let choices = sort(keys(a:choices))
 
     try
-      let strategy = g:phpactorInputListStrategy
-      call call(strategy, [a:label, choices, a:multi, a:ResultHandler])
+        let strategy = g:phpactorInputListStrategy
+        call call(strategy, [a:label, choices, a:multi, a:ResultHandler])
     catch /E117/
-      redraw!
-      echo 'The strategy "'. strategy .'" is unknown, check the value of "g:phpactorInputListStrategy".'
+        redraw!
+        echo 'The strategy "'. strategy .'" is unknown, check the value of "g:phpactorInputListStrategy".'
     endtry
 endfunction
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "phpactor/logging-extension": "~0.2",
         "phpactor/path-finder": "~0.1",
         "phpactor/reference-finder-rpc-extension": "~0.1",
-        "phpactor/rpc-extension": "~0.2",
+        "phpactor/rpc-extension": "^0.2.1",
         "phpactor/source-code-filesystem": "~0.1",
         "phpactor/source-code-filesystem-extension": "~0.1",
         "phpactor/text-document": "~1.1.2",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
         "sebastian/diff": "^3.0",
         "symfony/filesystem": "^3.3",
         "symfony/yaml": "^3.3",
-        "webmozart/glob": "^4.1"
+        "webmozart/glob": "^4.1",
+        "dantleech/invoke": "dev-master"
     },
     "require-dev": {
         "symfony/debug": "^4.0",
@@ -66,7 +67,7 @@
     },
     "config": {
         "platform": {
-            "php": "7.1.3"
+            "php": "7.2.0"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "symfony/filesystem": "^3.3",
         "symfony/yaml": "^3.3",
         "webmozart/glob": "^4.1",
-        "dantleech/invoke": "dev-master"
+        "dantleech/invoke": "^1.0.1"
     },
     "require-dev": {
         "symfony/debug": "^4.0",
@@ -69,5 +69,11 @@
         "platform": {
             "php": "7.2.0"
         }
+    },
+    "scripts": {
+        "integrate": [
+            "vendor/bin/phpunit",
+            "vendor/bin/php-cs-fixer fix"
+        ]
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "01fd9474dfc05580849e040e3ac18c9b",
+    "content-hash": "f0ad39e3462ddefbeeb96079dc77c1e5",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -306,6 +306,47 @@
                 "performance"
             ],
             "time": "2019-11-06T16:40:04+00:00"
+        },
+        {
+            "name": "dantleech/invoke",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dantleech/invoke.git",
+                "reference": "cd7a41cc2a915939fab12720dffe1f41684848f4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dantleech/invoke/zipball/cd7a41cc2a915939fab12720dffe1f41684848f4",
+                "reference": "cd7a41cc2a915939fab12720dffe1f41684848f4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.13",
+                "phpstan/phpstan": "^0.11.4",
+                "phpunit/phpunit": "^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DTL\\Invoke\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "daniel leech",
+                    "email": "daniel@dantleech.com"
+                }
+            ],
+            "description": "Emulate named parameters",
+            "time": "2019-12-18T09:44:11+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -1821,12 +1862,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/rpc-extension.git",
-                "reference": "1f4ae33c4bc6e0c0006164e6294940abd33c151d"
+                "reference": "8ed9a1709c885b87415341897387cb34dad2bd94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/rpc-extension/zipball/1f4ae33c4bc6e0c0006164e6294940abd33c151d",
-                "reference": "1f4ae33c4bc6e0c0006164e6294940abd33c151d",
+                "url": "https://api.github.com/repos/phpactor/rpc-extension/zipball/8ed9a1709c885b87415341897387cb34dad2bd94",
+                "reference": "8ed9a1709c885b87415341897387cb34dad2bd94",
                 "shasum": ""
             },
             "require": {
@@ -1864,7 +1905,7 @@
                 }
             ],
             "description": "RPC Extension",
-            "time": "2019-12-04T19:51:46+00:00"
+            "time": "2020-02-29T09:54:08+00:00"
         },
         {
             "name": "phpactor/source-code-filesystem",
@@ -5680,16 +5721,17 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "dantleech/invoke": 20,
         "phpactor/test-utils": 20,
         "friendsofphp/php-cs-fixer": 20
     },
-    "prefer-stable": false,
+    "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^7.1"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.1.3"
+        "php": "7.2.0"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f0ad39e3462ddefbeeb96079dc77c1e5",
+    "content-hash": "77cafd9d809485bb153f836182dd0750",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -309,7 +309,7 @@
         },
         {
             "name": "dantleech/invoke",
-            "version": "dev-master",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dantleech/invoke.git",
@@ -5721,11 +5721,10 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "dantleech/invoke": 20,
         "phpactor/test-utils": 20,
         "friendsofphp/php-cs-fixer": 20
     },
-    "prefer-stable": true,
+    "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": "^7.1"

--- a/lib/Extension/CodeTransformExtra/CodeTransformExtraExtension.php
+++ b/lib/Extension/CodeTransformExtra/CodeTransformExtraExtension.php
@@ -30,7 +30,6 @@ use Phpactor\Container\ContainerBuilder;
 use Phpactor\Container\Extension;
 use Phpactor\Extension\CodeTransformExtra\Rpc\ImportMissingClassesHandler;
 use Phpactor\Extension\CodeTransform\CodeTransformExtension;
-use Phpactor\Extension\Core\CoreExtension;
 use Phpactor\Extension\Logger\LoggingExtension;
 use Phpactor\Extension\Php\Model\PhpVersionResolver;
 use Phpactor\Extension\Rpc\RpcExtension;

--- a/lib/Extension/ContextMenu/ContextMenuExtension.php
+++ b/lib/Extension/ContextMenu/ContextMenuExtension.php
@@ -7,6 +7,7 @@ use Phpactor\Extension\ContextMenu\Handler\ContextMenuHandler;
 use Phpactor\Container\Extension;
 use Phpactor\Container\ContainerBuilder;
 use Phpactor\Container\Container;
+use Phpactor\Extension\ContextMenu\Model\ContextMenu;
 use Phpactor\Extension\Rpc\RpcExtension;
 use Phpactor\Extension\WorseReflection\WorseReflectionExtension;
 use Phpactor\MapResolver\Resolver;
@@ -25,7 +26,7 @@ class ContextMenuExtension implements Extension
                 $container->get(WorseReflectionExtension::SERVICE_REFLECTOR),
                 $container->get(CodeTransformExtension::SERVICE_CLASS_INTERESTING_OFFSET_FINDER),
                 $container->get('application.helper.class_file_normalizer'),
-                json_decode(file_get_contents(__DIR__ . '/menu.json'), true),
+                ContextMenu::fromArray(json_decode(file_get_contents(__DIR__ . '/menu.json'), true)),
                 $container
             );
         }, [ RpcExtension::TAG_RPC_HANDLER => ['name' => ContextMenuHandler::NAME] ]);

--- a/lib/Extension/ContextMenu/Handler/ContextMenuHandler.php
+++ b/lib/Extension/ContextMenu/Handler/ContextMenuHandler.php
@@ -3,6 +3,7 @@
 namespace Phpactor\Extension\ContextMenu\Handler;
 
 use Phpactor\CodeTransform\Domain\Helper\InterestingOffsetFinder;
+use Phpactor\Extension\ContextMenu\Model\Action;
 use Phpactor\Extension\ContextMenu\Model\ContextMenu;
 use Phpactor\MapResolver\Resolver;
 use Phpactor\Extension\Rpc\Handler;
@@ -144,7 +145,9 @@ class ContextMenuHandler implements Handler
                     self::PARAMETER_ACTION,
                     sprintf('%s "%s":', ucfirst($symbol->symbolType()), $symbol->name()),
                     array_combine(array_keys($symbolMenu), array_keys($symbolMenu))
-                )
+                )->withKeys(array_combine(array_keys($symbolMenu), array_map(function (Action $action) {
+                    return $action->key();
+                }, $symbolMenu)))
             ]
         );
     }

--- a/lib/Extension/ContextMenu/Model/Action.php
+++ b/lib/Extension/ContextMenu/Model/Action.php
@@ -34,7 +34,7 @@ class Action
         return $this->parameters;
     }
 
-    public function key(): string
+    public function key(): ?string
     {
         return $this->key;
     }

--- a/lib/Extension/ContextMenu/Model/Action.php
+++ b/lib/Extension/ContextMenu/Model/Action.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Phpactor\Extension\ContextMenu\Model;
+
+class Action
+{
+    /**
+     * @var string
+     */
+    private $action;
+    /**
+     * @var string|null
+     */
+    private $key;
+    /**
+     * @var array
+     */
+    private $parameters;
+
+    public function __construct(string $action, ?string $key = null, array $parameters = [])
+    {
+        $this->action = $action;
+        $this->key = $key;
+        $this->parameters = $parameters;
+    }
+
+    public function action(): string
+    {
+        return $this->action;
+    }
+
+    public function parameters(): array
+    {
+        return $this->parameters;
+    }
+
+    public function key(): string
+    {
+        return $this->key;
+    }
+}

--- a/lib/Extension/ContextMenu/Model/ContextMenu.php
+++ b/lib/Extension/ContextMenu/Model/ContextMenu.php
@@ -24,9 +24,10 @@ class ContextMenu
         }
 
         $this->contexts = $contexts;
+        $this->validate();
     }
 
-    public function fromArray(array $array)
+    public function fromArray(array $array): self
     {
         return Invoke::new(self::class, $array);
     }
@@ -61,5 +62,32 @@ class ContextMenu
         }
 
         return $this->actions[$name];
+    }
+
+    private function validate(): void
+    {
+        $missingActions = [];
+        foreach ($this->contexts as $name => $actions) {
+            $keys = [];
+            foreach ($actions as $actionName) {
+
+                if (!isset($this->actions[$actionName])) {
+                    throw new RuntimeException(sprintf(
+                        'Action "%s" used in context "%s" does not exist, known actions: "%s"'
+                    , $actionName, $name, implode('", "', array_keys($this->actions))));
+                }
+
+                $action = $this->actions[$actionName];
+
+                if (isset($keys[$action->key()])) {
+                    throw new RuntimeException(sprintf(
+                        'Key "%s" in context "%s" mapped by action "%s" is already used by action "%s"',
+                        $action->key(), $name, $actionName, $keys[$action->key()]
+                    ));
+                }
+
+                $keys[$action->key()] = $actionName;
+            }
+        }
     }
 }

--- a/lib/Extension/ContextMenu/Model/ContextMenu.php
+++ b/lib/Extension/ContextMenu/Model/ContextMenu.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Phpactor\Extension\ContextMenu\Model;
+
+use DTL\Invoke\Invoke;
+use RuntimeException;
+
+class ContextMenu
+{
+    /**
+     * @var array
+     */
+    private $actions = [];
+
+    /**
+     * @var array
+     */
+    private $contexts = [];
+
+    public function __construct(array $actions, array $contexts)
+    {
+        foreach ($actions as $name => $action) {
+            $this->actions[$name] = Invoke::new(Action::class, $action);
+        }
+
+        $this->contexts = $contexts;
+    }
+
+    public function fromArray(array $array)
+    {
+        return Invoke::new(self::class, $array);
+    }
+
+    public function hasContext(string $context): bool
+    {
+        return isset($this->contexts[$context]);
+    }
+
+    public function forContext(string $context): array
+    {
+        if (!isset($this->contexts[$context])) {
+            throw new RuntimeException(sprintf(
+                'Context "%s" does not exist',
+                $context
+            ));
+        }
+
+        return array_combine($this->contexts[$context], array_map(function (string $action) {
+            return $this->getAction($action);
+        }, $this->contexts[$context]));
+    }
+
+    private function getAction(string $name): Action
+    {
+        if (!isset($this->actions[$name])) {
+            throw new RuntimeException(sprintf(
+                'Action "%s" does not exist, known actions: "%s"',
+                $name,
+                implode('", "', array_keys($this->actions))
+            ));
+        }
+
+        return $this->actions[$name];
+    }
+}

--- a/lib/Extension/ContextMenu/Model/ContextMenu.php
+++ b/lib/Extension/ContextMenu/Model/ContextMenu.php
@@ -27,7 +27,7 @@ class ContextMenu
         $this->validate();
     }
 
-    public function fromArray(array $array): self
+    public static function fromArray(array $array): self
     {
         return Invoke::new(self::class, $array);
     }

--- a/lib/Extension/ContextMenu/Model/ContextMenu.php
+++ b/lib/Extension/ContextMenu/Model/ContextMenu.php
@@ -70,11 +70,13 @@ class ContextMenu
         foreach ($this->contexts as $name => $actions) {
             $keys = [];
             foreach ($actions as $actionName) {
-
                 if (!isset($this->actions[$actionName])) {
                     throw new RuntimeException(sprintf(
-                        'Action "%s" used in context "%s" does not exist, known actions: "%s"'
-                    , $actionName, $name, implode('", "', array_keys($this->actions))));
+                        'Action "%s" used in context "%s" does not exist, known actions: "%s"',
+                        $actionName,
+                        $name,
+                        implode('", "', array_keys($this->actions))
+                    ));
                 }
 
                 $action = $this->actions[$actionName];
@@ -82,7 +84,10 @@ class ContextMenu
                 if (isset($keys[$action->key()])) {
                     throw new RuntimeException(sprintf(
                         'Key "%s" in context "%s" mapped by action "%s" is already used by action "%s"',
-                        $action->key(), $name, $actionName, $keys[$action->key()]
+                        $action->key(),
+                        $name,
+                        $actionName,
+                        $keys[$action->key()]
                     ));
                 }
 

--- a/lib/Extension/ContextMenu/menu.json
+++ b/lib/Extension/ContextMenu/menu.json
@@ -27,7 +27,7 @@
                 "source": "%source%"
             }
         },
-        "cycle_visiblity": {
+        "cycle_visibility": {
             "action": "change_visibility",
             "key": "v",
             "parameters": {
@@ -38,7 +38,7 @@
         },
         "find_references": {
             "action": "references",
-            "key": "r",
+            "key": "f",
             "parameters": {
                 "offset": "%offset%",
                 "source": "%source%",
@@ -56,7 +56,7 @@
         },
         "replace_references": {
             "action": "references",
-            "key": "R",
+            "key": "r",
             "parameters": {
                 "offset": "%offset%",
                 "source": "%source%",
@@ -74,14 +74,14 @@
         },
         "class_new": {
             "action": "class_new",
-            "key": "c",
+            "key": "l",
             "parameters": {
                 "current_path": "%path%"
             }
         },
         "copy": {
             "action": "copy_class",
-            "key": "C",
+            "key": "c",
             "parameters": {
                 "source_path": "%path%"
             }
@@ -125,7 +125,7 @@
         },
         "import": {
             "action": "import_class",
-            "key": "u",
+            "key": "p",
             "parameters": {
                 "offset": "%offset%",
                 "path": "%current_path%",
@@ -134,7 +134,7 @@
         },
         "import_missing_classes": {
             "action": "import_missing_classes",
-            "key": "U",
+            "key": "o",
             "parameters": {
                 "path": "%current_path%",
                 "source": "%source%"
@@ -151,7 +151,7 @@
         },
         "goto_implementation": {
             "action": "goto_implementation",
-            "key": "l",
+            "key": "_",
             "parameters": {
                 "offset": "%offset%",
                 "source": "%source%",
@@ -205,7 +205,7 @@
             "goto_implementation"
         ],
         "property": [
-            "cycle_visiblity",
+            "cycle_visibility",
             "find_references",
             "generate_accessor",
             "goto_definition",
@@ -213,7 +213,7 @@
             "hover"
         ],
         "method": [
-            "cycle_visiblity",
+            "cycle_visibility",
             "find_references",
             "generate_method",
             "goto_definition",

--- a/lib/Extension/ContextMenu/menu.json
+++ b/lib/Extension/ContextMenu/menu.json
@@ -1,7 +1,8 @@
 {
-    "variable": {
+    "actions": {
         "rename_variable": {
             "action": "rename_variable",
+            "key": "r",
             "parameters": {
                 "path": "%current_path%",
                 "offset": "%offset%",
@@ -15,9 +16,7 @@
                 "offset": "%offset%",
                 "source": "%source%"
             }
-        }
-    },
-    "string": {
+        },
         "extract_constant": {
             "action": "extract_constant",
             "parameters": {
@@ -25,19 +24,7 @@
                 "offset": "%offset%",
                 "source": "%source%"
             }
-        }
-    },
-    "number": {
-        "extract_constant": {
-            "action": "extract_constant",
-            "parameters": {
-                "path": "%path%",
-                "offset": "%offset%",
-                "source": "%source%"
-            }
-        }
-    },
-    "constant": {
+        },
         "cycle_visiblity": {
             "action": "change_visibility",
             "parameters": {
@@ -60,15 +47,15 @@
                 "offset": "%offset%",
                 "source": "%source%",
                 "path": "%path%"
-            }
-        },
-        "replace_references": {
-            "action": "references",
-            "parameters": {
-                "offset": "%offset%",
-                "source": "%source%",
-                "path": "%current_path%",
-                "mode": "replace"
+            },
+            "replace_references": {
+                "action": "references",
+                "parameters": {
+                    "offset": "%offset%",
+                    "source": "%source%",
+                    "path": "%current_path%",
+                    "mode": "replace"
+                }
             }
         },
         "hover": {
@@ -77,9 +64,7 @@
                 "offset": "%offset%",
                 "source": "%source%"
             }
-        }
-    },
-    "class": {
+        },
         "class_new": {
             "action": "class_new",
             "parameters": {
@@ -90,22 +75,6 @@
             "action": "copy_class",
             "parameters": {
                 "source_path": "%path%"
-            }
-        },
-        "find_references": {
-            "action": "references",
-            "parameters": {
-                "offset": "%offset%",
-                "source": "%source%",
-                "path": "%current_path%"
-            }
-        },
-        "goto_definition": {
-            "action": "goto_definition",
-            "parameters": {
-                "offset": "%offset%",
-                "source": "%source%",
-                "path": "%path%"
             }
         },
         "inflect": {
@@ -133,15 +102,6 @@
                 "source": "%source%"
             }
         },
-        "replace_references": {
-            "action": "references",
-            "parameters": {
-                "offset": "%offset%",
-                "source": "%source%",
-                "mode": "replace",
-                "path": "%current_path%"
-            }
-        },
         "transform_file": {
             "action": "transform",
             "parameters": {
@@ -164,13 +124,6 @@
                 "source": "%source%"
             }
         },
-        "hover": {
-            "action": "hover",
-            "parameters": {
-                "offset": "%offset%",
-                "source": "%source%"
-            }
-        },
         "generate_accessor": {
             "action": "generate_accessor",
             "parameters": {
@@ -188,105 +141,57 @@
             }
         }
     },
-    "property": {
-        "cycle_visiblity": {
-            "action": "change_visibility",
-            "parameters": {
-                "offset": "%offset%",
-                "source": "%source%",
-                "path": "%current_path%"
-            }
-        },
-        "find_references": {
-            "action": "references",
-            "parameters": {
-                "offset": "%offset%",
-                "source": "%source%",
-                "path": "%current_path%"
-            }
-        },
-        "generate_accessor": {
-            "action": "generate_accessor",
-            "parameters": {
-                "path": "%path%",
-                "names": "%symbol%",
-                "source": "%source%",
-                "offset": "%offset%"
-            }
-        },
-        "goto_definition": {
-            "action": "goto_definition",
-            "parameters": {
-                "offset": "%offset%",
-                "source": "%source%",
-                "path": "%path%"
-            }
-        },
-        "replace_references": {
-            "action": "references",
-            "parameters": {
-                "offset": "%offset%",
-                "source": "%source%",
-                "path": "%current_path%",
-                "mode": "replace"
-            }
-        },
-        "hover": {
-            "action": "hover",
-            "parameters": {
-                "offset": "%offset%",
-                "source": "%source%"
-            }
-        }
-    },
-    "method": {
-        "cycle_visiblity": {
-            "action": "change_visibility",
-            "parameters": {
-                "offset": "%offset%",
-                "source": "%source%",
-                "path": "%current_path%"
-            }
-        },
-        "find_references": {
-            "action": "references",
-            "parameters": {
-                "offset": "%offset%",
-                "source": "%source%",
-                "path": "%current_path%"
-            }
-        },
-        "generate_method": {
-            "action": "generate_method",
-            "parameters": {
-                "path": "%current_path%",
-                "offset": "%offset%",
-                "source": "%source%"
-            }
-        },
-        "goto_definition": {
-            "action": "goto_definition",
-            "parameters": {
-                "offset": "%offset%",
-                "source": "%source%",
-                "path": "%path%"
-            }
-        },
-        "replace_references": {
-            "action": "references",
-            "parameters": {
-                "offset": "%offset%",
-                "path": "%current_path%",
-                "source": "%source%",
-                "mode": "replace"
-            }
-        },
-        "hover": {
-            "action": "hover",
-            "parameters": {
-                "offset": "%offset%",
-                "source": "%source%"
-            }
-        }
+    "contexts": {
+        "variable": [
+            "rename_variable",
+            "hover"
+        ],
+        "string": [
+            "extract_constant",
+            "hover"
+        ],
+        "number": [
+            "extract_constant"
+        ],
+        "constant": [
+            "cycle_visibility",
+            "find_references",
+            "goto_definition",
+            "replace_references",
+            "hover"
+        ],
+        "class": [
+            "class_new",
+            "copy",
+            "find_references",
+            "goto_definition",
+            "inflect",
+            "move",
+            "navigate",
+            "override_method",
+            "replace_references",
+            "transform_file",
+            "import",
+            "import_missing_classes",
+            "hover",
+            "generate_accessor",
+            "goto_implementation"
+        ],
+        "property": [
+            "cycle_visiblity",
+            "find_references",
+            "generate_accessor",
+            "goto_definition",
+            "replace_references",
+            "hover"
+        ],
+        "method": [
+            "cycle_visiblity",
+            "find_references",
+            "generate_method",
+            "goto_definition",
+            "replace_references",
+            "hover"
+        ]
     }
 }

--- a/lib/Extension/ContextMenu/menu.json
+++ b/lib/Extension/ContextMenu/menu.json
@@ -12,6 +12,7 @@
         },
         "hover": {
             "action": "hover",
+            "key": "h",
             "parameters": {
                 "offset": "%offset%",
                 "source": "%source%"
@@ -19,6 +20,7 @@
         },
         "extract_constant": {
             "action": "extract_constant",
+            "key": "e",
             "parameters": {
                 "path": "%path%",
                 "offset": "%offset%",
@@ -27,6 +29,7 @@
         },
         "cycle_visiblity": {
             "action": "change_visibility",
+            "key": "v",
             "parameters": {
                 "offset": "%offset%",
                 "source": "%source%",
@@ -35,6 +38,7 @@
         },
         "find_references": {
             "action": "references",
+            "key": "r",
             "parameters": {
                 "offset": "%offset%",
                 "source": "%source%",
@@ -43,23 +47,26 @@
         },
         "goto_definition": {
             "action": "goto_definition",
+            "key": "g",
             "parameters": {
                 "offset": "%offset%",
                 "source": "%source%",
                 "path": "%path%"
-            },
-            "replace_references": {
-                "action": "references",
-                "parameters": {
-                    "offset": "%offset%",
-                    "source": "%source%",
-                    "path": "%current_path%",
-                    "mode": "replace"
-                }
+            }
+        },
+        "replace_references": {
+            "action": "references",
+            "key": "R",
+            "parameters": {
+                "offset": "%offset%",
+                "source": "%source%",
+                "path": "%current_path%",
+                "mode": "replace"
             }
         },
         "hover": {
             "action": "hover",
+            "key": "h",
             "parameters": {
                 "offset": "%offset%",
                 "source": "%source%"
@@ -67,36 +74,42 @@
         },
         "class_new": {
             "action": "class_new",
+            "key": "c",
             "parameters": {
                 "current_path": "%path%"
             }
         },
         "copy": {
             "action": "copy_class",
+            "key": "C",
             "parameters": {
                 "source_path": "%path%"
             }
         },
         "inflect": {
             "action": "class_inflect",
+            "key": "i",
             "parameters": {
                 "current_path": "%path%"
             }
         },
         "move": {
             "action": "move_class",
+            "key": "m",
             "parameters": {
                 "source_path": "%path%"
             }
         },
         "navigate": {
             "action": "navigate",
+            "key": "n",
             "parameters": {
                 "source_path": "%path%"
             }
         },
         "override_method": {
             "action": "override_method",
+            "key": "v",
             "parameters": {
                 "path": "%current_path%",
                 "source": "%source%"
@@ -104,6 +117,7 @@
         },
         "transform_file": {
             "action": "transform",
+            "key": "t",
             "parameters": {
                 "path": "%path%",
                 "source": "%source%"
@@ -111,6 +125,7 @@
         },
         "import": {
             "action": "import_class",
+            "key": "u",
             "parameters": {
                 "offset": "%offset%",
                 "path": "%current_path%",
@@ -119,6 +134,7 @@
         },
         "import_missing_classes": {
             "action": "import_missing_classes",
+            "key": "U",
             "parameters": {
                 "path": "%current_path%",
                 "source": "%source%"
@@ -126,6 +142,7 @@
         },
         "generate_accessor": {
             "action": "generate_accessor",
+            "key": "a",
             "parameters": {
                 "path": "%path%",
                 "source": "%source%",
@@ -134,10 +151,20 @@
         },
         "goto_implementation": {
             "action": "goto_implementation",
+            "key": "l",
             "parameters": {
                 "offset": "%offset%",
                 "source": "%source%",
                 "path": "%path%"
+            }
+        },
+        "generate_method": {
+            "action": "generate_method",
+            "key": "m",
+            "parameters": {
+                "path": "%current_path%",
+                "offset": "%offset%",
+                "source": "%source%"
             }
         }
     },

--- a/lib/Extension/Php/Model/RuntimePhpVersionResolver.php
+++ b/lib/Extension/Php/Model/RuntimePhpVersionResolver.php
@@ -2,8 +2,6 @@
 
 namespace Phpactor\Extension\Php\Model;
 
-use Phpactor\Extension\Php\Model\PhpVersionResolver;
-
 class RuntimePhpVersionResolver implements PhpVersionResolver
 {
     /**

--- a/tests/Unit/Extension/ContextMenu/Handler/ContextMenuHandlerTest.php
+++ b/tests/Unit/Extension/ContextMenu/Handler/ContextMenuHandlerTest.php
@@ -3,6 +3,7 @@
 namespace Phpactor\Tests\Unit\Extension\ContextMenu\Handler;
 
 use Phpactor\CodeTransform\Domain\Helper\InterestingOffsetFinder;
+use Phpactor\Extension\ContextMenu\Model\ContextMenu;
 use Phpactor\Extension\Rpc\Handler;
 use Phpactor\Extension\ContextMenu\Handler\ContextMenuHandler;
 use Phpactor\TextDocument\ByteOffset;
@@ -78,6 +79,20 @@ class ContextMenuHandlerTest extends HandlerTestCase
 
     public function testNoActionsAvailable()
     {
+        $this->menu = ContextMenu::fromArray([
+            'actions' => [
+                Symbol::VARIABLE => [
+                    'action' => self::VARIABLE_ACTION,
+                    'parameters' => [
+                        'one' => 1,
+                    ],
+                ]
+            ],
+            'contexts' => [
+                Symbol::VARIABLE => [
+                ]
+            ]
+        ]);
         $source = SourceCode::fromPathAndString(
             '/hello.php',
             '<?php $hello = "world"; echo $hello;'
@@ -99,14 +114,21 @@ class ContextMenuHandlerTest extends HandlerTestCase
 
     public function testReturnMenu()
     {
-        $this->menu = [
-            Symbol::VARIABLE => [
-                'action' => self::VARIABLE_ACTION,
-                'parameters' => [
-                    'one' => 1,
-                ],
+        $this->menu = ContextMenu::fromArray([
+            'actions' => [
+                Symbol::VARIABLE => [
+                    'action' => self::VARIABLE_ACTION,
+                    'parameters' => [
+                        'one' => 1,
+                    ],
+                ]
+            ],
+            'contexts' => [
+                Symbol::VARIABLE => [
+                    Symbol::VARIABLE
+                ]
             ]
-        ];
+        ]);
 
         $source = SourceCode::fromPathAndString(
             '/hello.php',
@@ -130,14 +152,21 @@ class ContextMenuHandlerTest extends HandlerTestCase
 
     public function testReturnMenuWithOriginalOffset()
     {
-        $this->menu = [
-            Symbol::VARIABLE => [
-                'action' => self::VARIABLE_ACTION,
-                'parameters' => [
-                    'one' => 1,
-                ],
+        $this->menu = ContextMenu::fromArray([
+            'actions' => [
+                Symbol::VARIABLE => [
+                    'action' => self::VARIABLE_ACTION,
+                    'parameters' => [
+                        'one' => 1,
+                    ],
+                ]
+            ],
+            'contexts' => [
+                Symbol::VARIABLE => [
+                    Symbol::VARIABLE
+                ]
             ]
-        ];
+        ]);
 
         $source = SourceCode::fromPathAndString(
             '/hello.php',
@@ -185,8 +214,8 @@ class ContextMenuHandlerTest extends HandlerTestCase
             EchoResponse::fromMessage('Hello')
         );
 
-        $this->menu = [
-            Symbol::VARIABLE => [
+        $this->menu = ContextMenu::fromArray([
+            'actions' => [
                 self::VARIABLE_ACTION => [
                     'action' => self::VARIABLE_ACTION,
                     'parameters' => [
@@ -194,9 +223,14 @@ class ContextMenuHandlerTest extends HandlerTestCase
                         'some_offset' => '%offset%',
                         'some_path' => '%path%',
                     ],
-                ],
+                ]
+            ],
+            'contexts' => [
+                Symbol::VARIABLE => [
+                    self::VARIABLE_ACTION
+                ]
             ]
-        ];
+        ]);
 
         $action = $this->handle(ContextMenuHandler::NAME, [
             'action' => self::VARIABLE_ACTION,

--- a/tests/Unit/Extension/ContextMenu/Model/ContextMenuTest.php
+++ b/tests/Unit/Extension/ContextMenu/Model/ContextMenuTest.php
@@ -4,12 +4,13 @@ namespace Phpactor\Tests\Unit\Extension\ContextMenu\Model;
 
 use PHPUnit\Framework\TestCase;
 use Phpactor\Extension\ContextMenu\Model\ContextMenu;
+use RuntimeException;
 
 class ContextMenuTest extends TestCase
 {
     public function testCreateFromArray()
     {
-        ContextMenu::fromArray([
+        $menu = ContextMenu::fromArray([
             'actions' => [
                 'do_something' => [
                     'action' => 'blah',
@@ -22,6 +23,51 @@ class ContextMenuTest extends TestCase
             'contexts' => [
                 'class' => [
                     'do_something',
+                ],
+            ],
+        ]);
+        self::assertNotNull($menu);
+    }
+
+    public function testExceptionIfKeyIsRepeatedInContext()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Key "b" in context "foo" mapped by action "action2" is already used by action "action1"');
+        ContextMenu::fromArray([
+            'actions' => [
+                'action1' => [
+                    'action' => 'blah',
+                    'key' => 'b',
+                ],
+                'action2' => [
+                    'action' => 'blah',
+                    'key' => 'b',
+                ],
+            ],
+            'contexts' => [
+                'foo' => [
+                    'action1',
+                    'action2',
+                ],
+            ],
+        ]);
+    }
+
+    public function testActionDoesNotExist()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Action "a" used in context "foo" does not exist');
+        ContextMenu::fromArray([
+            'actions' => [
+                'b' => [
+                    'action' => 'blah',
+                    'key' => 'b',
+                ],
+            ],
+            'contexts' => [
+                'foo' => [
+                    'a',
+                    'b',
                 ],
             ],
         ]);

--- a/tests/Unit/Extension/ContextMenu/Model/ContextMenuTest.php
+++ b/tests/Unit/Extension/ContextMenu/Model/ContextMenuTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Phpactor\Tests\Unit\Extension\ContextMenu\Model;
+
+use PHPUnit\Framework\TestCase;
+use Phpactor\Extension\ContextMenu\Model\ContextMenu;
+
+class ContextMenuTest extends TestCase
+{
+    public function testCreateFromArray()
+    {
+        ContextMenu::fromArray([
+            'actions' => [
+                'do_something' => [
+                    'action' => 'blah',
+                    'key' => 'a',
+                    'parameters' => [
+                        'path' => '%path%',
+                    ],
+                ],
+            ],
+            'contexts' => [
+                'class' => [
+                    'do_something',
+                ],
+            ],
+        ]);
+    }
+}

--- a/tests/Unit/Extension/PhpVersionResolver/Model/ComposerPhpVersionResolverTest.php
+++ b/tests/Unit/Extension/PhpVersionResolver/Model/ComposerPhpVersionResolverTest.php
@@ -2,7 +2,6 @@
 
 namespace Phpactor\Tests\Unit\Extension\PhpVersionResolver\Model;
 
-use PHPUnit\Framework\TestCase;
 use Phpactor\Extension\Php\Model\ComposerPhpVersionResolver;
 use Phpactor\Tests\IntegrationTestCase;
 
@@ -11,7 +10,8 @@ class ComposerPhpVersionResolverTest extends IntegrationTestCase
     public function testReturnsPlatform()
     {
         $this->workspace()->reset();
-        $this->workspace()->loadManifest(<<<'EOT'
+        $this->workspace()->loadManifest(
+            <<<'EOT'
 // File: composer.json
 {
     "require": {
@@ -27,7 +27,8 @@ EOT
     public function testReturnsPlatformWithHigherPrio()
     {
         $this->workspace()->reset();
-        $this->workspace()->loadManifest(<<<'EOT'
+        $this->workspace()->loadManifest(
+            <<<'EOT'
 // File: composer.json
 {
     "require": {


### PR DESCRIPTION
Allows the definition of key preferences to the context menu.

Note that we use VIM's `confirm` dialogue, which is case sensitive - which limits some our options when choosing keys.

Fixes #896 