### PR TITLE
Rename class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Bug fixes:
 Features:
 
   - [language-server] Ensure workspace is indexed before finding references - @dantleech
+  - [language-server] Support for renaming class names (short only) - @dantleech
   - [language-server] Rename class members and variables - @BladeMF, @dantleech
   - [language-server] Basic support for workspace symbols.
   - [language-server] Added basic PHP linting by default.

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "composer/xdebug-handler": "^1.1",
         "dantleech/invoke": "^1.0.1",
         "monolog/monolog": "^1.0",
-        "phpactor/class-mover": "^0.1.4",
+        "phpactor/class-mover": "^0.2.0",
         "phpactor/class-to-file": "^0.4.0",
         "phpactor/class-to-file-extension": "^0.2.2",
         "phpactor/code-transform": "^0.4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c66ce3c3f4a1761295166d22b0ec7839",
+    "content-hash": "3347ae2bbda676c7a7ee7a0507ac8dcf",
     "packages": [
         {
             "name": "amphp/amp",
@@ -2217,21 +2217,25 @@
         },
         {
             "name": "phpactor/class-mover",
-            "version": "0.1.4",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/class-mover.git",
-                "reference": "374ee3d36137ad9dc3ecee5fd5f4043b029bdaf6"
+                "reference": "47166e1fb095ff178dacb7a1b765b5c6e59f42e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/class-mover/zipball/374ee3d36137ad9dc3ecee5fd5f4043b029bdaf6",
-                "reference": "374ee3d36137ad9dc3ecee5fd5f4043b029bdaf6",
+                "url": "https://api.github.com/repos/phpactor/class-mover/zipball/47166e1fb095ff178dacb7a1b765b5c6e59f42e5",
+                "reference": "47166e1fb095ff178dacb7a1b765b5c6e59f42e5",
                 "shasum": ""
             },
             "require": {
                 "microsoft/tolerant-php-parser": "@dev",
                 "php": "^7.3 || ^8.0",
+                "phpactor/code-builder": "^0.4.1",
+                "phpactor/code-transform-extension": "^0.2.1",
+                "phpactor/container": "^2.0",
+                "phpactor/text-document": "^1.2",
                 "phpactor/worse-reflection": "~0.4.4",
                 "psr/log": "~1.0",
                 "symfony/filesystem": "^4.2 || ^5.0"
@@ -2244,10 +2248,11 @@
                 "phpunit/phpunit": "^9.0",
                 "symfony/console": "^4.3 || ^5.1"
             },
+            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.1.x-dev"
+                    "dev-master": "0.2.x-dev"
                 }
             },
             "autoload": {
@@ -2267,9 +2272,9 @@
             ],
             "description": "Library for moving classes",
             "support": {
-                "source": "https://github.com/phpactor/class-mover/tree/0.1.4"
+                "source": "https://github.com/phpactor/class-mover/tree/master"
             },
-            "time": "2021-02-06T14:38:53+00:00"
+            "time": "2021-04-17T16:51:54+00:00"
         },
         {
             "name": "phpactor/class-to-file",
@@ -3441,17 +3446,18 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/language-server-phpactor-extensions.git",
-                "reference": "f7f3ccd054c4d955447b2c9797f580f6150832b6"
+                "reference": "941fad521088e9e0e855de69c828ff5be9e3ded1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/language-server-phpactor-extensions/zipball/f7f3ccd054c4d955447b2c9797f580f6150832b6",
-                "reference": "f7f3ccd054c4d955447b2c9797f580f6150832b6",
+                "url": "https://api.github.com/repos/phpactor/language-server-phpactor-extensions/zipball/941fad521088e9e0e855de69c828ff5be9e3ded1",
+                "reference": "941fad521088e9e0e855de69c828ff5be9e3ded1",
                 "shasum": ""
             },
             "require": {
                 "dantleech/object-renderer": "^0.1.1",
                 "php": "^7.3 || ^8.0",
+                "phpactor/class-mover": "^0.2.0",
                 "phpactor/code-transform": "^0.4.0",
                 "phpactor/code-transform-extension": "^0.2.1",
                 "phpactor/completion": "~0.4.3",
@@ -3517,7 +3523,7 @@
                 "issues": "https://github.com/phpactor/language-server-phpactor-extensions/issues",
                 "source": "https://github.com/phpactor/language-server-phpactor-extensions/tree/master"
             },
