### PR TITLE
bugfix: Fix nullable parameter types

### DIFF
--- a/lib/WorseReflection/Core/Util/NodeUtil.php
+++ b/lib/WorseReflection/Core/Util/NodeUtil.php
@@ -10,6 +10,21 @@ use Microsoft\PhpParser\Token;
 class NodeUtil
 {
     /**
+     * @param Token|Node|mixed $nodeOrToken
+     */
+    public static function nameFromTokenOrNode(Node $node, $nodeOrToken): string
+    {
+        if ($nodeOrToken instanceof Token) {
+            return (string)$nodeOrToken->getText($node->getFileContents());
+        }
+        if ($nodeOrToken instanceof Node) {
+            return (string)$nodeOrToken->getText();
+        }
+
+        return '';
+    }
+
+    /**
      * @param Token|QualifiedName|mixed $name
      */
     public static function nameFromTokenOrQualifiedName(Node $node, $name): string

--- a/lib/WorseReflection/Tests/SelfTest/SelfTest.php
+++ b/lib/WorseReflection/Tests/SelfTest/SelfTest.php
@@ -27,6 +27,7 @@ class SelfTest extends IntegrationTestCase
     public function provideSelf(): Generator
     {
         foreach ([
+            'flow',
             'generics',
         ] as $topic) {
             foreach ((array)glob(__DIR__ . '/' . $topic . '/*.test') as $fname) {

--- a/lib/WorseReflection/Tests/SelfTest/flow/assert.test
+++ b/lib/WorseReflection/Tests/SelfTest/flow/assert.test
@@ -1,0 +1,9 @@
+<?php
+
+namespace Foo;
+
+function foo($foo) {
+    assert($foo instanceof Bar);
+    wrAssertType('Foo\Bar', $foo);
+}
+

--- a/lib/WorseReflection/Tests/SelfTest/flow/function_params.test
+++ b/lib/WorseReflection/Tests/SelfTest/flow/function_params.test
@@ -1,0 +1,7 @@
+<?php
+
+function foo(?Foo $foo = null) {
+    wrAssertType('?Foo', $foo);
+}
+
+

--- a/lib/WorseReflection/Tests/SelfTest/flow/if_remove_null_type1.test
+++ b/lib/WorseReflection/Tests/SelfTest/flow/if_remove_null_type1.test
@@ -1,0 +1,11 @@
+<?php
+
+function foo(?string $foo) {
+    if (!$foo) {
+        return;
+    }
+
+    // @todo the null type should be stripped
+    wrAssertType('?string', $foo);
+}
+

--- a/lib/WorseReflection/Tests/SelfTest/flow/if_remove_null_type2.test
+++ b/lib/WorseReflection/Tests/SelfTest/flow/if_remove_null_type2.test
@@ -1,0 +1,11 @@
+<?php
+
+function foo(?Foo $foo = null) {
+    if (null === $foo) {
+        return;
+    }
+
+    // @todo the null type should be stripped
+    wrAssertType('?Foo', $foo);
+}
+


### PR DESCRIPTION
Perform completion on nullable members. The new type system confused the class member completor and it was not completing nullable types.

In the medium term the type inference system needs to be updated to properly support type subtraction.