### PR TITLE
Composer Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ Changelog
 Features:
 
   - [vim-plugin] Ability to set custom project root strategy (#1027) - @przepompownia
+  - [indexer-extension] Workspace reference finder (classes,functions,members) - @dantleech
+  - [worse-reflection] Support "final" keyword - @dantleech
+  - [language-server-hover] Show "final" keyword on class hover - @dantleech
+  - [language-server-hover] Show inherited method documentation - @dantleech
+
+Improvements:
+
+  - [language-server-bridge] Service to convert Phpactor Locations to LSP locations - @dantleech
+
+Bug fixes;
+
+  - [ampfs-watch] Inotify watcher not reporting error when out of available
+    watchers
+    (https://github.com/phpactor/amp-fswatch/commit/1e38faadc3fb73158de9a966ee12d17992dad4fe)
+    - @dantleech
+  - [ampfs-watch] Buffered watcher not allowing errors to bubble up
+    (https://github.com/phpactor/amp-fswatch/commit/b5cb54b6d01a9ec3dcbfdcca804c2d63c0e84a19)
+    - @dantleech
+  - [language-server] Ensure that `result` key is missing when `NULL` (some
+    clients require it) - @dantleech
 
 ## 2020-05-03 0.15.0
 

--- a/bin/phpactor
+++ b/bin/phpactor
@@ -1,7 +1,6 @@
 #!/usr/bin/env php
 <?php
 
-use Symfony\Component\Debug\Debug;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Phpactor\Application;

--- a/composer.lock
+++ b/composer.lock
@@ -1645,16 +1645,16 @@
         },
         {
             "name": "phpactor/amp-fswatch",
-            "version": "0.1.0",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/amp-fswatch.git",
-                "reference": "cff72b08ececee613ef06511ffee27edb51e999e"
+                "reference": "2c54c449a2465ee96f848bef73d91027401a35e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/amp-fswatch/zipball/cff72b08ececee613ef06511ffee27edb51e999e",
-                "reference": "cff72b08ececee613ef06511ffee27edb51e999e",
+                "url": "https://api.github.com/repos/phpactor/amp-fswatch/zipball/2c54c449a2465ee96f848bef73d91027401a35e9",
+                "reference": "2c54c449a2465ee96f848bef73d91027401a35e9",
                 "shasum": ""
             },
             "require": {
@@ -1693,7 +1693,7 @@
                 }
             ],
             "description": "Async Filesystem Watcher for Amphp",
-            "time": "2020-04-26T07:46:54+00:00"
+            "time": "2020-05-15T07:05:52+00:00"
         },
         {
             "name": "phpactor/class-mover",
@@ -2592,18 +2592,18 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/indexer-extension.git",
-                "reference": "cd71499d9e2a0a818fb285e89d11da9ca1ab1dde"
+                "reference": "a3e0055f111919666a8818d55d381004fae8d109"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/indexer-extension/zipball/cd71499d9e2a0a818fb285e89d11da9ca1ab1dde",
-                "reference": "cd71499d9e2a0a818fb285e89d11da9ca1ab1dde",
+                "url": "https://api.github.com/repos/phpactor/indexer-extension/zipball/a3e0055f111919666a8818d55d381004fae8d109",
+                "reference": "a3e0055f111919666a8818d55d381004fae8d109",
                 "shasum": ""
             },
             "require": {
                 "dantleech/invoke": "^1.0",
                 "php": "^7.3",
-                "phpactor/amp-fswatch": "^0.1.0",
+                "phpactor/amp-fswatch": "^0.1.1",
                 "phpactor/name-specification": "^0.1",
                 "phpactor/reference-finder": "^0.1.3",
                 "phpactor/reference-finder-extension": "^0.1.3",
@@ -2646,7 +2646,7 @@
                 }
             ],
             "description": "Indexer and related integrations",
-            "time": "2020-05-11T06:50:50+00:00"
+            "time": "2020-05-14T21:50:31+00:00"
         },
         {
             "name": "phpactor/language-server",
@@ -2654,12 +2654,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/language-server.git",
-                "reference": "d2df60a309c56ac20445e3859833f021ff9f2eb7"
+                "reference": "944fa1c8f67de2342796207b2ca28a979da471a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/language-server/zipball/d2df60a309c56ac20445e3859833f021ff9f2eb7",
-                "reference": "d2df60a309c56ac20445e3859833f021ff9f2eb7",
+                "url": "https://api.github.com/repos/phpactor/language-server/zipball/944fa1c8f67de2342796207b2ca28a979da471a3",
+                "reference": "944fa1c8f67de2342796207b2ca28a979da471a3",
                 "shasum": ""
             },
             "require": {
@@ -2704,7 +2704,7 @@
                 }
             ],
             "description": "Phpactor Language Server",
