### PR TITLE
Fix commands

### DIFF
--- a/doc/phpactor.txt
+++ b/doc/phpactor.txt
@@ -91,6 +91,60 @@ https://github.com/kristijanhusak/deoplete-phpactor
 ==============================================================================
 COMMANDS                                                   *phpactor-commands*
 
+:[range][N]PhpactorExtractMethod                      *:PhpactorExtractMethod*
+  Extract a new method from the current selection
+
+:[range][N]PhpactorExtractExpression              *:PhpactorExtractExpression*
+  Extract the selected expression and assign it to a variable before (placing
+  it before the current statement)
+
+:[N]PhpactorExtractConstant                         *:PhpactorExtractConstant*
+  Extract a constant from a literal
+
+:[N]PhpactorImportClass                                 *:PhpactorImportClass*
+  Import the name under the cusor. If multiple options are available, you are
+  able to choose one.
+
+:[N]PhpactorImportMissingClasses               *:PhpactorImportMissingClasses*
+  Attempt to import all non-resolvable classes in the current class (based on
+  offset position)
+
+:[N]PhpactorHover                                             *:PhpactorHover*
+  Show information about the symbol under the cursor.
+
+:[N]PhpactorContextMenu                                 *:PhpactorContextMenu*
+  Show the context menu for the current cursor position.
+
+:[N]PhpactorCopyFile                                       *:PhpactorCopyFile*
+  Copy the current file - updating the namespace and class name according to
+  the new file location and name
+
+:[N]PhpactorMoveFile                                       *:PhpactorMoveFile*
+  Move the current file - updating the namespace and class name according to
+  the new file location and name
+
+:[N]PhpactorClassInflect                               *:PhpactorClassInflect*
+  Inflect a new class from the current class (e.g. generate an interface for
+  the current class)
+
+:[N]PhpactorFindReferences                           *:PhpactorFindReferences*
+  Attempt to find all references to the class name or method under the cursor.
+  The results will be loaded into the quik-fix list
+
+:[N]PhpactorNavigate                                       *:PhpactorNavigate*
+  Navigate - jump to the parent class, interface, or any of the relationships
+  defined in `navigation.destinations`
+  https://phpactor.github.io/phpactor/configuration.html#reference
+
+:[N]PhpactorChangeVisibility                       *:PhpactorChangeVisibility*
+  Rotate the visiblity of the method under the cursor
+
+:[N]PhpactorGenerateAccessors                     *:PhpactorGenerateAccessors*
+  Generate accessors for the current class
+
+:[N]PhpactorTransform                                     *:PhpactorTransform*
+  Automatically add any missing properties to a class
+
 :PhpactorUpdate                                              *:PhpactorUpdate*
   Update Phpactor to the latest version using the branch defined with
   |g:phpactorBranch|
@@ -104,33 +158,24 @@ COMMANDS                                                   *phpactor-commands*
 :PhpactorConfig                                              *:PhpactorConfig*
   Dump Phpactor's configuration
 
-:[range]PhpactorExtractMethod                         *:PhpactorExtractMethod*
-  Extract a new method from the current selection
+:PhpactorExtensionList                                *:PhpactorExtensionList*
+  List all installed extensions
 
-:[range]PhpactorExtractExpression                 *:PhpactorExtractExpression*
-  Extract the selected expression and assign it to a variable before (placing
-  it before the current statement)
+:PhpactorExtensionInstall                          *:PhpactorExtensionInstall*
+  Install an extension
 
-:PhpactorExtractConstant                            *:PhpactorExtractConstant*
-  Extract a constant from a literal
+:PhpactorExtensionRemove                            *:PhpactorExtensionRemove*
+  Remove an extension
 
 :PhpactorClassExpand                                    *:PhpactorClassExpand*
   Expand the class name under the cursor to it's fully-qualified-name
 
-:PhpactorImportClass                                    *:PhpactorImportClass*
-  Import the name under the cusor. If multiple options are available, you are
-  able to choose one.
-
-:PhpactorImportMissingClasses                  *:PhpactorImportMissingClasses*
-  Attempt to import all non-resolvable classes in the current class (based on
-  offset position)
+:PhpactorClassNew                                          *:PhpactorClassNew*
+  Create a new class. You will be offered a choice of templates.
 
 :PhpactorGotoDefinition                              *:PhpactorGotoDefinition*
   Goto the definition of the class, method or function under the cursor. Open
   the definition in the current window.
