### PR TITLE
fix: phpactor#Status()

### DIFF
--- a/autoload/phpactor.vim
+++ b/autoload/phpactor.vim
@@ -303,12 +303,13 @@ endfunction
 
 function! phpactor#Status()
     if exists(':terminal')
+        let l:cmd = g:phpactorPhpBin . ' ' . g:phpactorbinpath . ' status'
         if has('nvim')
-            split term://phpactor\ status
+            execute 'split term://' . l:cmd
             " Press any key to leave
             normal i
         else
-            terminal phpactor status
+            execute 'terminal ' . l:cmd
         endif
     else
         call phpactor#rpc("status", {'type': 'formatted'})


### PR DESCRIPTION
Fix #1073 
Relates to #1085 and #1110 

The issue was that the function was always using `php` to start PHP and the `phpactor` executable must be in the `PATH`.
Now the function use `g:phpactorPhpBin` to have the right `php` binary (like if the user wants to use a specific PHP version)
And `g:phpactorbinpath` to locate the `phpactor` binary properly.