### PR TITLE
improvement: Add phpactor status to :healthcheck

### DIFF
--- a/autoload/health/phpactor.vim
+++ b/autoload/health/phpactor.vim
@@ -1,0 +1,40 @@
+function! s:check_info(status) abort
+  call health#report_start('Info')
+
+  call health#report_info('Phpactor version: '. a:status.phpactor_version)
+  call health#report_info('PHP version: '. a:status.php_version)
+  call health#report_info('Filesystems'. join(a:status.filesystems, ', '))
+  call health#report_info('Working directory'. a:status.cwd)
+endfunction
+
+function! s:check_diagnostics(diagnostics) abort
+  call health#report_start('Diagnostics')
+
+  for [l:diagnostic, l:isOk] in items(a:diagnostics)
+    if l:isOk
+      call health#report_ok(l:diagnostic)
+    else
+      call health#report_warn(l:diagnostic)
+    endif
+  endfor
+endfunction
+
+function! s:check_config_files(configFiles) abort
+  call health#report_start('Config files (missing is not bad)')
+
+  for [l:configFile, l:isOk] in items(a:configFiles)
+    if l:isOk
+      call health#report_ok(l:configFile)
+    else
+      call health#report_warn(l:configFile)
+    endif
+  endfor
+endfunction
+
+function! health#phpactor#check() abort
+  let l:status = phpactor#rpc('status', {'type': 'detailed'})
+
+  call s:check_info(l:status)
+  call s:check_diagnostics(l:status.diagnostics)
+  call s:check_config_files(l:status.config_files)
+endfunction

--- a/autoload/phpactor.vim
+++ b/autoload/phpactor.vim
@@ -302,7 +302,17 @@ function! phpactor#CacheClear()
 endfunction
 
 function! phpactor#Status()
-    call phpactor#rpc("status", {})
+    if exists(':terminal')
+        if has('nvim')
+            split term://phpactor\ status
+            " Press any key to leave
+            normal i
+        else
+            terminal phpactor status
+        endif
+    else
+        call phpactor#rpc("status", {'type': 'formatted'})
+    endif
 endfunction
 
 function! phpactor#Config()

--- a/tests/Unit/Extension/Core/Rpc/StatusHandlerTest.php
+++ b/tests/Unit/Extension/Core/Rpc/StatusHandlerTest.php
@@ -4,6 +4,7 @@ namespace Phpactor\Tests\Unit\Extension\Core\Rpc;
 
 use Phpactor\ConfigLoader\Adapter\PathCandidate\AbsolutePathCandidate;
 use Phpactor\ConfigLoader\Core\PathCandidates;
+use Phpactor\Extension\Rpc\Response\ReturnResponse;
 use Phpactor\Tests\Unit\Extension\Rpc\HandlerTestCase;
 use Phpactor\Extension\Rpc\Handler;
 use Phpactor\Extension\Core\Application\Status;
@@ -37,7 +38,7 @@ class StatusHandlerTest extends HandlerTestCase
         );
     }
 
-    public function testStatus()
+    public function testMessageStatus()
     {
         $this->status->check()->willReturn([
             'php_version' => '7.1',
@@ -53,5 +54,40 @@ class StatusHandlerTest extends HandlerTestCase
 
         $response = $this->handle('status', []);
         $this->assertInstanceOf(EchoResponse::class, $response);
+    }
+
+    public function testDetailStatus(): void
+    {
+        $this->status->check()->willReturn([
+            'php_version' => '7.1',
+            'phpactor_version' => 'version one',
+            'cwd' => '/path/to/here',
+            'good' => ['i am good'],
+            'bad' => ['i am bad'],
+            'config_files' => [
+                '/config/file1.yml' => true,
+                '/config/file2.yml' => false,
+            ],
+            'filesystems' => ['git', 'simple'],
+        ]);
+
+        $expected = [
+            'php_version' => '7.1',
+            'phpactor_version' => 'version one',
+            'cwd' => '/path/to/here',
+            'config_files' => [
+                '/config/file1.yml' => true,
+                '/config/file2.yml' => false,
+            ],
+            'filesystems' => ['git', 'simple'],
+            'diagnostics' => [
+                'i am good' => true,
+                'i am bad' => false,
+            ],
+        ];
+
+        $response = $this->handle('status', ['type' => 'detailed']);
+        $this->assertInstanceOf(ReturnResponse::class, $response);
+        $this->assertEquals($expected, $response->value());
     }
 }


### PR DESCRIPTION
I learned recently that it was possible to add plugins information to the result of `:healthcheck`

This PR adds a result similar to the CLI command `phpactor status` to the health check system.

It also make `phpactor#Status()` use `:terminal` if available in order to have a better result than just a print.