### PR TITLE
Fix regression in generate accessor behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Improvements:
 
 Bug fixes:
 
+  - [code-transform] Generate accessor doesn't work on selected property (regression)
   - [vim-plugin] Configuration was not global (#964) - @elythyr
   - [class-mover] `$` was removed when renaming static variables (#925) -
     @dantleech


### PR DESCRIPTION
When invoked on a specific property, that accessor should be immediately generated. Currently it gives a choice of all the properties regardless. cc @elythyr 