### PR TITLE
Support for watchman

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1570,16 +1570,16 @@
         },
         {
             "name": "microsoft/tolerant-php-parser",
-            "version": "v0.0.22",
+            "version": "v0.0.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/microsoft/tolerant-php-parser.git",
-                "reference": "3fdca6be0f9dc318b8c440d0c0f2a47a173de7a6"
+                "reference": "1d76657e3271754515ace52501d3e427eca42ad0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/microsoft/tolerant-php-parser/zipball/3fdca6be0f9dc318b8c440d0c0f2a47a173de7a6",
-                "reference": "3fdca6be0f9dc318b8c440d0c0f2a47a173de7a6",
+                "url": "https://api.github.com/repos/microsoft/tolerant-php-parser/zipball/1d76657e3271754515ace52501d3e427eca42ad0",
+                "reference": "1d76657e3271754515ace52501d3e427eca42ad0",
                 "shasum": ""
             },
             "require": {
@@ -1607,7 +1607,7 @@
                 }
             ],
             "description": "Tolerant PHP-to-AST parser designed for IDE usage scenarios",
-            "time": "2020-08-08T23:25:34+00:00"
+            "time": "2020-09-13T17:29:12+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -1757,16 +1757,16 @@
         },
         {
             "name": "phpactor/amp-fswatch",
-            "version": "0.1.1",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/amp-fswatch.git",
-                "reference": "463ff941ddf02a3237406c8e2fef515a9b21dd1b"
+                "reference": "1575c389d00e469b8d88026426fc2b1e891ce049"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/amp-fswatch/zipball/463ff941ddf02a3237406c8e2fef515a9b21dd1b",
-                "reference": "463ff941ddf02a3237406c8e2fef515a9b21dd1b",
+                "url": "https://api.github.com/repos/phpactor/amp-fswatch/zipball/1575c389d00e469b8d88026426fc2b1e891ce049",
+                "reference": "1575c389d00e469b8d88026426fc2b1e891ce049",
                 "shasum": ""
             },
             "require": {
@@ -1779,6 +1779,7 @@
             "require-dev": {
                 "amphp/phpunit-util": "^1.3",
                 "friendsofphp/php-cs-fixer": "^2.15.0",
+                "jangregor/phpstan-prophecy": "^0.8.0",
                 "phpactor/test-utils": "^1.0.2",
                 "phpstan/phpstan": "^0.12.0",
                 "phpunit/phpunit": "^8.0"
@@ -1786,7 +1787,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.1.x-dev"
+                    "dev-master": "0.2.x-dev"
                 }
             },
             "autoload": {
@@ -1805,7 +1806,7 @@
                 }
             ],
             "description": "Async Filesystem Watcher for Amphp",
-            "time": "2020-05-23T14:15:40+00:00"
+            "time": "2020-09-20T09:37:22+00:00"
         },
         {
             "name": "phpactor/class-mover",
@@ -2722,18 +2723,18 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/indexer-extension.git",
-                "reference": "f2833eb1acbc195fc6fefea6aff282db977e2c54"
+                "reference": "110335a71e4220f82e8bd0bf877ae8b826f2410c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/indexer-extension/zipball/f2833eb1acbc195fc6fefea6aff282db977e2c54",
-                "reference": "f2833eb1acbc195fc6fefea6aff282db977e2c54",
+                "url": "https://api.github.com/repos/phpactor/indexer-extension/zipball/110335a71e4220f82e8bd0bf877ae8b826f2410c",
+                "reference": "110335a71e4220f82e8bd0bf877ae8b826f2410c",
                 "shasum": ""
             },
             "require": {
                 "dantleech/invoke": "^1.0",
                 "php": "^7.3",
-                "phpactor/amp-fswatch": "^0.1.1",
+                "phpactor/amp-fswatch": "^0.2.0",
                 "phpactor/container": "^1.3.3",
                 "phpactor/name-specification": "^0.1",
                 "phpactor/reference-finder": "^0.1.3",
@@ -2778,7 +2779,7 @@
                 }
             ],
             "description": "Indexer and related integrations",
