### PR TITLE
Fix/#1085 status does not use correct working directory

### DIFF
--- a/autoload/phpactor.vim
+++ b/autoload/phpactor.vim
@@ -303,7 +303,12 @@ endfunction
 
 function! phpactor#Status()
     if exists(':terminal')
-        let l:cmd = g:phpactorPhpBin . ' ' . g:phpactorbinpath . ' status'
+        let l:workspaceDir = phpactor#getRootDirectory()
+
+        " note that we should escape these arguments, but using the list syntax
+        " here causes tests to fail on travis with VIM 8.3 ...
+        let l:cmd = g:phpactorPhpBin . ' ' . g:phpactorbinpath . ' status --working-dir=' . l:workspaceDir
+
         if has('nvim')
             execute 'split term://' . l:cmd
             " Press any key to leave

--- a/lib/Phpactor.php
+++ b/lib/Phpactor.php
@@ -62,15 +62,19 @@ class Phpactor
     {
         $config = [];
 
-        $cwd = getcwd();
+        $projectRoot = getcwd();
+
+        if ($input->hasParameterOption([ '--working-dir', '-d' ])) {
+            $projectRoot = $input->getParameterOption([ '--working-dir', '-d' ]);
+        }
 
         $loader = ConfigLoaderBuilder::create()
             ->enableJsonDeserializer('json')
             ->enableYamlDeserializer('yaml')
             ->addXdgCandidate('phpactor', 'phpactor.json', 'json')
             ->addXdgCandidate('phpactor', 'phpactor.yml', 'yaml')
-            ->addCandidate($cwd . '/.phpactor.json', 'json')
-            ->addCandidate($cwd . '/.phpactor.yml', 'yaml')
+            ->addCandidate($projectRoot . '/.phpactor.json', 'json')
+            ->addCandidate($projectRoot . '/.phpactor.yml', 'yaml')
             ->loader();
 
         $config = $loader->load();
@@ -82,7 +86,7 @@ class Phpactor
         $config = self::configureLanguageServer($config);
 
         if ($input->hasParameterOption([ '--working-dir', '-d' ])) {
-            $config[FilePathResolverExtension::PARAM_PROJECT_ROOT] = $cwd = $input->getParameterOption([ '--working-dir', '-d' ]);
+            $config[FilePathResolverExtension::PARAM_PROJECT_ROOT] = $projectRoot;
         }
 
         if (!isset($config[CoreExtension::PARAM_XDEBUG_DISABLE]) || $config[CoreExtension::PARAM_XDEBUG_DISABLE]) {


### PR DESCRIPTION
Since I have no memory, as my wife love to remind me, on my previous fix I forgot to deal with the missing `--working-dir` option.

This PR fix that, when testing it I realized that the candidates we add to identify config files at the root of the project were still using `getcwd` instead of the command line option if provided, so I fixed that too.