### PR TITLE
Initial vint support

### DIFF
--- a/autoload/phpactor.vim
+++ b/autoload/phpactor.vim
@@ -11,7 +11,7 @@
 "     https://github.com/google/vimdoc. See
 "     https://phpactor.github.io/phpactor/developing.html#vim-help
 
-function! phpactor#Update()
+function! phpactor#Update() abort
     let current = getcwd()
     execute 'cd ' . g:phpactorpath
     echo system('git checkout ' . g:phpactorBranch)
@@ -20,7 +20,7 @@ function! phpactor#Update()
     execute 'cd ' .  current
 endfunction
 
-function! phpactor#Complete(findstart, base)
+function! phpactor#Complete(findstart, base) abort
 
     let lineOffset = line2byte(line("."))
 
@@ -73,7 +73,7 @@ function! phpactor#Complete(findstart, base)
     return completions
 endfunction
 
-function! phpactor#_completeTruncateLabel(label, length)
+function! phpactor#_completeTruncateLabel(label, length) abort
     if strlen(a:label) < a:length
         return a:label
     endif
@@ -81,11 +81,11 @@ function! phpactor#_completeTruncateLabel(label, length)
     return strpart(a:label, 0, a:length - 3) . '...'
 endfunction
 
-function! phpactor#_completionItemHash(completion)
+function! phpactor#_completionItemHash(completion) abort
     return a:completion['word'] . a:completion['menu'] . a:completion['kind']
 endfunction
 
-function! phpactor#_completeImportClass(completedItem)
+function! phpactor#_completeImportClass(completedItem) abort
 
     if !has_key(a:completedItem, "word")
         return
@@ -110,7 +110,7 @@ function! phpactor#_completeImportClass(completedItem)
 
 endfunction
 
-function! phpactor#ExtractMethod(...)
+function! phpactor#ExtractMethod(...) abort
     let positions = {}
 
     if 0 == a:0 " Visual mode - backward compatibility
@@ -129,7 +129,7 @@ function! phpactor#ExtractMethod(...)
     call phpactor#rpc("extract_method", { "path": phpactor#_path(), "offset_start": positions.start, "offset_end": positions.end, "source": phpactor#_source()})
 endfunction
 
-function! phpactor#ExtractExpression(type)
+function! phpactor#ExtractExpression(type) abort
     let positions = {}
 
     if v:true == a:type  " Invoked from Visual mode - backward compatibility
@@ -151,11 +151,11 @@ function! phpactor#ExtractExpression(type)
     call phpactor#rpc("extract_expression", { "path": phpactor#_path(), "offset_start": positions.start, "offset_end": positions.end, "source": phpactor#_source()})
 endfunction
 
-function! phpactor#ExtractConstant()
+function! phpactor#ExtractConstant() abort
     call phpactor#rpc("extract_constant", { "offset": phpactor#_offset(), "source": phpactor#_source(), "path": phpactor#_path()})
 endfunction
 
-function! phpactor#ClassExpand()
+function! phpactor#ClassExpand() abort
     let word = expand("<cword>")
     let classInfo = phpactor#rpc("class_search", { "short_name": word })
 
@@ -171,17 +171,17 @@ function! phpactor#ClassExpand()
     execute "normal! ciw" . namespace_prefix.word
 endfunction
 
-function! phpactor#UseAdd()
+function! phpactor#UseAdd() abort
     call phpactor#ImportClass()
 endfunction
-function! phpactor#ImportClass()
+function! phpactor#ImportClass() abort
     call phpactor#rpc("import_class", {"offset": phpactor#_offset(), "source": phpactor#_source(), "path": expand('%:p')})
 endfunction
-function! phpactor#ImportMissingClasses()
+function! phpactor#ImportMissingClasses() abort
     call phpactor#rpc("import_missing_classes", {"source": phpactor#_source(), "path": expand('%:p')})
 endfunction
 
-function! phpactor#_GotoDefinitionTarget(target)
+function! phpactor#_GotoDefinitionTarget(target) abort
     call phpactor#rpc("goto_definition", {
                 \"offset": phpactor#_offset(),
                 \"source": phpactor#_source(),
@@ -189,10 +189,10 @@ function! phpactor#_GotoDefinitionTarget(target)
                 \"target": a:target,
                 \'language': &ft})
 endfunction
