### PR TITLE
Prepare Phpactor 16 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
  
-## develop (0.16.0)
+## 2020-06-09 (0.16.0)
 
 Features:
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "phpactor/phpactor",
     "description": "PHP refactoring and intellisense tool for text editors",
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true,
     "license": "MIT",
     "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6ee0d11ce0e68aa233578b375ace052e",
+    "content-hash": "e1e790b6bc4f2d581d7871dbc86ef459",
     "packages": [
         {
             "name": "amphp/amp",
@@ -1866,7 +1866,7 @@
         },
         {
             "name": "phpactor/code-builder",
-            "version": "dev-master",
+            "version": "0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/code-builder.git",
@@ -1918,16 +1918,16 @@
         },
         {
             "name": "phpactor/code-transform",
-            "version": "dev-master",
+            "version": "0.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/code-transform.git",
-                "reference": "eb31b9874a31ace1a8e5665f7d8ecb91025097a2"
+                "reference": "13efb324adba2ef4e17be8fee3b452718451437b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/code-transform/zipball/eb31b9874a31ace1a8e5665f7d8ecb91025097a2",
-                "reference": "eb31b9874a31ace1a8e5665f7d8ecb91025097a2",
+                "url": "https://api.github.com/repos/phpactor/code-transform/zipball/13efb324adba2ef4e17be8fee3b452718451437b",
+                "reference": "13efb324adba2ef4e17be8fee3b452718451437b",
                 "shasum": ""
             },
             "require": {
@@ -1966,11 +1966,11 @@
                 }
             ],
             "description": "Applies introspective transformations on source code",
