### PR TITLE
Fix ftplugin

### DIFF
--- a/autoload/phpactor.vim
+++ b/autoload/phpactor.vim
@@ -89,6 +89,10 @@ endfunction
 
 function! phpactor#_completeImportClass(completedItem)
 
+    if get(b:, 'phpactorOmniAutoClassImport', g:phpactorOmniAutoClassImport) != v:true
+      return
+    endif
+
     if !has_key(a:completedItem, "word")
         return
     endif

--- a/autoload/phpactor.vim
+++ b/autoload/phpactor.vim
@@ -11,6 +11,8 @@
 "     https://github.com/google/vimdoc. See
 "     https://phpactor.github.io/phpactor/developing.html#vim-help
 
+let s:_phpactorCompletionMeta = {}
+
 function! phpactor#Update()
     let current = getcwd()
     execute 'cd ' . g:phpactorpath
@@ -53,7 +55,7 @@ function! phpactor#Complete(findstart, base)
     let issues = result['issues']
 
     let completions = []
-    let g:_phpactorCompletionMeta = {}
+    let s:_phpactorCompletionMeta = {}
 
     if !empty(suggestions)
         for suggestion in suggestions
@@ -66,7 +68,7 @@ function! phpactor#Complete(findstart, base)
                         \ 'icase': g:phpactorCompletionIgnoreCase
                         \ }
             call add(completions, completion)
-            let g:_phpactorCompletionMeta[phpactor#_completionItemHash(completion)] = suggestion
+            let s:_phpactorCompletionMeta[phpactor#_completionItemHash(completion)] = suggestion
         endfor
     endif
 
@@ -92,11 +94,11 @@ function! phpactor#_completeImportClass(completedItem)
     endif
 
     let hash = phpactor#_completionItemHash(a:completedItem)
-    if !has_key(g:_phpactorCompletionMeta, hash)
+    if !has_key(s:_phpactorCompletionMeta, hash)
         return
     endif
 
-    let suggestion = g:_phpactorCompletionMeta[hash]
+    let suggestion = s:_phpactorCompletionMeta[hash]
 
     if !empty(get(suggestion, "class_import", ""))
         call phpactor#rpc("import_class", {
@@ -106,7 +108,7 @@ function! phpactor#_completeImportClass(completedItem)
                     \ "path": expand('%:p')})
     endif
 
-    let g:_phpactorCompletionMeta = {}
+    let s:_phpactorCompletionMeta = {}
 
 endfunction
 

--- a/ftplugin/php.vim
+++ b/ftplugin/php.vim
@@ -1,57 +1,15 @@
-if exists('g:phpactorLoaded')
-  finish
-endif
+function! s:import_on_complete_done(completed_item) abort
+    if get(b:, 'phpactorOmniAutoClassImport', g:phpactorOmniAutoClassImport) != v:true
+      return
+    endif
 
-let g:phpactorLoaded = 1
-let g:phpactorpath = expand('<sfile>:p:h') . '/..'
-let g:phpactorbinpath = g:phpactorpath. '/bin/phpactor'
-let g:phpactorInitialCwd = getcwd()
-let g:phpactorCompleteLabelTruncateLength=50
+    call phpactor#_completeImportClass(a:completed_item)
+endfunction
 
-""
-" Path to the PHP binary used by Phpactor
-let g:phpactorPhpBin = get(g:, 'phpactorPhpBin', 'php')
-
-""
-" The Phpactor branch to use when calling @command(PhpactorUpdate)
-let g:phpactorBranch = get(g:, 'phpactorBranch', 'master')
-
-""
-" Automatically import classes when using VIM native omni-completion
-let g:phpactorOmniAutoClassImport = get(g:, 'phpactorOmniAutoClassImport', v:true)
-
-""
-" Ignore case when suggestion completion results
-let g:phpactorCompletionIgnoreCase = get(g:, 'phpactorCompletionIgnoreCase', 1)
-
-""
-" Function to use when populating a list of code references. The default
-" is to use the VIM quick-fix list.
-let g:phpactorQuickfixStrategy = get(g:, 'phpactorQuickfixStrategy', 'phpactor#quickfix#vim')
-
-""
-" Function to use when presenting a user with a choice of options. The default
-" is to use the VIM inputlist.
-let g:phpactorInputListStrategy = get(g:, 'phpactorInputListStrategy', 'phpactor#input#list#inputlist')
-
-""
-" When jumping to a file location: if the target file open in a window, switch
-" to that window instead of switching buffers.  The default is false.
-let g:phpactorUseOpenWindows = get(g:, 'phpactorUseOpenWindows', v:false)
-
-""
-" The list of files that determine workspace root directory
-" if contained within
-let g:phpactorProjectRootPatterns = get(g:, 'phpactorProjectRootPatterns', ['composer.json', '.git', '.phpactor.json', '.phpactor.yml'])
-
-""
-" The list of directories that should not be considered as workspace root directory
-" (in addition to '/' which is always considered)
-let g:phpactorGlobalRootPatterns = get(g:, 'phpactorGlobalRootPatterns', ['/', '/home'])
-
-if g:phpactorOmniAutoClassImport == v:true
-    autocmd CompleteDone *.php call phpactor#_completeImportClass(v:completed_item)
-endif
+augroup PhpactorInit
+    autocmd! * <buffer>
+    autocmd CompleteDone <buffer> call <SID>import_on_complete_done(v:completed_item)
+augroup END
 
 
 " vim: et ts=4 sw=4 fdm=marker