-            "time": "2020-05-07T20:00:46+00:00"
+            "time": "2020-05-11T19:50:24+00:00"
         },
         {
             "name": "phpactor/language-server-extension",
@@ -2769,12 +2769,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/language-server-phpactor-extensions.git",
-                "reference": "aba2dadb591fff1c3ec255aabc65c8cee6550e26"
+                "reference": "457265a133fe1b164642ecf8e928909e155dbd11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/language-server-phpactor-extensions/zipball/aba2dadb591fff1c3ec255aabc65c8cee6550e26",
-                "reference": "aba2dadb591fff1c3ec255aabc65c8cee6550e26",
+                "url": "https://api.github.com/repos/phpactor/language-server-phpactor-extensions/zipball/457265a133fe1b164642ecf8e928909e155dbd11",
+                "reference": "457265a133fe1b164642ecf8e928909e155dbd11",
                 "shasum": ""
             },
             "require": {
@@ -2794,6 +2794,7 @@
                 "phpactor/logging-extension": "~0.3.3",
                 "phpactor/reference-finder-extension": "^0.1.5",
                 "phpactor/text-document": "^1.2.2",
+                "phpactor/worse-reflection": "~0.4.2",
                 "phpactor/worse-reflection-extension": "~0.2.3"
             },
             "require-dev": {
@@ -2832,7 +2833,7 @@
                 }
             ],
             "description": "Provides an (experimental) LSP compatible Language Server Platform",
-            "time": "2020-05-11T07:03:30+00:00"
+            "time": "2020-05-12T22:03:28+00:00"
         },
         {
             "name": "phpactor/logging-extension",
@@ -3464,12 +3465,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/worse-reflection.git",
-                "reference": "6035ff33e465409c59dd84ece78f114a6cd34579"
+                "reference": "3ba785d0de4a798de542ff03073c48b4a0a960c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/worse-reflection/zipball/6035ff33e465409c59dd84ece78f114a6cd34579",
-                "reference": "6035ff33e465409c59dd84ece78f114a6cd34579",
+                "url": "https://api.github.com/repos/phpactor/worse-reflection/zipball/3ba785d0de4a798de542ff03073c48b4a0a960c0",
+                "reference": "3ba785d0de4a798de542ff03073c48b4a0a960c0",
                 "shasum": ""
             },
             "require": {
@@ -3511,7 +3512,7 @@
                 }
             ],
             "description": "Lazy AST reflector that is much worse than better",
