### PR TITLE
Fix goto commands

### DIFF
--- a/autoload/phpactor.vim
+++ b/autoload/phpactor.vim
@@ -220,30 +220,6 @@ function! phpactor#GotoDefinition(...)
         \ "mods": mods,
     \ })
 endfunction
-""
-" deprecated, use @function(phpactor#gotodefinition) instead
-"
-" as with @function(phpactor#gotodefinition) but open in a vertical split.
-function! phpactor#GotoDefinitionVsplit()
-    echoerr "phpactor#GotoDefinitionVsplit is deprecated use phpactor#GotoDefinition('vsplit') instead"
-    call phpactor#GotoDefinition('vsplit')
-endfunction
-""
-" deprecated, use @function(phpactor#gotodefinition) instead
-"
-" as with @function(phpactor#gotodefinition) but open in an horizontal split.
-function! phpactor#GotoDefinitionHsplit()
-    echoerr "phpactor#GotoDefinitionHsplit is deprecated use phpactor#GotoDefinition('split') instead"
-    call phpactor#GotoDefinition('split')
-endfunction
-""
-" deprecated, use @function(phpactor#gotodefinition) instead
-"
-" as with @function(phpactor#gotodefinition) but open in a new tab.
-function! phpactor#GotoDefinitionTab()
-    echoerr "phpactor#GotoDefinitionTab is deprecated use phpactor#GotoDefinition('tabnew') instead"
-    call phpactor#GotoDefinition('tabnew')
-endfunction
 
 ""
 " @usage [target] [mods]

--- a/autoload/phpactor.vim
+++ b/autoload/phpactor.vim
@@ -186,17 +186,45 @@ function! phpactor#ImportMissingClasses()
     call phpactor#rpc("import_missing_classes", {"source": phpactor#_source(), "path": expand('%:p')})
 endfunction
 
-function! phpactor#_GotoDefinitionTarget(target)
+""
+" @default target=`focused_window`
+"
+" Goto the definition of the symbol under the cursor.
+" Open the definition in the [target] window, see @section(window-target) for
+" the list of possible targets.
+function! phpactor#GotoDefinition(...)
     call phpactor#rpc("goto_definition", {
                 \"offset": phpactor#_offset(),
                 \"source": phpactor#_source(),
                 \"path": expand('%:p'),
-                \"target": a:target,
+                \"target": a:0 ? a:1 : 'focused_window',
                 \'language': &ft})
 endfunction
-function! phpactor#GotoDefinition()
-    call phpactor#_GotoDefinitionTarget('focused_window')
+""
+" deprecated, use @function(phpactor#gotodefinition) instead
+"
+" as with @function(phpactor#gotodefinition) but open in a vertical split.
+function! phpactor#GotoDefinitionVsplit()
+    echoerr "phpactor#GotoDefinitionVsplit is deprecated use phpactor#GotoDefinition('vsplit') instead"
+    call phpactor#GotoDefinition('vsplit')
 endfunction
+""
+" deprecated, use @function(phpactor#gotodefinition) instead
+"
+" as with @function(phpactor#gotodefinition) but open in an horizontal split.
+function! phpactor#GotoDefinitionHsplit()
+    echoerr "phpactor#GotoDefinitionHsplit is deprecated use phpactor#GotoDefinition('hsplit') instead"
+    call phpactor#GotoDefinition('hsplit')
+endfunction
+""
+" deprecated, use @function(phpactor#gotodefinition) instead
+"
+" as with @function(phpactor#gotodefinition) but open in a new tab.
+function! phpactor#GotoDefinitionTab()
+    echoerr "phpactor#GotoDefinitionTab is deprecated use phpactor#GotoDefinition('new_tab') instead"
+    call phpactor#GotoDefinition('new_tab')
+endfunction
+
 function! phpactor#GotoImplementations()
     call phpactor#rpc("goto_implementation", {
                 \"offset": phpactor#_offset(),
@@ -204,15 +232,6 @@ function! phpactor#GotoImplementations()
                 \"path": expand('%:p'),
                 \"target": 'focused_window',
                 \'language': &ft})
-endfunction
-function! phpactor#GotoDefinitionVsplit()
-    call phpactor#_GotoDefinitionTarget('vsplit')
-endfunction
-function! phpactor#GotoDefinitionHsplit()
-    call phpactor#_GotoDefinitionTarget('hsplit')
-endfunction
-function! phpactor#GotoDefinitionTab()
-    call phpactor#_GotoDefinitionTarget('new_tab')
 endfunction
 
 function! phpactor#GotoType()

