### PR TITLE
Add support for JSON schema and config file initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /cache
 /extensions
 /phpbench.json
+/phpactor.schema.json
 
 # File frequently used for testing
 /lib/Test.php

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Changelog
 
 Features:
 
+  - [config] JSON schema support
+  - [cli] `phpactor config:init` command to create or update config (to
+    include JSON schema location)
+
+## 2022-01-03 (0.18.0)
+
+Features:
+
   - [language-server] Import all names refactoring - @dantleech
   - [language-server] Extract expression - @BladeMF
   - [language-server] Extract method generation - @BladeMF

--- a/composer.json
+++ b/composer.json
@@ -45,12 +45,12 @@
         "symfony/filesystem": "^4.2 || ^5.0",
         "symfony/yaml": "^4.3 || ^5.1",
         "thecodingmachine/safe": "~1.1.0",
-        "webmozart/glob": "^4.4"
+        "webmozart/glob": "^4.4",
+        "phpactor/debug-extension": "^0.1.2"
     },
     "require-dev": {
         "dantleech/what-changed": "~0.4",
         "friendsofphp/php-cs-fixer": "^2.17",
-        "phpactor/debug-extension": "^0.1.1",
         "phpactor/test-utils": "^1.1.3",
         "phpbench/phpbench": "^1.0.0",
         "phpstan/phpstan": "~0.12.0",
@@ -84,7 +84,10 @@
         "bin/phpactor"
     ],
     "scripts": {
-        "post-install-cmd": "bin/phpactor extension:update",
+        "post-install-cmd": [
+            "bin/phpactor development:config-json-schema phpactor.schema.json",
+            "bin/phpactor extension:update"
+        ],
         "integrate": [
             "vendor/bin/phpstan analyse",
             "vendor/bin/phpunit",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5473c625d5c923247023ec3bef5ca7e4",
+    "content-hash": "d091cfb2baa2e8aafd30edd8c0907322",
     "packages": [
         {
             "name": "amphp/amp",
@@ -1286,7 +1286,7 @@
         },
         {
             "name": "dantleech/invoke",
-            "version": "2.0.0",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dantleech/invoke.git",
@@ -1307,6 +1307,7 @@
                 "phpstan/phpstan": "^0.12.0",
                 "phpunit/phpunit": "^8.0"
             },
+            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -2250,7 +2251,7 @@
         },
         {
             "name": "phpactor/completion",
-            "version": "0.4.6",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/completion.git",
@@ -2282,6 +2283,7 @@
                 "phpunit/phpunit": "~9.0",
                 "symfony/var-dumper": "^5.2"
             },
+            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -2305,13 +2307,13 @@
             ],
             "description": "Completion library for Worse Reflection",
             "support": {
-                "source": "https://github.com/phpactor/completion/tree/0.4.6"
+                "source": "https://github.com/phpactor/completion/tree/0.4.5"
             },
             "time": "2021-12-28T21:09:41+00:00"
         },
         {
             "name": "phpactor/completion-extension",
-            "version": "0.2.5",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/completion-extension.git",
@@ -2336,6 +2338,7 @@
                 "phpstan/phpstan": "~0.12.0",
                 "phpunit/phpunit": "^9.0"
             },
+            "default-branch": true,
             "type": "phpactor-extension",
             "extra": {
                 "branch-alias": {
@@ -2361,7 +2364,7 @@
             "description": "Phpactor Code Completion Extension",
             "support": {
                 "issues": "https://github.com/phpactor/completion-extension/issues",
-                "source": "https://github.com/phpactor/completion-extension/tree/0.2.5"
+                "source": "https://github.com/phpactor/completion-extension/tree/0.2.4"
             },
             "time": "2021-02-06T14:38:53+00:00"
         },
@@ -2702,6 +2705,67 @@
             "time": "2021-02-06T14:38:57+00:00"
         },
         {
+            "name": "phpactor/debug-extension",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpactor/debug-extension.git",
+                "reference": "c8c2a3141b5593b7865f920a52302ddbced66b97"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpactor/debug-extension/zipball/c8c2a3141b5593b7865f920a52302ddbced66b97",
+                "reference": "c8c2a3141b5593b7865f920a52302ddbced66b97",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8.0",
+                "phpactor/console-extension": "^0.1.6",
+                "phpactor/container": "^2.0.0",
+                "symfony/debug": "^4.4",
+                "symfony/var-dumper": "^5.0"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.0",
+                "friendsofphp/php-cs-fixer": "^2.17",
+                "phpactor/test-utils": "^1.1",
+                "phpstan/phpstan": "~0.12.0",
+                "phpunit/phpunit": "^9.1"
+            },
+            "default-branch": true,
+            "type": "phpactor-extension",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.1.x-dev"
+                },
+                "phpactor.extension_class": "Phpactor\\Extension\\Debug\\DebugExtension"
+            },
+            "autoload": {
+                "files": [
+                    "lib/bootstrap.php"
+                ],
+                "psr-4": {
+                    "Phpactor\\Extension\\Debug\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Leech",
+                    "email": "daniel@dantleech.com"
+                }
+            ],
+            "description": "Add some debugging facilities",
+            "support": {
+                "issues": "https://github.com/phpactor/debug-extension/issues",
+                "source": "https://github.com/phpactor/debug-extension/tree/master"
+            },
+            "time": "2022-02-05T11:09:30+00:00"
+        },
+        {
             "name": "phpactor/docblock",
             "version": "0.3.5",
             "source": {
@@ -2928,20 +2992,20 @@
         },
         {
             "name": "phpactor/indexer-extension",
-            "version": "0.3.3",
+            "version": "0.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/indexer-extension.git",
-                "reference": "e4d6d34cd902f332f4b0d791dbe7f527cacf57bd"
+                "reference": "ed0c5fc34ba4d2999b16eec13461723851be3161"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/indexer-extension/zipball/e4d6d34cd902f332f4b0d791dbe7f527cacf57bd",
-                "reference": "e4d6d34cd902f332f4b0d791dbe7f527cacf57bd",
+                "url": "https://api.github.com/repos/phpactor/indexer-extension/zipball/ed0c5fc34ba4d2999b16eec13461723851be3161",
+                "reference": "ed0c5fc34ba4d2999b16eec13461723851be3161",
                 "shasum": ""
             },
             "require": {
-                "dantleech/invoke": "^2.0",
+                "dantleech/invoke": "^1.0",
                 "php": "^7.3 || ^8.0",
                 "phpactor/amp-fswatch": "^0.2.0",
                 "phpactor/container": "^2.0.0",
@@ -2992,28 +3056,28 @@
             "description": "Indexer and related integrations",
             "support": {
                 "issues": "https://github.com/phpactor/indexer-extension/issues",
-                "source": "https://github.com/phpactor/indexer-extension/tree/0.3.3"
+                "source": "https://github.com/phpactor/indexer-extension/tree/0.3.2"
             },
-            "time": "2022-02-10T19:19:47+00:00"
+            "time": "2021-12-29T22:18:08+00:00"
         },
         {
             "name": "phpactor/language-server",
-            "version": "1.1.2",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/language-server.git",
-                "reference": "302e70d85b39ad0d5c368900b94b7cd6d3b77a05"
+                "reference": "4484ff7a423bec2179b5c1e089cabad409b60c89"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/language-server/zipball/302e70d85b39ad0d5c368900b94b7cd6d3b77a05",
-                "reference": "302e70d85b39ad0d5c368900b94b7cd6d3b77a05",
+                "url": "https://api.github.com/repos/phpactor/language-server/zipball/4484ff7a423bec2179b5c1e089cabad409b60c89",
+                "reference": "4484ff7a423bec2179b5c1e089cabad409b60c89",
                 "shasum": ""
             },
             "require": {
                 "amphp/socket": "^1.1",
                 "dantleech/argument-resolver": "^1.1",
-                "dantleech/invoke": "^2.0",
+                "dantleech/invoke": "^1.1.2",
                 "php": "^7.3 || ^8.0",
                 "phpactor/language-server-protocol": "~0.1",
                 "psr/event-dispatcher": "^1.0",
@@ -3057,9 +3121,9 @@
             "description": "Generic Language Server Platform",
             "support": {
                 "issues": "https://github.com/phpactor/language-server/issues",
-                "source": "https://github.com/phpactor/language-server/tree/1.1.2"
+                "source": "https://github.com/phpactor/language-server/tree/1.1.1"
             },
-            "time": "2022-02-10T19:14:44+00:00"
+            "time": "2021-09-20T11:37:12+00:00"
         },
         {
             "name": "phpactor/language-server-extension",
@@ -3124,7 +3188,7 @@
         },
         {
             "name": "phpactor/language-server-phpactor-extensions",
-            "version": "0.5.3",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/language-server-phpactor-extensions.git",
@@ -3175,6 +3239,7 @@
                 "phpunit/phpunit": "^9.0",
                 "symfony/var-dumper": "^5.1"
             },
+            "default-branch": true,
             "type": "phpactor-extension",
             "extra": {
                 "branch-alias": {
@@ -3205,26 +3270,26 @@
             "description": "Provides an (experimental) LSP compatible Language Server Platform",
             "support": {
                 "issues": "https://github.com/phpactor/language-server-phpactor-extensions/issues",
-                "source": "https://github.com/phpactor/language-server-phpactor-extensions/tree/0.5.3"
+                "source": "https://github.com/phpactor/language-server-phpactor-extensions/tree/master"
             },
             "time": "2022-02-05T11:13:42+00:00"
         },
         {
             "name": "phpactor/language-server-protocol",
-            "version": "0.3.1",
+            "version": "0.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/language-server-protocol.git",
-                "reference": "306dd561711833f2a05a63b8332dc717d7ea5001"
+                "reference": "630c01ecdaf0a4e7dc48896c978c007e93ee3b1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/language-server-protocol/zipball/306dd561711833f2a05a63b8332dc717d7ea5001",
-                "reference": "306dd561711833f2a05a63b8332dc717d7ea5001",
+                "url": "https://api.github.com/repos/phpactor/language-server-protocol/zipball/630c01ecdaf0a4e7dc48896c978c007e93ee3b1d",
+                "reference": "630c01ecdaf0a4e7dc48896c978c007e93ee3b1d",
                 "shasum": ""
             },
             "require": {
-                "dantleech/invoke": "^2.0",
+                "dantleech/invoke": "^1.0.2",
                 "php": "^7.3 || ^8.0"
             },
             "require-dev": {
@@ -3257,9 +3322,9 @@
             "description": "Langauge Server Protocol for PHP (transpiled)",
             "support": {
                 "issues": "https://github.com/phpactor/language-server-protocol/issues",
-                "source": "https://github.com/phpactor/language-server-protocol/tree/0.3.1"
+                "source": "https://github.com/phpactor/language-server-protocol/tree/0.3.0"
             },
-            "time": "2022-02-10T19:12:34+00:00"
+            "time": "2022-01-03T19:06:04+00:00"
         },
         {
             "name": "phpactor/logging-extension",
@@ -4830,6 +4895,74 @@
             "time": "2022-01-26T16:28:35+00:00"
         },
         {
+            "name": "symfony/debug",
+            "version": "v4.4.37",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/debug.git",
+                "reference": "5de6c6e7f52b364840e53851c126be4d71e60470"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/5de6c6e7f52b364840e53851c126be4d71e60470",
+                "reference": "5de6c6e7f52b364840e53851c126be4d71e60470",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3",
+                "psr/log": "^1|^2|^3"
+            },
+            "conflict": {
+                "symfony/http-kernel": "<3.4"
+            },
+            "require-dev": {
+                "symfony/http-kernel": "^3.4|^4.0|^5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Debug\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools to ease debugging PHP code",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/debug/tree/v4.4.37"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-01-02T09:41:36+00:00"
+        },
+        {
             "name": "symfony/deprecation-contracts",
             "version": "v2.5.0",
             "source": {
@@ -5902,6 +6035,95 @@
             "time": "2022-01-02T09:53:40+00:00"
         },
         {
+            "name": "symfony/var-dumper",
+            "version": "v5.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-dumper.git",
+                "reference": "970a01f208bf895c5f327ba40b72288da43adec4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/970a01f208bf895c5f327ba40b72288da43adec4",
+                "reference": "970a01f208bf895c5f327ba40b72288da43adec4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<5.4.3",
+                "symfony/console": "<4.4"
+            },
+            "require-dev": {
+                "ext-iconv": "*",
+                "symfony/console": "^4.4|^5.0|^6.0",
+                "symfony/process": "^4.4|^5.0|^6.0",
+                "symfony/uid": "^5.1|^6.0",
+                "twig/twig": "^2.13|^3.0.4"
+            },
+            "suggest": {
+                "ext-iconv": "To convert non-UTF-8 strings to UTF-8 (or symfony/polyfill-iconv in case ext-iconv cannot be used).",
+                "ext-intl": "To show region name in time zone dump",
+                "symfony/console": "To use the ServerDumpCommand and/or the bin/var-dump-server script"
+            },
+            "bin": [
+                "Resources/bin/var-dump-server"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions/dump.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\VarDumper\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides mechanisms for walking through any arbitrary PHP variable",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "debug",
+                "dump"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/var-dumper/tree/v5.4.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-01-17T16:30:37+00:00"
+        },
+        {
             "name": "symfony/yaml",
             "version": "v5.4.3",
             "source": {
@@ -6005,6 +6227,12 @@
                 }
             },
             "autoload": {
+                "psr-4": {
+                    "Safe\\": [
+                        "lib/",
+                        "generated/"
+                    ]
+                },
                 "files": [
                     "generated/apache.php",
                     "generated/apc.php",
@@ -6094,13 +6322,7 @@
                     "generated/zip.php",
                     "generated/zlib.php",
                     "lib/special_cases.php"
-                ],
-                "psr-4": {
-                    "Safe\\": [
-                        "lib/",
-                        "generated/"
-                    ]
-                }
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -7029,16 +7251,16 @@
         },
         {
             "name": "phar-io/version",
-            "version": "3.1.1",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "15a90844ad40f127afd244c0cad228de2a80052a"
+                "reference": "bae7c545bef187884426f042434e561ab1ddb182"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/15a90844ad40f127afd244c0cad228de2a80052a",
-                "reference": "15a90844ad40f127afd244c0cad228de2a80052a",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/bae7c545bef187884426f042434e561ab1ddb182",
+                "reference": "bae7c545bef187884426f042434e561ab1ddb182",
                 "shasum": ""
             },
             "require": {
@@ -7074,9 +7296,9 @@
             "description": "Library for handling version information and constraints",
             "support": {
                 "issues": "https://github.com/phar-io/version/issues",
-                "source": "https://github.com/phar-io/version/tree/3.1.1"
+                "source": "https://github.com/phar-io/version/tree/3.1.0"
             },
-            "time": "2022-02-07T21:56:48+00:00"
+            "time": "2021-02-23T14:00:09+00:00"
         },
         {
             "name": "php-cs-fixer/diff",
@@ -7132,65 +7354,6 @@
                 "source": "https://github.com/PHP-CS-Fixer/diff/tree/v1.3.1"
             },
             "time": "2020-10-14T08:39:05+00:00"
-        },
-        {
-            "name": "phpactor/debug-extension",
-            "version": "0.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpactor/debug-extension.git",
-                "reference": "514740f714f4c42541ae42698804262da3622175"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/debug-extension/zipball/514740f714f4c42541ae42698804262da3622175",
-                "reference": "514740f714f4c42541ae42698804262da3622175",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.3 || ^8.0",
-                "phpactor/console-extension": "^0.1.6",
-                "phpactor/container": "^2.0.0",
-                "symfony/debug": "^4.4",
-                "symfony/var-dumper": "^5.0"
-            },
-            "require-dev": {
-                "ergebnis/composer-normalize": "^2.0",
-                "friendsofphp/php-cs-fixer": "^2.17",
-                "phpstan/phpstan": "~0.12.0",
-                "phpunit/phpunit": "^9.1"
-            },
-            "type": "phpactor-extension",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "0.1.x-dev"
-                },
-                "phpactor.extension_class": "Phpactor\\Extension\\Debug\\DebugExtension"
-            },
-            "autoload": {
-                "files": [
-                    "lib/bootstrap.php"
-                ],
-                "psr-4": {
-                    "Phpactor\\Extension\\Debug\\": "lib/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Daniel Leech",
-                    "email": "daniel@dantleech.com"
-                }
-            ],
-            "description": "Add some debugging facilities",
-            "support": {
-                "issues": "https://github.com/phpactor/debug-extension/issues",
-                "source": "https://github.com/phpactor/debug-extension/tree/0.1.1"
-            },
-            "time": "2021-02-06T14:38:57+00:00"
         },
         {
             "name": "phpactor/test-utils",
@@ -8159,11 +8322,11 @@
                 }
             },
             "autoload": {
-                "files": [
-                    "src/Framework/Assert/Functions.php"
-                ],
                 "classmap": [
                     "src/"
+                ],
+                "files": [
+                    "src/Framework/Assert/Functions.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -8689,16 +8852,16 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.4",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "19c519631c5a511b7ed0ad64a6713fdb3fd25fe4"
+                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/19c519631c5a511b7ed0ad64a6713fdb3fd25fe4",
-                "reference": "19c519631c5a511b7ed0ad64a6713fdb3fd25fe4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/23bd5951f7ff26f12d4e3242864df3e08dec4e49",
+                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49",
                 "shasum": ""
             },
             "require": {
@@ -8741,7 +8904,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.4"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.3"
             },
             "funding": [
                 {
@@ -8749,7 +8912,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-10T07:01:19+00:00"
+            "time": "2021-06-11T13:31:12+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -9148,74 +9311,6 @@
             "time": "2020-09-28T06:39:44+00:00"
         },
         {
-            "name": "symfony/debug",
-            "version": "v4.4.37",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/debug.git",
-                "reference": "5de6c6e7f52b364840e53851c126be4d71e60470"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/5de6c6e7f52b364840e53851c126be4d71e60470",
-                "reference": "5de6c6e7f52b364840e53851c126be4d71e60470",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1.3",
-                "psr/log": "^1|^2|^3"
-            },
-            "conflict": {
-                "symfony/http-kernel": "<3.4"
-            },
-            "require-dev": {
-                "symfony/http-kernel": "^3.4|^4.0|^5.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Debug\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides tools to ease debugging PHP code",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/debug/tree/v4.4.37"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-01-02T09:41:36+00:00"
-        },
-        {
             "name": "symfony/event-dispatcher",
             "version": "v5.4.3",
             "source": {
@@ -9579,95 +9674,6 @@
             "time": "2022-01-02T09:53:40+00:00"
         },
         {
-            "name": "symfony/var-dumper",
-            "version": "v5.4.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "970a01f208bf895c5f327ba40b72288da43adec4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/970a01f208bf895c5f327ba40b72288da43adec4",
-                "reference": "970a01f208bf895c5f327ba40b72288da43adec4",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.5",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php80": "^1.16"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<5.4.3",
-                "symfony/console": "<4.4"
-            },
-            "require-dev": {
-                "ext-iconv": "*",
-                "symfony/console": "^4.4|^5.0|^6.0",
-                "symfony/process": "^4.4|^5.0|^6.0",
-                "symfony/uid": "^5.1|^6.0",
-                "twig/twig": "^2.13|^3.0.4"
-            },
-            "suggest": {
-                "ext-iconv": "To convert non-UTF-8 strings to UTF-8 (or symfony/polyfill-iconv in case ext-iconv cannot be used).",
-                "ext-intl": "To show region name in time zone dump",
-                "symfony/console": "To use the ServerDumpCommand and/or the bin/var-dump-server script"
-            },
-            "bin": [
-                "Resources/bin/var-dump-server"
-            ],
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "Resources/functions/dump.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Component\\VarDumper\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides mechanisms for walking through any arbitrary PHP variable",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "debug",
-                "dump"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v5.4.3"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-01-17T16:30:37+00:00"
-        },
-        {
             "name": "theseer/tokenizer",
             "version": "1.2.1",
             "source": {
@@ -9719,7 +9725,7 @@
         }
     ],
     "aliases": [],
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
@@ -9730,5 +9736,5 @@
     "platform-overrides": {
         "php": "7.3.0"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/lib/Extension/CodeTransformExtra/Rpc/ExtractExpressionHandler.php
+++ b/lib/Extension/CodeTransformExtra/Rpc/ExtractExpressionHandler.php
@@ -3,7 +3,6 @@
 namespace Phpactor\Extension\CodeTransformExtra\Rpc;
 
 use Phpactor\CodeTransform\Domain\Refactor\ExtractExpression;
-use Phpactor\Extension\Rpc\Response;
 use Phpactor\MapResolver\Resolver;
 use Phpactor\Extension\Rpc\Response\Input\TextInput;
 use Phpactor\Extension\Rpc\Response\UpdateFileSourceResponse;

--- a/lib/Extension/Core/CoreExtension.php
+++ b/lib/Extension/Core/CoreExtension.php
@@ -8,6 +8,8 @@ use Phpactor\Extension\Core\Command\DebugContainerCommand;
 use Phpactor\Extension\Core\Rpc\CacheClearHandler;
 use Phpactor\Extension\Core\Rpc\ConfigHandler;
 use Phpactor\Extension\Core\Rpc\StatusHandler;
+use Phpactor\Extension\Debug\Command\InitConfigCommand;
+use Phpactor\Extension\Debug\Model\ConfigInitializer;
 use Phpactor\Extension\Php\Model\PhpVersionResolver;
 use Phpactor\Extension\Rpc\RpcExtension;
 use Phpactor\FilePathResolverExtension\FilePathResolverExtension;
@@ -48,6 +50,7 @@ class CoreExtension implements Extension
             self::PARAM_COMMAND => null,
             self::PARAM_WARN_ON_DEVELOP => true,
             self::PARAM_MIN_MEMORY_LIMIT => 1610612736,
+            '$schema' => '',
         ]);
         $schema->setDescriptions([
             self::PARAM_XDEBUG_DISABLE => 'If XDebug should be automatically disabled',
@@ -76,6 +79,15 @@ class CoreExtension implements Extension
                 $container->get(FilePathResolverExtension::SERVICE_EXPANDERS)
             );
         }, [ ConsoleExtension::TAG_COMMAND => [ 'name' => 'config:dump']]);
