### PR TITLE
Language server Changes

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2487,12 +2487,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/indexer-extension.git",
-                "reference": "ffc4a9efef8d48abee31a968add0fd1c965d5a59"
+                "reference": "c3786003f2e6456610bb17c5a82f77949277afe9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/indexer-extension/zipball/ffc4a9efef8d48abee31a968add0fd1c965d5a59",
-                "reference": "ffc4a9efef8d48abee31a968add0fd1c965d5a59",
+                "url": "https://api.github.com/repos/phpactor/indexer-extension/zipball/c3786003f2e6456610bb17c5a82f77949277afe9",
+                "reference": "c3786003f2e6456610bb17c5a82f77949277afe9",
                 "shasum": ""
             },
             "require": {
@@ -2541,7 +2541,7 @@
                 }
             ],
             "description": "Indexer and related integrations",
-            "time": "2020-04-13T13:27:34+00:00"
+            "time": "2020-04-13T14:24:53+00:00"
         },
         {
             "name": "phpactor/language-server",

--- a/composer.lock
+++ b/composer.lock
@@ -558,6 +558,51 @@
             "time": "2018-10-24T03:34:54+00:00"
         },
         {
+            "name": "brick/math",
+            "version": "0.8.14",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/brick/math.git",
+                "reference": "6f7a46b5c3d487b277f38fbd17df57d348cace8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/brick/math/zipball/6f7a46b5c3d487b277f38fbd17df57d348cace8a",
+                "reference": "6f7a46b5c3d487b277f38fbd17df57d348cace8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "2.*",
+                "phpunit/phpunit": "7.*",
+                "vimeo/psalm": "3.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Brick\\Math\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Arbitrary-precision arithmetic library",
+            "keywords": [
+                "Arbitrary-precision",
+                "BigInteger",
+                "BigRational",
+                "arithmetic",
+                "bigdecimal",
+                "bignum",
+                "brick",
+                "math"
+            ],
+            "time": "2020-02-17T13:57:43+00:00"
+        },
+        {
             "name": "composer/ca-bundle",
             "version": "dev-master",
             "source": {
@@ -629,12 +674,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "8e2e9caf6a5021a1afbbc0aae1e32937024f249d"
+                "reference": "19902ba6a9fdb1b46e3feca4cf333e91af469067"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/8e2e9caf6a5021a1afbbc0aae1e32937024f249d",
-                "reference": "8e2e9caf6a5021a1afbbc0aae1e32937024f249d",
+                "url": "https://api.github.com/repos/composer/composer/zipball/19902ba6a9fdb1b46e3feca4cf333e91af469067",
+                "reference": "19902ba6a9fdb1b46e3feca4cf333e91af469067",
                 "shasum": ""
             },
             "require": {
@@ -701,7 +746,7 @@
                 "dependency",
                 "package"
             ],
-            "time": "2020-04-10T09:44:13+00:00"
+            "time": "2020-04-13T10:41:02+00:00"
         },
         {
             "name": "composer/semver",
@@ -1503,12 +1548,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/amp-fswatch.git",
-                "reference": "5c9cb7f1c3539df4ddf1df21482dabc54eae0a24"
+                "reference": "ae059fa3e537b49d7947c92e1d9747f515fc1b48"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/amp-fswatch/zipball/5c9cb7f1c3539df4ddf1df21482dabc54eae0a24",
-                "reference": "5c9cb7f1c3539df4ddf1df21482dabc54eae0a24",
+                "url": "https://api.github.com/repos/phpactor/amp-fswatch/zipball/ae059fa3e537b49d7947c92e1d9747f515fc1b48",
+                "reference": "ae059fa3e537b49d7947c92e1d9747f515fc1b48",
                 "shasum": ""
             },
             "require": {
@@ -1546,7 +1591,7 @@
                 }
             ],
             "description": "Async Filesystem Watcher for Amphp",
-            "time": "2020-03-29T17:18:21+00:00"
+            "time": "2020-04-13T14:05:30+00:00"
         },
         {
             "name": "phpactor/class-mover",
@@ -2442,12 +2487,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/indexer-extension.git",
-                "reference": "18c31a231babf86bee1c7a609d74adecfd333de0"
+                "reference": "ffc4a9efef8d48abee31a968add0fd1c965d5a59"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/indexer-extension/zipball/18c31a231babf86bee1c7a609d74adecfd333de0",
-                "reference": "18c31a231babf86bee1c7a609d74adecfd333de0",
+                "url": "https://api.github.com/repos/phpactor/indexer-extension/zipball/ffc4a9efef8d48abee31a968add0fd1c965d5a59",
+                "reference": "ffc4a9efef8d48abee31a968add0fd1c965d5a59",
                 "shasum": ""
             },
             "require": {
@@ -2496,7 +2541,7 @@
                 }
             ],
             "description": "Indexer and related integrations",
-            "time": "2020-04-13T08:19:31+00:00"
+            "time": "2020-04-13T13:27:34+00:00"
         },
         {
             "name": "phpactor/language-server",
@@ -2504,12 +2549,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/language-server.git",
-                "reference": "659f0581cae396578d77342f0413b227d76c3fdc"
+                "reference": "dbc11faf7b31c421e3d4c272e56cf0da257d400c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/language-server/zipball/659f0581cae396578d77342f0413b227d76c3fdc",
-                "reference": "659f0581cae396578d77342f0413b227d76c3fdc",
+                "url": "https://api.github.com/repos/phpactor/language-server/zipball/dbc11faf7b31c421e3d4c272e56cf0da257d400c",
+                "reference": "dbc11faf7b31c421e3d4c272e56cf0da257d400c",
                 "shasum": ""
             },
             "require": {
@@ -2518,7 +2563,8 @@
                 "dantleech/invoke": "^1.0",
                 "felixfbecker/language-server-protocol": "^1.0",
                 "php": "^7.2",
-                "psr/log": "^1.0"
+                "psr/log": "^1.0",
+                "ramsey/uuid": "^4.0"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^2.15.0",
@@ -2551,7 +2597,7 @@
                 }
             ],
             "description": "Phpactor Language Server",
