### PR TITLE
Fix "VIM Plugin" example mappings and add missing command definitions

### DIFF
--- a/doc/phpactor.txt
+++ b/doc/phpactor.txt
@@ -191,20 +191,22 @@ Phpactor does not assume any mappings automatically, the following mappings
 are available for you to copy:
 >
 
-  nmap <Leader>u :PhpactorImportClass<CR>
-  nmap <Leader>ua :PhpactorImportAllClasses<CR>
-  nmap <Leader>mm :PhpactorContextMenu()<CR>
-  nmap <Leader>nn :PhpactorNavigate()<CR>
-  nmap <Leader>oo :PhpactorGotoDefinition()<CR>
-  nmap <Leader>oh :PhpactorGotoDefinitionHsplit()<CR>
-  nmap <Leader>ov :PhpactorGotoDefinitionVsplit()<CR>
-  nmap <Leader>ot :PhpactorGotoDefinitionTab()<CR>
-  nmap <Leader>K :PhpactorHover()<CR>
-  nmap <Leader>tt :PhpactorTransform()<CR>
-  nmap <Leader>cc :PhpactorClassNew()<CR>
-  nmap <silent><Leader>ee :PhpactorExtractExpression(v:false)<CR>
-  vmap <silent><Leader>ee :<C-U>PhpactorExtractExpression(v:true)<CR>
-  vmap <silent><Leader>em :<C-U>PhpactorExtractMethod()<CR>
+  augroup PhpactorMappings
+    au!
+    au FileType php nmap <Leader>u :PhpactorImportClass<CR>
+    au FileType php nmap <Leader>mm :PhpactorContextMenu<CR>
+    au FileType php nmap <Leader>nn :PhpactorNavigate<CR>
+    au FileType php nmap <Leader>oo :PhpactorGotoDefinition<CR>
+    au FileType php nmap <Leader>oh :PhpactorGotoDefinitionHsplit<CR>
+    au FileType php nmap <Leader>ov :PhpactorGotoDefinitionVsplit<CR>
+    au FileType php nmap <Leader>ot :PhpactorGotoDefinitionTab<CR>
+    au FileType php nmap <Leader>K :PhpactorHover<CR>
+    au FileType php nmap <Leader>tt :PhpactorTransform<CR>
+    au FileType php nmap <Leader>cc :PhpactorClassNew<CR>
+    au FileType php nmap <silent><Leader>ee :PhpactorExtractExpression<CR>
+    au FileType php vmap <silent><Leader>ee :<C-u>PhpactorExtractExpression<CR>
+    au FileType php vmap <silent><Leader>em :<C-u>PhpactorExtractMethod<CR>
+  augroup END
 <
 
 

--- a/doc/phpactor.txt
+++ b/doc/phpactor.txt
@@ -193,19 +193,20 @@ are available for you to copy:
 
   augroup PhpactorMappings
     au!
-    au FileType php nmap <Leader>u :PhpactorImportClass<CR>
-    au FileType php nmap <Leader>mm :PhpactorContextMenu<CR>
-    au FileType php nmap <Leader>nn :PhpactorNavigate<CR>
-    au FileType php nmap <Leader>oo :PhpactorGotoDefinition<CR>
-    au FileType php nmap <Leader>oh :PhpactorGotoDefinitionHsplit<CR>
-    au FileType php nmap <Leader>ov :PhpactorGotoDefinitionVsplit<CR>
-    au FileType php nmap <Leader>ot :PhpactorGotoDefinitionTab<CR>
-    au FileType php nmap <Leader>K :PhpactorHover<CR>
-    au FileType php nmap <Leader>tt :PhpactorTransform<CR>
-    au FileType php nmap <Leader>cc :PhpactorClassNew<CR>
-    au FileType php nmap <silent><Leader>ee :PhpactorExtractExpression<CR>
-    au FileType php vmap <silent><Leader>ee :<C-u>PhpactorExtractExpression<CR>
-    au FileType php vmap <silent><Leader>em :<C-u>PhpactorExtractMethod<CR>
+    au FileType php nmap <buffer> <Leader>u :PhpactorImportClass<CR>
+    au FileType php nmap <buffer> <Leader>ua :PhpactorImportMissingClasses<CR>
+    au FileType php nmap <buffer> <Leader>mm :PhpactorContextMenu<CR>
+    au FileType php nmap <buffer> <Leader>nn :PhpactorNavigate<CR>
+    au FileType php nmap <buffer> <Leader>oo :PhpactorGotoDefinition<CR>
+    au FileType php nmap <buffer> <Leader>oh :PhpactorGotoDefinitionHsplit<CR>
+    au FileType php nmap <buffer> <Leader>ov :PhpactorGotoDefinitionVsplit<CR>
+    au FileType php nmap <buffer> <Leader>ot :PhpactorGotoDefinitionTab<CR>
+    au FileType php nmap <buffer> <Leader>K :PhpactorHover<CR>
+    au FileType php nmap <buffer> <Leader>tt :PhpactorTransform<CR>
+    au FileType php nmap <buffer> <Leader>cc :PhpactorClassNew<CR>
+    au FileType php nmap <buffer> <silent> <Leader>ee :PhpactorExtractExpression<CR>
+    au FileType php vmap <buffer> <silent> <Leader>ee :<C-u>PhpactorExtractExpression<CR>
+    au FileType php vmap <buffer> <silent> <Leader>em :<C-u>PhpactorExtractMethod<CR>
   augroup END
 <
 