-            "time": "2021-04-17T12:47:43+00:00"
+            "time": "2021-04-17T16:57:18+00:00"
         },
         {
             "name": "phpactor/language-server-protocol",

--- a/lib/Extension/ClassMover/Application/ClassCopy.php
+++ b/lib/Extension/ClassMover/Application/ClassCopy.php
@@ -109,14 +109,15 @@ class ClassCopy
             $srcClassName = $this->classFileNormalizer->fileToClass($srcPath->path());
             $destClassName = $this->classFileNormalizer->fileToClass($destPath->path());
 
-            $references = $this->classMover->findReferences($this->filesystem->getContents($srcPath), $srcClassName);
+            $source = $this->filesystem->getContents($srcPath);
+            $references = $this->classMover->findReferences($source, $srcClassName);
             $logger->replacing($destPath, $references, FullyQualifiedName::fromString($destClassName));
-            $source = $this->classMover->replaceReferences(
+            $edits = $this->classMover->replaceReferences(
                 $references,
                 $destClassName
             );
 
-            $this->filesystem->writeContents($destPath, (string) $source);
+            $this->filesystem->writeContents($destPath, (string) $edits->apply($source));
             $copyReport->destFiles()->next();
         }
     }

--- a/lib/Extension/ClassMover/Application/ClassMover.php
+++ b/lib/Extension/ClassMover/Application/ClassMover.php
@@ -155,7 +155,8 @@ class ClassMover
     private function replaceReferences(ClassMoverLogger $logger, Filesystem $filesystem, string $srcName, string $destName): void
     {
         foreach ($filesystem->fileList()->existing()->phpFiles() as $filePath) {
-            $references = $this->classMover->findReferences($filesystem->getContents($filePath), $srcName);
+            $source = $filesystem->getContents($filePath);
+            $references = $this->classMover->findReferences($source, $srcName);
 
             if ($references->references()->isEmpty()) {
                 continue;
@@ -163,12 +164,12 @@ class ClassMover
 
             $logger->replacing($filePath, $references, FullyQualifiedName::fromString($destName));
 
-            $source = $this->classMover->replaceReferences(
+            $edits = $this->classMover->replaceReferences(
                 $references,
                 $destName
             );
 
-            $filesystem->writeContents($filePath, (string) $source);
+            $filesystem->writeContents($filePath, $edits->apply($source));
         }
     }
 

--- a/lib/Extension/ClassMover/ClassMoverExtension.php
+++ b/lib/Extension/ClassMover/ClassMoverExtension.php
@@ -96,7 +96,7 @@ class ClassMoverExtension implements Extension
         $container->register('application.class_mover', function (Container $container) {
             return new ClassMoverApp(
                 $container->get('application.helper.class_file_normalizer'),
-                $container->get('class_mover.class_mover'),
+                $container->get(ClassMover::class),
                 $container->get('source_code_filesystem.registry'),
                 $container->get(NavigationExtension::SERVICE_PATH_FINDER)
             );
@@ -105,7 +105,7 @@ class ClassMoverExtension implements Extension
         $container->register('application.class_copy', function (Container $container) {
             return new ClassCopy(
                 $container->get('application.helper.class_file_normalizer'),
-                $container->get('class_mover.class_mover'),
+                $container->get(ClassMover::class),
                 $container->get('source_code_filesystem.registry')->get('git')
             );
         });

--- a/lib/Extension/ClassMover/ClassMoverExtension.php
+++ b/lib/Extension/ClassMover/ClassMoverExtension.php
@@ -2,6 +2,7 @@
 
 namespace Phpactor\Extension\ClassMover;
 
+use Phpactor\CodeBuilder\Domain\Updater;
 use Phpactor\Extension\ClassMover\Application\ClassCopy;
 use Phpactor\Extension\ClassMover\Application\ClassMover as ClassMoverApp;
 use Phpactor\Extension\ClassMover\Application\ClassReferences;
@@ -75,17 +76,6 @@ class ClassMoverExtension implements Extension
 
     private function registerClassMover(ContainerBuilder $container): void
     {
-        $container->register('class_mover.class_mover', function (Container $container) {
-            return new ClassMover(
-                $container->get('class_mover.class_finder'),
-                $container->get('class_mover.ref_replacer')
-            );
-        });
-
-        $container->register('class_mover.class_finder', function (Container $container) {
-            return new TolerantClassFinder();
-        });
-
         $container->register('class_mover.member_finder', function (Container $container) {
             return new WorseTolerantMemberFinder(
                 $container->get(WorseReflectionExtension::SERVICE_REFLECTOR)
@@ -97,7 +87,7 @@ class ClassMoverExtension implements Extension
         });
 
         $container->register('class_mover.ref_replacer', function (Container $container) {
-            return new TolerantClassReplacer();
+            return new TolerantClassReplacer($container->get(Updater::class));
         });
     }
 

--- a/lib/Phpactor.php
+++ b/lib/Phpactor.php
@@ -2,6 +2,7 @@
 
 namespace Phpactor;
 
+use Phpactor\ClassMover\Extension\ClassMoverExtension as MainClassMoverExtension;
 use Phpactor\Container\Container;
 use Phpactor\Extension\Debug\DebugExtension;
 use Phpactor\Extension\LanguageServerBridge\LanguageServerBridgeExtension;
@@ -104,6 +105,7 @@ class Phpactor
             ClassToFileExtraExtension::class,
             ClassToFileExtension::class,
             ClassMoverExtension::class,
+            MainClassMoverExtension::class,
             CodeTransformExtension::class,
             CodeTransformExtraExtension::class,
             CompletionExtraExtension::class,

--- a/tests/Unit/Extension/ClassMover/Command/Logger/SymfonyConsoleMoveLoggerTest.php
+++ b/tests/Unit/Extension/ClassMover/Command/Logger/SymfonyConsoleMoveLoggerTest.php
@@ -3,6 +3,7 @@
 namespace Phpactor\Tests\Unit\Extension\ClassMover\Command\Logger;
 
 use PHPUnit\Framework\TestCase;
+use Phpactor\TextDocument\TextDocumentBuilder;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Phpactor\Extension\ClassMover\Command\Logger\SymfonyConsoleMoveLogger;
 use Phpactor\ClassMover\Domain\SourceCode;
@@ -31,7 +32,7 @@ class SymfonyConsoleMoveLoggerTest extends TestCase
     public function testReplacing(): void
     {
         $references = new FoundReferences(
-            SourceCode::fromString(
+            TextDocumentBuilder::create(
                 <<<'EOT'
                     <?php
 
@@ -55,7 +56,7 @@ class SymfonyConsoleMoveLoggerTest extends TestCase
                         }
                     }
                     EOT
-            ),
+            )->build(),
             FullyQualifiedName::fromString('Acme'),
             NamespacedClassReferences::fromNamespaceAndClassRefs(
                 NamespaceReference::fromNameAndPosition(Namespace_::fromString('Foobar'), Position::fromStartAndEnd(10, 20)),


### PR DESCRIPTION
This PR adds support for renaming classes (only the short names). It makes use of the existing legacy functionality, which simplifies maintainence and also makes integrating namespace / folder movement operations a bit easier as this already works in leagcy.

```
  phpactor/class-mover 374ee3d3..47166e1f

    [2021-04-17 15:21:24] 0d8d935f dantleech Migrating to use text edits
    [2021-04-17 15:35:34] 74053928 dantleech Use code updater to update classes
    [2021-04-17 15:39:03] 111f4b25 dantleech Bump dev to 2.0
    [2021-04-17 16:45:21] b80e83f4 dantleech Added extension
    [2021-04-17 16:51:38] 47166e1f dantleech Added test for container extension

  phpactor/language-server-phpactor-extensions f7f3ccd0..941fad52

    [2021-04-17 16:02:13] 02af2840 dantleech Adding class renamer
    [2021-04-17 16:36:21] 637a2257 dantleech Implement class renamer
    [2021-04-17 16:38:08] 68a19526 dantleech Applies CS fixes
    [2021-04-17 16:52:15] 654eb5e0 dantleech Register class renamer
    [2021-04-17 16:57:18] 941fad52 dantleech Updated phpbench config
```

cc @blademf