-            "time": "2020-04-11T16:51:11+00:00"
+            "time": "2020-04-13T08:58:50+00:00"
         },
         {
             "name": "phpactor/language-server-extension",
@@ -3438,6 +3484,154 @@
                 "psr-3"
             ],
             "time": "2020-03-23T09:12:05+00:00"
+        },
+        {
+            "name": "ramsey/collection",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ramsey/collection.git",
+                "reference": "925ad8cf55ba7a3fc92e332c58fd0478ace3e1ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ramsey/collection/zipball/925ad8cf55ba7a3fc92e332c58fd0478ace3e1ca",
+                "reference": "925ad8cf55ba7a3fc92e332c58fd0478ace3e1ca",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
+                "fzaninotto/faker": "^1.5",
+                "jakub-onderka/php-parallel-lint": "^1",
+                "jangregor/phpstan-prophecy": "^0.6",
+                "mockery/mockery": "^1.3",
+                "phpstan/extension-installer": "^1",
+                "phpstan/phpdoc-parser": "0.4.1",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-mockery": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpunit/phpunit": "^8.5",
+                "slevomat/coding-standard": "^6.0",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Ramsey\\Collection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Ramsey",
+                    "email": "ben@benramsey.com",
+                    "homepage": "https://benramsey.com"
+                }
+            ],
+            "description": "A PHP 7.2+ library for representing and manipulating collections.",
+            "homepage": "https://github.com/ramsey/collection",
+            "keywords": [
+                "array",
+                "collection",
+                "hash",
+                "map",
+                "queue",
+                "set"
+            ],
+            "time": "2020-01-05T00:22:59+00:00"
+        },
+        {
+            "name": "ramsey/uuid",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ramsey/uuid.git",
+                "reference": "b3c39208757f739e3e53c391e21dc7fc6afa1cf5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/b3c39208757f739e3e53c391e21dc7fc6afa1cf5",
+                "reference": "b3c39208757f739e3e53c391e21dc7fc6afa1cf5",
+                "shasum": ""
+            },
+            "require": {
+                "brick/math": "^0.8",
+                "ext-json": "*",
+                "php": "^7.2 || ^8",
+                "ramsey/collection": "^1.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "replace": {
+                "rhumsaa/uuid": "self.version"
+            },
+            "require-dev": {
+                "codeception/aspect-mock": "^3",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2",
+                "doctrine/annotations": "^1.8",
+                "goaop/framework": "^2",
+                "mockery/mockery": "^1.3",
+                "moontoast/math": "^1.1",
+                "paragonie/random-lib": "^2",
+                "php-mock/php-mock-mockery": "^1.3",
+                "php-mock/php-mock-phpunit": "^2.5",
+                "php-parallel-lint/php-parallel-lint": "^1.1",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpdoc-parser": "0.4.3",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-mockery": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpunit/phpunit": "^8.5",
+                "psy/psysh": "^0.10.0",
+                "slevomat/coding-standard": "^6.0",
+                "squizlabs/php_codesniffer": "^3.5",
+                "vimeo/psalm": "3.9.4"
+            },
+            "suggest": {
+                "ext-bcmath": "Enables faster math with arbitrary-precision integers using BCMath.",
+                "ext-ctype": "Enables faster processing of character classification using ctype functions.",
+                "ext-gmp": "Enables faster math with arbitrary-precision integers using GMP.",
+                "ext-uuid": "Enables the use of PeclUuidTimeGenerator and PeclUuidRandomGenerator.",
+                "paragonie/random-lib": "Provides RandomLib for use with the RandomLibAdapter",
+                "ramsey/uuid-doctrine": "Allows the use of Ramsey\\Uuid\\Uuid as Doctrine field type."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ramsey\\Uuid\\": "src/"
+                },
+                "files": [
+                    "src/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A PHP library for generating and working with universally unique identifiers (UUIDs).",
+            "homepage": "https://github.com/ramsey/uuid",
+            "keywords": [
+                "guid",
+                "identifier",
+                "uuid"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/ramsey",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-03-31T21:52:23+00:00"
         },
         {
             "name": "sebastian/diff",

--- a/lib/Phpactor.php
+++ b/lib/Phpactor.php
@@ -3,6 +3,7 @@
 namespace Phpactor;
 
 use Phpactor\Extension\LanguageServerCompletion\LanguageServerCompletionExtension;
+use Phpactor\Extension\LanguageServerIndexer\LanguageServerIndexerExtension;
 use Phpactor\Extension\LanguageServerReferenceFinder\LanguageServerReferenceFinderExtension;
 use Phpactor\Extension\LanguageServerWorseReflection\LanguageServerWorseReflectionExtension;
 use Phpactor\Extension\LanguageServer\LanguageServerExtension;
@@ -111,6 +112,7 @@ class Phpactor
             LanguageServerCompletionExtension::class,
             LanguageServerReferenceFinderExtension::class,
             LanguageServerWorseReflectionExtension::class,
+            LanguageServerIndexerExtension::class,
             IndexerExtension::class,
         ];
 


### PR DESCRIPTION
- Adds option to enable index watchers
- Reduces CPU load of watchers (inotify, find and php)
- Introduces a PHP watcher (as a last resort)
- Uses the correct default index "glob" filter pattern (`*.php`)
- Updates the Languaege Server package (allows bi-directional communication)
- Renames indexer package to indexer-extension