-
-:PhpactorGotoType                                          *:PhpactorGotoType*
-  Goto type (class) of the symbol under the cursor.
 
 :PhpactorGotoDefinitionVsplit                  *:PhpactorGotoDefinitionVsplit*
   As with |:PhpactorGotoDefinition| but open in a vertical split.
@@ -141,57 +186,12 @@ COMMANDS                                                   *phpactor-commands*
 :PhpactorGotoDefinitionTab                        *:PhpactorGotoDefinitionTab*
   As with |:PhpactorGotoDefinition| but open in a new tab
 
+:PhpactorGotoType                                          *:PhpactorGotoType*
+  Goto type (class) of the symbol under the cursor.
+
 :PhpactorGotoImplementations                    *:PhpactorGotoImplementations*
   Load all implementations of the class under the cursor into the quick-fix
   list.
-
-:PhpactorHover                                                *:PhpactorHover*
-  Show information about the symbol under the cursor.
-
-:PhpactorContextMenu                                    *:PhpactorContextMenu*
-  Show the context menu for the current cursor position.
-
-:PhpactorCopyFile                                          *:PhpactorCopyFile*
-  Copy the current file - updating the namespace and class name according to
-  the new file location and name
-
-:PhpactorMoveFile                                          *:PhpactorMoveFile*
-  Move the current file - updating the namespace and class name according to
-  the new file location and name
-
-:PhpactorExtensionList                                *:PhpactorExtensionList*
-  List all installed extensions
-
-:PhpactorExtensionInstall                          *:PhpactorExtensionInstall*
-  Install an extension
-
-:PhpactorExtensionRemove                            *:PhpactorExtensionRemove*
-  Remove an extension
-
-:PhpactorClassNew                                          *:PhpactorClassNew*
-  Create a new class. You will be offered a choice of templates.
-
-:PhpactorClassInflect                                  *:PhpactorClassInflect*
-  Inflect a new class from the current class (e.g. generate an interface for
-  the current class)
-
-:PhpactorFindReferences                              *:PhpactorFindReferences*
-  Attempt to find all references to the class name or method under the cursor.
-  The results will be loaded into the quik-fix list
-
-:PhpactorNavigate                                          *:PhpactorNavigate*
-  Navigate - jump to the parent class, interface, or any of the relationships
-  defined in `navigation.destinations`
-  https://phpactor.github.io/phpactor/configuration.html#reference
-
-:PhpactorChangeVisibility                          *:PhpactorChangeVisibility*
-  Rotate the visiblity of the method under the cursor
-
-:PhpactorGenerateAccessors                        *:PhpactorGenerateAccessors*
-  Generate accessors for the current class
-
-:PhpactorTransform                                        *:PhpactorTransform*
-  Automatically add any missing properties to a class
 
 ==============================================================================
 MAPPINGS                                                   *phpactor-mappings*

--- a/ftplugin/php/commands.vim
+++ b/ftplugin/php/commands.vim
@@ -1,130 +1,101 @@
 ""
-" Update Phpactor to the latest version using the branch
-" defined with @setting(g:phpactorBranch)
-command! -nargs=0 PhpactorUpdate call phpactor#Update()
-
-""
-" Clear the entire cache - this will take effect for all projects.
-command! -nargs=0 PhpactorCacheClear call phpactor#CacheClear()
-
-""
-" Show some information about Phpactor's status
-command! -nargs=0 PhpactorStatus call phpactor#Status()
-
-""
-" Dump Phpactor's configuration
-command! -nargs=0 PhpactorConfig call phpactor#Config()
-
-""
 " Extract a new method from the current selection
-command! -range=% PhpactorExtractMethod call phpactor#ExtractMethod()
+command! -buffer -range=% PhpactorExtractMethod call phpactor#ExtractMethod()
 
 ""
 " Extract the selected expression and assign it to a variable before (placing
 " it before the current statement)
-command! -range=% PhpactorExtractExpression call phpactor#ExtractExpression('v')
+command! -buffer -range=% PhpactorExtractExpression call phpactor#ExtractExpression('v')
 
 ""
 " Extract a constant from a literal
