### PR TITLE
bugfix: Fix behavior where located source not containing thing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Bug fixes:
   - [class-mover] Fix long standing bug with aliased imports being duplicated
     on class move and other strange issues.
   - [lsp] Fix call to properties() on non-class in generate accessors provider.
+  - [lsp] Fix unresolvable classes not being listed in code actions
 
 Improvements:
 

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Helper/WorseUnresolvableClassNameFinderTest.php
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Helper/WorseUnresolvableClassNameFinderTest.php
@@ -10,6 +10,9 @@ use Phpactor\CodeTransform\Tests\Adapter\WorseReflection\WorseTestCase;
 use Phpactor\Name\QualifiedName;
 use Phpactor\TextDocument\ByteOffset;
 use Phpactor\TextDocument\TextDocumentBuilder;
+use Phpactor\WorseReflection\Core\SourceCode;
+use Phpactor\WorseReflection\Core\SourceCodeLocator\StringSourceLocator;
+use Phpactor\WorseReflection\ReflectorBuilder;
 
 class WorseUnresolvableClassNameFinderTest extends WorseTestCase
 {
@@ -422,5 +425,27 @@ class WorseUnresolvableClassNameFinderTest extends WorseTestCase
             ,[
             ]
         ];
+    }
+
+    public function testSourceCanBeFoundButNoClassIsContainedInIt(): void
+    {
+        $finder = new WorseUnresolvableClassNameFinder(
+            ReflectorBuilder::create()->addLocator(new StringSourceLocator(SourceCode::fromString('')))->build()
+        );
+        $found = $finder->find(
+            TextDocumentBuilder::create('<?php Foobar::class;')->build()
+        );
+        self::assertCount(1, $found);
+    }
+
+    public function testSourceCanBeFoundButNoFunctionIsContainedInIt(): void
+    {
+        $finder = new WorseUnresolvableClassNameFinder(
+            ReflectorBuilder::create()->addLocator(new StringSourceLocator(SourceCode::fromString('')))->build()
+        );
+        $found = $finder->find(
+            TextDocumentBuilder::create('<?php barboo();')->build()
+        );
+        self::assertCount(1, $found);
     }
 }


### PR DESCRIPTION
unresolvable classes were not being suggsted for import in a Drupal
project which had a classmap/ - this is because the "finder", for
perforamnce reasons, only located the source for the given name. As
classmap class location is YOLO it always located the source and the
name was reported as "resolved".