### PR TITLE
Update reference.rst

### DIFF
--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -7,4 +7,3 @@ Reference
 
    reference/*
    language-server
-   reference/indexer


### PR DESCRIPTION
This is a simple cosmetic fix. 

The item "Indexer" is shown twice under the "Reference" section due to it being included 
by `reference/*` and explicitly as `reference/indexer`, which is dropped by this PR.