-            "time": "2020-06-04T21:07:35+00:00"
+            "time": "2020-06-09T20:14:11+00:00"
         },
         {
             "name": "phpactor/code-transform-extension",
-            "version": "dev-master",
+            "version": "0.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/code-transform-extension.git",
@@ -2024,7 +2024,7 @@
         },
         {
             "name": "phpactor/completion",
-            "version": "dev-master",
+            "version": "0.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/completion.git",
@@ -2083,7 +2083,7 @@
         },
         {
             "name": "phpactor/completion-extension",
-            "version": "dev-master",
+            "version": "0.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/completion-extension.git",
@@ -2183,7 +2183,7 @@
         },
         {
             "name": "phpactor/completion-worse-extension",
-            "version": "dev-master",
+            "version": "0.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/completion-worse-extension.git",
@@ -2235,7 +2235,7 @@
         },
         {
             "name": "phpactor/composer-autoloader-extension",
-            "version": "dev-master",
+            "version": "0.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/composer-autoloader-extension.git",
@@ -2383,7 +2383,7 @@
         },
         {
             "name": "phpactor/container",
-            "version": "dev-master",
+            "version": "1.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/container.git",
@@ -2474,7 +2474,7 @@
         },
         {
             "name": "phpactor/extension-manager-extension",
-            "version": "dev-master",
+            "version": "0.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/extension-manager-extension.git",
@@ -2621,7 +2621,7 @@
         },
         {
             "name": "phpactor/indexer-extension",
-            "version": "dev-master",
+            "version": "0.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/indexer-extension.git",
@@ -2684,7 +2684,7 @@
         },
         {
             "name": "phpactor/language-server",
-            "version": "dev-master",
+            "version": "0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/language-server.git",
@@ -2742,7 +2742,7 @@
         },
         {
             "name": "phpactor/language-server-extension",
-            "version": "dev-master",
+            "version": "0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/language-server-extension.git",
@@ -2799,7 +2799,7 @@
         },
         {
             "name": "phpactor/language-server-phpactor-extensions",
-            "version": "dev-master",
+            "version": "0.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/language-server-phpactor-extensions.git",
@@ -2922,7 +2922,7 @@
         },
         {
             "name": "phpactor/map-resolver",
-            "version": "dev-master",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/map-resolver.git",
@@ -3057,7 +3057,7 @@
         },
         {
             "name": "phpactor/php-extension",
-            "version": "dev-master",
+            "version": "0.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/php-extension.git",
@@ -3108,7 +3108,7 @@
         },
         {
             "name": "phpactor/reference-finder",
-            "version": "dev-master",
+            "version": "0.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/reference-finder.git",
@@ -3158,7 +3158,7 @@
         },
         {
             "name": "phpactor/reference-finder-extension",
-            "version": "dev-master",
+            "version": "0.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/reference-finder-extension.git",
@@ -3407,7 +3407,7 @@
         },
         {
             "name": "phpactor/text-document",
-            "version": "dev-master",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/text-document.git",
@@ -3456,7 +3456,7 @@
         },
         {
             "name": "phpactor/worse-reference-finder-extension",
-            "version": "dev-master",
+            "version": "0.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/worse-reference-finder-extension.git",
@@ -3508,7 +3508,7 @@
         },
         {
             "name": "phpactor/worse-reference-finders",
-            "version": "dev-master",
+            "version": "0.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/worse-reference-finder.git",
@@ -3559,7 +3559,7 @@
         },
         {
             "name": "phpactor/worse-reflection",
-            "version": "dev-master",
+            "version": "0.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/worse-reflection.git",
@@ -5988,7 +5988,7 @@
         },
         {
             "name": "phpactor/debug-extension",
-            "version": "dev-master",
+            "version": "0.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/debug-extension.git",
@@ -8048,7 +8048,7 @@
         }
     ],
     "aliases": [],
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "stability-flags": {
         "phpactor/debug-extension": 20,
         "friendsofphp/php-cs-fixer": 20


### PR DESCRIPTION
## 2020-06-09 (0.16.0)

Features:

  - [vim-plugin] Ability to set custom project root strategy (#1027) - @przepompownia
  - [indexer-extension] Workspace reference finder (classes,functions,members) - @dantleech
  - [worse-reflection] Support "final" keyword - @dantleech
  - [language-server-hover] Show "final" keyword on class hover - @dantleech
  - [language-server-hover] Show inherited method documentation - @dantleech
  - [language-server-code-transform] Add command to import class - @dantleech
  - [language-server-completion] Automatically import class on completion confirm - @dantleech
  - [code-transform] Consider current class as a potential conflict for imports - @dantleech
  - [completion] Indexed class name and function completion - @dantleech
  - [indexer-extension] Support "deep references" (search over all implementaions) - @dantleech
  - [composer] Enable disbaling of autoloader inclusion via. `composer.enable` - @dantleech
  - [lanaguage-server-completion] Auto-import functions - @dantleech

Improvements:

  - [code-builder] Removed functionality to "update" parameters: was very
    buggy. Now only new parameters will be added when updating methods via.
    generate method.
  - [language-server-bridge] Service to convert Phpactor Locations to LSP locations - @dantleech
  - [code-transform] Class import updates context name on alias - @dantleech
  - [documentation] Generate the configuration reference - @dantleech
  - [completion-worse] Allow completors to be disabled via `completion_worse.disabled_completors` - @dantleech 
  - [indexer-extension] Validate search results (remove from search index if invalid).
  - [language-server] Exit session immediately if NULL given as CWD (instead of crashing).
  - [container] Adds command for introspecting the container (`container:dump`) - @dantleech
  - [indexer-extension] Increase priority of indexer source-locators (they should come before the composer locators) - @dantleech
  - [language-server] Show explicit meassage when indexer dies

Bug fixes;

  - [completion] Completion limit of 32 imposed in 0.15 removed.
  - [ampfs-watch] Inotify watcher not reporting error when out of available
    watchers
    (https://github.com/phpactor/amp-fswatch/commit/1e38faadc3fb73158de9a966ee12d17992dad4fe)
    - @dantleech
  - [ampfs-watch] Buffered watcher not allowing errors to bubble up
    (https://github.com/phpactor/amp-fswatch/commit/b5cb54b6d01a9ec3dcbfdcca804c2d63c0e84a19)
    - @dantleech
  - [language-server] Ensure that `result` key is missing when `NULL` (some
    clients require it) - @dantleech
  - [code-transform] Fixed occasional whitespace issues when importing classes
  - [language-server] Support for LSP commands
  - [indexer] Fixed crash with empty class name
