### PR TITLE
add_missing_assignments -> add_missing_properties

### DIFF
--- a/doc/lsp/code-actions.rst
+++ b/doc/lsp/code-actions.rst
@@ -14,7 +14,7 @@ List of currently available code actions:
 +---------------------------------------------+---------------------------------------+
 | :ref:`refactoring_complete_constructor`     | ``quickfix.complete_constructor``     |
 +---------------------------------------------+---------------------------------------+
-| :ref:`refactoring_add_missing_assignements` | ``quickfix.add_missing_properties``   |
+| :ref:`refactoring_add_missing_properties`   | ``quickfix.add_missing_properties``   |
 +---------------------------------------------+---------------------------------------+
 | :ref:`implement_contracts`                  | ``quickfix.implement_contracts``      |
 +---------------------------------------------+---------------------------------------+

--- a/doc/reference/refactorings.rst
+++ b/doc/reference/refactorings.rst
@@ -11,7 +11,7 @@ Refactoring
 Fixes
 =====
 
-.. _refactoring_add_missing_properties:
+.. _refactoring_add_missing_assignments:
 
 Add Missing Properties
 -----------------------

--- a/doc/reference/refactorings.rst
+++ b/doc/reference/refactorings.rst
@@ -11,9 +11,9 @@ Refactoring
 Fixes
 =====
 
-.. _refactoring_add_missing_assignements:
+.. _refactoring_add_missing_properties:
 
-Add Missing Assignments
+Add Missing Properties
 -----------------------
 
 Automatically add any missing properties to a class.
@@ -24,7 +24,7 @@ Automatically add any missing properties to a class.
 
        .. code-block::
 
-           $ phpactor class:transform path/to/Class.php --transform=add_missing_assignments
+           $ phpactor class:transform path/to/Class.php --transform=add_missing_properties
 
    .. tab:: VIM Context Menu
 

--- a/doc/reference/refactorings.rst
+++ b/doc/reference/refactorings.rst
@@ -11,7 +11,7 @@ Refactoring
 Fixes
 =====
 
-.. _refactoring_add_missing_assignments:
+.. _refactoring_add_missing_properties:
 
 Add Missing Properties
 -----------------------


### PR DESCRIPTION
Hi,

Just realised that the up to date name is add_missing_properties, right?

---

Should this go to master or develop? It seems develop is behind master