-command! -nargs=0 PhpactorExtractConstant call phpactor#ExtractConstant()
+command! -buffer -nargs=0 PhpactorExtractConstant call phpactor#ExtractConstant()
 
 ""
 " Expand the class name under the cursor to it's fully-qualified-name
-command! -nargs=0 PhpactorClassExpand call phpactor#ClassExpand()
+command! -buffer -nargs=0 PhpactorClassExpand call phpactor#ClassExpand()
 
 ""
 " Import the name under the cusor. If multiple options are available, you
 " are able to choose one.
-command! -nargs=0 PhpactorImportClass call phpactor#ImportClass()
+command! -buffer -nargs=0 PhpactorImportClass call phpactor#ImportClass()
 
 ""
 " Attempt to import all non-resolvable classes in the current class (based
 " on offset position)
-command! -nargs=0 PhpactorImportMissingClasses call phpactor#ImportMissingClasses()
+command! -buffer -nargs=0 PhpactorImportMissingClasses call phpactor#ImportMissingClasses()
 
 ""
 " Goto the definition of the class, method or function under the cursor. Open
 " the definition in the current window.
-command! -nargs=0 PhpactorGotoDefinition call phpactor#GotoDefinition()
+command! -buffer -nargs=0 PhpactorGotoDefinition call phpactor#GotoDefinition()
 
 ""
 " Goto type (class) of the symbol under the cursor.
-command! -nargs=0 PhpactorGotoType call phpactor#GotoType()
+command! -buffer -nargs=0 PhpactorGotoType call phpactor#GotoType()
 
 ""
 " As with @command(PhpactorGotoDefinition) but open in a vertical split.
-command! -nargs=0 PhpactorGotoDefinitionVsplit call phpactor#GotoDefinitionVsplit()
+command! -buffer -nargs=0 PhpactorGotoDefinitionVsplit call phpactor#GotoDefinitionVsplit()
 
 ""
 " As with @command(PhpactorGotoDefinition) but open in a horizontal split.
-command! -nargs=0 PhpactorGotoDefinitionHsplit call phpactor#GotoDefinitionHsplit()
+command! -buffer -nargs=0 PhpactorGotoDefinitionHsplit call phpactor#GotoDefinitionHsplit()
 
 ""
 " As with @command(PhpactorGotoDefinition) but open in a new tab
-command! -nargs=0 PhpactorGotoDefinitionTab call phpactor#GotoDefinitionTab()
+command! -buffer -nargs=0 PhpactorGotoDefinitionTab call phpactor#GotoDefinitionTab()
 
 ""
 " Load all implementations of the class under the cursor into the quick-fix
 " list.
-command! -nargs=0 PhpactorGotoImplementations call phpactor#GotoImplementations()
+command! -buffer -nargs=0 PhpactorGotoImplementations call phpactor#GotoImplementations()
 
 ""
 " Show information about the symbol under the cursor.
-command! -nargs=0 PhpactorHover call phpactor#Hover()
+command! -buffer -nargs=0 PhpactorHover call phpactor#Hover()
 
 ""
 " Show the context menu for the current cursor position.
-command! -nargs=0 PhpactorContextMenu call phpactor#ContextMenu()
+command! -buffer -nargs=0 PhpactorContextMenu call phpactor#ContextMenu()
 
 ""
 " Copy the current file - updating the namespace and class name according to
 " the new file location and name
-command! -nargs=0 PhpactorCopyFile call phpactor#CopyFile()
+command! -buffer -nargs=0 PhpactorCopyFile call phpactor#CopyFile()
 
 ""
 " Move the current file - updating the namespace and class name according to
 " the new file location and name
-command! -nargs=0 PhpactorMoveFile call phpactor#MoveFile()
-
-""
-" List all installed extensions
-command! -nargs=0 PhpactorExtensionList call phpactor#ExtensionList()
-
-""
-" Install an extension
-command! -nargs=1 PhpactorExtensionInstall call phpactor#ExtensionInstall(<q-args>)
-
-""
-" Remove an extension
-command! -nargs=1 PhpactorExtensionRemove call phpactor#ExtensionRemove(<q-args>)
+command! -buffer -nargs=0 PhpactorMoveFile call phpactor#MoveFile()
 
 ""
 " Create a new class. You will be offered a choice of templates.