--- a/ftplugin/php/commands.vim
+++ b/ftplugin/php/commands.vim
@@ -115,7 +115,7 @@ command! -nargs=0 PhpactorFindReferences call phpactor#FindReferences()
 ""
 " Navigate - jump to the parent class, interface, or any of the relationships
 " defined in `navigation.destinations` https://phpactor.github.io/phpactor/configuration.html#reference
-command! -nargs=0 PhpactorNavigate call phpactor#Naviagate()
+command! -nargs=0 PhpactorNavigate call phpactor#Navigate()
 
 ""
 " Rotate the visiblity of the method under the cursor

--- a/ftplugin/php/commands.vim
+++ b/ftplugin/php/commands.vim
@@ -124,3 +124,7 @@ command! -nargs=0 PhpactorChangeVisibility call phpactor#ChangeVisibility()
 ""
 " Generate accessors for the current class
 command! -nargs=0 PhpactorGenerateAccessors call phpactor#GenerateAccessors()
+
+""
+" Automatically add any missing properties to a class
+command! -nargs=0 PhpactorTransform call phpactor#Transform()

--- a/ftplugin/php/mappings.vim
+++ b/ftplugin/php/mappings.vim
@@ -4,19 +4,21 @@
 " Phpactor does not assume any mappings automatically, the following mappings
 " are available for you to copy: >
 "
-"   nmap <Leader>u :PhpactorImportClass<CR>
-"   nmap <Leader>ua :PhpactorImportAllClasses<CR>
-"   nmap <Leader>mm :PhpactorContextMenu()<CR>
-"   nmap <Leader>nn :PhpactorNavigate()<CR>
-"   nmap <Leader>oo :PhpactorGotoDefinition()<CR>
-"   nmap <Leader>oh :PhpactorGotoDefinitionHsplit()<CR>
-"   nmap <Leader>ov :PhpactorGotoDefinitionVsplit()<CR>
-"   nmap <Leader>ot :PhpactorGotoDefinitionTab()<CR>
-"   nmap <Leader>K :PhpactorHover()<CR>
-"   nmap <Leader>tt :PhpactorTransform()<CR>
-"   nmap <Leader>cc :PhpactorClassNew()<CR>
-"   nmap <silent><Leader>ee :PhpactorExtractExpression(v:false)<CR>
-"   vmap <silent><Leader>ee :<C-U>PhpactorExtractExpression(v:true)<CR>
-"   vmap <silent><Leader>em :<C-U>PhpactorExtractMethod()<CR>
+"   augroup PhpactorMappings
+"     au!
+"     au FileType php nmap <Leader>u :PhpactorImportClass<CR>
+"     au FileType php nmap <Leader>mm :PhpactorContextMenu<CR>
+"     au FileType php nmap <Leader>nn :PhpactorNavigate<CR>
+"     au FileType php nmap <Leader>oo :PhpactorGotoDefinition<CR>
+"     au FileType php nmap <Leader>oh :PhpactorGotoDefinitionHsplit<CR>
+"     au FileType php nmap <Leader>ov :PhpactorGotoDefinitionVsplit<CR>
+"     au FileType php nmap <Leader>ot :PhpactorGotoDefinitionTab<CR>
+"     au FileType php nmap <Leader>K :PhpactorHover<CR>
+"     au FileType php nmap <Leader>tt :PhpactorTransform<CR>
+"     au FileType php nmap <Leader>cc :PhpactorClassNew<CR>
+"     au FileType php nmap <silent><Leader>ee :PhpactorExtractExpression<CR>
+"     au FileType php vmap <silent><Leader>ee :<C-u>PhpactorExtractExpression<CR>
+"     au FileType php vmap <silent><Leader>em :<C-u>PhpactorExtractMethod<CR>
+"   augroup END
 " <
 "

