### PR TITLE
Fix class move issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Bug fixes:
   - [wr] detect branch determination with throw expression
   - [cr] add missing properties: correctly infer type from call expressions
   - [filesystem] Fix "too many files open" issue #1376
+  - [class-mover] Fix long standing bug with aliased imports being duplicated
+    on class move and other strange issues.
 
 Improvements:
 

--- a/lib/ClassMover/Domain/Reference/ClassReference.php
+++ b/lib/ClassMover/Domain/Reference/ClassReference.php
@@ -17,6 +17,10 @@ final class ClassReference
 
     private $importedNameRef;
 
+    private bool $hasAlias = false;
+
+    private bool $isImport = false;
+
     public function __toString()
     {
         return (string) $this->fullName;
@@ -27,7 +31,9 @@ final class ClassReference
         FullyQualifiedName $fullName,
         Position $position,
         ImportedNameReference $importedNameRef,
-        bool $isClassDeclaration = false
+        bool $isClassDeclaration = false,
+        bool $hasAlias = false,
+        bool $isImport = false
     ) {
         $new = new self();
         $new->position = $position;
@@ -35,6 +41,8 @@ final class ClassReference
         $new->fullName = $fullName;
         $new->importedNameRef = $importedNameRef;
         $new->isClassDeclaration = $isClassDeclaration;
+        $new->hasAlias = $hasAlias;
+        $new->isImport = $isImport;
 
         return $new;
     }
@@ -62,5 +70,15 @@ final class ClassReference
     public function isClassDeclaration(): bool
     {
         return $this->isClassDeclaration;
+    }
+
+    public function hasAlias(): bool
+    {
+        return $this->hasAlias;
+    }
+
+    public function isImport(): bool
+    {
+        return $this->isImport;
     }
 }

--- a/lib/ClassMover/Tests/Adapter/TolerantParser/TolerantClassReplacerTest.php
+++ b/lib/ClassMover/Tests/Adapter/TolerantParser/TolerantClassReplacerTest.php
@@ -35,7 +35,7 @@ class TolerantClassReplacerTest extends TestCase
                 return $line !== '';
             }));
         };
-        $this->assertStringContainsString($stripEmptyLines($expectedSource), $stripEmptyLines($edits->apply($source->__toString())));
+        self::assertStringContainsString($stripEmptyLines($expectedSource), $stripEmptyLines($edits->apply($source->__toString())));
     }
 
     public function provideTestFind()
@@ -46,6 +46,8 @@ class TolerantClassReplacerTest extends TestCase
                 'Acme\\Foobar\\Warble',
                 'BarBar\\Hello',
                 <<<'EOT'
+                    <?php
+                    namespace Acme;
                     use BarBar\Hello;
                     use Acme\Foobar\Barfoo;
                     use Acme\Barfoo as ZedZed;
@@ -62,6 +64,7 @@ class TolerantClassReplacerTest extends TestCase
                 'Acme\\Hello',
                 'Acme\\Definee',
                 <<<'EOT'
+                    <?php
                     namespace Acme;
 
                     use Acme\Foobar\Warble;
@@ -90,6 +93,7 @@ class TolerantClassReplacerTest extends TestCase
                 'Acme\\Barfoo',
                 'Acme\\Definee\\Barfoo',
                 <<<'EOT'
+                    <?php
                     namespace Acme;
 
                     use Acme\Definee\Barfoo;
@@ -116,6 +120,7 @@ class TolerantClassReplacerTest extends TestCase
                 'Phpactor\ClassMover\Tests\Adapter\TolerantParser\Example5Interface',
                 'Phpactor\ClassMover\Tests\Adapter\TolerantParser\BarBar\FoobarInterface',
                 <<<'EOT'
+                    <?php
                     namespace Phpactor\ClassMover\Tests\Adapter\TolerantParser\BarBar;
                     EOT
             ],
@@ -132,7 +137,16 @@ class TolerantClassReplacerTest extends TestCase
                 'Acme\\ClassMover\\RefFinder\\RefFinder\\TolerantRefFinder',
                 'Acme\\ClassMover\\RefFinder\\RefFinder\\Foobar',
                 <<<'EOT'
-                    Foobar::class
+                    <?php
+                    namespace Acme;
+                    use Acme\ClassMover\RefFinder\RefFinder\Foobar;
+                    class Hello
+                    {
+                        public function something(): void
+                        {
+                            Foobar::class;
+                        }
+                    }
                     EOT
             ],
             'Class which includes use statement for itself' => [
@@ -148,6 +162,7 @@ class TolerantClassReplacerTest extends TestCase
                 'ClassOne',
                 'Phpactor\ClassMover\Example8',
                 <<<'EOT'
+                    <?php
                     namespace Phpactor\ClassMover;
 
 
@@ -165,12 +180,40 @@ class TolerantClassReplacerTest extends TestCase
                 'Example',
                 'Phpactor\ClassMover\Example',
                 <<<'EOT'
+                    <?php
 
                     use Phpactor\ClassMover\Example;
 
                     class ClassOne
                     {
                         public function build(): Example
+                    EOT
+            ],
+            'Aliased class' => [
+                'Example10.php',
+                'Foobar\Example',
+                'Phpactor\ClassMover\Example',
+                <<<'EOT'
+                    <?php
+
+                    use Phpactor\ClassMover\Example as BadExample;
+
+                    class ClassOne
+                    {
+                        public function build(): BadExample
+                    EOT
+            ],
+            'Aliased class named the same' => [
+                'Example11.php',
+                'Foobar\Example',
+                'Phpactor\ClassMover\Example',
+                <<<'EOT'
+                    <?php
+
+                    use Phpactor\ClassMover\Example as BadExample;
+                    class Example extends BadExample
+                    {
+                    }
                     EOT
             ],
         ];

--- a/lib/ClassMover/Tests/Adapter/TolerantParser/examples/Example10.php
+++ b/lib/ClassMover/Tests/Adapter/TolerantParser/examples/Example10.php
@@ -1,0 +1,10 @@
+<?php
+
+use Foobar\Example as BadExample;
+
+class ClassOne
+{
+    public function build(): BadExample
+    {
+    }
+}

--- a/lib/ClassMover/Tests/Adapter/TolerantParser/examples/Example11.php
+++ b/lib/ClassMover/Tests/Adapter/TolerantParser/examples/Example11.php
@@ -1,0 +1,7 @@
+<?php
+
+use Foobar\Example as BadExample;
+
+class Example extends BadExample
+{
+}


### PR DESCRIPTION
This PR fixes some long-standing (5 year) bugs with the class mover.

- It does not try and re-import imported classes
- Will not re-import aliased classes