--- a/autoload/phpactor.vim
+++ b/autoload/phpactor.vim
@@ -763,6 +763,30 @@ function! phpactor#_rpc_dispatch(actionName, parameters)
     throw "Do not know how to handle action '" . a:actionName . "'"
 endfunction
 
+""
+" @section Window targets, window-targets
+" @parentsection commands
+"
+" Phpactor provide a few window targets to use with some commands.
+" See @command(PhpactorGotoDefinition) for an example of how to use them.
+"
+" Possible values are:
+" * `e`, `edit`, `ex`
+" * `new`, `vne`, `vnew`
+" * `sp`, `split`, `vs`, `vsplit`
+" * `vie`, `view`, `sv`, `sview`, `splitview`
+" * `tabe`, `tabedit`, `tabnew`
+
+function! phpactor#_window_targets() abort
+  return [
+        \ 'e', 'edit', 'ex',
+        \ 'new', 'vne', 'vnew',
+        \ 'sp', 'split', 'vs', 'vsplit',
+        \ 'vie', 'view', 'sv', 'sview', 'splitview',
+        \ 'tabe', 'tabedit', 'tabnew',
+        \ ]
+endfunction
+
 function! s:openFileInSelectedTarget(filePath, target, mods, useOpenWindow, forceReload)
     let l:bufferNumber = bufnr(a:filePath . '$')
 
@@ -776,6 +800,15 @@ function! s:openFileInSelectedTarget(filePath, target, mods, useOpenWindow, forc
             endif
             return
         endif
+    endif
+
+    if -1 == index(phpactor#_window_targets(), a:target)
+      echohl WarningMsg
+      echomsg printf('Error executing: %s %s %s', a:mods, a:target, a:filePath)
+      echomsg printf('Invalid target: %s', a:target)
+      echomsg printf('Valid targets are: %s', join(phpactor#_window_targets(), ', '))
+      echohl None
+      return
     endif
 
     execute printf('%s %s %s', a:mods, a:target, a:filePath)

--- a/autoload/phpactor.vim
+++ b/autoload/phpactor.vim
@@ -234,11 +234,18 @@ function! phpactor#GotoImplementations()
                 \'language': &ft})
 endfunction
 
-function! phpactor#GotoType()
+""
+" @default target=`focused_window`
+"
+" Goto the implementation of the symbol under the cursor.
+" Opens in the [target] window, see @section(window-target) for
+" the list of possible targets.
+function! phpactor#GotoType(...)
     call phpactor#rpc('goto_type', {
         \'offset': phpactor#_offset(),
         \'source': phpactor#_source(),
         \'path': expand('%:p'),
+        \"target": a:0 ? a:1 : 'focused_window',
         \'language': &filetype})
 endfunction
 

--- a/autoload/phpactor.vim
+++ b/autoload/phpactor.vim
@@ -225,12 +225,20 @@ function! phpactor#GotoDefinitionTab()
     call phpactor#GotoDefinition('new_tab')
 endfunction
 
-function! phpactor#GotoImplementations()
+""
+" @default target=`focused_window`
+"
+" Goto the implementation of the symbol under the cursor.
+" Opens in the [target] window, see @section(window-target) for
+" the list of possible targets.
+" If there is more than one result the quickfix strategy will be used and [target]
+" will be ignored, see @setting(g:phpactorQuickfixStrategy).
+function! phpactor#GotoImplementations(...)
     call phpactor#rpc("goto_implementation", {
                 \"offset": phpactor#_offset(),
                 \"source": phpactor#_source(),
                 \"path": expand('%:p'),
-                \"target": 'focused_window',
+                \"target": a:0 ? a:1 : 'focused_window',
                 \'language': &ft})
 endfunction
 

--- a/autoload/phpactor.vim
+++ b/autoload/phpactor.vim
@@ -1,6 +1,5 @@
 ""
 " @section Introduction, intro
-" @library
 " @order intro config completion commands mappings
 "
 " Phpactor is a auto-completion, refactoring and code-navigation tool for PHP.

--- a/doc/phpactor.txt
+++ b/doc/phpactor.txt
@@ -7,6 +7,7 @@ CONTENTS                                                   *phpactor-contents*
   2. Configuration...........................................|phpactor-config|
   3. Completion..........................................|phpactor-completion|
   4. Commands..............................................|phpactor-commands|
+      1. Window targets..............................|phpactor-window-targets|
   5. Mappings..............................................|phpactor-mappings|
 
 ==============================================================================
@@ -175,18 +176,26 @@ COMMANDS                                                   *phpactor-commands*
 :PhpactorClassNew                                          *:PhpactorClassNew*
   Create a new class. You will be offered a choice of templates.
 