-function! phpactor#GotoDefinition()
+function! phpactor#GotoDefinition() abort
     call phpactor#_GotoDefinitionTarget('focused_window')
 endfunction
-function! phpactor#GotoImplementations()
+function! phpactor#GotoImplementations() abort
     call phpactor#rpc("goto_implementation", {
                 \"offset": phpactor#_offset(),
                 \"source": phpactor#_source(),
@@ -200,41 +200,41 @@ function! phpactor#GotoImplementations()
                 \"target": 'focused_window',
                 \'language': &ft})
 endfunction
-function! phpactor#GotoDefinitionVsplit()
+function! phpactor#GotoDefinitionVsplit() abort
     call phpactor#_GotoDefinitionTarget('vsplit')
 endfunction
-function! phpactor#GotoDefinitionHsplit()
+function! phpactor#GotoDefinitionHsplit() abort
     call phpactor#_GotoDefinitionTarget('hsplit')
 endfunction
-function! phpactor#GotoDefinitionTab()
+function! phpactor#GotoDefinitionTab() abort
     call phpactor#_GotoDefinitionTarget('new_tab')
 endfunction
 
-function! phpactor#Hover()
+function! phpactor#Hover() abort
     call phpactor#rpc("hover", { "offset": phpactor#_offset(), "source": phpactor#_source() })
 endfunction
 
-function! phpactor#ContextMenu()
+function! phpactor#ContextMenu() abort
     call phpactor#rpc("context_menu", { "offset": phpactor#_offset(), "source": phpactor#_source(), "current_path": expand('%:p') })
 endfunction
 
-function! phpactor#CopyFile()
+function! phpactor#CopyFile() abort
     call phpactor#rpc("copy_class", { "source_path": phpactor#_path() })
 endfunction
 
-function! phpactor#MoveFile()
+function! phpactor#MoveFile() abort
     call phpactor#rpc("move_class", { "source_path": phpactor#_path() })
 endfunction
 
-function! phpactor#OffsetTypeInfo()
+function! phpactor#OffsetTypeInfo() abort
     call phpactor#rpc("offset_info", { "offset": phpactor#_offset(), "source": phpactor#_source()})
 endfunction
 
-function! phpactor#ExtensionList()
+function! phpactor#ExtensionList() abort
     call phpactor#rpc("extension_list", {})
 endfunction
 
-function! phpactor#ExtensionInstall(...)
+function! phpactor#ExtensionInstall(...) abort
     if v:false != get(a:,1, v:false)
         call phpactor#rpc("extension_install", {"extension_name":get(a:,1)})
         return
@@ -242,7 +242,7 @@ function! phpactor#ExtensionInstall(...)
     call phpactor#rpc("extension_install", {})
 endfunction
 
-function! phpactor#ExtensionRemove(...)
+function! phpactor#ExtensionRemove(...) abort
     if v:false != get(a:,1, v:false)
         call phpactor#rpc("extension_remove", {"extension_name":get(a:,1)})
         return
@@ -250,7 +250,7 @@ function! phpactor#ExtensionRemove(...)
     call phpactor#rpc("extension_remove", {})
 endfunction
 
