### PR TITLE
Fix order references

### DIFF
--- a/lib/Extension/ClassMover/Rpc/ReferencesHandler.php
+++ b/lib/Extension/ClassMover/Rpc/ReferencesHandler.php
@@ -266,27 +266,37 @@ class ReferencesHandler extends AbstractHandler
         string $source = null,
         string $replacement = null
     ) {
-        switch ($symbolContext->symbol()->symbolType()) {
-            case Symbol::CLASS_:
-                [$source, $references] = $this->classReferences($filesystem, $symbolContext, $source, $replacement);
-                break;
-            case Symbol::METHOD:
-                [$source, $references] = $this->memberReferences($filesystem, $symbolContext, ClassMemberQuery::TYPE_METHOD, $source, $replacement);
-                break;
-            case Symbol::PROPERTY:
-                [$source, $references] = $this->memberReferences($filesystem, $symbolContext, ClassMemberQuery::TYPE_PROPERTY, $source, $replacement);
-                break;
-            case Symbol::CONSTANT:
-                [$source, $references] = $this->memberReferences($filesystem, $symbolContext, ClassMemberQuery::TYPE_CONSTANT, $source, $replacement);
-                break;
-            default:
-                throw new \RuntimeException(sprintf(
-                    'Cannot find references for symbol type "%s"',
-                    $symbolContext->symbol()->symbolType()
-                ));
-        }
+        [$source, $references] = $this->doPerformFindOrReplaceReferences(
+            $symbolContext,
+            $filesystem,
+            $source,
+            $replacement,
+        );
 
         return [$source, $this->sortReferences($references)];
+    }
+
+    private function doPerformFindOrReplaceReferences(
+        SymbolContext $symbolContext,
+        string $filesystem,
+        string $source = null,
+        string $replacement = null
+    ) {
+        switch ($symbolContext->symbol()->symbolType()) {
+            case Symbol::CLASS_:
+                return $this->classReferences($filesystem, $symbolContext, $source, $replacement);
+            case Symbol::METHOD:
+                return $this->memberReferences($filesystem, $symbolContext, ClassMemberQuery::TYPE_METHOD, $source, $replacement);
+            case Symbol::PROPERTY:
+                return $this->memberReferences($filesystem, $symbolContext, ClassMemberQuery::TYPE_PROPERTY, $source, $replacement);
+            case Symbol::CONSTANT:
+                return $this->memberReferences($filesystem, $symbolContext, ClassMemberQuery::TYPE_CONSTANT, $source, $replacement);
+        }
+
+        throw new \RuntimeException(sprintf(
+            'Cannot find references for symbol type "%s"',
+            $symbolContext->symbol()->symbolType()
+        ));
     }
 
     public function sortReferences(array $fileReferences): array

--- a/lib/Extension/ClassMover/Rpc/ReferencesHandler.php
+++ b/lib/Extension/ClassMover/Rpc/ReferencesHandler.php
@@ -299,10 +299,10 @@ class ReferencesHandler extends AbstractHandler
         ));
     }
 
-    public function sortReferences(array $fileReferences): array
+    private function sortReferences(array $fileReferences): array
     {
         // Sort the references for each file
-        \array_walk($fileReferences, function (array &$fileReference) {
+        array_walk($fileReferences, function (array &$fileReference) {
             if (empty($fileReference['references'])) {
                 return; // Do nothing if there is no references
             }


### PR DESCRIPTION
Order the result of the find references feature.
Fix https://github.com/phpactor/phpactor/issues/1105

Update both the RPC handler and the `phpactor#quickfix#fzf` strategy, see the related commit for an explanation but the problem was that the current implementation did not preserve the order of the provided entries.