-            "time": "2020-05-10T14:15:33+00:00"
+            "time": "2020-05-11T19:58:33+00:00"
         },
         {
             "name": "phpactor/worse-reflection-extension",
@@ -4234,16 +4235,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.16.0",
+            "version": "v1.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "1aab00e39cebaef4d8652497f46c15c1b7e45294"
+                "reference": "e94c8b1bbe2bc77507a1056cdb06451c75b427f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/1aab00e39cebaef4d8652497f46c15c1b7e45294",
-                "reference": "1aab00e39cebaef4d8652497f46c15c1b7e45294",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e94c8b1bbe2bc77507a1056cdb06451c75b427f9",
+                "reference": "e94c8b1bbe2bc77507a1056cdb06451c75b427f9",
                 "shasum": ""
             },
             "require": {
@@ -4255,7 +4256,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.16-dev"
+                    "dev-master": "1.17-dev"
                 }
             },
             "autoload": {
@@ -4302,20 +4303,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-08T16:50:20+00:00"
+            "time": "2020-05-12T16:14:59+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.16.0",
+            "version": "v1.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "a54881ec0ab3b2005c406aed0023c062879031e7"
+                "reference": "fa79b11539418b02fc5e1897267673ba2c19419c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/a54881ec0ab3b2005c406aed0023c062879031e7",
-                "reference": "a54881ec0ab3b2005c406aed0023c062879031e7",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/fa79b11539418b02fc5e1897267673ba2c19419c",
+                "reference": "fa79b11539418b02fc5e1897267673ba2c19419c",
                 "shasum": ""
             },
             "require": {
@@ -4327,7 +4328,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.16-dev"
+                    "dev-master": "1.17-dev"
                 }
             },
             "autoload": {
@@ -4375,20 +4376,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-08T16:50:20+00:00"
+            "time": "2020-05-12T16:47:27+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.16.0",
+            "version": "v1.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "7e95fe59d12169fcf4041487e4bf34fca37ee0ed"
+                "reference": "a760d8964ff79ab9bf057613a5808284ec852ccc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/7e95fe59d12169fcf4041487e4bf34fca37ee0ed",
-                "reference": "7e95fe59d12169fcf4041487e4bf34fca37ee0ed",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/a760d8964ff79ab9bf057613a5808284ec852ccc",
+                "reference": "a760d8964ff79ab9bf057613a5808284ec852ccc",
                 "shasum": ""
             },
             "require": {
@@ -4397,7 +4398,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.16-dev"
+                    "dev-master": "1.17-dev"
                 }
             },
             "autoload": {
@@ -4447,7 +4448,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-02T14:56:09+00:00"
+            "time": "2020-05-12T16:47:27+00:00"
         },
         {
             "name": "symfony/process",
@@ -5292,12 +5293,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "b2175d15df9bd2d2557cd1fd9d86eb43da67bc0f"
+                "reference": "c5b135f0431dac5285fb307ff89962a93e5c073b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/b2175d15df9bd2d2557cd1fd9d86eb43da67bc0f",
-                "reference": "b2175d15df9bd2d2557cd1fd9d86eb43da67bc0f",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/c5b135f0431dac5285fb307ff89962a93e5c073b",
+                "reference": "c5b135f0431dac5285fb307ff89962a93e5c073b",
                 "shasum": ""
             },
             "require": {
@@ -5381,7 +5382,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-05-05T19:54:55+00:00"
+            "time": "2020-05-14T07:43:33+00:00"
         },
         {
             "name": "lstrojny/functional-php",
@@ -7322,16 +7323,16 @@
         },
         {
             "name": "symfony/polyfill-php70",
-            "version": "v1.16.0",
+            "version": "v1.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php70.git",
-                "reference": "6cc55bd2a085dbe05b4122c1987a82897b8da419"
+                "reference": "82225c2d7d23d7e70515496d249c0152679b468e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/6cc55bd2a085dbe05b4122c1987a82897b8da419",
-                "reference": "6cc55bd2a085dbe05b4122c1987a82897b8da419",
+                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/82225c2d7d23d7e70515496d249c0152679b468e",
+                "reference": "82225c2d7d23d7e70515496d249c0152679b468e",
                 "shasum": ""
             },
             "require": {
@@ -7341,7 +7342,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.16-dev"
+                    "dev-master": "1.17-dev"
                 }
             },
             "autoload": {
@@ -7391,20 +7392,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-02T14:56:09+00:00"
+            "time": "2020-05-12T16:47:27+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.16.0",
+            "version": "v1.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "42fda6d7380e5c940d7f68341ccae89d5ab9963b"
+                "reference": "f048e612a3905f34931127360bdd2def19a5e582"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/42fda6d7380e5c940d7f68341ccae89d5ab9963b",
-                "reference": "42fda6d7380e5c940d7f68341ccae89d5ab9963b",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/f048e612a3905f34931127360bdd2def19a5e582",
+                "reference": "f048e612a3905f34931127360bdd2def19a5e582",
                 "shasum": ""
             },
             "require": {
@@ -7413,7 +7414,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.16-dev"
+                    "dev-master": "1.17-dev"
                 }
             },
             "autoload": {
@@ -7460,7 +7461,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-08T17:28:34+00:00"
+            "time": "2020-05-12T16:47:27+00:00"
         },
         {
             "name": "symfony/stopwatch",

--- a/lib/Phpactor.php
+++ b/lib/Phpactor.php
@@ -2,6 +2,7 @@
 
 namespace Phpactor;
 
+use Phpactor\Extension\LanguageServerBridge\LanguageServerBridgeExtension;
 use Phpactor\Extension\LanguageServerCompletion\LanguageServerCompletionExtension;
 use Phpactor\Extension\LanguageServerHover\LanguageServerHoverExtension;
 use Phpactor\Extension\LanguageServerIndexer\LanguageServerIndexerExtension;
@@ -115,6 +116,7 @@ class Phpactor
             LanguageServerWorseReflectionExtension::class,
             LanguageServerIndexerExtension::class,
             LanguageServerHoverExtension::class,
+            LanguageServerBridgeExtension::class,
             IndexerExtension::class,
         ];
 


### PR DESCRIPTION
TODO:

- [x] Buffered watcher still doesn't work ... : it only yields once update is received AND timeout exceeded. but should yield when timeout is exceeeded.

```
  phpactor/amp-fswatch cff72b08ec..b5cb54b6d0

    [2020-05-12 08:43:57] Delay after buffer has been cleared
    [2020-05-14 21:12:57] Handle inotify exiting  Often Inotify will exit because it ran out of watchers, handle this scenario.
    [2020-05-14 21:39:43] Refactored buffered watcher not to use AsyncCall  Allow exceptions to bubble up from co-routine instead.

  phpactor/indexer-extension cd71499d9e..a3e0055f11

    [2020-05-14 21:50:31] Require ampfs-watch 1.1

  phpactor/language-server d2df60a309..944fa1c8f6

    [2020-05-11 16:58:54] Do not allow registeration of services with string keys.  Service must be a list of method names on the handler.
    [2020-05-11 19:48:39] Ensure that result is always set  Some language clients require that NULL values are not included, while others require (CoC) that NULL is present for one of error or result.

  phpactor/language-server-phpactor-extensions aba2dadb59..457265a133

    [2020-05-11 17:10:26] Change message to show only "risky" (i.e. maybe) references if they were encountered.
    [2020-05-11 20:01:16] Add support for rendering final keyword
    [2020-05-12 18:27:28] Added service for converting Phpactor locations to LSP locations
    [2020-05-12 18:38:22] Updated handlers to use location converter
    [2020-05-12 18:41:36] Added extension to serve bin
    [2020-05-12 18:41:48] CS fixes
    [2020-05-12 20:33:13] Show prefix if overridden method  Show inherited docs  Updated templates
    [2020-05-12 22:03:28] Fixed spacing

  phpactor/worse-reflection 6035ff33e4..3ba785d0de

    [2020-05-11 19:58:33] Add support for class is final
```