-:PhpactorGotoDefinition                              *:PhpactorGotoDefinition*
-  Goto the definition of the class, method or function under the cursor. Open
-  the definition in the current window.
+:PhpactorGotoDefinition [target]                     *:PhpactorGotoDefinition*
+  [target] is `focused_window` if omitted.
+
+  Goto the definition of the symbol under the cursor. Opens in the [target]
+  window, see |phpactor-window-target| for the list of possible targets.
 
 :PhpactorGotoDefinitionVsplit                  *:PhpactorGotoDefinitionVsplit*
+  deprecated, use |:PhpactorGotoDefinition| instead
+
   As with |:PhpactorGotoDefinition| but open in a vertical split.
 
 :PhpactorGotoDefinitionHsplit                  *:PhpactorGotoDefinitionHsplit*
-  As with |:PhpactorGotoDefinition| but open in a horizontal split.
+  deprecated, use |:PhpactorGotoDefinition| instead
+
+  As with |:PhpactorGotoDefinition| but open in an horizontal split.
 
 :PhpactorGotoDefinitionTab                        *:PhpactorGotoDefinitionTab*
-  As with |:PhpactorGotoDefinition| but open in a new tab
+  deprecated, use |:PhpactorGotoDefinition| instead
+
+  As with |:PhpactorGotoDefinition| but open in a new tab.
 
 :PhpactorGotoType                                          *:PhpactorGotoType*
   Goto type (class) of the symbol under the cursor.
@@ -194,6 +203,21 @@ COMMANDS                                                   *phpactor-commands*
 :PhpactorGotoImplementations                    *:PhpactorGotoImplementations*
   Load all implementations of the class under the cursor into the quick-fix
   list.
+
+==============================================================================
+WINDOW TARGETS                                       *phpactor-window-targets*
+
+
+Phpactor provide a few window targets to use with some commands and functions.
+See |:PhpactorGotoDefinition| or |phpactor#GotoDefinition()| for an example of
+how to use them.
+
+Possible values are:
+  * `focused_window`: open in the current window or in the window containing
+    the destination buffer if it exists in the current tab
+  * `hsplit`: open in an horizontal split window
+  * `vplist`: open in a vertical split window
+  * `new_tab`: open in a new tab
 
 ==============================================================================
 MAPPINGS                                                   *phpactor-mappings*

--- a/doc/phpactor.txt
+++ b/doc/phpactor.txt
@@ -177,10 +177,25 @@ COMMANDS                                                   *phpactor-commands*
   Create a new class. You will be offered a choice of templates.
 
 :PhpactorGotoDefinition [target]                     *:PhpactorGotoDefinition*
-  [target] is `focused_window` if omitted.
+  [target] is `edit` if omitted.
 
   Goto the definition of the symbol under the cursor. Opens in the [target]
   window, see |phpactor-window-target| for the list of possible targets.
+  |<mods>| can be provided to the command to change how the window will be
+  opened.
+
+  Examples:
+>
+      " Opens in the current buffer
+      PhpactorGotoDefinition
+
+      " Opens in a vertical split opened on the right side
+      botright PhpactorGotoDefinition vsplit
+      vertical botright PhpactorGotoDefinition split
+
+      " Opens in a new tab
+      PhpactorGotoDefinition tabnew
+<
 
 :PhpactorGotoDefinitionVsplit                  *:PhpactorGotoDefinitionVsplit*
   deprecated, use |:PhpactorGotoDefinition| instead
@@ -198,33 +213,31 @@ COMMANDS                                                   *phpactor-commands*
   As with |:PhpactorGotoDefinition| but open in a new tab.
 
 :PhpactorGotoType [target]                                 *:PhpactorGotoType*
-  [target] is `focused_window` if omitted.
 
-  Goto the type of the symbol under the cursor. Opens in the [target] window,
-  see |phpactor-window-target| for the list of possible targets.
+  Same as |:PhpactorGotoDefinition| but goto the type of the symbol under the
+  cursor.
 
 :PhpactorGotoImplementations [target]           *:PhpactorGotoImplementations*
-  [target] is `focused_window` if omitted.
 
-  Goto the implementation of the symbol under the cursor. Opens in the
-  [target] window, see |phpactor-window-target| for the list of possible
-  targets. If there is more than one result the quickfix strategy will be used
-  and [target] will be ignored, see |g:phpactorQuickfixStrategy|.
+  Same as |:PhpactorGotoDefinition| but goto the implmentation of the symbol
+  under the cursor.
+
+  If there is more than one result the quickfix strategy will be used and
+  [target] will be ignored, see |g:phpactorQuickfixStrategy|.
 
 ==============================================================================
 WINDOW TARGETS                                       *phpactor-window-targets*
 
 
