### PR TITLE
Add regression test for `ClassSearch` including non-PHP files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "phpactor/reference-finder-extension": "^0.1.7",
         "phpactor/reference-finder-rpc-extension": "^0.1.5",
         "phpactor/rpc-extension": "^0.2.3",
-        "phpactor/source-code-filesystem": "^0.1.6",
+        "phpactor/source-code-filesystem": "^0.1.7",
         "phpactor/source-code-filesystem-extension": "^0.1.5",
         "phpactor/text-document": "^1.2.3",
         "phpactor/worse-reference-finder-extension": "^0.1.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d37cd15970cabbd5fe0ba35b7cf1673d",
+    "content-hash": "55fd3c6e293b324c139ec34f98b7fd26",
     "packages": [
         {
             "name": "amphp/amp",
@@ -4111,16 +4111,16 @@
         },
         {
             "name": "phpactor/source-code-filesystem",
-            "version": "0.1.6",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/source-code-filesystem.git",
-                "reference": "6ca0c64462b59c6d47f12fef5d4013229e346f68"
+                "reference": "860f83fd8df18be4cdbb5e3a1a3ae562afc3b923"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/source-code-filesystem/zipball/6ca0c64462b59c6d47f12fef5d4013229e346f68",
-                "reference": "6ca0c64462b59c6d47f12fef5d4013229e346f68",
+                "url": "https://api.github.com/repos/phpactor/source-code-filesystem/zipball/860f83fd8df18be4cdbb5e3a1a3ae562afc3b923",
+                "reference": "860f83fd8df18be4cdbb5e3a1a3ae562afc3b923",
                 "shasum": ""
             },
             "require": {
@@ -4138,6 +4138,7 @@
                 "phpunit/phpunit": "^9.0",
                 "symfony/var-dumper": "^5.2"
             },
+            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -4161,9 +4162,9 @@
             ],
             "description": "Filesystem library for working with source code files",
             "support": {
-                "source": "https://github.com/phpactor/source-code-filesystem/tree/0.1.6"
+                "source": "https://github.com/phpactor/source-code-filesystem/tree/master"
             },
-            "time": "2021-02-06T14:38:53+00:00"
+            "time": "2021-03-07T16:35:13+00:00"
         },
         {
             "name": "phpactor/source-code-filesystem-extension",

--- a/tests/Assets/Projects/Animals/lib/Badger.php.html
+++ b/tests/Assets/Projects/Animals/lib/Badger.php.html
@@ -1,0 +1,4 @@
+<p>This file emulates a coverage report to ensure only PHP files are found by ClassSearch.</p>
+<p>See Phpactor\Tests\System\Extension\SourceCodeFilesystem\Command\ClassSearchCommandTest</p>
+
+<p>Context: https://github.com/phpactor/phpactor/issues/1216</p>

--- a/tests/System/Extension/SourceCodeFilesystem/Command/ClassSearchCommandTest.php
+++ b/tests/System/Extension/SourceCodeFilesystem/Command/ClassSearchCommandTest.php
@@ -13,7 +13,7 @@ class ClassSearchCommandTest extends SystemTestCase
     }
 
     /**
-     * @testdox It should return information baesd on a class "short" name.
+     * @testdox It should return information based on a class "short" name.
      */
     public function testSearchName(): void
     {
@@ -23,7 +23,7 @@ class ClassSearchCommandTest extends SystemTestCase
     }
 
     /**
-     * @testdox It should return information baesd on a class "short" name.
+     * @testdox It should return JSON information based on a class "short" name.
      */
     public function testSearchNameJson(): void
     {
@@ -32,7 +32,9 @@ class ClassSearchCommandTest extends SystemTestCase
         $this->assertStringContainsString('Badger.php"', $process->getOutput());
     }
 
-    /** @testdox It should not return non-PHP files in results. */
+    /**
+     * @testdox It should not return non-PHP files in results.
+     */
     public function testSearchNameOnlyPhp()
     {
         $process = $this->phpactor('class:search "Badger"');
@@ -40,6 +42,9 @@ class ClassSearchCommandTest extends SystemTestCase
         $this->assertStringNotContainsString('Badger.php.html', $process->getOutput());
     }
 
+    /**
+     * @testdox It should return information based on a fully-qualified class name.
+     */
     public function testSearchByQualifiedName(): void
     {
         $process = $this->phpactor('class:search "Badger\\Carnivorous" --format=json');
@@ -48,7 +53,7 @@ class ClassSearchCommandTest extends SystemTestCase
     }
 
     /**
-     * @testdox It should return information baesd on a class "short" name.
+     * @testdox It should return information based on an "internal" class name.
      */
     public function testSearchNameInternalName(): void
     {

--- a/tests/System/Extension/SourceCodeFilesystem/Command/ClassSearchCommandTest.php
+++ b/tests/System/Extension/SourceCodeFilesystem/Command/ClassSearchCommandTest.php
@@ -32,6 +32,14 @@ class ClassSearchCommandTest extends SystemTestCase
         $this->assertStringContainsString('Badger.php"', $process->getOutput());
     }
 
+    /** @testdox It should not return non-PHP files in results. */
+    public function testSearchNameOnlyPhp()
+    {
+        $process = $this->phpactor('class:search "Badger"');
+        $this->assertSuccess($process);
+        $this->assertStringNotContainsString('Badger.php.html', $process->getOutput());
+    }
+
     public function testSearchByQualifiedName(): void
     {
         $process = $this->phpactor('class:search "Badger\\Carnivorous" --format=json');


### PR DESCRIPTION
Adds a regression test for phpactor/source-code-filesystem#19 and updates the testdox around it.

---

**Original text:**

The `named()` method actually filters for "Foo*" which produces many
results that aren't PHP classes at all. This resolves the issue by
instead comparing against the *full* filename.

With this change, running `phpactor class:search 'User'` is close to 14
times faster, reduced down to ~0.3s from the 4 seconds it took before.