-command! -nargs=0 PhpactorClassNew call phpactor#ClassNew()
+command! -buffer -nargs=0 PhpactorClassNew call phpactor#ClassNew()
 
 ""
 " Inflect a new class from the current class (e.g. generate an interface for
 " the current class)
-command! -nargs=0 PhpactorClassInflect call phpactor#ClassInflect()
+command! -buffer -nargs=0 PhpactorClassInflect call phpactor#ClassInflect()
 
 ""
 " Attempt to find all references to the class name or method under the cursor.
 " The results will be loaded into the quik-fix list
-command! -nargs=0 PhpactorFindReferences call phpactor#FindReferences()
+command! -buffer -nargs=0 PhpactorFindReferences call phpactor#FindReferences()
 
 ""
 " Navigate - jump to the parent class, interface, or any of the relationships
 " defined in `navigation.destinations` https://phpactor.github.io/phpactor/configuration.html#reference
-command! -nargs=0 PhpactorNavigate call phpactor#Navigate()
+command! -buffer -nargs=0 PhpactorNavigate call phpactor#Navigate()
 
 ""
 " Rotate the visiblity of the method under the cursor
-command! -nargs=0 PhpactorChangeVisibility call phpactor#ChangeVisibility()
+command! -buffer -nargs=0 PhpactorChangeVisibility call phpactor#ChangeVisibility()
 
 ""
 " Generate accessors for the current class
-command! -nargs=0 PhpactorGenerateAccessors call phpactor#GenerateAccessors()
+command! -buffer -nargs=0 PhpactorGenerateAccessors call phpactor#GenerateAccessors()
 
 ""
 " Automatically add any missing properties to a class
-command! -nargs=0 PhpactorTransform call phpactor#Transform()
+command! -buffer -nargs=0 PhpactorTransform call phpactor#Transform()

--- a/ftplugin/php/commands.vim
+++ b/ftplugin/php/commands.vim
@@ -12,10 +12,6 @@ command! -buffer -range=% PhpactorExtractExpression call phpactor#ExtractExpress
 command! -buffer -nargs=0 PhpactorExtractConstant call phpactor#ExtractConstant()
 
 ""
-" Expand the class name under the cursor to it's fully-qualified-name
-command! -buffer -nargs=0 PhpactorClassExpand call phpactor#ClassExpand()
-
-""
 " Import the name under the cusor. If multiple options are available, you
 " are able to choose one.
 command! -buffer -nargs=0 PhpactorImportClass call phpactor#ImportClass()
@@ -24,32 +20,6 @@ command! -buffer -nargs=0 PhpactorImportClass call phpactor#ImportClass()
 " Attempt to import all non-resolvable classes in the current class (based
 " on offset position)
 command! -buffer -nargs=0 PhpactorImportMissingClasses call phpactor#ImportMissingClasses()
-
-""
-" Goto the definition of the class, method or function under the cursor. Open
-" the definition in the current window.
-command! -buffer -nargs=0 PhpactorGotoDefinition call phpactor#GotoDefinition()
-
-""
-" Goto type (class) of the symbol under the cursor.
-command! -buffer -nargs=0 PhpactorGotoType call phpactor#GotoType()
-
-""
-" As with @command(PhpactorGotoDefinition) but open in a vertical split.
-command! -buffer -nargs=0 PhpactorGotoDefinitionVsplit call phpactor#GotoDefinitionVsplit()
-
-""
-" As with @command(PhpactorGotoDefinition) but open in a horizontal split.
-command! -buffer -nargs=0 PhpactorGotoDefinitionHsplit call phpactor#GotoDefinitionHsplit()
-
-""
-" As with @command(PhpactorGotoDefinition) but open in a new tab
-command! -buffer -nargs=0 PhpactorGotoDefinitionTab call phpactor#GotoDefinitionTab()
-
-""
-" Load all implementations of the class under the cursor into the quick-fix
-" list.
-command! -buffer -nargs=0 PhpactorGotoImplementations call phpactor#GotoImplementations()
 
 ""
 " Show information about the symbol under the cursor.
@@ -68,10 +38,6 @@ command! -buffer -nargs=0 PhpactorCopyFile call phpactor#CopyFile()
 " Move the current file - updating the namespace and class name according to
 " the new file location and name
 command! -buffer -nargs=0 PhpactorMoveFile call phpactor#MoveFile()