-Phpactor provide a few window targets to use with some commands and functions.
-See |:PhpactorGotoDefinition| or |phpactor#GotoDefinition()| for an example of
-how to use them.
+Phpactor provide a few window targets to use with some commands. See
+|:PhpactorGotoDefinition| for an example of how to use them.
 
 Possible values are:
-  * `focused_window`: open in the current window or in the window containing
-    the destination buffer if it exists in the current tab
-  * `hsplit`: open in an horizontal split window
-  * `vplist`: open in a vertical split window
-  * `new_tab`: open in a new tab
+  * `e`, `edit`, `ex`
+  * `new`, `vne`, `vnew`
+  * `sp`, `split`, `vs`, `vsplit`
+  * `vie`, `view`, `sv`, `sview`, `splitview`
+  * `tabe`, `tabedit`, `tabnew`
 
 ==============================================================================
 MAPPINGS                                                   *phpactor-mappings*
@@ -244,11 +257,11 @@ are available for you to copy:
     au FileType php,cucumber nmap <buffer> <Leader>o
         \ :PhpactorGotoDefinition<CR>
     au FileType php,cucumber nmap <buffer> <Leader>Oh
-        \ :PhpactorGotoDefinition hsplit<CR>
+        \ :PhpactorGotoDefinition split<CR>
     au FileType php,cucumber nmap <buffer> <Leader>Ov
         \ :PhpactorGotoDefinition vsplit<CR>
     au FileType php,cucumber nmap <buffer> <Leader>Ot
-        \ :PhpactorGotoDefinition new_tab<CR>
+        \ :PhpactorGotoDefinition tabnew<CR>
     au FileType php nmap <buffer> <Leader>K :PhpactorHover<CR>
     au FileType php nmap <buffer> <Leader>tt :PhpactorTransform<CR>
     au FileType php nmap <buffer> <Leader>cc :PhpactorClassNew<CR>

--- a/doc/phpactor.txt
+++ b/doc/phpactor.txt
@@ -203,9 +203,13 @@ COMMANDS                                                   *phpactor-commands*
   Goto the type of the symbol under the cursor. Opens in the [target] window,
   see |phpactor-window-target| for the list of possible targets.
 
-:PhpactorGotoImplementations                    *:PhpactorGotoImplementations*
-  Load all implementations of the class under the cursor into the quick-fix
-  list.
+:PhpactorGotoImplementations [target]           *:PhpactorGotoImplementations*
+  [target] is `focused_window` if omitted.
+
+  Goto the implementation of the symbol under the cursor. Opens in the
+  [target] window, see |phpactor-window-target| for the list of possible
+  targets. If there is more than one result the quickfix strategy will be used
+  and [target] will be ignored, see |g:phpactorQuickfixStrategy|.
 
 ==============================================================================
 WINDOW TARGETS                                       *phpactor-window-targets*

--- a/doc/phpactor.txt
+++ b/doc/phpactor.txt
@@ -244,11 +244,11 @@ are available for you to copy:
     au FileType php,cucumber nmap <buffer> <Leader>o
         \ :PhpactorGotoDefinition<CR>
     au FileType php,cucumber nmap <buffer> <Leader>Oh
-        \ :PhpactorGotoDefinitionHsplit<CR>
+        \ :PhpactorGotoDefinition hsplit<CR>
     au FileType php,cucumber nmap <buffer> <Leader>Ov
-        \ :PhpactorGotoDefinitionVsplit<CR>
+        \ :PhpactorGotoDefinition vsplit<CR>
     au FileType php,cucumber nmap <buffer> <Leader>Ot
-        \ :PhpactorGotoDefinitionTab<CR>
+        \ :PhpactorGotoDefinition new_tab<CR>
     au FileType php nmap <buffer> <Leader>K :PhpactorHover<CR>
     au FileType php nmap <buffer> <Leader>tt :PhpactorTransform<CR>
     au FileType php nmap <buffer> <Leader>cc :PhpactorClassNew<CR>

--- a/doc/phpactor.txt
+++ b/doc/phpactor.txt
@@ -197,8 +197,11 @@ COMMANDS                                                   *phpactor-commands*
 
   As with |:PhpactorGotoDefinition| but open in a new tab.
 
-:PhpactorGotoType                                          *:PhpactorGotoType*
-  Goto type (class) of the symbol under the cursor.
+:PhpactorGotoType [target]                                 *:PhpactorGotoType*
+  [target] is `focused_window` if omitted.
+
+  Goto the type of the symbol under the cursor. Opens in the [target] window,
+  see |phpactor-window-target| for the list of possible targets.
 
 :PhpactorGotoImplementations                    *:PhpactorGotoImplementations*
   Load all implementations of the class under the cursor into the quick-fix