-            "time": "2020-08-17T14:38:18+00:00"
+            "time": "2020-09-20T09:41:43+00:00"
         },
         {
             "name": "phpactor/language-server",
@@ -2905,12 +2906,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/language-server-phpactor-extensions.git",
-                "reference": "84b37f21d3518fddfe389d2f2ef6ef57c89db56a"
+                "reference": "d5c6c4d3d5f3e8683ea30a8908c348034517de7d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/language-server-phpactor-extensions/zipball/84b37f21d3518fddfe389d2f2ef6ef57c89db56a",
-                "reference": "84b37f21d3518fddfe389d2f2ef6ef57c89db56a",
+                "url": "https://api.github.com/repos/phpactor/language-server-phpactor-extensions/zipball/d5c6c4d3d5f3e8683ea30a8908c348034517de7d",
+                "reference": "d5c6c4d3d5f3e8683ea30a8908c348034517de7d",
                 "shasum": ""
             },
             "require": {
@@ -2972,7 +2973,7 @@
                 }
             ],
             "description": "Provides an (experimental) LSP compatible Language Server Platform",
-            "time": "2020-09-13T10:05:27+00:00"
+            "time": "2020-09-20T10:22:03+00:00"
         },
         {
             "name": "phpactor/language-server-protocol",
@@ -5694,12 +5695,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "a7f8a9f521cb795f3664406a49d7159c36276db2"
+                "reference": "fbf43aa0edfb6eacb43a669691231805eb6ca9dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/a7f8a9f521cb795f3664406a49d7159c36276db2",
-                "reference": "a7f8a9f521cb795f3664406a49d7159c36276db2",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/fbf43aa0edfb6eacb43a669691231805eb6ca9dd",
+                "reference": "fbf43aa0edfb6eacb43a669691231805eb6ca9dd",
                 "shasum": ""
             },
             "require": {
@@ -5783,7 +5784,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-08-08T09:35:01+00:00"
+            "time": "2020-09-16T17:28:19+00:00"
         },
         {
             "name": "lstrojny/functional-php",
@@ -6497,16 +6498,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.2.1",
+            "version": "5.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "d870572532cd70bc3fab58f2e23ad423c8404c44"
+                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/d870572532cd70bc3fab58f2e23ad423c8404c44",
-                "reference": "d870572532cd70bc3fab58f2e23ad423c8404c44",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/069a785b2141f5bcf49f3e353548dc1cce6df556",
+                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556",
                 "shasum": ""
             },
             "require": {
@@ -6545,20 +6546,20 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2020-08-15T11:14:08+00:00"
+            "time": "2020-09-03T19:13:55+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "e878a14a65245fbe78f8080eba03b47c3b705651"
+                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e878a14a65245fbe78f8080eba03b47c3b705651",
-                "reference": "e878a14a65245fbe78f8080eba03b47c3b705651",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
+                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
                 "shasum": ""
             },
             "require": {
@@ -6590,7 +6591,7 @@
                 }
             ],
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
-            "time": "2020-06-27T10:12:23+00:00"
+            "time": "2020-09-17T18:55:26+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -6657,16 +6658,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.42",
+            "version": "0.12.43",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "7c43b7c2d5ca6554f6231e82e342a710163ac5f4"
+                "reference": "54221b44766cb4bdfe40d1828d5bba5dd79c38c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/7c43b7c2d5ca6554f6231e82e342a710163ac5f4",
-                "reference": "7c43b7c2d5ca6554f6231e82e342a710163ac5f4",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/54221b44766cb4bdfe40d1828d5bba5dd79c38c6",
+                "reference": "54221b44766cb4bdfe40d1828d5bba5dd79c38c6",
                 "shasum": ""
             },
             "require": {
@@ -6709,7 +6710,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-02T13:14:53+00:00"
+            "time": "2020-09-19T21:19:38+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/doc/reference/configuration.rst
+++ b/doc/reference/configuration.rst
@@ -79,7 +79,25 @@ ClassToFileExtension
 
 
 
+Root path of the project (e.g. where composer.json is)
+
+
 **Default**: ``"%project_root%"``
+
+
+.. _param_class_to_file.brute_force_conversion:
+
+
+``class_to_file.brute_force_conversion``
+""""""""""""""""""""""""""""""""""""""""
+
+
+
+
+If composer not found, fallback to scanning all files (very time consuming depending on project size)
+
+
+**Default**: ``true``
 
 
 .. _CodeTransformExtension:
@@ -841,6 +859,21 @@ Allow method names to be re-mapped. Useful for maintaining backwards compatibili
 **Default**: ``[]``
 
 
+.. _param_language_server.diagnostic_sleep_time:
+
+
+``language_server.diagnostic_sleep_time``
+"""""""""""""""""""""""""""""""""""""""""
+
+
+
+
+Amount of time to wait before analyzing the code again for diagnostics
+
+
+**Default**: ``1000``
+
+
 .. _LanguageServerCompletionExtension:
 
 
@@ -926,7 +959,7 @@ IndexerExtension
 List of allowed watchers. The first watcher that supports the current system will be used
 
 
-**Default**: ``["inotify","find","php"]``
+**Default**: ``["watchman","inotify","find","php"]``
 
 
 .. _param_indexer.index_path:
@@ -972,6 +1005,21 @@ Glob patterns to exclude while indexing
 
 
 **Default**: ``["\/vendor\/**\/Tests\/**\/*","\/vendor\/**\/tests\/**\/*","\/vendor\/composer\/**\/*"]``
+
+
+.. _param_indexer.stub_paths:
+
+
+``indexer.stub_paths``
+""""""""""""""""""""""
+
+
+
+
+Paths to folders where code stubs are located
+
+
+**Default**: ``[]``
 
 
 .. _param_indexer.poll_time:
@@ -1047,4 +1095,73 @@ Recurse over class implementations to resolve all class implementations (not jus
 
 
 **Default**: ``true``
+
+
+.. _BehatExtension:
+
+
+BehatExtension
+--------------
+
+
+.. _param_behat.config_path:
+
+
+``behat.config_path``
+"""""""""""""""""""""
+
+
+
+
+**Default**: ``"%project_root%\/behat.yml"``
+
+
+.. _LanguageServerPhpstanExtension:
+
+
+LanguageServerPhpstanExtension
+------------------------------
+
+
+.. _param_language_server_phpstan.bin:
+
+
+``language_server_phpstan.bin``
+"""""""""""""""""""""""""""""""
+
+
+
+
+**Default**: ``"%project_root%\/vendor\/bin\/phpstan"``
+
+
+.. _param_phpstan.level:
+
+
+``phpstan.level``
+"""""""""""""""""
+
+
+
+
+**Default**: ``null``
+
+
+.. _PhpSpecExtension:
+
+
+PhpSpecExtension
+----------------
+
+
+.. _param_phpspec.spec_prefix:
+
+
+``phpspec.spec_prefix``
+"""""""""""""""""""""""
+
+
+
+
+**Default**: ``"spec"``
 

--- a/doc/reference/indexer.rst
+++ b/doc/reference/indexer.rst
@@ -6,7 +6,7 @@ Indexer
 The indexer scans your project directory and records meta-information about
 classes and functions in your project.
 
-The indexer *only required* for some features (such as
+The indexer required only for some features (such as
 :ref:`navigation_goto_implementation`).
 
 .. _indexer_building:
@@ -58,19 +58,58 @@ Watching
 
 File watchers are used to keep the index up-to-date.
 
-The type of watcher used depends on your system. Currently the following
-watchers will be used, in order of priority:
+Several watching systems can be used, by default Phpactor will choose the
+first supported one:
 
-1. ``inotifywait``: **Linux** only, react immediately[1] to file changes.
+watchman
+~~~~~~~~
 
-2. ``find``: **Linux/Mac/POSIX** Poll the system for changes every 5 seconds.
+**Linux/Mac** cross platform, reacts immediately to file changes, see Watchman_ documentation.
 
-3. ``php``: **Any system**: Poll system using PHP (slow) every 5 seconds.
+Watchman is the recommended watcher.
 
-To contribute to the available watchers see `amp-fswatch
-<https://github.com/phpactor/amp-fswatch>`_.
+Installation:
 
-If you want to find out which watcher your system is using, enable _`logging`.
+.. tabs::
+
+    .. tab:: Debian/Ubuntu
+       
+        .. code-block:: bash
+
+            apt install watchman
+
+    .. tab:: MacOS
+       
+        .. code-block:: bash
+
+            brew install watchman
+
+inotifywait
+~~~~~~~~~~~
+
+**Linux** only, react immediately to file changes.
+
+Installation
+
+.. tabs::
+
+    .. tab:: Debian/Ubuntu
+       
+        .. code-block:: bash
+
+            apt install inotify-tools
+
+find
+~~~~
+
+**Linux/Mac/POSIX** Poll the system for changes every 5 seconds.
+
+This tool should be installed by default.
+
+php
+~~~
+
+**Any system**: Poll system using PHP (slow) every 5 seconds.
 
 .. _indexer_querying:
 
@@ -129,7 +168,7 @@ It may not be installed, on Debian/Ubuntu
 
 .. code:: sh
 
-   $ sudo apt-get install inotify-tools
+   $ sudo apt install inotify-tools
 
 Inotify: ``inotify`` limit reached
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
  ```
microsoft/tolerant-php-parser 3fdca6be..1d76657e

    [2020-08-07 09:21:14] 98fbbd20 PythooonUser Adding declare directive list support
    [2020-08-07 09:21:57] ceb5125f PythooonUser Adding test case for simple list
    [2020-08-07 09:22:36] 63cf35a3 PythooonUser Updating existing test structures
    [2020-08-07 09:22:52] b1e2ec09 PythooonUser :lipstick:
    [2020-08-07 11:12:35] a5621549 PythooonUser Fixing start tag length by including whitespace tokens
    [2020-08-10 08:27:54] ec691a00 PythooonUser Making changes backwards compatible
    [2020-08-10 14:20:57] 6b07adda PythooonUser Refactoring modified type behaviors
    [2020-08-19 23:38:24] 3a174a95 TysonAndre Add support for php 8.0 `#[` attribute groups  This supports the grouped attributes syntax that will be in PHP 8....
    [2020-09-06 15:28:44] 673bacf4 TysonAndre Improve the lookahead check for attributes on expressions
    [2020-09-11 00:25:50] 4e9127ce TysonAndre Also handle `new #[MyAttr] class {...}`  I forgot that anonymous classes were parsed into an ObjectCreationExpres...
    [2020-09-11 00:41:52] 6d546ce0 TysonAndre Support attributes on traits and interfaces  They were already supported on ClassDeclaration. The php runtime all...
    [2020-09-12 12:42:15] ba3805be TysonAndre Fix infinite loop parsing `trait #[`  Fixes #343
    [2020-09-12 12:47:50] 494acd88 TysonAndre Start running tests in travis with nightly  Whenever Travis provides a stable 8.0 label, that can be switched to....
    [2020-09-13 00:24:46] 42ddd210 TysonAndre Fix handling of named label for goto.  The label is a standalone statement just like any other statement. It isn'...
    [2020-09-13 15:52:55] 0c991bcd TysonAndre Warn about #[] attribute groups of 0 length  Each attribute group must have 1 or more elements. The same approach...

  phpactor/amp-fswatch 463ff941..1575c389

    [2020-09-19 10:03:59] 7a9cc1b1 dantleech Use a file reference rather than a time stamp.  The BSD variant doesn't seem to understand the `.u` format for the...
    [2020-09-19 10:08:47] 245ece2f dantleech Fix CS
    [2020-09-19 11:26:47] 80f82fb1 dantleech Introducing Watchman Watcher
    [2020-09-19 13:10:34] 3487ca11 dantleech Multiple path support watchman
    [2020-09-19 13:11:54] 8b0df86b dantleech Removed dead config
    [2020-09-19 13:38:56] af0c1f87 dantleech Reverted test changes
    [2020-09-19 13:45:21] 0d01f27d dantleech Updated README
    [2020-09-19 14:00:22] d8f2e493 dantleech Use since()
    [2020-09-19 14:17:54] 53bc95f5 dantleech Require since time
    [2020-09-19 14:20:47] f591b8db dantleech Load watchman
    [2020-09-19 14:27:31] ad7167de dantleech Install watchman from releases
    [2020-09-19 14:29:48] 7d258dc7 dantleech sudo
    [2020-09-19 14:33:19] a5a78b43 dantleech Move sahare dlibs
    [2020-09-19 14:37:29] 55e5f8b2 dantleech Add missing dir
    [2020-09-19 14:43:50] dc1f265e dantleech Permissions!
    [2020-09-19 14:55:11] dfdbffd5 dantleech Watch
    [2020-09-20 08:51:34] 97eb435c dantleech Implement name() method
    [2020-09-20 09:22:24] 99a06f2b dantleech Fix watcher
    [2020-09-20 09:24:32] b7944a1b dantleech Add test for get name
    [2020-09-20 09:33:09] 1575c389 dantleech Renamed name() => describe()

  phpactor/indexer-extension f2833eb1..110335a7

    [2020-09-20 09:21:42] 110335a7 dantleech Add watchman support  Use describe

  phpactor/language-server-phpactor-extensions 84b37f21..c737d530

    [2020-09-13 10:30:26] 85e4643c dantleech Fix deprecated formatting
    [2020-09-13 10:31:10] 965500b8 dantleech Fix tests
    [2020-09-20 09:46:11] ec2fb13b dantleech Show watcher description in initialization message
    [2020-09-20 09:54:52] c737d530 dantleech Start watch before showing done message
```