-
-""
-" Create a new class. You will be offered a choice of templates.
-command! -buffer -nargs=0 PhpactorClassNew call phpactor#ClassNew()
 
 ""
 " Inflect a new class from the current class (e.g. generate an interface for

--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -3,6 +3,8 @@ if exists('g:loaded_phpactor')
 endif
 
 let g:loaded_phpactor = 1
+
+" Config {{{
 let g:phpactorpath = expand('<sfile>:p:h') . '/..'
 let g:phpactorbinpath = g:phpactorpath. '/bin/phpactor'
 let g:phpactorInitialCwd = getcwd()
@@ -48,5 +50,40 @@ let g:phpactorProjectRootPatterns = get(g:, 'phpactorProjectRootPatterns', ['com
 " The list of directories that should not be considered as workspace root directory
 " (in addition to '/' which is always considered)
 let g:phpactorGlobalRootPatterns = get(g:, 'phpactorGlobalRootPatterns', ['/', '/home'])
+
+" Config }}}
+
+" Commands {{{
+
+""
+" Update Phpactor to the latest version using the branch
+" defined with @setting(g:phpactorBranch)
+command! -nargs=0 PhpactorUpdate call phpactor#Update()
+
+""
+" Clear the entire cache - this will take effect for all projects.
+command! -nargs=0 PhpactorCacheClear call phpactor#CacheClear()
+
+""
+" Show some information about Phpactor's status
+command! -nargs=0 PhpactorStatus call phpactor#Status()
+
+""
+" Dump Phpactor's configuration
+command! -nargs=0 PhpactorConfig call phpactor#Config()
+
+""
+" List all installed extensions
+command! -nargs=0 PhpactorExtensionList call phpactor#ExtensionList()
+
+""
+" Install an extension
+command! -nargs=1 PhpactorExtensionInstall call phpactor#ExtensionInstall(<q-args>)
+
+""
+" Remove an extension
+command! -nargs=1 PhpactorExtensionRemove call phpactor#ExtensionRemove(<q-args>)
+
+" Commands }}}
 
 " vim: et ts=4 sw=4 fdm=marker

--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -84,6 +84,40 @@ command! -nargs=1 PhpactorExtensionInstall call phpactor#ExtensionInstall(<q-arg
 " Remove an extension
 command! -nargs=1 PhpactorExtensionRemove call phpactor#ExtensionRemove(<q-args>)
 
+""
+" Expand the class name under the cursor to it's fully-qualified-name
+command! -nargs=0 PhpactorClassExpand call phpactor#ClassExpand()
+
+""
+" Create a new class. You will be offered a choice of templates.
+command! -nargs=0 PhpactorClassNew call phpactor#ClassNew()
+
+""
+" Goto the definition of the class, method or function under the cursor. Open
+" the definition in the current window.
+command! -nargs=0 PhpactorGotoDefinition call phpactor#GotoDefinition()
+
+""
+" As with @command(PhpactorGotoDefinition) but open in a vertical split.
+command! -nargs=0 PhpactorGotoDefinitionVsplit call phpactor#GotoDefinitionVsplit()
+
+""
+" As with @command(PhpactorGotoDefinition) but open in a horizontal split.
+command! -nargs=0 PhpactorGotoDefinitionHsplit call phpactor#GotoDefinitionHsplit()
+
+""
+" As with @command(PhpactorGotoDefinition) but open in a new tab
+command! -nargs=0 PhpactorGotoDefinitionTab call phpactor#GotoDefinitionTab()
+
+""
+" Goto type (class) of the symbol under the cursor.
+command! -nargs=0 PhpactorGotoType call phpactor#GotoType()
+
+""
+" Load all implementations of the class under the cursor into the quick-fix
+" list.
+command! -nargs=0 PhpactorGotoImplementations call phpactor#GotoImplementations()
+
 " Commands }}}
 
 " vim: et ts=4 sw=4 fdm=marker


### PR DESCRIPTION
This PR is about fixing the commands declared in `ftplugin/php/commands.vim`.

All the commands are global when most of them should be local to a buffer.
I moved the commands that should be global to `plugin/phpactor.vim` so we need to merge https://github.com/phpactor/phpactor/pull/964 and I need to rebase this branch before we can merge.