-function! phpactor#Transform(...)
+function! phpactor#Transform(...) abort
     let transform = get(a:, 1, '')
 
     let args = { "path": phpactor#_path(), "source": phpactor#_source() }
@@ -262,67 +262,67 @@ function! phpactor#Transform(...)
     call phpactor#rpc("transform", args)
 endfunction
 
-function! phpactor#ClassNew()
+function! phpactor#ClassNew() abort
     call phpactor#rpc("class_new", { "current_path": phpactor#_path() })
 endfunction
 
-function! phpactor#ClassInflect()
+function! phpactor#ClassInflect() abort
     call phpactor#rpc("class_inflect", { "current_path": phpactor#_path() })
 endfunction
 
 " Deprecated!! Use FindReferences
-function! phpactor#ClassReferences()
+function! phpactor#ClassReferences() abort
     call phpactor#FindReferences()
 endfunction
 
-function! phpactor#FindReferences()
+function! phpactor#FindReferences() abort
     call phpactor#rpc("references", { "offset": phpactor#_offset(), "source": phpactor#_source(), "path": phpactor#_path()})
 endfunction
 
-function! phpactor#Navigate()
+function! phpactor#Navigate() abort
     call phpactor#rpc("navigate", { "source_path": phpactor#_path() })
 endfunction
 
-function! phpactor#CacheClear()
+function! phpactor#CacheClear() abort
     call phpactor#rpc("cache_clear", {})
 endfunction
 
-function! phpactor#Status()
+function! phpactor#Status() abort
     call phpactor#rpc("status", {})
 endfunction
 
-function! phpactor#Config()
+function! phpactor#Config() abort
     call phpactor#rpc("config", {})
 endfunction
 
-function! phpactor#GetNamespace()
+function! phpactor#GetNamespace() abort
     let fileInfo = phpactor#rpc("file_info", { "path": phpactor#_path() })
 
     return fileInfo['class_namespace']
 endfunction
 
-function! phpactor#GetClassFullName()
+function! phpactor#GetClassFullName() abort
     let fileInfo = phpactor#rpc("file_info", { "path": phpactor#_path() })
 
     return fileInfo['class']
 endfunction
 
-function! phpactor#ChangeVisibility()
+function! phpactor#ChangeVisibility() abort
     call phpactor#rpc("change_visibility", { "offset": phpactor#_offset(), "source": phpactor#_source(), "path": expand('%:p') })
 endfunction
 
-function! phpactor#GenerateAccessors()
+function! phpactor#GenerateAccessors() abort
     call phpactor#rpc("generate_accessor", { "source": phpactor#_source(), "path": expand('%:p'), 'offset': phpactor#_offset() })
 endfunction
 
 """""""""""""""""""""""
 " Utility functions
 """""""""""""""""""""""
-function! s:isOpenInCurrentWindow(filePath)
+function! s:isOpenInCurrentWindow(filePath) abort
   return expand('%:p') == a:filePath
 endfunction
 
-function! phpactor#_switchToBufferOrEdit(filePath)
+function! phpactor#_switchToBufferOrEdit(filePath) abort
     if s:isOpenInCurrentWindow(a:filePath)
         return v:false
     endif
@@ -336,19 +336,19 @@ function! phpactor#_switchToBufferOrEdit(filePath)
     exec command
 endfunction
 
-function! phpactor#_offset()
+function! phpactor#_offset() abort
     return line2byte(line('.')) + col('.') - 1
 endfunction
 
-function! phpactor#_source()
+function! phpactor#_source() abort
     return join(getline(1,'$'), "\n")
 endfunction
 
-function! phpactor#_path()
+function! phpactor#_path() abort
     return expand('%:p')
 endfunction
 
-function! s:getStartOffsetFromMark(mark, linewise)
+function! s:getStartOffsetFromMark(mark, linewise) abort
     let [line, column] = getpos(a:mark)[1:2]
     let offset = line2byte(line)
 
@@ -359,7 +359,7 @@ function! s:getStartOffsetFromMark(mark, linewise)
     return offset + column - 2
 endfunction
 
-function! s:getEndOffsetFromMark(mark, linewise)
+function! s:getEndOffsetFromMark(mark, linewise) abort
     let [line, column] = getpos(a:mark)[1:2]
     let offset = line2byte(line)
     let lineLenght = strlen(getline(line))
@@ -376,15 +376,15 @@ function! s:getEndOffsetFromMark(mark, linewise)
     return offset + column - 1
 endfunction
 
-function! phpactor#_selectionStart()
+function! phpactor#_selectionStart() abort
     return s:getStartOffsetFromMark("'<", v:false)
 endfunction
 
-function! phpactor#_selectionEnd()
+function! phpactor#_selectionEnd() abort
     return s:getEndOffsetFromMark("'>", v:false)
 endfunction
 
-function! phpactor#_applyTextEdits(path, edits)
+function! phpactor#_applyTextEdits(path, edits) abort
     call phpactor#_switchToBufferOrEdit(a:path)
 
     let postCursorPosition = getpos('.')
@@ -427,7 +427,7 @@ endfunction
 " RPC -->-->-->-->-->--
 """""""""""""""""""""""
 
-function! phpactor#rpc(action, arguments)
+function! phpactor#rpc(action, arguments) abort
     " Remove any existing output in the message window
     execute ':redraw'
 
@@ -457,7 +457,7 @@ function! phpactor#rpc(action, arguments)
     endif
 endfunction
 
-function! phpactor#_rpc_dispatch(actionName, parameters)
+function! phpactor#_rpc_dispatch(actionName, parameters) abort
 
     " >> return_choice
     if a:actionName == "return"
@@ -646,7 +646,7 @@ function! phpactor#_rpc_dispatch(actionName, parameters)
     throw "Do not know how to handle action '" . a:actionName . "'"
 endfunction
 
-function! s:openFileInSelectedTarget(filePath, target, useOpenWindow, forceReload)
+function! s:openFileInSelectedTarget(filePath, target, useOpenWindow, forceReload) abort
     let bufferNumber = bufnr(a:filePath . "$")
     if v:true == a:useOpenWindow && -1 != bufferNumber
         let firstWindowId = get(win_findbuf(bufferNumber), 0, v:null)
@@ -681,13 +681,13 @@ function! s:openFileInSelectedTarget(filePath, target, useOpenWindow, forceReloa
     endif
 endfunction
 
-function! phpactor#_rpc_dispatch_input_handler(Next, parameters, parameterName, result)
+function! phpactor#_rpc_dispatch_input_handler(Next, parameters, parameterName, result) abort
     let a:parameters[a:parameterName] = a:result
 
     call a:Next(a:parameters)
 endfunction
 
-function! phpactor#_rpc_dispatch_input(inputs, action, parameters)
+function! phpactor#_rpc_dispatch_input(inputs, action, parameters) abort
     let input = remove(a:inputs, 0)
     let inputParameters = input['parameters']
 

--- a/autoload/phpactor.vim
+++ b/autoload/phpactor.vim
@@ -10,6 +10,9 @@
 " NOTE: This help is auto-generated from the VimScript using
 "     https://github.com/google/vimdoc. See
 "     https://phpactor.github.io/phpactor/developing.html#vim-help
+" vint: -ProhibitUnnecessaryDoubleQuote
+" vint: -ProhibitImplicitScopeVariable
+" vint: -ProhibitAbbreviationOption
 
 function! phpactor#Update() abort
     let current = getcwd()

--- a/autoload/phpactor.vim
+++ b/autoload/phpactor.vim
@@ -116,14 +116,14 @@ endfunction
 function! phpactor#ExtractMethod(...) abort
     let positions = {}
 
-    if 0 == a:0 " Visual mode - backward compatibility
+    if 0 ==# a:0 " Visual mode - backward compatibility
         let positions.start = phpactor#_selectionStart()
         let positions.end = phpactor#_selectionEnd()
     elseif a:1 ==? 'v' " Visual mode
         let positions.start = phpactor#_selectionStart()
         let positions.end = phpactor#_selectionEnd()
     else " Linewise or characterwise motion
-        let linewise = 'line' == a:1
+        let linewise = 'line' ==# a:1
 
         let positions.start = s:getStartOffsetFromMark("'[", linewise)
         let positions.end = s:getEndOffsetFromMark("']", linewise)
@@ -135,17 +135,17 @@ endfunction
 function! phpactor#ExtractExpression(type) abort
     let positions = {}
 
-    if v:true == a:type  " Invoked from Visual mode - backward compatibility
+    if v:true ==# a:type  " Invoked from Visual mode - backward compatibility
         let positions.start = phpactor#_selectionStart()
         let positions.end = phpactor#_selectionEnd()
-    elseif v:false == a:type " Invoked from an offset - backward compatibility
+    elseif v:false ==# a:type " Invoked from an offset - backward compatibility
         let positions.start = phpactor#_offset()
         let positions.end = v:null
     elseif a:type ==? 'v' " Visual mode
         let positions.start = phpactor#_selectionStart()
         let positions.end = phpactor#_selectionEnd()
     else " Linewise or characterwise motion
-        let linewise = 'line' == a:type
+        let linewise = 'line' ==# a:type
 
         let positions.start = s:getStartOffsetFromMark("'[", linewise)
         let positions.end = s:getEndOffsetFromMark("']", linewise)
@@ -258,7 +258,7 @@ function! phpactor#Transform(...) abort
 
     let args = { "path": phpactor#_path(), "source": phpactor#_source() }
 
-    if transform != ''
+    if transform !=# ''
         let args.transform = transform
     endif
 
@@ -322,7 +322,7 @@ endfunction
 " Utility functions
 """""""""""""""""""""""
 function! s:isOpenInCurrentWindow(filePath) abort
-  return expand('%:p') == a:filePath
+  return expand('%:p') ==# a:filePath
 endfunction
 
 function! phpactor#_switchToBufferOrEdit(filePath) abort
@@ -332,7 +332,7 @@ function! phpactor#_switchToBufferOrEdit(filePath) abort
 
     let bufferNumber = bufnr(a:filePath . '$')
 
-    let command = (bufferNumber == -1)
+    let command = (bufferNumber ==# -1)
           \ ? ":edit " . a:filePath
           \ : ":buffer " . bufferNumber
 
@@ -355,7 +355,7 @@ function! s:getStartOffsetFromMark(mark, linewise) abort
     let [line, column] = getpos(a:mark)[1:2]
     let offset = line2byte(line)
 
-    if v:true == a:linewise
+    if v:true ==# a:linewise
         return offset - 1
     endif
 
@@ -367,7 +367,7 @@ function! s:getEndOffsetFromMark(mark, linewise) abort
     let offset = line2byte(line)
     let lineLenght = strlen(getline(line))
 
-    if v:true == a:linewise
+    if v:true ==# a:linewise
         return offset + lineLenght - 1
     endif
 
@@ -413,7 +413,7 @@ function! phpactor#_applyTextEdits(path, edits) abort
             endif
         endif
 
-        let newLines = edit.text == "\n" ? [''] : split(edit.text, "\n")
+        let newLines = edit.text ==# "\n" ? [''] : split(edit.text, "\n")
         keepjumps call append(startLine, newLines)
 
         if startLine < curLine
@@ -439,7 +439,7 @@ function! phpactor#rpc(action, arguments) abort
     let cmd = g:phpactorPhpBin . ' ' . g:phpactorbinpath . ' rpc --working-dir=' . g:phpactorInitialCwd
     let result = system(cmd, json_encode(request))
 
-    if (v:shell_error == 0)
+    if (v:shell_error ==# 0)
         try
             let response = json_decode(result)
         catch
@@ -463,12 +463,12 @@ endfunction
 function! phpactor#_rpc_dispatch(actionName, parameters) abort
 
     " >> return_choice
-    if a:actionName == "return"
+    if a:actionName ==# "return"
         return a:parameters["value"]
     endif
 
     " >> return_choice
-    if a:actionName == "return_choice"
+    if a:actionName ==# "return_choice"
         let list = []
         let c = 1
         for choice in a:parameters["choices"]
@@ -478,7 +478,7 @@ function! phpactor#_rpc_dispatch(actionName, parameters) abort
 
         let choice = inputlist(list)
 
-        if (choice == 0)
+        if (choice ==# 0)
             return
         endif
 
@@ -488,19 +488,19 @@ function! phpactor#_rpc_dispatch(actionName, parameters) abort
     endif
 
     " >> echo
-    if a:actionName == "echo"
+    if a:actionName ==# "echo"
         echo a:parameters["message"]
         return
     endif
 
     " >> error
-    if a:actionName == "error"
+    if a:actionName ==# "error"
         echo "Error from Phpactor: " . a:parameters["message"]
         return
     endif
 
     " >> collection
-    if a:actionName == "collection"
+    if a:actionName ==# "collection"
         for action in a:parameters["actions"]
             let result = phpactor#_rpc_dispatch(action["name"], action["parameters"])
 
@@ -513,7 +513,7 @@ function! phpactor#_rpc_dispatch(actionName, parameters) abort
     endif
 
     " >> open_file
-    if a:actionName == "open_file"
+    if a:actionName ==# "open_file"
         let changedFileOrWindow = v:true
 
         call s:openFileInSelectedTarget(
@@ -523,7 +523,7 @@ function! phpactor#_rpc_dispatch(actionName, parameters) abort
               \ a:parameters["force_reload"]
               \ )
 
-        if a:parameters["target"] == 'focused_window'
+        if a:parameters["target"] ==# 'focused_window'
             let changedFileOrWindow = !s:isOpenInCurrentWindow(a:parameters["path"])
         endif
 
@@ -537,10 +537,10 @@ function! phpactor#_rpc_dispatch(actionName, parameters) abort
     endif
 
     " >> close_file
-    if a:actionName == "close_file"
+    if a:actionName ==# "close_file"
         let bufferNumber = bufnr(a:parameters['path']. '$')
 
-        if (bufferNumber == -1)
+        if (bufferNumber ==# -1)
             return
         endif
 
@@ -549,10 +549,10 @@ function! phpactor#_rpc_dispatch(actionName, parameters) abort
     endif
 
     " >> file references
-    if a:actionName == "file_references"
+    if a:actionName ==# "file_references"
         " if there is only one file, and it is the open file, don't
         " bother opening the quick fix window
-        if len(a:parameters['file_references']) == 1
+        if len(a:parameters['file_references']) ==# 1
             let fileRefs = a:parameters['file_references'][0]
             if -1 != match(fileRefs['file'], bufname('%') . '$')
                 return
@@ -577,7 +577,7 @@ function! phpactor#_rpc_dispatch(actionName, parameters) abort
     endif
 
     " >> input_callback
-    if a:actionName == "input_callback"
+    if a:actionName ==# "input_callback"
         let inputs = a:parameters['inputs']
         let action = a:parameters['callback']['action']
         let parameters = a:parameters['callback']['parameters']
@@ -592,7 +592,7 @@ function! phpactor#_rpc_dispatch(actionName, parameters) abort
     endif
 
     " >> information
-    if a:actionName == "information"
+    if a:actionName ==# "information"
         " We write to a temporary file and then "edit" it in the preview
         " window. Not sure if there is a better way to do this.
         let temp = resolve(tempname())
@@ -613,13 +613,13 @@ function! phpactor#_rpc_dispatch(actionName, parameters) abort
     "       offset is not taken into account, so same-line edits will cause an
     "       incorrect post-edit cursor character offset.
     "
-    if a:actionName == "update_file_source"
+    if a:actionName ==# "update_file_source"
         call phpactor#_applyTextEdits(a:parameters['path'], a:parameters['edits'])
         return
     endif
 
     " >> replace_file_source
-    if a:actionName == "replace_file_source"
+    if a:actionName ==# "replace_file_source"
 
         " if the file is open in a buffer, reload it before replacing it's
         " source (avoid file-modified-on-disk errors)
@@ -651,7 +651,7 @@ endfunction
 
 function! s:openFileInSelectedTarget(filePath, target, useOpenWindow, forceReload) abort
     let bufferNumber = bufnr(a:filePath . "$")
-    if v:true == a:useOpenWindow && -1 != bufferNumber
+    if v:true ==# a:useOpenWindow && -1 != bufferNumber
         let firstWindowId = get(win_findbuf(bufferNumber), 0, v:null)
 
         if v:null != firstWindowId
@@ -660,25 +660,25 @@ function! s:openFileInSelectedTarget(filePath, target, useOpenWindow, forceReloa
         endif
     endif
 
-    if a:target == 'focused_window'
+    if a:target ==# 'focused_window'
         call phpactor#_switchToBufferOrEdit(a:filePath)
-        if v:true == a:forceReload
+        if v:true ==# a:forceReload
           exec "e!"
         endif
         return
     endif
 
-    if a:target == 'vsplit'
+    if a:target ==# 'vsplit'
         exec ":vsplit " . a:filePath
         return
     endif
 
-    if a:target == 'hsplit'
+    if a:target ==# 'hsplit'
         exec ":split " . a:filePath
         return
     endif
 
-    if a:target == 'new_tab'
+    if a:target ==# 'new_tab'
         exec ":tabnew " . a:filePath
         return
     endif
@@ -707,25 +707,25 @@ function! phpactor#_rpc_dispatch_input(inputs, action, parameters) abort
     " Remove any existing output in the message window
     execute ':redraw'
 
-    if 'text' == input['type']
+    if 'text' ==# input['type']
         let TypeHandler = function('phpactor#input#text', [
             \ inputParameters['label'],
             \ inputParameters['default'],
             \ inputParameters['type']
         \ ])
-    elseif 'choice' == input['type']
+    elseif 'choice' ==# input['type']
         let TypeHandler = function('phpactor#input#choice', [
             \ inputParameters['label'],
             \ inputParameters['choices'],
             \ inputParameters['keyMap']
         \ ])
-    elseif 'list' == input['type']
+    elseif 'list' ==# input['type']
         let TypeHandler = function('phpactor#input#list', [
             \ inputParameters['label'],
             \ inputParameters['choices'],
             \ inputParameters['multi']
         \ ])
-    elseif 'confirm' == input['type']
+    elseif 'confirm' ==# input['type']
         let TypeHandler = function('phpactor#input#confirm', [
             \ inputParameters['label']
         \ ])

--- a/autoload/phpactor/input.vim
+++ b/autoload/phpactor/input.vim
@@ -9,7 +9,7 @@ function! phpactor#input#text(label, default, completionType, ResultHandler) abo
 endfunction
 
 function! phpactor#input#confirm(label, ResultHandler) abort
-    let l:hoice = confirm(a:label, "&Yes\n&No\n")
+    let l:choice = confirm(a:label, "&Yes\n&No\n")
 
     if l:choice == 1
         let l:response = v:true

--- a/autoload/phpactor/input.vim
+++ b/autoload/phpactor/input.vim
@@ -1,109 +1,109 @@
-function! phpactor#input#text(label, default, completionType, ResultHandler)
+function! phpactor#input#text(label, default, completionType, ResultHandler) abort
     if v:null != a:completionType
-        let text = input(a:label, a:default, a:completionType)
+        let l:text = input(a:label, a:default, a:completionType)
     else
-        let text = input(a:label, a:default)
+        let l:text = input(a:label, a:default)
     endif
 
-    call a:ResultHandler(text)
+    call a:ResultHandler(l:text)
 endfunction
 
-function! phpactor#input#confirm(label, ResultHandler)
-    let choice = confirm(a:label, "&Yes\n&No\n")
+function! phpactor#input#confirm(label, ResultHandler) abort
+    let l:hoice = confirm(a:label, "&Yes\n&No\n")
 
-    if choice == 1
-        let response = v:true
+    if l:choice == 1
+        let l:response = v:true
     else
-        let response = v:false
+        let l:response = v:false
     endif
 
-    call a:ResultHandler(response)
+    call a:ResultHandler(l:response)
 endfunction
 
 let s:usedShortcuts = []
-function! phpactor#input#choice(label, choices, keyMap, ResultHandler)
+function! phpactor#input#choice(label, choices, keyMap, ResultHandler) abort
     let s:usedShortcuts = []
-    let list = []
+    let l:list = []
 
     if empty(a:choices)
-        call confirm("No choices available")
-        throw "cancelled"
+        call confirm('No choices available')
+        throw 'cancelled'
     endif
 
-    for choiceLabel in keys(a:choices)
-        let buffer = []
+    for l:choiceLabel in keys(a:choices)
+        let l:buffer = []
 
         " note that a:keyMap can be an empty list because PHP's json_decode
         " can't tell the difference between an empty list and an empty dict
-        if !empty(a:keyMap) && has_key(a:keyMap, choiceLabel) && !empty(a:keyMap[choiceLabel])
-            let confirmLabel = s:determineConfirmLabelFromPreference(choiceLabel, a:keyMap[choiceLabel])
+        if !empty(a:keyMap) && has_key(a:keyMap, l:choiceLabel) && !empty(a:keyMap[l:choiceLabel])
+            let l:confirmLabel = s:determineConfirmLabelFromPreference(l:choiceLabel, a:keyMap[l:choiceLabel])
         else
-            let confirmLabel = s:determineConfirmLabel(choiceLabel)
+            let l:confirmLabel = s:determineConfirmLabel(l:choiceLabel)
         endif
 
-        call add(list, confirmLabel)
+        call add(l:list, l:confirmLabel)
     endfor
 
-    let choice = confirm(a:label, join(list, "\n"))
+    let l:choice = confirm(a:label, join(l:list, "\n"))
 
-    if (choice == 0)
+    if (l:choice == 0)
         " this is an exception, not a message!
-        throw "cancelled"
+        throw 'cancelled'
     endif
 
-    call a:ResultHandler(keys(a:choices)[choice - 1])
+    call a:ResultHandler(keys(a:choices)[l:choice - 1])
 endfunction
 
-function! s:determineConfirmLabelFromPreference(choiceLabel, preference)
-    let buffer = []
-    let foundShortcut = v:false
+function! s:determineConfirmLabelFromPreference(choiceLabel, preference) abort
+    let l:buffer = []
+    let l:foundShortcut = v:false
 
-    for char in split(a:choiceLabel, '\zs')
-        if foundShortcut == v:false && tolower(char) == tolower(a:preference)
-            let foundShortcut = v:true
+    for l:char in split(a:choiceLabel, '\zs')
+        if l:foundShortcut == v:false && tolower(l:char) == tolower(a:preference)
+            let l:foundShortcut = v:true
 
-            call add(buffer, '&' . a:preference)
+            call add(l:buffer, '&' . a:preference)
             call add(s:usedShortcuts, a:preference)
             continue
         endif
 
-        call add(buffer, char)
+        call add(l:buffer, l:char)
     endfor
 
-    if foundShortcut == v:false
+    if l:foundShortcut == v:false
         " Could not find char in the label - add the shortcut at the end
-        call add(buffer, '&' . a:preference)
+        call add(l:buffer, '&' . a:preference)
     endif
 
-    return join(buffer, "")
+    return join(l:buffer, '')
 endfunction
 
-function! s:determineConfirmLabel(choiceLabel)
-    let foundShortcut = v:false
-    let buffer = []
-    for char in split(a:choiceLabel, '\zs')
-        if v:false == foundShortcut && -1 == index(s:usedShortcuts, tolower(char))
-            let foundShortcut = v:true
+function! s:determineConfirmLabel(choiceLabel) abort
+    let l:foundShortcut = v:false
+    let l:buffer = []
+    for l:char in split(a:choiceLabel, '\zs')
+        if v:false == l:foundShortcut && -1 == index(s:usedShortcuts, tolower(l:char))
+            let l:foundShortcut = v:true
 
-            call add(buffer, '&')
-            call add(s:usedShortcuts, tolower(char))
+            call add(l:buffer, '&')
+            call add(s:usedShortcuts, tolower(l:char))
         endif
 
-        call add(buffer, char)
+        call add(l:buffer, l:char)
     endfor
 
-    return join(buffer, "")
+    return join(l:buffer, '')
 endfunction
 
-function! phpactor#input#list(label, choices, multi, ResultHandler)
-    let choices = sort(keys(a:choices))
+function! phpactor#input#list(label, choices, multi, ResultHandler) abort
+    let l:choices = sort(keys(a:choices))
 
     try
-        let strategy = g:phpactorInputListStrategy
-        call call(strategy, [a:label, choices, a:multi, a:ResultHandler])
+        let l:strategy = g:phpactorInputListStrategy
+        call call(l:strategy, [a:label, l:choices, a:multi, a:ResultHandler])
     catch /E117/
         redraw!
-        echo 'The strategy "'. strategy .'" is unknown, check the value of "g:phpactorInputListStrategy".'
+        echo 'The strategy "'. l:strategy .'" is unknown, check the value of "g:phpactorInputListStrategy".'
     endtry
 endfunction
 


### PR DESCRIPTION
Updates `phpactor.vim` as far as I dare to fix issues reported by [Vint](https://github.com/Vimjas/vint)  - a CS tool for VimL.

Note that the VimLParser used by Vint does not understand the following (and we cannot ignore them it seems):

```
    let sink = {
        \ 'sink': {key -> a:ResultHandler(a:choices[key - 1])},
    \ }
```
```
unexpected token: > (see ynkdir/vim-vimlparser) 
```

or

```
  let items = map(copy(a:lines), {key, value -> a:results[value]})
```
```
unexpected token: , (see ynkdir/vim-vimlparser) 
```

There is an open pull request for this (only 5 days old): https://github.com/vim-jp/vim-vimlparser/issues/150

@elythyr I have to admit that I don't understand this syntax - can it be replaced with something else? :eyes:

It would be great to get Vint running in Travis, but the above seems to prevent us (cannot ignore parser errors).