--- a/doc/phpactor.txt
+++ b/doc/phpactor.txt
@@ -255,13 +255,7 @@ are available for you to copy:
     au FileType php nmap <buffer> <Leader>mm :PhpactorContextMenu<CR>
     au FileType php nmap <buffer> <Leader>nn :PhpactorNavigate<CR>
     au FileType php,cucumber nmap <buffer> <Leader>o
-        \ :PhpactorGotoDefinition<CR>
-    au FileType php,cucumber nmap <buffer> <Leader>Oh
-        \ :PhpactorGotoDefinition split<CR>
-    au FileType php,cucumber nmap <buffer> <Leader>Ov
-        \ :PhpactorGotoDefinition vsplit<CR>
-    au FileType php,cucumber nmap <buffer> <Leader>Ot
-        \ :PhpactorGotoDefinition tabnew<CR>
+        \ :PhpactorGotoDefinition edit<CR>
     au FileType php nmap <buffer> <Leader>K :PhpactorHover<CR>
     au FileType php nmap <buffer> <Leader>tt :PhpactorTransform<CR>
     au FileType php nmap <buffer> <Leader>cc :PhpactorClassNew<CR>

--- a/ftplugin/php/mappings.vim
+++ b/ftplugin/php/mappings.vim
@@ -12,13 +12,7 @@
 "     au FileType php nmap <buffer> <Leader>mm :PhpactorContextMenu<CR>
 "     au FileType php nmap <buffer> <Leader>nn :PhpactorNavigate<CR>
 "     au FileType php,cucumber nmap <buffer> <Leader>o
-"         \ :PhpactorGotoDefinition<CR>
-"     au FileType php,cucumber nmap <buffer> <Leader>Oh 
-"         \ :PhpactorGotoDefinition split<CR>
-"     au FileType php,cucumber nmap <buffer> <Leader>Ov 
-"         \ :PhpactorGotoDefinition vsplit<CR>
-"     au FileType php,cucumber nmap <buffer> <Leader>Ot 
-"         \ :PhpactorGotoDefinition tabnew<CR>
+"         \ :PhpactorGotoDefinition edit<CR>
 "     au FileType php nmap <buffer> <Leader>K :PhpactorHover<CR>
 "     au FileType php nmap <buffer> <Leader>tt :PhpactorTransform<CR>
 "     au FileType php nmap <buffer> <Leader>cc :PhpactorClassNew<CR>

--- a/ftplugin/php/mappings.vim
+++ b/ftplugin/php/mappings.vim
@@ -14,11 +14,11 @@
 "     au FileType php,cucumber nmap <buffer> <Leader>o
 "         \ :PhpactorGotoDefinition<CR>
 "     au FileType php,cucumber nmap <buffer> <Leader>Oh 
-"         \ :PhpactorGotoDefinition hsplit<CR>
+"         \ :PhpactorGotoDefinition split<CR>
 "     au FileType php,cucumber nmap <buffer> <Leader>Ov 
 "         \ :PhpactorGotoDefinition vsplit<CR>
 "     au FileType php,cucumber nmap <buffer> <Leader>Ot 
-"         \ :PhpactorGotoDefinition new_tab<CR>
+"         \ :PhpactorGotoDefinition tabnew<CR>
 "     au FileType php nmap <buffer> <Leader>K :PhpactorHover<CR>
 "     au FileType php nmap <buffer> <Leader>tt :PhpactorTransform<CR>
 "     au FileType php nmap <buffer> <Leader>cc :PhpactorClassNew<CR>

--- a/ftplugin/php/mappings.vim
+++ b/ftplugin/php/mappings.vim
@@ -14,11 +14,11 @@
 "     au FileType php,cucumber nmap <buffer> <Leader>o
 "         \ :PhpactorGotoDefinition<CR>
 "     au FileType php,cucumber nmap <buffer> <Leader>Oh 
-"         \ :PhpactorGotoDefinitionHsplit<CR>
+"         \ :PhpactorGotoDefinition hsplit<CR>
 "     au FileType php,cucumber nmap <buffer> <Leader>Ov 
-"         \ :PhpactorGotoDefinitionVsplit<CR>
+"         \ :PhpactorGotoDefinition vsplit<CR>
 "     au FileType php,cucumber nmap <buffer> <Leader>Ot 
-"         \ :PhpactorGotoDefinitionTab<CR>
+"         \ :PhpactorGotoDefinition new_tab<CR>
 "     au FileType php nmap <buffer> <Leader>K :PhpactorHover<CR>
 "     au FileType php nmap <buffer> <Leader>tt :PhpactorTransform<CR>
 "     au FileType php nmap <buffer> <Leader>cc :PhpactorClassNew<CR>