--- a/ftplugin/php/mappings.vim
+++ b/ftplugin/php/mappings.vim
@@ -6,19 +6,20 @@
 "
 "   augroup PhpactorMappings
 "     au!
-"     au FileType php nmap <Leader>u :PhpactorImportClass<CR>
-"     au FileType php nmap <Leader>mm :PhpactorContextMenu<CR>
-"     au FileType php nmap <Leader>nn :PhpactorNavigate<CR>
-"     au FileType php nmap <Leader>oo :PhpactorGotoDefinition<CR>
-"     au FileType php nmap <Leader>oh :PhpactorGotoDefinitionHsplit<CR>
-"     au FileType php nmap <Leader>ov :PhpactorGotoDefinitionVsplit<CR>
-"     au FileType php nmap <Leader>ot :PhpactorGotoDefinitionTab<CR>
-"     au FileType php nmap <Leader>K :PhpactorHover<CR>
-"     au FileType php nmap <Leader>tt :PhpactorTransform<CR>
-"     au FileType php nmap <Leader>cc :PhpactorClassNew<CR>
-"     au FileType php nmap <silent><Leader>ee :PhpactorExtractExpression<CR>
-"     au FileType php vmap <silent><Leader>ee :<C-u>PhpactorExtractExpression<CR>
-"     au FileType php vmap <silent><Leader>em :<C-u>PhpactorExtractMethod<CR>
+"     au FileType php nmap <buffer> <Leader>u :PhpactorImportClass<CR>
+"     au FileType php nmap <buffer> <Leader>ua :PhpactorImportMissingClasses<CR>
+"     au FileType php nmap <buffer> <Leader>mm :PhpactorContextMenu<CR>
+"     au FileType php nmap <buffer> <Leader>nn :PhpactorNavigate<CR>
+"     au FileType php nmap <buffer> <Leader>oo :PhpactorGotoDefinition<CR>
+"     au FileType php nmap <buffer> <Leader>oh :PhpactorGotoDefinitionHsplit<CR>
+"     au FileType php nmap <buffer> <Leader>ov :PhpactorGotoDefinitionVsplit<CR>
+"     au FileType php nmap <buffer> <Leader>ot :PhpactorGotoDefinitionTab<CR>
+"     au FileType php nmap <buffer> <Leader>K :PhpactorHover<CR>
+"     au FileType php nmap <buffer> <Leader>tt :PhpactorTransform<CR>
+"     au FileType php nmap <buffer> <Leader>cc :PhpactorClassNew<CR>
+"     au FileType php nmap <buffer> <silent> <Leader>ee :PhpactorExtractExpression<CR>
+"     au FileType php vmap <buffer> <silent> <Leader>ee :<C-u>PhpactorExtractExpression<CR>
+"     au FileType php vmap <buffer> <silent> <Leader>em :<C-u>PhpactorExtractMethod<CR>
 "   augroup END
 " <
 "


### PR DESCRIPTION
@dantleech 

Thanks for this tools and vim plugin.

- [Vim] Fix typo, `phpactor#Naviagate()` -> `phpactor#Navigate()`
- [Vim] Added command definition for `PhpactorTransform`
- [Vim] Adjustments related to vim mapping
    - Command mapping contains `()`, so fix it.
    - `PhpactorImportAllClasses` command does not exist and has been removed from the mapping
    - Changed to map only php filetype