### PR TITLE
Support LSP Document Symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog
 Improvements:
 
   - [language-server] New LSP protocol and general refactoring - @dantleech
+  - [language-server] Support document symbols (f.e. showing code outline for document)
 
 ## 2020-06-09 (0.16.1)
 

--- a/composer.lock
+++ b/composer.lock
@@ -2766,12 +2766,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/language-server.git",
-                "reference": "e6cc8265a8c1d66bab6ce4eb6dcc81964ac36111"
+                "reference": "cdc02e3c04a31600a4b440c26e17151399ae5966"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/language-server/zipball/e6cc8265a8c1d66bab6ce4eb6dcc81964ac36111",
-                "reference": "e6cc8265a8c1d66bab6ce4eb6dcc81964ac36111",
+                "url": "https://api.github.com/repos/phpactor/language-server/zipball/cdc02e3c04a31600a4b440c26e17151399ae5966",
+                "reference": "cdc02e3c04a31600a4b440c26e17151399ae5966",
                 "shasum": ""
             },
             "require": {
@@ -2820,7 +2820,7 @@
                 }
             ],
             "description": "Generic Language Server Platform",
-            "time": "2020-07-29T18:08:02+00:00"
+            "time": "2020-07-30T20:01:00+00:00"
         },
         {
             "name": "phpactor/language-server-extension",
@@ -2885,12 +2885,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/language-server-phpactor-extensions.git",
-                "reference": "bdab7a14c91e3b273b8b1946d3ff6ba7855bbd30"
+                "reference": "96c18de72fd23e862bde781b09e36465ebf98092"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/language-server-phpactor-extensions/zipball/bdab7a14c91e3b273b8b1946d3ff6ba7855bbd30",
-                "reference": "bdab7a14c91e3b273b8b1946d3ff6ba7855bbd30",
+                "url": "https://api.github.com/repos/phpactor/language-server-phpactor-extensions/zipball/96c18de72fd23e862bde781b09e36465ebf98092",
+                "reference": "96c18de72fd23e862bde781b09e36465ebf98092",
                 "shasum": ""
             },
             "require": {
@@ -2951,7 +2951,7 @@
                 }
             ],
             "description": "Provides an (experimental) LSP compatible Language Server Platform",
-            "time": "2020-07-29T17:38:30+00:00"
+            "time": "2020-07-30T19:53:55+00:00"
         },
         {
             "name": "phpactor/language-server-protocol",
@@ -3533,12 +3533,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/text-document.git",
-                "reference": "f8dae6aa7013a1ddb237fe885b1a516c098a3718"
+                "reference": "ab5177217b7eb0064b8a67bb3c88a67265383510"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/text-document/zipball/f8dae6aa7013a1ddb237fe885b1a516c098a3718",
-                "reference": "f8dae6aa7013a1ddb237fe885b1a516c098a3718",
+                "url": "https://api.github.com/repos/phpactor/text-document/zipball/ab5177217b7eb0064b8a67bb3c88a67265383510",
+                "reference": "ab5177217b7eb0064b8a67bb3c88a67265383510",
                 "shasum": ""
             },
             "require": {
@@ -3574,7 +3574,7 @@
                 }
             ],
             "description": "Collection of value objects for representing and referencing text documents",
-            "time": "2020-07-26T20:36:51+00:00"
+            "time": "2020-07-30T19:59:46+00:00"
         },
         {
             "name": "phpactor/worse-reference-finder-extension",
@@ -6662,16 +6662,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.33",
+            "version": "0.12.34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "46e698a0452526a05c4a351d7c47c4b8c37a548d"
+                "reference": "ad75388d71fb0b4a954f71a852fd989915a51cb7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/46e698a0452526a05c4a351d7c47c4b8c37a548d",
-                "reference": "46e698a0452526a05c4a351d7c47c4b8c37a548d",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ad75388d71fb0b4a954f71a852fd989915a51cb7",
+                "reference": "ad75388d71fb0b4a954f71a852fd989915a51cb7",
                 "shasum": ""
             },
             "require": {
@@ -6714,7 +6714,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-19T22:10:11+00:00"
+            "time": "2020-07-30T15:31:10+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/doc/lsp/support.rst
+++ b/doc/lsp/support.rst
@@ -24,7 +24,7 @@ See the `Language Server Specification`_ for details.
 +-------------------------+---+-------------------------------------+
 | Document Highlight      | ✘ |                                     |
 +-------------------------+---+-------------------------------------+
-| Document Symbol         | ✘ |                                     |
+| Document Symbol         | ✔ | For structural elements             |
 +-------------------------+---+-------------------------------------+
 | Code Action             | ✘ | Supported by RPC [#rpc]_ [#code]_   |
 +-------------------------+---+-------------------------------------+

--- a/lib/Phpactor.php
+++ b/lib/Phpactor.php
@@ -10,6 +10,7 @@ use Phpactor\Extension\LanguageServerCompletion\LanguageServerCompletionExtensio
 use Phpactor\Extension\LanguageServerHover\LanguageServerHoverExtension;
 use Phpactor\Extension\LanguageServerIndexer\LanguageServerIndexerExtension;
 use Phpactor\Extension\LanguageServerReferenceFinder\LanguageServerReferenceFinderExtension;
+use Phpactor\Extension\LanguageServerSymbolProvider\LanguageServerSymbolProviderExtension;
 use Phpactor\Extension\LanguageServerWorseReflection\LanguageServerWorseReflectionExtension;
 use Phpactor\Extension\LanguageServer\LanguageServerExtension;
 use Phpactor\Indexer\Extension\IndexerExtension;
@@ -122,6 +123,7 @@ class Phpactor
             LanguageServerHoverExtension::class,
             LanguageServerBridgeExtension::class,
             LanguageServerCodeTransformExtension::class,
+            LanguageServerSymbolProviderExtension::class,
             IndexerExtension::class,
         ];
 


### PR DESCRIPTION
Support for the `textDocument/documentSymbol` LSP method.

Allows for example:

- Document outlines (e.g. `:CocList outline`)
- COC Text Objects (e.g. text objects for selecting classes and functions):

```
xmap if <Plug>(coc-funcobj-i)
omap if <Plug>(coc-funcobj-i)
xmap af <Plug>(coc-funcobj-a)
omap af <Plug>(coc-funcobj-a)
xmap ic <Plug>(coc-classobj-i)
omap ic <Plug>(coc-classobj-i)
xmap ac <Plug>(coc-classobj-a)
omap ac <Plug>(coc-classobj-a)
```