--- a/ftplugin/php.vim
+++ b/ftplugin/php.vim
@@ -1,14 +1,6 @@
-function! s:import_on_complete_done(completed_item) abort
-    if get(b:, 'phpactorOmniAutoClassImport', g:phpactorOmniAutoClassImport) != v:true
-      return
-    endif
-
-    call phpactor#_completeImportClass(a:completed_item)
-endfunction
-
 augroup PhpactorInit
     autocmd! * <buffer>
-    autocmd CompleteDone <buffer> call <SID>import_on_complete_done(v:completed_item)
+    autocmd CompleteDone <buffer> call phpactor#_completeImportClass(v:completed_item)
 augroup END
 
 

--- a/ftplugin/php.vim
+++ b/ftplugin/php.vim
@@ -7,7 +7,6 @@ let g:phpactorpath = expand('<sfile>:p:h') . '/..'
 let g:phpactorbinpath = g:phpactorpath. '/bin/phpactor'
 let g:phpactorInitialCwd = getcwd()
 let g:phpactorCompleteLabelTruncateLength=50
-let g:_phpactorCompletionMeta = {}
 
 ""
 " Path to the PHP binary used by Phpactor

--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -1,8 +1,8 @@
-if exists('g:phpactorLoaded')
+if exists('g:loaded_phpactor')
   finish
 endif
 
-let g:phpactorLoaded = 1
+let g:loaded_phpactor = 1
 let g:phpactorpath = expand('<sfile>:p:h') . '/..'
 let g:phpactorbinpath = g:phpactorpath. '/bin/phpactor'
 let g:phpactorInitialCwd = getcwd()

--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -1,0 +1,52 @@
+if exists('g:phpactorLoaded')
+  finish
+endif
+
+let g:phpactorLoaded = 1
+let g:phpactorpath = expand('<sfile>:p:h') . '/..'
+let g:phpactorbinpath = g:phpactorpath. '/bin/phpactor'
+let g:phpactorInitialCwd = getcwd()
+let g:phpactorCompleteLabelTruncateLength=50
+
+""
+" Path to the PHP binary used by Phpactor
+let g:phpactorPhpBin = get(g:, 'phpactorPhpBin', 'php')
+
+""
+" The Phpactor branch to use when calling @command(PhpactorUpdate)
+let g:phpactorBranch = get(g:, 'phpactorBranch', 'master')
+
+""
+" Automatically import classes when using VIM native omni-completion
+let g:phpactorOmniAutoClassImport = get(g:, 'phpactorOmniAutoClassImport', v:true)
+
+""
+" Ignore case when suggestion completion results
+let g:phpactorCompletionIgnoreCase = get(g:, 'phpactorCompletionIgnoreCase', 1)
+
+""
+" Function to use when populating a list of code references. The default
+" is to use the VIM quick-fix list.
+let g:phpactorQuickfixStrategy = get(g:, 'phpactorQuickfixStrategy', 'phpactor#quickfix#vim')
+
+""
+" Function to use when presenting a user with a choice of options. The default
+" is to use the VIM inputlist.
+let g:phpactorInputListStrategy = get(g:, 'phpactorInputListStrategy', 'phpactor#input#list#inputlist')
+
+""
+" When jumping to a file location: if the target file open in a window, switch
+" to that window instead of switching buffers.  The default is false.
+let g:phpactorUseOpenWindows = get(g:, 'phpactorUseOpenWindows', v:false)
+
+""
+" The list of files that determine workspace root directory
+" if contained within
+let g:phpactorProjectRootPatterns = get(g:, 'phpactorProjectRootPatterns', ['composer.json', '.git', '.phpactor.json', '.phpactor.yml'])
+
+""
+" The list of directories that should not be considered as workspace root directory
+" (in addition to '/' which is always considered)
+let g:phpactorGlobalRootPatterns = get(g:, 'phpactorGlobalRootPatterns', ['/', '/home'])
+
+" vim: et ts=4 sw=4 fdm=marker


### PR DESCRIPTION
I think we made some mistakes with our migration to a filetype plugin.
The idea is great, the way we did it need to be improved.

The main idea is that configuration are still global so they should not be in the `ftplugin` directory.
I know it's in contradiction with what I said in an issue...
But after thinking about it make sense for **global** configuration.
The rest, which can be related to a buffer only should stay in the `ftplugin` directory.

There is also the problem mentioned by @przepompownia saying that `ftplugin/php.vim` could be sourced only once.
That's because of the condition to check if phpactor is loaded.
But this condition has two main purpose:
* Avoid loading the file twice (could create some errors if we didn't do things correctly)
* Allow a user to disable the plugin from it's vimrc if he wants to

This is not related to filetype plugins and should not be there, also it does not follow the recommendation (see commit message).

As always, I tried to be as clear as possible in my commit messages so if you have any question you can check them our just ask here :)