--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -93,21 +93,33 @@ command! -nargs=0 PhpactorClassExpand call phpactor#ClassExpand()
 command! -nargs=0 PhpactorClassNew call phpactor#ClassNew()
 
 ""
-" Goto the definition of the class, method or function under the cursor. Open
-" the definition in the current window.
-command! -nargs=0 PhpactorGotoDefinition call phpactor#GotoDefinition()
-
+" @default target=`focused_window`
+"
+" Goto the definition of the symbol under the cursor.
+" Opens in the [target] window, see @section(window-target) for
+" the list of possible targets.
+command! -nargs=? -complete=customlist,s:CompleteWindowTarget PhpactorGotoDefinition call phpactor#GotoDefinition(<f-args>)
 ""
+" deprecated, use @command(PhpactorGotoDefinition) instead
+"
 " As with @command(PhpactorGotoDefinition) but open in a vertical split.
-command! -nargs=0 PhpactorGotoDefinitionVsplit call phpactor#GotoDefinitionVsplit()
-
+command! -nargs=0 PhpactorGotoDefinitionVsplit 
+  \ echoerr 'PhpactorGotoDefinitionVsplit is deprecated, use PhpactorGotoDefinition instead' |
+  \ PhpactorGotoDefinition vsplit
 ""
-" As with @command(PhpactorGotoDefinition) but open in a horizontal split.
-command! -nargs=0 PhpactorGotoDefinitionHsplit call phpactor#GotoDefinitionHsplit()
-
+" deprecated, use @command(PhpactorGotoDefinition) instead
+"
+" As with @command(PhpactorGotoDefinition) but open in an horizontal split.
+command! -nargs=0 PhpactorGotoDefinitionHsplit 
+  \ echoerr 'PhpactorGotoDefinitionHsplit is deprecated, use PhpactorGotoDefinition instead' |
+  \ PhpactorGotoDefinition hsplit
 ""
-" As with @command(PhpactorGotoDefinition) but open in a new tab
-command! -nargs=0 PhpactorGotoDefinitionTab call phpactor#GotoDefinitionTab()
+" deprecated, use @command(PhpactorGotoDefinition) instead
+"
+" As with @command(PhpactorGotoDefinition) but open in a new tab.
+command! -nargs=0 PhpactorGotoDefinitionTab 
+  \ echoerr 'PhpactorGotoDefinitionTab is deprecated, use PhpactorGotoDefinition instead' |
+  \ PhpactorGotoDefinition new_tab
 
 ""
 " Goto type (class) of the symbol under the cursor.
@@ -119,5 +131,29 @@ command! -nargs=0 PhpactorGotoType call phpactor#GotoType()
 command! -nargs=0 PhpactorGotoImplementations call phpactor#GotoImplementations()
 
 " Commands }}}
+
+" Functions {{{
+
+""
+" @section Window targets, window-targets
+" @parentsection commands
+"
+" Phpactor provide a few window targets to use with some commands and
+" functions.
+" See @command(PhpactorGotoDefinition) or @function(phpactor#GotoDefinition)
+" for an example of how to use them.
+"
+" Possible values are:
+" * `focused_window`: open in the current window or in the window containing the
+"   destination buffer if it exists in the current tab
+" * `hsplit`: open in an horizontal split window
+" * `vplist`: open in a vertical split window
+" * `new_tab`: open in a new tab
+
+function! s:CompleteWindowTarget(...) abort
+  return ['focused_window', 'vsplit', 'hsplit', 'new_tab']
+endfunction
+
+" }}}
 
 " vim: et ts=4 sw=4 fdm=marker

--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -157,30 +157,8 @@ command! -nargs=? -complete=customlist,s:CompleteWindowTarget PhpactorGotoImplem
 
 " Functions {{{
 
-""
-" @section Window targets, window-targets
-" @parentsection commands
-"
-" Phpactor provide a few window targets to use with some commands.
-" See @command(PhpactorGotoDefinition) for an example of how to use them.
-"
-" Possible values are:
-" * `e`, `edit`, `ex`
-" * `new`, `vne`, `vnew`
-" * `sp`, `split`, `vs`, `vsplit`
-" * `vie`, `view`, `sv`, `sview`, `splitview`
-" * `tabe`, `tabedit`, `tabnew`
-
-let s:windowTargets = [
-  \ 'e', 'edit', 'ex',
-  \ 'new', 'vne', 'vnew',
-  \ 'sp', 'split', 'vs', 'vsplit',
-  \ 'vie', 'view', 'sv', 'sview', 'splitview',
-  \ 'tabe', 'tabedit', 'tabnew',
-\ ]
-
 function! s:CompleteWindowTarget(argLead, ...) abort