+
+        $container->register('command.config_initialize', function (Container $container) {
+            return new InitConfigCommand(
+                new ConfigInitializer(
+                    realpath(__DIR__ . '/../../..') . '/phpactor.schema.json',
+                    $container->getParameter(FilePathResolverExtension::PARAM_PROJECT_ROOT) . '/.phpactor.json'
+                )
+            );
+        }, [ ConsoleExtension::TAG_COMMAND => [ 'name' => 'config:initialize']]);
 
         $container->register('command.debug_container', function (Container $container) {
             return new DebugContainerCommand(

--- a/lib/Extension/Core/CoreExtension.php
+++ b/lib/Extension/Core/CoreExtension.php
@@ -41,6 +41,7 @@ class CoreExtension implements Extension
     const PARAM_COMMAND = 'command';
     const PARAM_WARN_ON_DEVELOP = 'core.warn_on_develop';
     const PARAM_MIN_MEMORY_LIMIT = 'core.min_memory_limit';
+    const PARAM_SCHEMA = '$schema';
 
     public function configure(Resolver $schema): void
     {
@@ -50,7 +51,7 @@ class CoreExtension implements Extension
             self::PARAM_COMMAND => null,
             self::PARAM_WARN_ON_DEVELOP => true,
             self::PARAM_MIN_MEMORY_LIMIT => 1610612736,
-            '$schema' => '',
+            self::PARAM_SCHEMA => '',
         ]);
         $schema->setDescriptions([
             self::PARAM_XDEBUG_DISABLE => 'If XDebug should be automatically disabled',
@@ -58,6 +59,7 @@ class CoreExtension implements Extension
             self::PARAM_DUMPER => 'Name of the "dumper" (renderer) to use for some CLI commands',
             self::PARAM_WARN_ON_DEVELOP => 'Internal use only: if an warning will be issed when on develop, may be removed in the future',
             self::PARAM_MIN_MEMORY_LIMIT => 'Ensure that PHP has a memory_limit of at least this amount in bytes',
+            self::PARAM_SCHEMA => 'Path to JSON schema, which can be used for config autocompletion, use phpactor config:initialize to update',
         ]);
     }
 

--- a/lib/Phpactor.php
+++ b/lib/Phpactor.php
@@ -230,7 +230,7 @@ class Phpactor
 
     public static function relativizePath(string $path): string
     {
-        if (0 === strpos($path, getcwd())) {
+        if (0 === strpos($path, (string)getcwd())) {
             return substr($path, strlen(getcwd()) + 1);
         }
 

--- a/lib/Test/Test.php
+++ b/lib/Test/Test.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Phpactor\Test;
-
-class Test
-{
-}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,17 +1,7 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Parameter \\#2 \\$dumper of method Phpactor\\\\Application\\:\\:handleException\\(\\) expects string, array\\<string\\>\\|bool\\|string\\|null given\\.$#"
-			count: 1
-			path: lib/Application.php
-
-		-
 			message: "#^Method Phpactor\\\\Application\\:\\:handleException\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: lib/Application.php
-
-		-
-			message: "#^Parameter \\#1 \\$e of method Phpactor\\\\Application\\:\\:serializeException\\(\\) expects Exception, Throwable given\\.$#"
 			count: 1
 			path: lib/Application.php
 
@@ -21,13 +11,13 @@ parameters:
 			path: lib/Application.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassCopy\\:\\:copy\\(\\) has no return typehint specified\\.$#"
+			message: "#^Parameter \\#1 \\$e of method Phpactor\\\\Application\\:\\:serializeException\\(\\) expects Exception, Throwable given\\.$#"
 			count: 1
-			path: lib/Extension/ClassMover/Application/ClassCopy.php
+			path: lib/Application.php
 
 		-
-			message: "#^Result of method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassCopy\\:\\:copyFile\\(\\) \\(void\\) is used\\.$#"
-			count: 2
+			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassCopy\\:\\:copy\\(\\) has no return typehint specified\\.$#"
+			count: 1
 			path: lib/Extension/ClassMover/Application/ClassCopy.php
 
 		-
@@ -41,12 +31,27 @@ parameters:
 			path: lib/Extension/ClassMover/Application/ClassCopy.php
 
 		-
+			message: "#^Result of method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassCopy\\:\\:copyFile\\(\\) \\(void\\) is used\\.$#"
+			count: 2
+			path: lib/Extension/ClassMover/Application/ClassCopy.php
+
+		-
+			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMemberReferences\\:\\:createQuery\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: lib/Extension/ClassMover/Application/ClassMemberReferences.php
+
+		-
+			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMemberReferences\\:\\:createQuery\\(\\) has parameter \\$memberType with no typehint specified\\.$#"
+			count: 1
+			path: lib/Extension/ClassMover/Application/ClassMemberReferences.php
+
+		-
 			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMemberReferences\\:\\:findOrReplaceReferences\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: lib/Extension/ClassMover/Application/ClassMemberReferences.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMemberReferences\\:\\:replaceInSource\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMemberReferences\\:\\:line\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: lib/Extension/ClassMover/Application/ClassMemberReferences.php
 
@@ -61,6 +66,21 @@ parameters:
 			path: lib/Extension/ClassMover/Application/ClassMemberReferences.php
 
 		-
+			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMemberReferences\\:\\:replaceInSource\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: lib/Extension/ClassMover/Application/ClassMemberReferences.php
+
+		-
+			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMemberReferences\\:\\:replaceReferencesInCode\\(\\) has parameter \\$list with no value type specified in iterable type Phpactor\\\\ClassMover\\\\Domain\\\\Reference\\\\MemberReferences\\.$#"
+			count: 1
+			path: lib/Extension/ClassMover/Application/ClassMemberReferences.php
+
+		-
+			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMemberReferences\\:\\:serializeReference\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: lib/Extension/ClassMover/Application/ClassMemberReferences.php
+
+		-
 			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMemberReferences\\:\\:serializeReferenceList\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: lib/Extension/ClassMover/Application/ClassMemberReferences.php
@@ -71,57 +91,7 @@ parameters:
 			path: lib/Extension/ClassMover/Application/ClassMemberReferences.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMemberReferences\\:\\:serializeReference\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Application/ClassMemberReferences.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMemberReferences\\:\\:line\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Application/ClassMemberReferences.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMemberReferences\\:\\:replaceReferencesInCode\\(\\) has parameter \\$list with no value type specified in iterable type Phpactor\\\\ClassMover\\\\Domain\\\\Reference\\\\MemberReferences\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Application/ClassMemberReferences.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMemberReferences\\:\\:createQuery\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Application/ClassMemberReferences.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMemberReferences\\:\\:createQuery\\(\\) has parameter \\$memberType with no typehint specified\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Application/ClassMemberReferences.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMover\\:\\:getRelatedFiles\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Application/ClassMover.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMover\\:\\:moveClass\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Application/ClassMover.php
-
-		-
-			message: "#^Result of method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMover\\:\\:moveFile\\(\\) \\(void\\) is used\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Application/ClassMover.php
-
-		-
-			message: "#^Parameter \\#2 \\$code of class RuntimeException constructor expects int, null given\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Application/ClassMover.php
-
-		-
 			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMover\\:\\:directoryMap\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Application/ClassMover.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMover\\:\\:replaceThoseReferences\\(\\) has parameter \\$files with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: lib/Extension/ClassMover/Application/ClassMover.php
 
@@ -141,29 +111,29 @@ parameters:
 			path: lib/Extension/ClassMover/Application/ClassMover.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassReferences\\:\\:replaceReferences\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMover\\:\\:getRelatedFiles\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: lib/Extension/ClassMover/Application/ClassReferences.php
+			path: lib/Extension/ClassMover/Application/ClassMover.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassReferences\\:\\:findReferences\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMover\\:\\:moveClass\\(\\) has no return typehint specified\\.$#"
 			count: 1
-			path: lib/Extension/ClassMover/Application/ClassReferences.php
+			path: lib/Extension/ClassMover/Application/ClassMover.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassReferences\\:\\:findOrReplaceReferences\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMover\\:\\:replaceThoseReferences\\(\\) has parameter \\$files with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: lib/Extension/ClassMover/Application/ClassReferences.php
+			path: lib/Extension/ClassMover/Application/ClassMover.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassReferences\\:\\:replaceInSource\\(\\) has parameter \\$className with no typehint specified\\.$#"
+			message: "#^Parameter \\#2 \\$code of class RuntimeException constructor expects int, null given\\.$#"
 			count: 1
-			path: lib/Extension/ClassMover/Application/ClassReferences.php
+			path: lib/Extension/ClassMover/Application/ClassMover.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassReferences\\:\\:replaceInSource\\(\\) has parameter \\$replace with no typehint specified\\.$#"
+			message: "#^Result of method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMover\\:\\:moveFile\\(\\) \\(void\\) is used\\.$#"
 			count: 1
-			path: lib/Extension/ClassMover/Application/ClassReferences.php
+			path: lib/Extension/ClassMover/Application/ClassMover.php
 
 		-
 			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassReferences\\:\\:fileReferences\\(\\) has no return typehint specified\\.$#"
@@ -191,7 +161,42 @@ parameters:
 			path: lib/Extension/ClassMover/Application/ClassReferences.php
 
 		-
-			message: "#^Right side of && is always true\\.$#"
+			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassReferences\\:\\:findOrReplaceReferences\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: lib/Extension/ClassMover/Application/ClassReferences.php
+
+		-
+			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassReferences\\:\\:findReferences\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: lib/Extension/ClassMover/Application/ClassReferences.php
+
+		-
+			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassReferences\\:\\:line\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: lib/Extension/ClassMover/Application/ClassReferences.php
+
+		-
+			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassReferences\\:\\:replaceInSource\\(\\) has parameter \\$className with no typehint specified\\.$#"
+			count: 1
+			path: lib/Extension/ClassMover/Application/ClassReferences.php
+
+		-
+			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassReferences\\:\\:replaceInSource\\(\\) has parameter \\$replace with no typehint specified\\.$#"
+			count: 1
+			path: lib/Extension/ClassMover/Application/ClassReferences.php
+
+		-
+			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassReferences\\:\\:replaceReferences\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: lib/Extension/ClassMover/Application/ClassReferences.php
+
+		-
+			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassReferences\\:\\:replaceReferencesInCode\\(\\) has parameter \\$list with no value type specified in iterable type Phpactor\\\\ClassMover\\\\Domain\\\\Reference\\\\NamespacedClassReferences\\.$#"
+			count: 1
+			path: lib/Extension/ClassMover/Application/ClassReferences.php
+
+		-
+			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassReferences\\:\\:serializeReference\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: lib/Extension/ClassMover/Application/ClassReferences.php
 
@@ -206,37 +211,17 @@ parameters:
 			path: lib/Extension/ClassMover/Application/ClassReferences.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassReferences\\:\\:serializeReference\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Application/ClassReferences.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassReferences\\:\\:line\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Application/ClassReferences.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassReferences\\:\\:replaceReferencesInCode\\(\\) has parameter \\$list with no value type specified in iterable type Phpactor\\\\ClassMover\\\\Domain\\\\Reference\\\\NamespacedClassReferences\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Application/ClassReferences.php
-
-		-
-			message: "#^Parameter \\#2 \\$subject of function preg_match expects string, string\\|false given\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Application/Finder/FileFinder.php
-
-		-
-			message: "#^Variable \\$member in PHPDoc tag @var does not match assigned variable \\$private\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Application/Finder/FileFinder.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\Finder\\\\FileFinder\\:\\:pathsFromReflectionClass\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Application/Finder/FileFinder.php
-
-		-
 			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\Finder\\\\FileFinder\\:\\:allPhpFiles\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: lib/Extension/ClassMover/Application/Finder/FileFinder.php
+
+		-
+			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\Finder\\\\FileFinder\\:\\:interfaceFilePaths\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: lib/Extension/ClassMover/Application/Finder/FileFinder.php
+
+		-
+			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\Finder\\\\FileFinder\\:\\:interfaceFilePaths\\(\\) has parameter \\$filePaths with no typehint specified\\.$#"
 			count: 1
 			path: lib/Extension/ClassMover/Application/Finder/FileFinder.php
 
@@ -251,6 +236,11 @@ parameters:
 			path: lib/Extension/ClassMover/Application/Finder/FileFinder.php
 
 		-
+			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\Finder\\\\FileFinder\\:\\:pathsFromReflectionClass\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: lib/Extension/ClassMover/Application/Finder/FileFinder.php
+
+		-
 			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\Finder\\\\FileFinder\\:\\:traitFilePaths\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: lib/Extension/ClassMover/Application/Finder/FileFinder.php
@@ -261,12 +251,12 @@ parameters:
 			path: lib/Extension/ClassMover/Application/Finder/FileFinder.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\Finder\\\\FileFinder\\:\\:interfaceFilePaths\\(\\) has no return typehint specified\\.$#"
+			message: "#^Parameter \\#2 \\$subject of function preg_match expects string, string\\|false given\\.$#"
 			count: 1
 			path: lib/Extension/ClassMover/Application/Finder/FileFinder.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\Finder\\\\FileFinder\\:\\:interfaceFilePaths\\(\\) has parameter \\$filePaths with no typehint specified\\.$#"
+			message: "#^Variable \\$member in PHPDoc tag @var does not match assigned variable \\$private\\.$#"
 			count: 1
 			path: lib/Extension/ClassMover/Application/Finder/FileFinder.php
 
@@ -291,101 +281,6 @@ parameters:
 			path: lib/Extension/ClassMover/Application/Logger/ClassMoverLogger.php
 
 		-
-			message: "#^Parameter \\#2 \\$default of method Phpactor\\\\Extension\\\\Core\\\\Console\\\\Prompt\\\\Prompt\\:\\:prompt\\(\\) expects string, array\\<string\\>\\|string\\|null given\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Command/ClassCopyCommand.php
-
-		-
-			message: "#^Parameter \\#2 \\$src of method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassCopy\\:\\:copy\\(\\) expects string, array\\<string\\>\\|string\\|null given\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Command/ClassCopyCommand.php
-
-		-
-			message: "#^Parameter \\#3 \\$dest of method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassCopy\\:\\:copy\\(\\) expects string, array\\<string\\>\\|string given\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Command/ClassCopyCommand.php
-
-		-
-			message: "#^Parameter \\#2 \\$srcPath of method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassCopy\\:\\:copyFile\\(\\) expects string, array\\<string\\>\\|string\\|null given\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Command/ClassCopyCommand.php
-
-		-
-			message: "#^Parameter \\#3 \\$destPath of method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassCopy\\:\\:copyFile\\(\\) expects string, array\\<string\\>\\|string given\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Command/ClassCopyCommand.php
-
-		-
-			message: "#^Parameter \\#2 \\$srcName of method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassCopy\\:\\:copyClass\\(\\) expects string, array\\<string\\>\\|string\\|null given\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Command/ClassCopyCommand.php
-
-		-
-			message: "#^Parameter \\#3 \\$destName of method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassCopy\\:\\:copyClass\\(\\) expects string, array\\<string\\>\\|string given\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Command/ClassCopyCommand.php
-
-		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, array\\<string\\>\\|bool\\|string\\|null given\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Command/ClassCopyCommand.php
-
-		-
-			message: "#^Parameter \\#2 \\$default of method Phpactor\\\\Extension\\\\Core\\\\Console\\\\Prompt\\\\Prompt\\:\\:prompt\\(\\) expects string, array\\<string\\>\\|string\\|null given\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Command/ClassMoveCommand.php
-
-		-
-			message: "#^Parameter \\#2 \\$filesystemName of method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMover\\:\\:move\\(\\) expects string, array\\<string\\>\\|bool\\|string\\|null given\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Command/ClassMoveCommand.php
-
-		-
-			message: "#^Parameter \\#3 \\$src of method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMover\\:\\:move\\(\\) expects string, array\\<string\\>\\|string\\|null given\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Command/ClassMoveCommand.php
-
-		-
-			message: "#^Parameter \\#4 \\$dest of method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMover\\:\\:move\\(\\) expects string, array\\<string\\>\\|string given\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Command/ClassMoveCommand.php
-
-		-
-			message: "#^Parameter \\#2 \\$filesystemName of method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMover\\:\\:moveFile\\(\\) expects string, array\\<string\\>\\|bool\\|string\\|null given\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Command/ClassMoveCommand.php
-
-		-
-			message: "#^Parameter \\#3 \\$srcPath of method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMover\\:\\:moveFile\\(\\) expects string, array\\<string\\>\\|string\\|null given\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Command/ClassMoveCommand.php
-
-		-
-			message: "#^Parameter \\#4 \\$destPath of method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMover\\:\\:moveFile\\(\\) expects string, array\\<string\\>\\|string given\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Command/ClassMoveCommand.php
-
-		-
-			message: "#^Parameter \\#2 \\$filesystemName of method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMover\\:\\:moveClass\\(\\) expects string, array\\<string\\>\\|bool\\|string\\|null given\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Command/ClassMoveCommand.php
-
-		-
-			message: "#^Parameter \\#3 \\$srcName of method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMover\\:\\:moveClass\\(\\) expects string, array\\<string\\>\\|string\\|null given\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Command/ClassMoveCommand.php
-
-		-
-			message: "#^Parameter \\#4 \\$destName of method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMover\\:\\:moveClass\\(\\) expects string, array\\<string\\>\\|string given\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Command/ClassMoveCommand.php
-
-		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, array\\<string\\>\\|bool\\|string\\|null given\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Command/ClassMoveCommand.php
-
-		-
 			message: "#^Property Phpactor\\\\Extension\\\\ClassMover\\\\Command\\\\Logger\\\\SymfonyConsoleCopyLogger\\:\\:\\$output has no typehint specified\\.$#"
 			count: 1
 			path: lib/Extension/ClassMover/Command/Logger/SymfonyConsoleCopyLogger.php
@@ -396,7 +291,7 @@ parameters:
 			path: lib/Extension/ClassMover/Command/Logger/SymfonyConsoleMoveLogger.php
 
 		-
-			message: "#^Parameter \\#1 \\$name of method Phpactor\\\\Extension\\\\Core\\\\Console\\\\Dumper\\\\DumperRegistry\\:\\:get\\(\\) expects string\\|null, array\\<string\\>\\|string\\|true given\\.$#"
+			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Command\\\\ReferencesClassCommand\\:\\:addReferenceRow\\(\\) has parameter \\$reference with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: lib/Extension/ClassMover/Command/ReferencesClassCommand.php
 
@@ -436,47 +331,12 @@ parameters:
 			path: lib/Extension/ClassMover/Command/ReferencesClassCommand.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Command\\\\ReferencesClassCommand\\:\\:addReferenceRow\\(\\) has parameter \\$reference with no value type specified in iterable type array\\.$#"
+			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Command\\\\ReferencesMemberCommand\\:\\:addReferenceRow\\(\\) has parameter \\$reference with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: lib/Extension/ClassMover/Command/ReferencesClassCommand.php
+			path: lib/Extension/ClassMover/Command/ReferencesMemberCommand.php
 
 		-
 			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Command\\\\ReferencesMemberCommand\\:\\:execute\\(\\) has parameter \\$bar with no typehint specified\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Command/ReferencesMemberCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$scope of method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMemberReferences\\:\\:findOrReplaceReferences\\(\\) expects string, array\\<string\\>\\|bool\\|string\\|null given\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Command/ReferencesMemberCommand.php
-
-		-
-			message: "#^Parameter \\#2 \\$class of method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMemberReferences\\:\\:findOrReplaceReferences\\(\\) expects string\\|null, array\\<string\\>\\|string\\|null given\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Command/ReferencesMemberCommand.php
-
-		-
-			message: "#^Parameter \\#3 \\$memberName of method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMemberReferences\\:\\:findOrReplaceReferences\\(\\) expects string\\|null, array\\<string\\>\\|string\\|null given\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Command/ReferencesMemberCommand.php
-
-		-
-			message: "#^Parameter \\#4 \\$memberType of method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMemberReferences\\:\\:findOrReplaceReferences\\(\\) expects string\\|null, array\\<string\\>\\|bool\\|string\\|null given\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Command/ReferencesMemberCommand.php
-
-		-
-			message: "#^Parameter \\#5 \\$replace of method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMemberReferences\\:\\:findOrReplaceReferences\\(\\) expects string\\|null, array\\<string\\>\\|bool\\|string\\|null given\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Command/ReferencesMemberCommand.php
-
-		-
-			message: "#^Parameter \\#6 \\$dryRun of method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMemberReferences\\:\\:findOrReplaceReferences\\(\\) expects bool, array\\<string\\>\\|bool\\|string\\|null given\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Command/ReferencesMemberCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$name of method Phpactor\\\\Extension\\\\Core\\\\Console\\\\Dumper\\\\DumperRegistry\\:\\:get\\(\\) expects string\\|null, array\\<string\\>\\|string\\|true given\\.$#"
 			count: 1
 			path: lib/Extension/ClassMover/Command/ReferencesMemberCommand.php
 
@@ -492,11 +352,6 @@ parameters:
 
 		-
 			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Command\\\\ReferencesMemberCommand\\:\\:renderTable\\(\\) has parameter \\$results with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Command/ReferencesMemberCommand.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Command\\\\ReferencesMemberCommand\\:\\:addReferenceRow\\(\\) has parameter \\$reference with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: lib/Extension/ClassMover/Command/ReferencesMemberCommand.php
 
@@ -521,17 +376,27 @@ parameters:
 			path: lib/Extension/ClassMover/Rpc/ClassMoveHandler.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Rpc\\\\ReferencesHandler\\:\\:handle\\(\\) has no return typehint specified\\.$#"
+			message: "#^If condition is always true\\.$#"
 			count: 1
 			path: lib/Extension/ClassMover/Rpc/ReferencesHandler.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Rpc\\\\ReferencesHandler\\:\\:handle\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
+			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Rpc\\\\ReferencesHandler\\:\\:classReferences\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: lib/Extension/ClassMover/Rpc/ReferencesHandler.php
 
 		-
-			message: "#^Parameter \\#3 \\$choices of static method Phpactor\\\\Extension\\\\Rpc\\\\Response\\\\Input\\\\ChoiceInput\\:\\:fromNameLabelChoicesAndDefault\\(\\) expects array, array\\|false given\\.$#"
+			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Rpc\\\\ReferencesHandler\\:\\:defaultReplacement\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: lib/Extension/ClassMover/Rpc/ReferencesHandler.php
+
+		-
+			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Rpc\\\\ReferencesHandler\\:\\:doPerformFindOrReplaceReferences\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: lib/Extension/ClassMover/Rpc/ReferencesHandler.php
+
+		-
+			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Rpc\\\\ReferencesHandler\\:\\:echoMessage\\(\\) has parameter \\$references with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: lib/Extension/ClassMover/Rpc/ReferencesHandler.php
 
@@ -541,22 +406,12 @@ parameters:
 			path: lib/Extension/ClassMover/Rpc/ReferencesHandler.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Rpc\\\\ReferencesHandler\\:\\:replaceReferences\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Rpc\\\\ReferencesHandler\\:\\:handle\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: lib/Extension/ClassMover/Rpc/ReferencesHandler.php
 
 		-
-			message: "#^Parameter \\#2 \\$oldSource of static method Phpactor\\\\Extension\\\\Rpc\\\\Response\\\\UpdateFileSourceResponse\\:\\:fromPathOldAndNewSource\\(\\) expects string, string\\|false given\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Rpc/ReferencesHandler.php
-
-		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Rpc/ReferencesHandler.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Rpc\\\\ReferencesHandler\\:\\:classReferences\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Rpc\\\\ReferencesHandler\\:\\:handle\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: lib/Extension/ClassMover/Rpc/ReferencesHandler.php
 
@@ -571,7 +426,7 @@ parameters:
 			path: lib/Extension/ClassMover/Rpc/ReferencesHandler.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Rpc\\\\ReferencesHandler\\:\\:doPerformFindOrReplaceReferences\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Rpc\\\\ReferencesHandler\\:\\:replaceReferences\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: lib/Extension/ClassMover/Rpc/ReferencesHandler.php
 
@@ -586,12 +441,7 @@ parameters:
 			path: lib/Extension/ClassMover/Rpc/ReferencesHandler.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Rpc\\\\ReferencesHandler\\:\\:echoMessage\\(\\) has parameter \\$references with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Rpc/ReferencesHandler.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Rpc\\\\ReferencesHandler\\:\\:defaultReplacement\\(\\) has no return typehint specified\\.$#"
+			message: "#^Parameter \\#2 \\$oldSource of static method Phpactor\\\\Extension\\\\Rpc\\\\Response\\\\UpdateFileSourceResponse\\:\\:fromPathOldAndNewSource\\(\\) expects string, string\\|false given\\.$#"
 			count: 1
 			path: lib/Extension/ClassMover/Rpc/ReferencesHandler.php
 
@@ -601,12 +451,12 @@ parameters:
 			path: lib/Extension/ClassToFileExtra/Application/FileInfo.php
 
 		-
-			message: "#^Property Phpactor\\\\Extension\\\\ClassToFileExtra\\\\Command\\\\FileInfoCommand\\:\\:\\$infoForOffset has no typehint specified\\.$#"
+			message: "#^Property Phpactor\\\\Extension\\\\ClassToFileExtra\\\\Command\\\\FileInfoCommand\\:\\:\\$dumperRegistry has no typehint specified\\.$#"
 			count: 1
 			path: lib/Extension/ClassToFileExtra/Command/FileInfoCommand.php
 
 		-
-			message: "#^Property Phpactor\\\\Extension\\\\ClassToFileExtra\\\\Command\\\\FileInfoCommand\\:\\:\\$dumperRegistry has no typehint specified\\.$#"
+			message: "#^Property Phpactor\\\\Extension\\\\ClassToFileExtra\\\\Command\\\\FileInfoCommand\\:\\:\\$infoForOffset has no typehint specified\\.$#"
 			count: 1
 			path: lib/Extension/ClassToFileExtra/Command/FileInfoCommand.php
 
@@ -626,12 +476,12 @@ parameters:
 			path: lib/Extension/CodeTransformExtra/Application/AbstractClassGenerator.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Application\\\\ClassInflect\\:\\:generateFromExisting\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: "#^Call to an undefined method Phpactor\\\\CodeTransform\\\\Domain\\\\Generator\\:\\:generateFromExisting\\(\\)\\.$#"
 			count: 1
 			path: lib/Extension/CodeTransformExtra/Application/ClassInflect.php
 
 		-
-			message: "#^Call to an undefined method Phpactor\\\\CodeTransform\\\\Domain\\\\Generator\\:\\:generateFromExisting\\(\\)\\.$#"
+			message: "#^Method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Application\\\\ClassInflect\\:\\:generateFromExisting\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: lib/Extension/CodeTransformExtra/Application/ClassInflect.php
 
@@ -656,18 +506,18 @@ parameters:
 			path: lib/Extension/CodeTransformExtra/Application/Transformer.php
 
 		-
-			message: "#^Parameter \\#2 \\$basePath of static method Webmozart\\\\PathUtil\\\\Path\\:\\:makeAbsolute\\(\\) expects string, string\\|false given\\.$#"
-			count: 1
-			path: lib/Extension/CodeTransformExtra/Application/Transformer.php
-
-		-
 			message: "#^Parameter \\#1 \\$code of static method Phpactor\\\\CodeTransform\\\\Domain\\\\SourceCode\\:\\:fromStringAndPath\\(\\) expects string, string\\|false given\\.$#"
 			count: 1
 			path: lib/Extension/CodeTransformExtra/Application/Transformer.php
 
 		-
-			message: "#^Parameter \\#1 \\$name of method Phpactor\\\\Extension\\\\Core\\\\Console\\\\Dumper\\\\DumperRegistry\\:\\:get\\(\\) expects string\\|null, array\\<string\\>\\|bool\\|string\\|null given\\.$#"
-			count: 2
+			message: "#^Parameter \\#2 \\$basePath of static method Webmozart\\\\PathUtil\\\\Path\\:\\:makeAbsolute\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: lib/Extension/CodeTransformExtra/Application/Transformer.php
+
+		-
+			message: "#^Method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Command\\\\ClassInflectCommand\\:\\:listGenerators\\(\\) has no return typehint specified\\.$#"
+			count: 1
 			path: lib/Extension/CodeTransformExtra/Command/ClassInflectCommand.php
 
 		-
@@ -676,52 +526,7 @@ parameters:
 			path: lib/Extension/CodeTransformExtra/Command/ClassInflectCommand.php
 
 		-
-			message: "#^Parameter \\#1 \\$srcPath of method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Application\\\\ClassInflect\\:\\:generateFromExisting\\(\\) expects string, array\\<string\\>\\|string\\|null given\\.$#"
-			count: 2
-			path: lib/Extension/CodeTransformExtra/Command/ClassInflectCommand.php
-
-		-
-			message: "#^Parameter \\#2 \\$dest of method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Application\\\\ClassInflect\\:\\:generateFromExisting\\(\\) expects string, array\\<string\\>\\|string\\|null given\\.$#"
-			count: 2
-			path: lib/Extension/CodeTransformExtra/Command/ClassInflectCommand.php
-
-		-
-			message: "#^Parameter \\#3 \\$variant of method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Application\\\\ClassInflect\\:\\:generateFromExisting\\(\\) expects string, array\\<string\\>\\|string\\|null given\\.$#"
-			count: 2
-			path: lib/Extension/CodeTransformExtra/Command/ClassInflectCommand.php
-
-		-
-			message: "#^Parameter \\#4 \\$overwrite of method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Application\\\\ClassInflect\\:\\:generateFromExisting\\(\\) expects bool, array\\<string\\>\\|bool\\|string\\|null given\\.$#"
-			count: 1
-			path: lib/Extension/CodeTransformExtra/Command/ClassInflectCommand.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Command\\\\ClassInflectCommand\\:\\:listGenerators\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: lib/Extension/CodeTransformExtra/Command/ClassInflectCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$name of method Phpactor\\\\Extension\\\\Core\\\\Console\\\\Dumper\\\\DumperRegistry\\:\\:get\\(\\) expects string\\|null, array\\<string\\>\\|bool\\|string\\|null given\\.$#"
-			count: 2
-			path: lib/Extension/CodeTransformExtra/Command/ClassNewCommand.php
-
-		-
 			message: "#^Method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Command\\\\ClassNewCommand\\:\\:process\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: lib/Extension/CodeTransformExtra/Command/ClassNewCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$src of method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Command\\\\ClassNewCommand\\:\\:generateSourceCode\\(\\) expects string, array\\<string\\>\\|string\\|null given\\.$#"
-			count: 1
-			path: lib/Extension/CodeTransformExtra/Command/ClassNewCommand.php
-
-		-
-			message: "#^Parameter \\#2 \\$variant of method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Command\\\\ClassNewCommand\\:\\:generateSourceCode\\(\\) expects string, array\\<string\\>\\|bool\\|string\\|null given\\.$#"
-			count: 1
-			path: lib/Extension/CodeTransformExtra/Command/ClassNewCommand.php
-
-		-
-			message: "#^Parameter \\#3 \\$overwrite of method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Application\\\\ClassNew\\:\\:generate\\(\\) expects bool, array\\<string\\>\\|bool\\|string\\|null given\\.$#"
 			count: 1
 			path: lib/Extension/CodeTransformExtra/Command/ClassNewCommand.php
 
@@ -731,14 +536,14 @@ parameters:
 			path: lib/Extension/CodeTransformExtra/Command/ClassTransformCommand.php
 
 		-
-			message: "#^Parameter \\#1 \\$path of static method Phpactor\\\\Phpactor\\:\\:normalizePath\\(\\) expects string, array\\<string\\>\\|string\\|null given\\.$#"
+			message: "#^Parameter \\#1 \\$code of static method Phpactor\\\\CodeTransform\\\\Domain\\\\SourceCode\\:\\:fromStringAndPath\\(\\) expects string, string\\|false given\\.$#"
 			count: 1
 			path: lib/Extension/CodeTransformExtra/Command/ClassTransformCommand.php
 
 		-
-			message: "#^Parameter \\#1 \\$code of static method Phpactor\\\\CodeTransform\\\\Domain\\\\SourceCode\\:\\:fromStringAndPath\\(\\) expects string, string\\|false given\\.$#"
+			message: "#^Method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Rpc\\\\AbstractClassGenerateHandler\\:\\:generate\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: lib/Extension/CodeTransformExtra/Command/ClassTransformCommand.php
+			path: lib/Extension/CodeTransformExtra/Rpc/AbstractClassGenerateHandler.php
 
 		-
 			message: "#^Method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Rpc\\\\AbstractClassGenerateHandler\\:\\:handle\\(\\) has no return typehint specified\\.$#"
@@ -747,16 +552,6 @@ parameters:
 
 		-
 			message: "#^Method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Rpc\\\\AbstractClassGenerateHandler\\:\\:handle\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Extension/CodeTransformExtra/Rpc/AbstractClassGenerateHandler.php
-
-		-
-			message: "#^Parameter \\#3 \\$choices of static method Phpactor\\\\Extension\\\\Rpc\\\\Response\\\\Input\\\\ChoiceInput\\:\\:fromNameLabelChoicesAndDefault\\(\\) expects array, array\\|false given\\.$#"
-			count: 1
-			path: lib/Extension/CodeTransformExtra/Rpc/AbstractClassGenerateHandler.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Rpc\\\\AbstractClassGenerateHandler\\:\\:generate\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: lib/Extension/CodeTransformExtra/Rpc/AbstractClassGenerateHandler.php
 
@@ -801,6 +596,16 @@ parameters:
 			path: lib/Extension/CodeTransformExtra/Rpc/ExtractMethodHandler.php
 
 		-
+			message: "#^Call to an undefined method Phpactor\\\\Extension\\\\Rpc\\\\Response\\\\Input\\\\ChoiceInput\\:\\:withMultiple\\(\\)\\.$#"
+			count: 1
+			path: lib/Extension/CodeTransformExtra/Rpc/GenerateAccessorHandler.php
+
+		-
+			message: "#^Method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Rpc\\\\GenerateAccessorHandler\\:\\:getPropertyContext\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Extension/CodeTransformExtra/Rpc/GenerateAccessorHandler.php
+
+		-
 			message: "#^Method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Rpc\\\\GenerateAccessorHandler\\:\\:handle\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: lib/Extension/CodeTransformExtra/Rpc/GenerateAccessorHandler.php
@@ -811,22 +616,7 @@ parameters:
 			path: lib/Extension/CodeTransformExtra/Rpc/GenerateAccessorHandler.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Rpc\\\\GenerateAccessorHandler\\:\\:getPropertyContext\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Extension/CodeTransformExtra/Rpc/GenerateAccessorHandler.php
-
-		-
 			message: "#^Method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Rpc\\\\GenerateAccessorHandler\\:\\:handleClass\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Extension/CodeTransformExtra/Rpc/GenerateAccessorHandler.php
-
-		-
-			message: "#^Call to an undefined method Phpactor\\\\Extension\\\\Rpc\\\\Response\\\\Input\\\\ChoiceInput\\:\\:withMultiple\\(\\)\\.$#"
-			count: 1
-			path: lib/Extension/CodeTransformExtra/Rpc/GenerateAccessorHandler.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Rpc\\\\GenerateAccessorHandler\\:\\:propertiesChoices\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: lib/Extension/CodeTransformExtra/Rpc/GenerateAccessorHandler.php
 
@@ -841,14 +631,9 @@ parameters:
 			path: lib/Extension/CodeTransformExtra/Rpc/GenerateAccessorHandler.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Rpc\\\\GenerateMethodHandler\\:\\:handle\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Rpc\\\\GenerateAccessorHandler\\:\\:propertiesChoices\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: lib/Extension/CodeTransformExtra/Rpc/GenerateMethodHandler.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Rpc\\\\GenerateMethodHandler\\:\\:handle\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Extension/CodeTransformExtra/Rpc/GenerateMethodHandler.php
+			path: lib/Extension/CodeTransformExtra/Rpc/GenerateAccessorHandler.php
 
 		-
 			message: "#^Method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Rpc\\\\GenerateMethodHandler\\:\\:determineOriginalSource\\(\\) has no return typehint specified\\.$#"
@@ -861,6 +646,21 @@ parameters:
 			path: lib/Extension/CodeTransformExtra/Rpc/GenerateMethodHandler.php
 
 		-
+			message: "#^Method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Rpc\\\\GenerateMethodHandler\\:\\:handle\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: lib/Extension/CodeTransformExtra/Rpc/GenerateMethodHandler.php
+
+		-
+			message: "#^Method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Rpc\\\\GenerateMethodHandler\\:\\:handle\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Extension/CodeTransformExtra/Rpc/GenerateMethodHandler.php
+
+		-
+			message: "#^Call to an undefined method Phpactor\\\\CodeTransform\\\\Domain\\\\Refactor\\\\ImportClass\\\\NameAlreadyUsedException\\:\\:name\\(\\)\\.$#"
+			count: 2
+			path: lib/Extension/CodeTransformExtra/Rpc/ImportClassHandler.php
+
+		-
 			message: "#^Method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Rpc\\\\ImportClassHandler\\:\\:handle\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: lib/Extension/CodeTransformExtra/Rpc/ImportClassHandler.php
@@ -868,11 +668,6 @@ parameters:
 		-
 			message: "#^Method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Rpc\\\\ImportClassHandler\\:\\:handle\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: lib/Extension/CodeTransformExtra/Rpc/ImportClassHandler.php
-
-		-
-			message: "#^Call to an undefined method Phpactor\\\\CodeTransform\\\\Domain\\\\Refactor\\\\ImportClass\\\\NameAlreadyUsedException\\:\\:name\\(\\)\\.$#"
-			count: 2
 			path: lib/Extension/CodeTransformExtra/Rpc/ImportClassHandler.php
 
 		-
@@ -889,16 +684,6 @@ parameters:
 			message: "#^Method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Rpc\\\\ImportMissingClassesHandler\\:\\:handle\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: lib/Extension/CodeTransformExtra/Rpc/ImportMissingClassesHandler.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Rpc\\\\OverrideMethodHandler\\:\\:handle\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: lib/Extension/CodeTransformExtra/Rpc/OverrideMethodHandler.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Rpc\\\\OverrideMethodHandler\\:\\:handle\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Extension/CodeTransformExtra/Rpc/OverrideMethodHandler.php
 
 		-
 			message: "#^Call to an undefined method Phpactor\\\\Extension\\\\Rpc\\\\Response\\\\Input\\\\ChoiceInput\\:\\:withMultiple\\(\\)\\.$#"
@@ -921,17 +706,27 @@ parameters:
 			path: lib/Extension/CodeTransformExtra/Rpc/OverrideMethodHandler.php
 
 		-
+			message: "#^Method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Rpc\\\\OverrideMethodHandler\\:\\:handle\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: lib/Extension/CodeTransformExtra/Rpc/OverrideMethodHandler.php
+
+		-
+			message: "#^Method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Rpc\\\\OverrideMethodHandler\\:\\:handle\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Extension/CodeTransformExtra/Rpc/OverrideMethodHandler.php
+
+		-
+			message: "#^Method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Rpc\\\\OverrideMethodHandler\\:\\:methodChoices\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: lib/Extension/CodeTransformExtra/Rpc/OverrideMethodHandler.php
+
+		-
 			message: "#^Method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Rpc\\\\OverrideMethodHandler\\:\\:parentClass\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: lib/Extension/CodeTransformExtra/Rpc/OverrideMethodHandler.php
 
 		-
 			message: "#^Strict comparison using \\=\\=\\= between null and Phpactor\\\\WorseReflection\\\\Core\\\\Reflection\\\\ReflectionClass will always evaluate to false\\.$#"
-			count: 1
-			path: lib/Extension/CodeTransformExtra/Rpc/OverrideMethodHandler.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Rpc\\\\OverrideMethodHandler\\:\\:methodChoices\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: lib/Extension/CodeTransformExtra/Rpc/OverrideMethodHandler.php
 
@@ -951,7 +746,7 @@ parameters:
 			path: lib/Extension/CompletionExtra/Application/Complete.php
 
 		-
-			message: "#^Property Phpactor\\\\Extension\\\\CompletionExtra\\\\Command\\\\CompleteCommand\\:\\:\\$complete has unknown class Phpactor\\\\Extension\\\\CompletionExtra\\\\Command\\\\Autocomplete as its type\\.$#"
+			message: "#^Call to method complete\\(\\) on an unknown class Phpactor\\\\Extension\\\\CompletionExtra\\\\Command\\\\Autocomplete\\.$#"
 			count: 1
 			path: lib/Extension/CompletionExtra/Command/CompleteCommand.php
 
@@ -961,17 +756,7 @@ parameters:
 			path: lib/Extension/CompletionExtra/Command/CompleteCommand.php
 
 		-
-			message: "#^Call to method complete\\(\\) on an unknown class Phpactor\\\\Extension\\\\CompletionExtra\\\\Command\\\\Autocomplete\\.$#"
-			count: 1
-			path: lib/Extension/CompletionExtra/Command/CompleteCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$filePath of method Phpactor\\\\Extension\\\\Core\\\\Application\\\\Helper\\\\FilesystemHelper\\:\\:contentsFromFileOrStdin\\(\\) expects string, array\\<string\\>\\|string\\|null given\\.$#"
-			count: 1
-			path: lib/Extension/CompletionExtra/Command/CompleteCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$name of method Phpactor\\\\Extension\\\\Core\\\\Console\\\\Dumper\\\\DumperRegistry\\:\\:get\\(\\) expects string\\|null, array\\<string\\>\\|bool\\|string\\|null given\\.$#"
+			message: "#^Property Phpactor\\\\Extension\\\\CompletionExtra\\\\Command\\\\CompleteCommand\\:\\:\\$complete has unknown class Phpactor\\\\Extension\\\\CompletionExtra\\\\Command\\\\Autocomplete as its type\\.$#"
 			count: 1
 			path: lib/Extension/CompletionExtra/Command/CompleteCommand.php
 
@@ -986,7 +771,7 @@ parameters:
 			path: lib/Extension/CompletionExtra/Rpc/HoverHandler.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\CompletionExtra\\\\Rpc\\\\HoverHandler\\:\\:renderMember\\(\\) never returns null so it can be removed from the return typehint\\.$#"
+			message: "#^Method Phpactor\\\\Extension\\\\CompletionExtra\\\\Rpc\\\\HoverHandler\\:\\:renderClass\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: lib/Extension/CompletionExtra/Rpc/HoverHandler.php
 
@@ -996,12 +781,12 @@ parameters:
 			path: lib/Extension/CompletionExtra/Rpc/HoverHandler.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\CompletionExtra\\\\Rpc\\\\HoverHandler\\:\\:renderVariable\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Phpactor\\\\Extension\\\\CompletionExtra\\\\Rpc\\\\HoverHandler\\:\\:renderMember\\(\\) never returns null so it can be removed from the return typehint\\.$#"
 			count: 1
 			path: lib/Extension/CompletionExtra/Rpc/HoverHandler.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\CompletionExtra\\\\Rpc\\\\HoverHandler\\:\\:renderClass\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Phpactor\\\\Extension\\\\CompletionExtra\\\\Rpc\\\\HoverHandler\\:\\:renderVariable\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: lib/Extension/CompletionExtra/Rpc/HoverHandler.php
 
@@ -1011,22 +796,12 @@ parameters:
 			path: lib/Extension/ContextMenu/ContextMenuExtension.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\ContextMenu\\\\Handler\\\\ContextMenuHandler\\:\\:handle\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Phpactor\\\\Extension\\\\ContextMenu\\\\Handler\\\\ContextMenuHandler\\:\\:actionSelectionAction\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: lib/Extension/ContextMenu/Handler/ContextMenuHandler.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\ContextMenu\\\\Handler\\\\ContextMenuHandler\\:\\:handle\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Extension/ContextMenu/Handler/ContextMenuHandler.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\ContextMenu\\\\Handler\\\\ContextMenuHandler\\:\\:resolveAction\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: lib/Extension/ContextMenu/Handler/ContextMenuHandler.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\ContextMenu\\\\Handler\\\\ContextMenuHandler\\:\\:resolveAction\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
+			message: "#^Method Phpactor\\\\Extension\\\\ContextMenu\\\\Handler\\\\ContextMenuHandler\\:\\:actionSelectionAction\\(\\) has parameter \\$symbolMenu with no typehint specified\\.$#"
 			count: 1
 			path: lib/Extension/ContextMenu/Handler/ContextMenuHandler.php
 
@@ -1041,22 +816,12 @@ parameters:
 			path: lib/Extension/ContextMenu/Handler/ContextMenuHandler.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\ContextMenu\\\\Handler\\\\ContextMenuHandler\\:\\:actionSelectionAction\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
+			message: "#^Method Phpactor\\\\Extension\\\\ContextMenu\\\\Handler\\\\ContextMenuHandler\\:\\:handle\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: lib/Extension/ContextMenu/Handler/ContextMenuHandler.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\ContextMenu\\\\Handler\\\\ContextMenuHandler\\:\\:actionSelectionAction\\(\\) has parameter \\$symbolMenu with no typehint specified\\.$#"
-			count: 1
-			path: lib/Extension/ContextMenu/Handler/ContextMenuHandler.php
-
-		-
-			message: "#^Parameter \\#3 \\$choices of static method Phpactor\\\\Extension\\\\Rpc\\\\Response\\\\Input\\\\ChoiceInput\\:\\:fromNameLabelChoices\\(\\) expects array, array\\<int\\|string, int\\|string\\>\\|false given\\.$#"
-			count: 1
-			path: lib/Extension/ContextMenu/Handler/ContextMenuHandler.php
-
-		-
-			message: "#^Parameter \\#1 \\$keyMap of method Phpactor\\\\Extension\\\\Rpc\\\\Response\\\\Input\\\\ChoiceInput\\:\\:withKeys\\(\\) expects array, array\\<int\\|string, string\\|null\\>\\|false given\\.$#"
+			message: "#^Method Phpactor\\\\Extension\\\\ContextMenu\\\\Handler\\\\ContextMenuHandler\\:\\:handle\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: lib/Extension/ContextMenu/Handler/ContextMenuHandler.php
 
@@ -1081,9 +846,14 @@ parameters:
 			path: lib/Extension/ContextMenu/Handler/ContextMenuHandler.php
 
 		-
-			message: "#^Property Phpactor\\\\Extension\\\\ContextMenu\\\\Model\\\\Action\\:\\:\\$parameters type has no value type specified in iterable type array\\.$#"
+			message: "#^Method Phpactor\\\\Extension\\\\ContextMenu\\\\Handler\\\\ContextMenuHandler\\:\\:resolveAction\\(\\) has no return typehint specified\\.$#"
 			count: 1
-			path: lib/Extension/ContextMenu/Model/Action.php
+			path: lib/Extension/ContextMenu/Handler/ContextMenuHandler.php
+
+		-
+			message: "#^Method Phpactor\\\\Extension\\\\ContextMenu\\\\Handler\\\\ContextMenuHandler\\:\\:resolveAction\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Extension/ContextMenu/Handler/ContextMenuHandler.php
 
 		-
 			message: "#^Method Phpactor\\\\Extension\\\\ContextMenu\\\\Model\\\\Action\\:\\:__construct\\(\\) has parameter \\$parameters with no value type specified in iterable type array\\.$#"
@@ -1096,14 +866,9 @@ parameters:
 			path: lib/Extension/ContextMenu/Model/Action.php
 
 		-
-			message: "#^Property Phpactor\\\\Extension\\\\ContextMenu\\\\Model\\\\ContextMenu\\:\\:\\$actions type has no value type specified in iterable type array\\.$#"
+			message: "#^Property Phpactor\\\\Extension\\\\ContextMenu\\\\Model\\\\Action\\:\\:\\$parameters type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: lib/Extension/ContextMenu/Model/ContextMenu.php
-
-		-
-			message: "#^Property Phpactor\\\\Extension\\\\ContextMenu\\\\Model\\\\ContextMenu\\:\\:\\$contexts type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Extension/ContextMenu/Model/ContextMenu.php
+			path: lib/Extension/ContextMenu/Model/Action.php
 
 		-
 			message: "#^Method Phpactor\\\\Extension\\\\ContextMenu\\\\Model\\\\ContextMenu\\:\\:__construct\\(\\) has parameter \\$actions with no value type specified in iterable type array\\.$#"
@@ -1116,17 +881,22 @@ parameters:
 			path: lib/Extension/ContextMenu/Model/ContextMenu.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\ContextMenu\\\\Model\\\\ContextMenu\\:\\:fromArray\\(\\) has parameter \\$array with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Extension/ContextMenu/Model/ContextMenu.php
-
-		-
 			message: "#^Method Phpactor\\\\Extension\\\\ContextMenu\\\\Model\\\\ContextMenu\\:\\:forContext\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: lib/Extension/ContextMenu/Model/ContextMenu.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\ContextMenu\\\\Model\\\\ContextMenu\\:\\:forContext\\(\\) should return array but returns array\\<Phpactor\\\\Extension\\\\ContextMenu\\\\Model\\\\Action\\>\\|false\\.$#"
+			message: "#^Method Phpactor\\\\Extension\\\\ContextMenu\\\\Model\\\\ContextMenu\\:\\:fromArray\\(\\) has parameter \\$array with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Extension/ContextMenu/Model/ContextMenu.php
+
+		-
+			message: "#^Property Phpactor\\\\Extension\\\\ContextMenu\\\\Model\\\\ContextMenu\\:\\:\\$actions type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Extension/ContextMenu/Model/ContextMenu.php
+
+		-
+			message: "#^Property Phpactor\\\\Extension\\\\ContextMenu\\\\Model\\\\ContextMenu\\:\\:\\$contexts type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: lib/Extension/ContextMenu/Model/ContextMenu.php
 
@@ -1151,11 +921,6 @@ parameters:
 			path: lib/Extension/Core/Application/Helper/FilesystemHelper.php
 
 		-
-			message: "#^Property Phpactor\\\\Extension\\\\Core\\\\Application\\\\Status\\:\\:\\$paths type has no value type specified in iterable type Phpactor\\\\ConfigLoader\\\\Core\\\\PathCandidates\\.$#"
-			count: 1
-			path: lib/Extension/Core/Application/Status.php
-
-		-
 			message: "#^Method Phpactor\\\\Extension\\\\Core\\\\Application\\\\Status\\:\\:__construct\\(\\) has parameter \\$paths with no value type specified in iterable type Phpactor\\\\ConfigLoader\\\\Core\\\\PathCandidates\\.$#"
 			count: 1
 			path: lib/Extension/Core/Application/Status.php
@@ -1176,22 +941,17 @@ parameters:
 			path: lib/Extension/Core/Application/Status.php
 
 		-
+			message: "#^Property Phpactor\\\\Extension\\\\Core\\\\Application\\\\Status\\:\\:\\$paths type has no value type specified in iterable type Phpactor\\\\ConfigLoader\\\\Core\\\\PathCandidates\\.$#"
+			count: 1
+			path: lib/Extension/Core/Application/Status.php
+
+		-
 			message: "#^Property Phpactor\\\\Extension\\\\Core\\\\Command\\\\CacheClearCommand\\:\\:\\$cache has no typehint specified\\.$#"
 			count: 1
 			path: lib/Extension/Core/Command/CacheClearCommand.php
 
 		-
-			message: "#^Property Phpactor\\\\Extension\\\\Core\\\\Command\\\\ConfigDumpCommand\\:\\:\\$config type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Extension/Core/Command/ConfigDumpCommand.php
-
-		-
-			message: "#^Property Phpactor\\\\Extension\\\\Core\\\\Command\\\\ConfigDumpCommand\\:\\:\\$paths has unknown class Phpactor\\\\Config\\\\Paths as its type\\.$#"
-			count: 1
-			path: lib/Extension/Core/Command/ConfigDumpCommand.php
-
-		-
-			message: "#^Property Phpactor\\\\Extension\\\\Core\\\\Command\\\\ConfigDumpCommand\\:\\:\\$expanders type has no value type specified in iterable type Phpactor\\\\FilePathResolver\\\\Expanders\\.$#"
+			message: "#^Iterating over an object of an unknown class Phpactor\\\\Config\\\\Paths\\.$#"
 			count: 1
 			path: lib/Extension/Core/Command/ConfigDumpCommand.php
 
@@ -1211,17 +971,27 @@ parameters:
 			path: lib/Extension/Core/Command/ConfigDumpCommand.php
 
 		-
-			message: "#^Property Phpactor\\\\Extension\\\\Core\\\\Command\\\\ConfigDumpCommand\\:\\:\\$paths \\(Phpactor\\\\Config\\\\Paths\\) does not accept Phpactor\\\\ConfigLoader\\\\Core\\\\PathCandidates\\.$#"
-			count: 1
-			path: lib/Extension/Core/Command/ConfigDumpCommand.php
-
-		-
 			message: "#^Parameter \\#1 \\$messages of method Symfony\\\\Component\\\\Console\\\\Output\\\\OutputInterface\\:\\:writeln\\(\\) expects iterable\\|string, string\\|false given\\.$#"
 			count: 1
 			path: lib/Extension/Core/Command/ConfigDumpCommand.php
 
 		-
-			message: "#^Iterating over an object of an unknown class Phpactor\\\\Config\\\\Paths\\.$#"
+			message: "#^Property Phpactor\\\\Extension\\\\Core\\\\Command\\\\ConfigDumpCommand\\:\\:\\$config type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Extension/Core/Command/ConfigDumpCommand.php
+
+		-
+			message: "#^Property Phpactor\\\\Extension\\\\Core\\\\Command\\\\ConfigDumpCommand\\:\\:\\$expanders type has no value type specified in iterable type Phpactor\\\\FilePathResolver\\\\Expanders\\.$#"
+			count: 1
+			path: lib/Extension/Core/Command/ConfigDumpCommand.php
+
+		-
+			message: "#^Property Phpactor\\\\Extension\\\\Core\\\\Command\\\\ConfigDumpCommand\\:\\:\\$paths \\(Phpactor\\\\Config\\\\Paths\\) does not accept Phpactor\\\\ConfigLoader\\\\Core\\\\PathCandidates\\.$#"
+			count: 1
+			path: lib/Extension/Core/Command/ConfigDumpCommand.php
+
+		-
+			message: "#^Property Phpactor\\\\Extension\\\\Core\\\\Command\\\\ConfigDumpCommand\\:\\:\\$paths has unknown class Phpactor\\\\Config\\\\Paths as its type\\.$#"
 			count: 1
 			path: lib/Extension/Core/Command/ConfigDumpCommand.php
 
@@ -1236,6 +1006,11 @@ parameters:
 			path: lib/Extension/Core/Console/Dumper/Dumper.php
 
 		-
+			message: "#^Method Phpactor\\\\Extension\\\\Core\\\\Console\\\\Dumper\\\\DumperRegistry\\:\\:__construct\\(\\) has parameter \\$dumpers with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Extension/Core/Console/Dumper/DumperRegistry.php
+
+		-
 			message: "#^Property Phpactor\\\\Extension\\\\Core\\\\Console\\\\Dumper\\\\DumperRegistry\\:\\:\\$default has no typehint specified\\.$#"
 			count: 1
 			path: lib/Extension/Core/Console/Dumper/DumperRegistry.php
@@ -1246,22 +1021,17 @@ parameters:
 			path: lib/Extension/Core/Console/Dumper/DumperRegistry.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\Core\\\\Console\\\\Dumper\\\\DumperRegistry\\:\\:__construct\\(\\) has parameter \\$dumpers with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Extension/Core/Console/Dumper/DumperRegistry.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\Core\\\\Console\\\\Dumper\\\\IndentedDumper\\:\\:dump\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Extension/Core/Console/Dumper/IndentedDumper.php
-
-		-
 			message: "#^Method Phpactor\\\\Extension\\\\Core\\\\Console\\\\Dumper\\\\IndentedDumper\\:\\:doDump\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: lib/Extension/Core/Console/Dumper/IndentedDumper.php
 
 		-
 			message: "#^Method Phpactor\\\\Extension\\\\Core\\\\Console\\\\Dumper\\\\IndentedDumper\\:\\:doDump\\(\\) has parameter \\$padding with no typehint specified\\.$#"
+			count: 1
+			path: lib/Extension/Core/Console/Dumper/IndentedDumper.php
+
+		-
+			message: "#^Method Phpactor\\\\Extension\\\\Core\\\\Console\\\\Dumper\\\\IndentedDumper\\:\\:dump\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: lib/Extension/Core/Console/Dumper/IndentedDumper.php
 
@@ -1316,19 +1086,19 @@ parameters:
 			path: lib/Extension/Core/Console/PhpactorCommandLoader.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\Core\\\\Console\\\\Prompt\\\\BashPrompt\\:\\:isSupported\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: lib/Extension/Core/Console/Prompt/BashPrompt.php
-
-		-
 			message: "#^Method Phpactor\\\\Extension\\\\Core\\\\Console\\\\Prompt\\\\BashPrompt\\:\\:getBashPath\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: lib/Extension/Core/Console/Prompt/BashPrompt.php
 
 		-
-			message: "#^Property Phpactor\\\\Extension\\\\Core\\\\Console\\\\Prompt\\\\ChainPrompt\\:\\:\\$prompts has no typehint specified\\.$#"
+			message: "#^Method Phpactor\\\\Extension\\\\Core\\\\Console\\\\Prompt\\\\BashPrompt\\:\\:isSupported\\(\\) has no return typehint specified\\.$#"
 			count: 1
-			path: lib/Extension/Core/Console/Prompt/ChainPrompt.php
+			path: lib/Extension/Core/Console/Prompt/BashPrompt.php
+
+		-
+			message: "#^Method Phpactor\\\\Extension\\\\Core\\\\Console\\\\Prompt\\\\BashPrompt\\:\\:prompt\\(\\) should return string but returns string\\|false\\.$#"
+			count: 1
+			path: lib/Extension/Core/Console/Prompt/BashPrompt.php
 
 		-
 			message: "#^Method Phpactor\\\\Extension\\\\Core\\\\Console\\\\Prompt\\\\ChainPrompt\\:\\:__construct\\(\\) has parameter \\$prompts with no value type specified in iterable type array\\.$#"
@@ -1337,6 +1107,11 @@ parameters:
 
 		-
 			message: "#^Method Phpactor\\\\Extension\\\\Core\\\\Console\\\\Prompt\\\\ChainPrompt\\:\\:isSupported\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: lib/Extension/Core/Console/Prompt/ChainPrompt.php
+
+		-
+			message: "#^Property Phpactor\\\\Extension\\\\Core\\\\Console\\\\Prompt\\\\ChainPrompt\\:\\:\\$prompts has no typehint specified\\.$#"
 			count: 1
 			path: lib/Extension/Core/Console/Prompt/ChainPrompt.php
 
@@ -1354,11 +1129,6 @@ parameters:
 			message: "#^Method Phpactor\\\\Extension\\\\Core\\\\Rpc\\\\CacheClearHandler\\:\\:handle\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: lib/Extension/Core/Rpc/CacheClearHandler.php
-
-		-
-			message: "#^Property Phpactor\\\\Extension\\\\Core\\\\Rpc\\\\ConfigHandler\\:\\:\\$config type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Extension/Core/Rpc/ConfigHandler.php
 
 		-
 			message: "#^Method Phpactor\\\\Extension\\\\Core\\\\Rpc\\\\ConfigHandler\\:\\:__construct\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
@@ -1381,12 +1151,27 @@ parameters:
 			path: lib/Extension/Core/Rpc/ConfigHandler.php
 
 		-
-			message: "#^Property Phpactor\\\\Extension\\\\Core\\\\Rpc\\\\StatusHandler\\:\\:\\$paths type has no value type specified in iterable type Phpactor\\\\ConfigLoader\\\\Core\\\\PathCandidates\\.$#"
+			message: "#^Property Phpactor\\\\Extension\\\\Core\\\\Rpc\\\\ConfigHandler\\:\\:\\$config type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Extension/Core/Rpc/ConfigHandler.php
+
+		-
+			message: "#^Method Phpactor\\\\Extension\\\\Core\\\\Rpc\\\\StatusHandler\\:\\:__construct\\(\\) has parameter \\$paths with no value type specified in iterable type Phpactor\\\\ConfigLoader\\\\Core\\\\PathCandidates\\.$#"
 			count: 1
 			path: lib/Extension/Core/Rpc/StatusHandler.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\Core\\\\Rpc\\\\StatusHandler\\:\\:__construct\\(\\) has parameter \\$paths with no value type specified in iterable type Phpactor\\\\ConfigLoader\\\\Core\\\\PathCandidates\\.$#"
+			message: "#^Method Phpactor\\\\Extension\\\\Core\\\\Rpc\\\\StatusHandler\\:\\:buildConfigFileMessage\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: lib/Extension/Core/Rpc/StatusHandler.php
+
+		-
+			message: "#^Method Phpactor\\\\Extension\\\\Core\\\\Rpc\\\\StatusHandler\\:\\:buildSupportMessage\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: lib/Extension/Core/Rpc/StatusHandler.php
+
+		-
+			message: "#^Method Phpactor\\\\Extension\\\\Core\\\\Rpc\\\\StatusHandler\\:\\:buildSupportMessage\\(\\) has parameter \\$diagnostics with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: lib/Extension/Core/Rpc/StatusHandler.php
 
@@ -1411,24 +1196,9 @@ parameters:
 			path: lib/Extension/Core/Rpc/StatusHandler.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\Core\\\\Rpc\\\\StatusHandler\\:\\:buildSupportMessage\\(\\) has no return typehint specified\\.$#"
+			message: "#^Property Phpactor\\\\Extension\\\\Core\\\\Rpc\\\\StatusHandler\\:\\:\\$paths type has no value type specified in iterable type Phpactor\\\\ConfigLoader\\\\Core\\\\PathCandidates\\.$#"
 			count: 1
 			path: lib/Extension/Core/Rpc/StatusHandler.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\Core\\\\Rpc\\\\StatusHandler\\:\\:buildSupportMessage\\(\\) has parameter \\$diagnostics with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Extension/Core/Rpc/StatusHandler.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\Core\\\\Rpc\\\\StatusHandler\\:\\:buildConfigFileMessage\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: lib/Extension/Core/Rpc/StatusHandler.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\LanguageServer\\\\Service\\\\OnDevelopWarningService\\:\\:services\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Extension/LanguageServer/Service/OnDevelopWarningService.php
 
 		-
 			message: "#^Method Phpactor\\\\Extension\\\\LanguageServer\\\\Service\\\\OnDevelopWarningService\\:\\:serviceAnnouncements\\(\\) return type with generic interface Amp\\\\Promise does not specify its types\\: TValue$#"
@@ -1436,22 +1206,12 @@ parameters:
 			path: lib/Extension/LanguageServer/Service/OnDevelopWarningService.php
 
 		-
-			message: "#^Property Phpactor\\\\Extension\\\\Navigation\\\\Application\\\\Navigator\\:\\:\\$autoCreateConfig type has no value type specified in iterable type array\\.$#"
+			message: "#^Method Phpactor\\\\Extension\\\\LanguageServer\\\\Service\\\\OnDevelopWarningService\\:\\:services\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: lib/Extension/Navigation/Application/Navigator.php
+			path: lib/Extension/LanguageServer/Service/OnDevelopWarningService.php
 
 		-
 			message: "#^Method Phpactor\\\\Extension\\\\Navigation\\\\Application\\\\Navigator\\:\\:__construct\\(\\) has parameter \\$autoCreateConfig with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Extension/Navigation/Application/Navigator.php
-
-		-
-			message: "#^Property Phpactor\\\\Extension\\\\Navigation\\\\Application\\\\Navigator\\:\\:\\$navigator \\(Phpactor\\\\Extension\\\\Navigation\\\\Application\\\\Navigator\\) does not accept Phpactor\\\\Extension\\\\Navigation\\\\Navigator\\\\Navigator\\.$#"
-			count: 1
-			path: lib/Extension/Navigation/Application/Navigator.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\Navigation\\\\Application\\\\Navigator\\:\\:destinationsFor\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: lib/Extension/Navigation/Application/Navigator.php
 
@@ -1466,7 +1226,22 @@ parameters:
 			path: lib/Extension/Navigation/Application/Navigator.php
 
 		-
+			message: "#^Method Phpactor\\\\Extension\\\\Navigation\\\\Application\\\\Navigator\\:\\:destinationsFor\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: lib/Extension/Navigation/Application/Navigator.php
+
+		-
 			message: "#^Method Phpactor\\\\Extension\\\\Navigation\\\\Application\\\\Navigator\\:\\:variant\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: lib/Extension/Navigation/Application/Navigator.php
+
+		-
+			message: "#^Property Phpactor\\\\Extension\\\\Navigation\\\\Application\\\\Navigator\\:\\:\\$autoCreateConfig type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Extension/Navigation/Application/Navigator.php
+
+		-
+			message: "#^Property Phpactor\\\\Extension\\\\Navigation\\\\Application\\\\Navigator\\:\\:\\$navigator \\(Phpactor\\\\Extension\\\\Navigation\\\\Application\\\\Navigator\\) does not accept Phpactor\\\\Extension\\\\Navigation\\\\Navigator\\\\Navigator\\.$#"
 			count: 1
 			path: lib/Extension/Navigation/Application/Navigator.php
 
@@ -1477,11 +1252,6 @@ parameters:
 
 		-
 			message: "#^Method Phpactor\\\\Extension\\\\Navigation\\\\Handler\\\\NavigateHandler\\:\\:handle\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Extension/Navigation/Handler/NavigateHandler.php
-
-		-
-			message: "#^Parameter \\#3 \\$choices of static method Phpactor\\\\Extension\\\\Rpc\\\\Response\\\\Input\\\\ChoiceInput\\:\\:fromNameLabelChoices\\(\\) expects array, array\\<int\\|string, int\\|string\\>\\|false given\\.$#"
 			count: 1
 			path: lib/Extension/Navigation/Handler/NavigateHandler.php
 
@@ -1531,21 +1301,6 @@ parameters:
 			path: lib/Extension/Navigation/Navigator/WorseReflectionNavigator.php
 
 		-
-			message: "#^Parameter \\#1 \\$filesystemName of method Phpactor\\\\Extension\\\\SourceCodeFilesystemExtra\\\\SourceCodeFilestem\\\\Application\\\\ClassSearch\\:\\:classSearch\\(\\) expects string, array\\<string\\>\\|bool\\|string\\|null given\\.$#"
-			count: 1
-			path: lib/Extension/SourceCodeFilesystemExtra/Command/ClassSearchCommand.php
-
-		-
-			message: "#^Parameter \\#2 \\$name of method Phpactor\\\\Extension\\\\SourceCodeFilesystemExtra\\\\SourceCodeFilestem\\\\Application\\\\ClassSearch\\:\\:classSearch\\(\\) expects string, array\\<string\\>\\|string\\|null given\\.$#"
-			count: 1
-			path: lib/Extension/SourceCodeFilesystemExtra/Command/ClassSearchCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$name of method Phpactor\\\\Extension\\\\Core\\\\Console\\\\Dumper\\\\DumperRegistry\\:\\:get\\(\\) expects string\\|null, array\\<string\\>\\|bool\\|string\\|null given\\.$#"
-			count: 1
-			path: lib/Extension/SourceCodeFilesystemExtra/Command/ClassSearchCommand.php
-
-		-
 			message: "#^Method Phpactor\\\\Extension\\\\SourceCodeFilesystemExtra\\\\Rpc\\\\ClassSearchHandler\\:\\:handle\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: lib/Extension/SourceCodeFilesystemExtra/Rpc/ClassSearchHandler.php
@@ -1556,27 +1311,7 @@ parameters:
 			path: lib/Extension/SourceCodeFilesystemExtra/Rpc/ClassSearchHandler.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\SourceCodeFilesystemExtra\\\\SourceCodeFilestem\\\\Application\\\\ClassSearch\\:\\:classSearch\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: lib/Extension/SourceCodeFilesystemExtra/SourceCodeFilestem/Application/ClassSearch.php
-
-		-
-			message: "#^Method Phpactor\\\\Filesystem\\\\Domain\\\\Filesystem\\:\\:fileList\\(\\) invoked with 1 parameter, 0 required\\.$#"
-			count: 1
-			path: lib/Extension/SourceCodeFilesystemExtra/SourceCodeFilestem/Application/ClassSearch.php
-
-		-
-			message: "#^PHPDoc tag @var for variable \\$files contains unknown class Phpactor\\\\Extension\\\\SourceCodeFilesystemExtra\\\\SourceCodeFilestem\\\\Application\\\\FileList\\.$#"
-			count: 1
-			path: lib/Extension/SourceCodeFilesystemExtra/SourceCodeFilestem/Application/ClassSearch.php
-
-		-
 			message: "#^Iterating over an object of an unknown class Phpactor\\\\Extension\\\\SourceCodeFilesystemExtra\\\\SourceCodeFilestem\\\\Application\\\\FileList\\.$#"
-			count: 1
-			path: lib/Extension/SourceCodeFilesystemExtra/SourceCodeFilestem/Application/ClassSearch.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\SourceCodeFilesystemExtra\\\\SourceCodeFilestem\\\\Application\\\\ClassSearch\\:\\:tryAndReflect\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: lib/Extension/SourceCodeFilesystemExtra/SourceCodeFilestem/Application/ClassSearch.php
 
@@ -1591,12 +1326,7 @@ parameters:
 			path: lib/Extension/SourceCodeFilesystemExtra/SourceCodeFilestem/Application/ClassSearch.php
 
 		-
-			message: "#^Parameter \\#3 \\$length of function substr expects int, int\\<0, max\\>\\|false given\\.$#"
-			count: 1
-			path: lib/Extension/SourceCodeFilesystemExtra/SourceCodeFilestem/Application/ClassSearch.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\SourceCodeFilesystemExtra\\\\SourceCodeFilestem\\\\Application\\\\ClassSearch\\:\\:resolveShortName\\(\\) has parameter \\$declaredClass with no typehint specified\\.$#"
+			message: "#^Method Phpactor\\\\Extension\\\\SourceCodeFilesystemExtra\\\\SourceCodeFilestem\\\\Application\\\\ClassSearch\\:\\:classSearch\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: lib/Extension/SourceCodeFilesystemExtra/SourceCodeFilestem/Application/ClassSearch.php
 
@@ -1606,12 +1336,32 @@ parameters:
 			path: lib/Extension/SourceCodeFilesystemExtra/SourceCodeFilestem/Application/ClassSearch.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\WorseReflectionExtra\\\\Application\\\\ClassReflector\\:\\:reflect\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: "#^Method Phpactor\\\\Extension\\\\SourceCodeFilesystemExtra\\\\SourceCodeFilestem\\\\Application\\\\ClassSearch\\:\\:resolveShortName\\(\\) has parameter \\$declaredClass with no typehint specified\\.$#"
 			count: 1
-			path: lib/Extension/WorseReflectionExtra/Application/ClassReflector.php
+			path: lib/Extension/SourceCodeFilesystemExtra/SourceCodeFilestem/Application/ClassSearch.php
 
 		-
-			message: "#^PHPDoc tag @var has invalid value \\(\\$method ReflectionMethod\\)\\: Unexpected token \"\\$method\", expected type at offset 9$#"
+			message: "#^Method Phpactor\\\\Extension\\\\SourceCodeFilesystemExtra\\\\SourceCodeFilestem\\\\Application\\\\ClassSearch\\:\\:tryAndReflect\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: lib/Extension/SourceCodeFilesystemExtra/SourceCodeFilestem/Application/ClassSearch.php
+
+		-
+			message: "#^Method Phpactor\\\\Filesystem\\\\Domain\\\\Filesystem\\:\\:fileList\\(\\) invoked with 1 parameter, 0 required\\.$#"
+			count: 1
+			path: lib/Extension/SourceCodeFilesystemExtra/SourceCodeFilestem/Application/ClassSearch.php
+
+		-
+			message: "#^PHPDoc tag @var for variable \\$files contains unknown class Phpactor\\\\Extension\\\\SourceCodeFilesystemExtra\\\\SourceCodeFilestem\\\\Application\\\\FileList\\.$#"
+			count: 1
+			path: lib/Extension/SourceCodeFilesystemExtra/SourceCodeFilestem/Application/ClassSearch.php
+
+		-
+			message: "#^Parameter \\#3 \\$length of function substr expects int\\|null, int\\|false given\\.$#"
+			count: 1
+			path: lib/Extension/SourceCodeFilesystemExtra/SourceCodeFilestem/Application/ClassSearch.php
+
+		-
+			message: "#^Call to an undefined method Phpactor\\\\WorseReflection\\\\Core\\\\Reflection\\\\ReflectionClassLike\\:\\:constants\\(\\)\\.$#"
 			count: 1
 			path: lib/Extension/WorseReflectionExtra/Application/ClassReflector.php
 
@@ -1631,17 +1381,12 @@ parameters:
 			path: lib/Extension/WorseReflectionExtra/Application/ClassReflector.php
 
 		-
-			message: "#^PHPDoc tag @var has invalid value \\(\\$parameter ReflectionParameter\\)\\: Unexpected token \"\\$parameter\", expected type at offset 9$#"
-			count: 1
-			path: lib/Extension/WorseReflectionExtra/Application/ClassReflector.php
-
-		-
 			message: "#^Call to an undefined method Phpactor\\\\WorseReflection\\\\Core\\\\Reflection\\\\ReflectionMember\\:\\:returnType\\(\\)\\.$#"
 			count: 1
 			path: lib/Extension/WorseReflectionExtra/Application/ClassReflector.php
 
 		-
-			message: "#^Call to an undefined method Phpactor\\\\WorseReflection\\\\Core\\\\Reflection\\\\ReflectionClassLike\\:\\:constants\\(\\)\\.$#"
+			message: "#^Method Phpactor\\\\Extension\\\\WorseReflectionExtra\\\\Application\\\\ClassReflector\\:\\:reflect\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: lib/Extension/WorseReflectionExtra/Application/ClassReflector.php
 
@@ -1651,27 +1396,27 @@ parameters:
 			path: lib/Extension/WorseReflectionExtra/Application/ClassReflector.php
 
 		-
+			message: "#^PHPDoc tag @var has invalid value \\(\\$method ReflectionMethod\\)\\: Unexpected token \"\\$method\", expected type at offset 9$#"
+			count: 1
+			path: lib/Extension/WorseReflectionExtra/Application/ClassReflector.php
+
+		-
+			message: "#^PHPDoc tag @var has invalid value \\(\\$parameter ReflectionParameter\\)\\: Unexpected token \"\\$parameter\", expected type at offset 9$#"
+			count: 1
+			path: lib/Extension/WorseReflectionExtra/Application/ClassReflector.php
+
+		-
 			message: "#^PHPDoc tag @var has invalid value \\(\\$property ReflectionProperty\\)\\: Unexpected token \"\\$property\", expected type at offset 9$#"
 			count: 1
 			path: lib/Extension/WorseReflectionExtra/Application/ClassReflector.php
 
 		-
-			message: "#^Property Phpactor\\\\Extension\\\\WorseReflectionExtra\\\\Application\\\\OffsetInfo\\:\\:\\$filesystemHelper has unknown class Phpactor\\\\Extension\\\\WorseReflectionExtra\\\\Application\\\\Helper\\\\FilesystemHelper as its type\\.$#"
-			count: 1
+			message: "#^Call to method classToFile\\(\\) on an unknown class Phpactor\\\\Extension\\\\WorseReflectionExtra\\\\Application\\\\Helper\\\\ClassFileNormalizer\\.$#"
+			count: 2
 			path: lib/Extension/WorseReflectionExtra/Application/OffsetInfo.php
 
 		-
-			message: "#^Property Phpactor\\\\Extension\\\\WorseReflectionExtra\\\\Application\\\\OffsetInfo\\:\\:\\$classFileNormalizer has unknown class Phpactor\\\\Extension\\\\WorseReflectionExtra\\\\Application\\\\Helper\\\\ClassFileNormalizer as its type\\.$#"
-			count: 1
-			path: lib/Extension/WorseReflectionExtra/Application/OffsetInfo.php
-
-		-
-			message: "#^Property Phpactor\\\\Extension\\\\WorseReflectionExtra\\\\Application\\\\OffsetInfo\\:\\:\\$classFileNormalizer \\(Phpactor\\\\Extension\\\\WorseReflectionExtra\\\\Application\\\\Helper\\\\ClassFileNormalizer\\) does not accept Phpactor\\\\Extension\\\\Core\\\\Application\\\\Helper\\\\ClassFileNormalizer\\.$#"
-			count: 1
-			path: lib/Extension/WorseReflectionExtra/Application/OffsetInfo.php
-
-		-
-			message: "#^Property Phpactor\\\\Extension\\\\WorseReflectionExtra\\\\Application\\\\OffsetInfo\\:\\:\\$filesystemHelper \\(Phpactor\\\\Extension\\\\WorseReflectionExtra\\\\Application\\\\Helper\\\\FilesystemHelper\\) does not accept Phpactor\\\\Extension\\\\Core\\\\Application\\\\Helper\\\\FilesystemHelper\\.$#"
+			message: "#^Call to method contentsFromFileOrStdin\\(\\) on an unknown class Phpactor\\\\Extension\\\\WorseReflectionExtra\\\\Application\\\\Helper\\\\FilesystemHelper\\.$#"
 			count: 1
 			path: lib/Extension/WorseReflectionExtra/Application/OffsetInfo.php
 
@@ -1686,32 +1431,32 @@ parameters:
 			path: lib/Extension/WorseReflectionExtra/Application/OffsetInfo.php
 
 		-
-			message: "#^Call to method contentsFromFileOrStdin\\(\\) on an unknown class Phpactor\\\\Extension\\\\WorseReflectionExtra\\\\Application\\\\Helper\\\\FilesystemHelper\\.$#"
-			count: 1
-			path: lib/Extension/WorseReflectionExtra/Application/OffsetInfo.php
-
-		-
 			message: "#^PHPDoc tag @var has invalid value \\(\\$local Variable\\)\\: Unexpected token \"\\$local\", expected type at offset 9$#"
 			count: 1
 			path: lib/Extension/WorseReflectionExtra/Application/OffsetInfo.php
 
 		-
-			message: "#^Call to method classToFile\\(\\) on an unknown class Phpactor\\\\Extension\\\\WorseReflectionExtra\\\\Application\\\\Helper\\\\ClassFileNormalizer\\.$#"
-			count: 2
+			message: "#^Property Phpactor\\\\Extension\\\\WorseReflectionExtra\\\\Application\\\\OffsetInfo\\:\\:\\$classFileNormalizer \\(Phpactor\\\\Extension\\\\WorseReflectionExtra\\\\Application\\\\Helper\\\\ClassFileNormalizer\\) does not accept Phpactor\\\\Extension\\\\Core\\\\Application\\\\Helper\\\\ClassFileNormalizer\\.$#"
+			count: 1
 			path: lib/Extension/WorseReflectionExtra/Application/OffsetInfo.php
 
 		-
-			message: "#^Parameter \\#1 \\$classOrFile of method Phpactor\\\\Extension\\\\WorseReflectionExtra\\\\Application\\\\ClassReflector\\:\\:reflect\\(\\) expects string, array\\<string\\>\\|string\\|null given\\.$#"
+			message: "#^Property Phpactor\\\\Extension\\\\WorseReflectionExtra\\\\Application\\\\OffsetInfo\\:\\:\\$classFileNormalizer has unknown class Phpactor\\\\Extension\\\\WorseReflectionExtra\\\\Application\\\\Helper\\\\ClassFileNormalizer as its type\\.$#"
 			count: 1
-			path: lib/Extension/WorseReflectionExtra/Command/ClassReflectorCommand.php
+			path: lib/Extension/WorseReflectionExtra/Application/OffsetInfo.php
 
 		-
-			message: "#^Parameter \\#1 \\$name of method Phpactor\\\\Extension\\\\Core\\\\Console\\\\Dumper\\\\DumperRegistry\\:\\:get\\(\\) expects string\\|null, array\\<string\\>\\|bool\\|string\\|null given\\.$#"
+			message: "#^Property Phpactor\\\\Extension\\\\WorseReflectionExtra\\\\Application\\\\OffsetInfo\\:\\:\\$filesystemHelper \\(Phpactor\\\\Extension\\\\WorseReflectionExtra\\\\Application\\\\Helper\\\\FilesystemHelper\\) does not accept Phpactor\\\\Extension\\\\Core\\\\Application\\\\Helper\\\\FilesystemHelper\\.$#"
 			count: 1
-			path: lib/Extension/WorseReflectionExtra/Command/ClassReflectorCommand.php
+			path: lib/Extension/WorseReflectionExtra/Application/OffsetInfo.php
 
 		-
-			message: "#^Property Phpactor\\\\Extension\\\\WorseReflectionExtra\\\\Command\\\\OffsetInfoCommand\\:\\:\\$infoForOffset has unknown class Phpactor\\\\Extension\\\\WorseReflectionExtra\\\\Command\\\\FileInfoAtOffset as its type\\.$#"
+			message: "#^Property Phpactor\\\\Extension\\\\WorseReflectionExtra\\\\Application\\\\OffsetInfo\\:\\:\\$filesystemHelper has unknown class Phpactor\\\\Extension\\\\WorseReflectionExtra\\\\Application\\\\Helper\\\\FilesystemHelper as its type\\.$#"
+			count: 1
+			path: lib/Extension/WorseReflectionExtra/Application/OffsetInfo.php
+
+		-
+			message: "#^Call to method infoForOffset\\(\\) on an unknown class Phpactor\\\\Extension\\\\WorseReflectionExtra\\\\Command\\\\FileInfoAtOffset\\.$#"
 			count: 1
 			path: lib/Extension/WorseReflectionExtra/Command/OffsetInfoCommand.php
 
@@ -1721,12 +1466,7 @@ parameters:
 			path: lib/Extension/WorseReflectionExtra/Command/OffsetInfoCommand.php
 
 		-
-			message: "#^Call to method infoForOffset\\(\\) on an unknown class Phpactor\\\\Extension\\\\WorseReflectionExtra\\\\Command\\\\FileInfoAtOffset\\.$#"
-			count: 1
-			path: lib/Extension/WorseReflectionExtra/Command/OffsetInfoCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$name of method Phpactor\\\\Extension\\\\Core\\\\Console\\\\Dumper\\\\DumperRegistry\\:\\:get\\(\\) expects string\\|null, array\\<string\\>\\|bool\\|string\\|null given\\.$#"
+			message: "#^Property Phpactor\\\\Extension\\\\WorseReflectionExtra\\\\Command\\\\OffsetInfoCommand\\:\\:\\$infoForOffset has unknown class Phpactor\\\\Extension\\\\WorseReflectionExtra\\\\Command\\\\FileInfoAtOffset as its type\\.$#"
 			count: 1
 			path: lib/Extension/WorseReflectionExtra/Command/OffsetInfoCommand.php
 
@@ -1741,29 +1481,14 @@ parameters:
 			path: lib/Extension/WorseReflectionExtra/Rpc/OffsetInfoHandler.php
 
 		-
-			message: "#^Parameter \\#1 \\$information of static method Phpactor\\\\Extension\\\\Rpc\\\\Response\\\\InformationResponse\\:\\:fromString\\(\\) expects string, string\\|false given\\.$#"
-			count: 1
-			path: lib/Extension/WorseReflectionExtra/Rpc/OffsetInfoHandler.php
-
-		-
 			message: "#^Method Phpactor\\\\Extension\\\\WorseReflectionExtra\\\\Rpc\\\\OffsetInfoHandler\\:\\:serialize\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: lib/Extension/WorseReflectionExtra/Rpc/OffsetInfoHandler.php
 
 		-
-			message: "#^Parameter \\#2 \\$needle of function strpos expects int\\|string, string\\|false given\\.$#"
+			message: "#^Parameter \\#1 \\$information of static method Phpactor\\\\Extension\\\\Rpc\\\\Response\\\\InformationResponse\\:\\:fromString\\(\\) expects string, string\\|false given\\.$#"
 			count: 1
-			path: lib/Phpactor.php
-
-		-
-			message: "#^Parameter \\#1 \\$string of function strlen expects string, string\\|false given\\.$#"
-			count: 1
-			path: lib/Phpactor.php
-
-		-
-			message: "#^Method Phpactor\\\\Phpactor\\:\\:isFile\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: lib/Phpactor.php
+			path: lib/Extension/WorseReflectionExtra/Rpc/OffsetInfoHandler.php
 
 		-
 			message: "#^Method Phpactor\\\\Phpactor\\:\\:configureExtensionManager\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
@@ -1776,12 +1501,22 @@ parameters:
 			path: lib/Phpactor.php
 
 		-
-			message: "#^Parameter \\#1 \\$filename of function is_dir expects string, string\\|false given\\.$#"
+			message: "#^Method Phpactor\\\\Phpactor\\:\\:isFile\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: lib/Phpactor.php
 
 		-
 			message: "#^Method Phpactor\\\\Phpactor\\:\\:resolveApplicationRoot\\(\\) should return string but returns string\\|false\\.$#"
+			count: 1
+			path: lib/Phpactor.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function is_dir expects string, string\\|false given\\.$#"
+			count: 1
+			path: lib/Phpactor.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function strlen expects string, string\\|false given\\.$#"
 			count: 1
 			path: lib/Phpactor.php
 

--- a/tests/Unit/Extension/CodeTransformExtra/Rpc/ExtractExpressionHandlerTest.php
+++ b/tests/Unit/Extension/CodeTransformExtra/Rpc/ExtractExpressionHandlerTest.php
@@ -6,7 +6,6 @@ use Phpactor\CodeTransform\Domain\Refactor\ExtractExpression;
 use Phpactor\Extension\CodeTransformExtra\Rpc\ExtractExpressionHandler;
 use Phpactor\Extension\Rpc\Handler;
 use Phpactor\Extension\Rpc\Response\InputCallbackResponse;
-use Phpactor\CodeTransform\Domain\SourceCode;
 use Phpactor\Extension\Rpc\Response\UpdateFileSourceResponse;
 use Phpactor\Extension\Rpc\Response\Input\TextInput;
 use Phpactor\Tests\Unit\Extension\Rpc\HandlerTestCase;

--- a/tests/Unit/Extension/CodeTransformExtra/Rpc/ExtractMethodHandlerTest.php
+++ b/tests/Unit/Extension/CodeTransformExtra/Rpc/ExtractMethodHandlerTest.php
@@ -4,7 +4,6 @@ namespace Phpactor\Tests\Unit\Extension\CodeTransformExtra\Rpc;
 
 use Phpactor\Extension\Rpc\Handler;
 use Phpactor\Extension\Rpc\Response\InputCallbackResponse;
-use Phpactor\CodeTransform\Domain\SourceCode;
 use Phpactor\Extension\Rpc\Response\UpdateFileSourceResponse;
 use Phpactor\CodeTransform\Domain\Refactor\ExtractMethod;
 use Phpactor\Extension\CodeTransformExtra\Rpc\ExtractMethodHandler;


### PR DESCRIPTION
This PR introduces:

- The generation of a JSON schema post-install.
- Command to create a new `.phpactor.json` file or update/add the schema location in an existing one.