-    return filter(copy(s:windowTargets), {k,v -> 0 == stridx(v, a:argLead)})
+    return filter(phpactor#windowTargets(), {k,v -> 0 == stridx(v, a:argLead)})
 endfunction
 
 " }}}

--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -130,9 +130,14 @@ command! -nargs=0 PhpactorGotoDefinitionTab
 command! -nargs=? -complete=customlist,s:CompleteWindowTarget PhpactorGotoType call phpactor#GotoType(<f-args>)
 
 ""
-" Load all implementations of the class under the cursor into the quick-fix
-" list.
-command! -nargs=0 PhpactorGotoImplementations call phpactor#GotoImplementations()
+" @default target=`focused_window`
+"
+" Goto the implementation of the symbol under the cursor.
+" Opens in the [target] window, see @section(window-target) for
+" the list of possible targets.
+" If there is more than one result the quickfix strategy will be used and [target]
+" will be ignored, see @setting(g:phpactorQuickfixStrategy).
+command! -nargs=? -complete=customlist,s:CompleteWindowTarget PhpactorGotoImplementations call phpactor#GotoImplementations(<f-args>)
 
 " Commands }}}
 

--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -93,51 +93,65 @@ command! -nargs=0 PhpactorClassExpand call phpactor#ClassExpand()
 command! -nargs=0 PhpactorClassNew call phpactor#ClassNew()
 
 ""
-" @default target=`focused_window`
+" @default target=`edit`
 "
 " Goto the definition of the symbol under the cursor.
 " Opens in the [target] window, see @section(window-target) for
 " the list of possible targets.
-command! -nargs=? -complete=customlist,s:CompleteWindowTarget PhpactorGotoDefinition call phpactor#GotoDefinition(<f-args>)
+" |<mods>| can be provided to the command to change how the window will be
+" opened.
+"
+" Examples:
+" >
+"     " Opens in the current buffer
+"     PhpactorGotoDefinition
+"
+"     " Opens in a vertical split opened on the right side
+"     botright PhpactorGotoDefinition vsplit
+"     vertical botright PhpactorGotoDefinition split
+"
+"     " Opens in a new tab
+"     PhpactorGotoDefinition tabnew
+" <
+command! -nargs=? -complete=customlist,s:CompleteWindowTarget PhpactorGotoDefinition call phpactor#GotoDefinition(<q-args>, <q-mods>)
 ""
 " deprecated, use @command(PhpactorGotoDefinition) instead
 "
 " As with @command(PhpactorGotoDefinition) but open in a vertical split.
-command! -nargs=0 PhpactorGotoDefinitionVsplit 
+command! -nargs=0 PhpactorGotoDefinitionVsplit
   \ echoerr 'PhpactorGotoDefinitionVsplit is deprecated, use PhpactorGotoDefinition instead' |
-  \ PhpactorGotoDefinition vsplit
+  \ <mods> PhpactorGotoDefinition vsplit
 ""
 " deprecated, use @command(PhpactorGotoDefinition) instead
 "
 " As with @command(PhpactorGotoDefinition) but open in an horizontal split.
-command! -nargs=0 PhpactorGotoDefinitionHsplit 
+command! -nargs=0 PhpactorGotoDefinitionHsplit
   \ echoerr 'PhpactorGotoDefinitionHsplit is deprecated, use PhpactorGotoDefinition instead' |
-  \ PhpactorGotoDefinition hsplit
+  \ <mods> PhpactorGotoDefinition hsplit
 ""
 " deprecated, use @command(PhpactorGotoDefinition) instead
 "
 " As with @command(PhpactorGotoDefinition) but open in a new tab.
-command! -nargs=0 PhpactorGotoDefinitionTab 
+command! -nargs=0 PhpactorGotoDefinitionTab
   \ echoerr 'PhpactorGotoDefinitionTab is deprecated, use PhpactorGotoDefinition instead' |
   \ PhpactorGotoDefinition new_tab
 
 ""
-" @default target=`focused_window`
+" @usage [target]
 "
-" Goto the type of the symbol under the cursor.
-" Opens in the [target] window, see @section(window-target) for
-" the list of possible targets.
-command! -nargs=? -complete=customlist,s:CompleteWindowTarget PhpactorGotoType call phpactor#GotoType(<f-args>)
+" Same as @command(PhpactorGotoDefinition) but goto the type of the symbol
+" under the cursor.
+command! -nargs=? -complete=customlist,s:CompleteWindowTarget PhpactorGotoType call phpactor#GotoType(<q-args>, <q-mods>)
 
 ""
-" @default target=`focused_window`
+" @usage [target]
 "
-" Goto the implementation of the symbol under the cursor.
-" Opens in the [target] window, see @section(window-target) for
-" the list of possible targets.
+" Same as @command(PhpactorGotoDefinition) but goto the implmentation of the
+" symbol under the cursor.
+"
 " If there is more than one result the quickfix strategy will be used and [target]
 " will be ignored, see @setting(g:phpactorQuickfixStrategy).
-command! -nargs=? -complete=customlist,s:CompleteWindowTarget PhpactorGotoImplementations call phpactor#GotoImplementations(<f-args>)
+command! -nargs=? -complete=customlist,s:CompleteWindowTarget PhpactorGotoImplementations call phpactor#GotoImplementations(<q-args>, <q-mods>)
 
 " Commands }}}
 
@@ -147,19 +161,23 @@ command! -nargs=? -complete=customlist,s:CompleteWindowTarget PhpactorGotoImplem
 " @section Window targets, window-targets
 " @parentsection commands
 "
-" Phpactor provide a few window targets to use with some commands and
-" functions.
-" See @command(PhpactorGotoDefinition) or @function(phpactor#GotoDefinition)
-" for an example of how to use them.
+" Phpactor provide a few window targets to use with some commands.
+" See @command(PhpactorGotoDefinition) for an example of how to use them.
 "
 " Possible values are:
-" * `focused_window`: open in the current window or in the window containing the
-"   destination buffer if it exists in the current tab
-" * `hsplit`: open in an horizontal split window
-" * `vplist`: open in a vertical split window
-" * `new_tab`: open in a new tab
+" * `e`, `edit`, `ex`
+" * `new`, `vne`, `vnew`
+" * `sp`, `split`, `vs`, `vsplit`
+" * `vie`, `view`, `sv`, `sview`, `splitview`
+" * `tabe`, `tabedit`, `tabnew`
 
-let s:windowTargets = ['focused_window', 'vsplit', 'hsplit', 'new_tab']
+let s:windowTargets = [
+  \ 'e', 'edit', 'ex',
+  \ 'new', 'vne', 'vnew',
+  \ 'sp', 'split', 'vs', 'vsplit',
+  \ 'vie', 'view', 'sv', 'sview', 'splitview',
+  \ 'tabe', 'tabedit', 'tabnew',
+\ ]
 
 function! s:CompleteWindowTarget(argLead, ...) abort
     return filter(copy(s:windowTargets), {k,v -> 0 == stridx(v, a:argLead)})

--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -159,8 +159,10 @@ command! -nargs=? -complete=customlist,s:CompleteWindowTarget PhpactorGotoImplem
 " * `vplist`: open in a vertical split window
 " * `new_tab`: open in a new tab
 
-function! s:CompleteWindowTarget(...) abort
-  return ['focused_window', 'vsplit', 'hsplit', 'new_tab']
+let s:windowTargets = ['focused_window', 'vsplit', 'hsplit', 'new_tab']
+
+function! s:CompleteWindowTarget(argLead, ...) abort
+    return filter(copy(s:windowTargets), {k,v -> 0 == stridx(v, a:argLead)})
 endfunction
 
 " }}}

--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -122,8 +122,12 @@ command! -nargs=0 PhpactorGotoDefinitionTab
   \ PhpactorGotoDefinition new_tab
 
 ""
-" Goto type (class) of the symbol under the cursor.
-command! -nargs=0 PhpactorGotoType call phpactor#GotoType()
+" @default target=`focused_window`
+"
+" Goto the type of the symbol under the cursor.
+" Opens in the [target] window, see @section(window-target) for
+" the list of possible targets.
+command! -nargs=? -complete=customlist,s:CompleteWindowTarget PhpactorGotoType call phpactor#GotoType(<f-args>)
 
 ""
 " Load all implementations of the class under the cursor into the quick-fix


### PR DESCRIPTION
As discussed the accumulation of commands to go to a definition was a bad idea.

##### Todo
- [x] Merge #965 first to avoid conflicts and rebase afterwards
- [x] Ensure the deprecated commands where in a previous release, delete them if not
- [x] Delete the deprecated autoload functions ? Since they are private I guess the deprecations does not affect the and I can delete immedialty, @dantleech ?
- [x] Improve the "window targets" to use valid vim commands like `edit`, `split` (ensure that the "window targets" are never sended by phpactor but only define in the plugin)
- [x] Use mods (`:h <mods>`) to control with more granularity how the window will be opened ? `toplef', `aboveleft`, etc.