### PR TITLE
Improved docblocks and code generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,16 @@ Bug fixes:
     on class move and other strange issues.
   - [lsp] Fix call to properties() on non-class in generate accessors provider.
   - [lsp] Fix unresolvable classes not being listed in code actions
+  - [cb] Do not apply HTML escaping when rendering code templates
 
 Improvements:
 
+  - [code-transform] Faithfully reproduce documented types in generated code
   - [docblock] New docblock parser to facilitate parsing complex types
   - [hover] Improve "offset" hover (mostly related to showing variable info)
   - [templates] Include templates for creating new interfaces, traits and enums
   - [wr] Resolve type from array access
+  - [cb] Preserve `?` operator as distinct from a union type
 
 Features:
 

--- a/lib/CodeBuilder/Adapter/Twig/TwigRenderer.php
+++ b/lib/CodeBuilder/Adapter/Twig/TwigRenderer.php
@@ -48,6 +48,7 @@ final class TwigRenderer implements Renderer
     {
         $twig = new Environment(new FilesystemLoader(__DIR__ . '/../../../../templates/code'), [
             'strict_variables' => true,
+            'autoescape' => false,
         ]);
         $twig->addExtension(new TwigExtension($this));
 

--- a/lib/CodeBuilder/Adapter/WorseReflection/WorseBuilderFactory.php
+++ b/lib/CodeBuilder/Adapter/WorseReflection/WorseBuilderFactory.php
@@ -3,6 +3,8 @@
 namespace Phpactor\CodeBuilder\Adapter\WorseReflection;
 
 use Phpactor\CodeBuilder\Domain\BuilderFactory;
+use Phpactor\CodeBuilder\Domain\Builder\ClassBuilder;
+use Phpactor\CodeBuilder\Domain\Builder\TraitBuilder;
 use Phpactor\TextDocument\TextDocument;
 use Phpactor\TextDocument\TextDocumentBuilder;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionClass;
@@ -88,6 +90,8 @@ class WorseBuilderFactory implements BuilderFactory
 
     private function buildProperty(ClassLikeBuilder $classBuilder, ReflectionProperty $property): void
     {
+        assert($classBuilder instanceof ClassBuilder || $classBuilder instanceof TraitBuilder);
+
         $propertyBuilder = $classBuilder->property($property->name());
         $propertyBuilder->visibility((string) $property->visibility());
 
@@ -95,6 +99,7 @@ class WorseBuilderFactory implements BuilderFactory
         if (TypeUtil::isDefined($type)) {
             $this->resolveClassMemberType($classBuilder, $property->class()->name(), $type);
             $propertyBuilder->type(TypeUtil::short($type));
+            $propertyBuilder->docType((string)$type);
         }
     }
 

--- a/lib/CodeBuilder/Domain/Builder/PropertyBuilder.php
+++ b/lib/CodeBuilder/Domain/Builder/PropertyBuilder.php
@@ -20,6 +20,8 @@ class PropertyBuilder extends AbstractBuilder implements NamedBuilder
 
     private ClassLikeBuilder $parent;
 
+    private ?Type $docType = null;
+
     public function __construct(ClassLikeBuilder $parent, string $name)
     {
         $this->parent = $parent;
@@ -45,6 +47,16 @@ class PropertyBuilder extends AbstractBuilder implements NamedBuilder
         return $this;
     }
 
+    public function docType(string $type): PropertyBuilder
+    {
+        $this->docType = Type::fromString($type);
+
+        return $this;
+    }
+
+    /**
+     * @param mixed $value
+     */
     public function defaultValue($value): PropertyBuilder
     {
         $this->defaultValue = DefaultValue::fromValue($value);
@@ -59,6 +71,7 @@ class PropertyBuilder extends AbstractBuilder implements NamedBuilder
             $this->visibility,
             $this->defaultValue,
             $this->type,
+            $this->docType,
             UpdatePolicy::fromModifiedState($this->isModified())
         );
     }

--- a/lib/CodeBuilder/Domain/Prototype/Property.php
+++ b/lib/CodeBuilder/Domain/Prototype/Property.php
@@ -12,11 +12,14 @@ final class Property extends Prototype
 
     private Type $type;
 
+    private Type $docType;
+
     public function __construct(
         string $name,
         Visibility $visibility = null,
         DefaultValue $defaultValue = null,
         Type $type = null,
+        Type $docType = null,
         UpdatePolicy $updatePolicy = null
     ) {
         parent::__construct($updatePolicy);
@@ -24,6 +27,8 @@ final class Property extends Prototype
         $this->visibility = $visibility ?: Visibility::public();
         $this->defaultValue = $defaultValue ?: DefaultValue::none();
         $this->type = $type ?: Type::none();
+        $this->docType = $docType ?: Type::none();
+        $this->updatePolicy = $updatePolicy;
     }
 
     public function name(): string
@@ -44,5 +49,24 @@ final class Property extends Prototype
     public function type(): Type
     {
         return $this->type;
+    }
+
+    public function docTypeOrType(): Type
+    {
+        if ($this->docType->notNone()) {
+            return $this->docType;
+        }
+
+        return $this->type;
+    }
+
+    public function docType(): Type
+    {
+        return $this->docType;
+    }
+
+    public function docTypeAddsAdditionalInfo(): bool
+    {
+        return (string)$this->docType !== (string)$this->type;
     }
 }

--- a/lib/CodeBuilder/Domain/Prototype/ReturnType.php
+++ b/lib/CodeBuilder/Domain/Prototype/ReturnType.php
@@ -22,11 +22,6 @@ final class ReturnType extends Prototype
         return new self(Type::fromString($string));
     }
 
-    public function nullable(): bool
-    {
-        return $this->type->nullable();
-    }
-
     public static function none()
     {
         return new self(Type::none());

--- a/lib/CodeBuilder/Domain/Prototype/Type.php
+++ b/lib/CodeBuilder/Domain/Prototype/Type.php
@@ -8,13 +8,10 @@ final class Type extends Prototype
 
     private bool $none = false;
 
-    private bool $nullable = false;
-
-    public function __construct(string $type = null, bool $nullable = false)
+    public function __construct(string $type = null)
     {
         parent::__construct();
         $this->type = $type;
-        $this->nullable = $nullable;
     }
 
     public function __toString()
@@ -22,12 +19,9 @@ final class Type extends Prototype
         return $this->type;
     }
 
-    public static function fromString(string $string): Type
+    public static function fromString(string $type): Type
     {
-        $nullable = 0 === strpos($string, '?');
-        $type = $nullable ? substr($string, 1) : $string;
-
-        return new self($type, $nullable);
+        return new self($type);
     }
 
     public static function none(): Type
@@ -40,24 +34,24 @@ final class Type extends Prototype
 
     public function namespace(): ?string
     {
-        if (null === $this->type) {
+        $type = $this->type;
+        if (null === $type) {
             return null;
         }
 
-        if (false === strrpos($this->type, '\\')) {
+        if (substr($type, 0, 1) === '?') {
+            $type = substr($type, 1);
+        }
+
+        if (false === strrpos($type, '\\')) {
             return null;
         }
 
-        return substr($this->type, 0, strrpos($this->type, '\\'));
+        return substr($type, 0, strrpos($type, '\\'));
     }
 
     public function notNone(): bool
     {
         return false === $this->none;
-    }
-
-    public function nullable(): bool
-    {
-        return $this->nullable;
     }
 }

--- a/lib/CodeBuilder/Tests/Adapter/UpdaterTestCase.php
+++ b/lib/CodeBuilder/Tests/Adapter/UpdaterTestCase.php
@@ -982,7 +982,7 @@ abstract class UpdaterTestCase extends TestCase
                         public $eyes
 
                         /**
-                         * @var Hello|null
+                         * @var ?Hello
                          */
                         public $propertyOne;
                     }

--- a/lib/CodeBuilder/Tests/Adapter/UpdaterTestCase.php
+++ b/lib/CodeBuilder/Tests/Adapter/UpdaterTestCase.php
@@ -960,6 +960,31 @@ abstract class UpdaterTestCase extends TestCase
                         public $propertyOne;
                     }
                     EOT
+        ];
+
+        yield 'It adds a generic typed property' => [
+                <<<'EOT'
+                    class Aardvark
+                    {
+                        public $eyes
+                    }
+                    EOT
+                , SourceCodeBuilder::create()
+                    ->class('Aardvark')
+                        ->property('propertyOne')->type('Hello<Bar>')->end()
+                    ->end()
+                    ->build(),
+                <<<'EOT'
+                    class Aardvark
+                    {
+                        public $eyes
+
+                        /**
+                         * @var Hello<Bar>
+                         */
+                        public $propertyOne;
+                    }
+                    EOT
             ];
 
         yield 'It adds a nullable typed property' => [

--- a/lib/CodeBuilder/Tests/Adapter/WorseReflection/WorseBuilderFactoryTest.php
+++ b/lib/CodeBuilder/Tests/Adapter/WorseReflection/WorseBuilderFactoryTest.php
@@ -124,10 +124,9 @@ class WorseBuilderFactoryTest extends TestCase
         $source = $this->build('<?php class Foobar { public function method(): ?string {} }');
         // TODO: Changed this from `?string`, not sure how it worked before
         $this->assertEquals(
-            'string',
+            '?string',
             $source->classes()->first()->methods()->first()->returnType()->__toString(),
         );
-        $this->assertTrue($source->classes()->first()->methods()->first()->returnType()->nullable(), 'Type is nullable');
     }
 
     public function testMethodProtected(): void
@@ -145,7 +144,7 @@ class WorseBuilderFactoryTest extends TestCase
     public function testMethodWithNullableParameter(): void
     {
         $source = $this->build('<?php class Foobar { public function method(?string $param) {} }');
-        $this->assertTrue($source->classes()->first()->methods()->first()->parameters()->first()->type()->nullable());
+        self::assertEquals('?string', (string)$source->classes()->first()->methods()->first()->parameters()->first()->type());
     }
 
     public function testMethodWithParameterByReference(): void

--- a/lib/CodeBuilder/Tests/Unit/Domain/Builder/SourceCodeBuilderTest.php
+++ b/lib/CodeBuilder/Tests/Unit/Domain/Builder/SourceCodeBuilderTest.php
@@ -266,8 +266,7 @@ class SourceCodeBuilderTest extends TestCase
                 ->defaultValue(1)
                 ->end(),
                 function (Method $method): void {
-                    $this->assertEquals('string', $method->returnType()->__toString());
-                    $this->assertTrue($method->returnType()->nullable());
+                    $this->assertEquals('?string', $method->returnType()->__toString());
                 }
         ],
             'Method mofifiers 1' => [

--- a/lib/CodeBuilder/Tests/Unit/Domain/Prototype/TypeTest.php
+++ b/lib/CodeBuilder/Tests/Unit/Domain/Prototype/TypeTest.php
@@ -53,25 +53,4 @@ class TypeTest extends TestCase
             null
         ];
     }
-
-    public function testItAllowsNullable(): void
-    {
-        $type = Type::fromString('Foo\\Bar');
-        $this->assertFalse($type->nullable());
-
-        $type = Type::fromString('string');
-        $this->assertFalse($type->nullable());
-
-        $type = Type::fromString('Foo\\Bar');
-        $this->assertFalse($type->nullable());
-
-        $type = Type::fromString('string');
-        $this->assertFalse($type->nullable());
-
-        $type = Type::fromString('?Foo\\Bar');
-        $this->assertTrue($type->nullable());
-
-        $type = Type::fromString('?string');
-        $this->assertTrue($type->nullable());
-    }
 }

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseExtractConstant.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseExtractConstant.php
@@ -67,7 +67,7 @@ class WorseExtractConstant implements ExtractConstant
         $builder = SourceCodeBuilder::create();
         $containerType = $symbolInformation->containerType();
 
-        if (!$containerType) {
+        if (!TypeUtil::isDefined($containerType)) {
             throw new TransformException(sprintf('Node does not belong to a class'));
         }
 

--- a/lib/CodeTransform/Adapter/WorseReflection/Transformer/AddMissingProperties.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Transformer/AddMissingProperties.php
@@ -76,7 +76,9 @@ class AddMissingProperties implements Transformer
 
                 $type = $offset->symbolContext()->type();
                 if (TypeUtil::isDefined($type)) {
-                    $propertyBuilder->type(TypeUtil::short($type));
+                    $type = TypeUtil::toLocalType($class->scope(), $type);
+                    $propertyBuilder->type($type->toPhpString());
+                    $propertyBuilder->docType((string)$type);
                 }
             }
         }

--- a/lib/CodeTransform/Adapter/WorseReflection/Transformer/CompleteConstructor.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Transformer/CompleteConstructor.php
@@ -13,7 +13,6 @@ use Phpactor\WorseReflection\Core\Reflection\ReflectionClass;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionInterface;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionMethod;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionParameter;
-use Phpactor\WorseReflection\Core\Type\ClassType;
 use Phpactor\WorseReflection\Reflector;
 use Phpactor\WorseReflection\Core\SourceCode as WorseSourceCode;
 use Phpactor\CodeBuilder\Domain\Updater;
@@ -69,13 +68,9 @@ class CompleteConstructor implements Transformer
                 $propertyBuilder->visibility($this->visibility);
                 $parameterType = $parameter->type();
                 if (TypeUtil::isDefined($parameterType)) {
-                    $typeName = TypeUtil::short($parameterType);
-                    $parameterType = TypeUtil::unwrapNullableType($parameterType);
-                    if ($parameterType instanceof ClassType) {
-                        $typeName = $class->scope()->resolveLocalName($parameterType->name())->__toString();
-                    }
-
-                    $propertyBuilder->type($typeName);
+                    $parameterType = TypeUtil::toLocalType($class->scope(), $parameterType);
+                    $propertyBuilder->type($parameterType->toPhpString());
+                    $propertyBuilder->docType((string)$parameterType);
                 }
             }
         }

--- a/lib/CodeTransform/Adapter/WorseReflection/Transformer/CompleteConstructor.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Transformer/CompleteConstructor.php
@@ -66,7 +66,7 @@ class CompleteConstructor implements Transformer
 
                 $propertyBuilder = $classBuilder->property($parameter->name());
                 $propertyBuilder->visibility($this->visibility);
-                $parameterType = $parameter->type();
+                $parameterType = $parameter->inferredTypes()->best();
                 if (TypeUtil::isDefined($parameterType)) {
                     $parameterType = TypeUtil::toLocalType($class->scope(), $parameterType);
                     $propertyBuilder->type($parameterType->toPhpString());

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Transformer/AddMissingPropertiesTest.php
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Transformer/AddMissingPropertiesTest.php
@@ -64,6 +64,43 @@ class AddMissingPropertiesTest extends WorseTestCase
                     EOT
 
             ],
+            'It adds missing properties with documented type' => [
+                <<<'EOT'
+                    <?php
+
+                    class Foobar
+                    {
+                        /**
+                         * @param array<string,mixed> $bar
+                         */
+                        public function hello(array $bar)
+                        {
+                            $this->hello = $bar;
+                        }
+                    }
+                    EOT
+                ,
+                <<<'EOT'
+                    <?php
+
+                    class Foobar
+                    {
+                        /**
+                         * @var array<string,mixed>
+                         */
+                        private $hello;
+
+                        /**
+                         * @param array<string,mixed> $bar
+                         */
+                        public function hello(array $bar)
+                        {
+                            $this->hello = $bar;
+                        }
+                    }
+                    EOT
+
+            ],
             'It ignores existing properties' => [
                 <<<'EOT'
                     <?php

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Transformer/CompleteConstructorTest.php
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Transformer/CompleteConstructorTest.php
@@ -272,6 +272,43 @@ class CompleteConstructorTest extends WorseTestCase
 
         ];
 
+        yield  'Adds documented types' => [
+            <<<'EOT'
+                <?php
+
+                class Foobar
+                {
+                    /**
+                     * @param Foo<string,Bar> $foo
+                     */
+                    public function __construct(array $foo)
+                    {
+                    }
+                }
+                EOT
+        ,
+            <<<'EOT'
+                <?php
+
+                class Foobar
+                {
+                    /**
+                     * @var Foo<string,Bar>
+                     */
+                    private $foo;
+
+                    /**
+                     * @param Foo<string,Bar> $foo
+                     */
+                    public function __construct(array $foo)
+                    {
+                        $this->foo = $foo;
+                    }
+                }
+                EOT
+
+        ];
+
         yield  'It is idempotent' => [
             <<<'EOT'
                 <?php

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Transformer/CompleteConstructorTest.php
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Transformer/CompleteConstructorTest.php
@@ -259,7 +259,7 @@ class CompleteConstructorTest extends WorseTestCase
                 class Foobar
                 {
                     /**
-                     * @var string|null
+                     * @var ?string
                      */
                     private $foo;
 

--- a/lib/Extension/CodeTransform/CodeTransformExtension.php
+++ b/lib/Extension/CodeTransform/CodeTransformExtension.php
@@ -315,6 +315,7 @@ class CodeTransformExtension implements Extension
         $container->register('code_transform.renderer', function (Container $container) {
             $twig = new Environment($container->get('code_transform.twig_loader'), [
                 'strict_variables' => true,
+                'autoescape' => false,
             ]);
             $renderer = new TwigRenderer($twig);
             $twig->addExtension(new TwigExtension($renderer, $container->get(TextFormat::class)));

--- a/lib/WorseReflection/Core/Inference/SymbolContextResolver.php
+++ b/lib/WorseReflection/Core/Inference/SymbolContextResolver.php
@@ -70,6 +70,7 @@ class SymbolContextResolver
     
     private Cache $cache;
 
+    
     public function __construct(
         Reflector $reflector,
         LoggerInterface $logger,

--- a/lib/WorseReflection/Core/Inference/SymbolContextResolver.php
+++ b/lib/WorseReflection/Core/Inference/SymbolContextResolver.php
@@ -70,7 +70,6 @@ class SymbolContextResolver
     
     private Cache $cache;
 
-    
     public function __construct(
         Reflector $reflector,
         LoggerInterface $logger,

--- a/lib/WorseReflection/Core/Inference/SymbolContextResolver.php
+++ b/lib/WorseReflection/Core/Inference/SymbolContextResolver.php
@@ -70,6 +70,7 @@ class SymbolContextResolver
     
     private Cache $cache;
 
+    
     public function __construct(
         Reflector $reflector,
         LoggerInterface $logger,
@@ -84,7 +85,49 @@ class SymbolContextResolver
         $this->cache = $cache;
     }
 
-    private function __resolveNode(Frame $frame, Node $node): NodeContext
+    /**
+     * @param Node|Token $node
+     */
+    public function resolveNode(Frame $frame, $node): NodeContext
+    {
+        try {
+            if (
+                $node instanceof ParserVariable
+                && $node->parent instanceof ScopedPropertyAccessExpression
+                && $node === $node->parent->memberName
+            ) {
+                return $this->doResolveNodeWithCache($frame, $node->parent);
+            }
+            return $this->doResolveNodeWithCache($frame, $node);
+        } catch (CouldNotResolveNode $couldNotResolveNode) {
+            return NodeContext::none()
+                ->withIssue($couldNotResolveNode->getMessage());
+        }
+    }
+
+    /**
+     * @param Node|Token $node
+     */
+    private function doResolveNodeWithCache(Frame $frame, $node): NodeContext
+    {
+        $key = 'sc:'.spl_object_hash($node);
+
+        return $this->cache->getOrSet($key, function () use ($frame, $node) {
+            if (false === $node instanceof Node) {
+                throw new CouldNotResolveNode(sprintf(
+                    'Non-node class passed to resolveNode, got "%s"',
+                    get_class($node)
+                ));
+            }
+
+            $context = $this->doResolveNode($frame, $node);
+            $context = $context->withScope(new ReflectionScope($this->reflector, $node));
+
+            return $context;
+        });
+    }
+
+    private function doResolveNode(Frame $frame, Node $node): NodeContext
     {
         $this->logger->debug(sprintf('Resolving: %s', get_class($node)));
 
@@ -190,7 +233,7 @@ class SymbolContextResolver
         }
 
         if ($node instanceof SubscriptExpression) {
-            $variableValue = $this->_resolveNode($frame, $node->postfixExpression);
+            $variableValue = $this->doResolveNodeWithCache($frame, $node->postfixExpression);
             return $this->resolveSubscriptExpression($frame, $variableValue, $node);
         }
 
@@ -221,7 +264,7 @@ class SymbolContextResolver
         }
 
         if ($node instanceof ArgumentExpression) {
-            return $this->_resolveNode($frame, $node->expression);
+            return $this->doResolveNodeWithCache($frame, $node->expression);
         }
 
         if ($node instanceof TernaryExpression) {
@@ -241,48 +284,6 @@ class SymbolContextResolver
             get_class($node),
             $node->getText()
         ));
-    }
-
-    /**
-     * @param Node|Token $node
-     */
-    public function resolveNode(Frame $frame, $node): NodeContext
-    {
-        try {
-            if (
-                $node instanceof ParserVariable
-                && $node->parent instanceof ScopedPropertyAccessExpression
-                && $node === $node->parent->memberName
-            ) {
-                return $this->_resolveNode($frame, $node->parent);
-            }
-            return $this->_resolveNode($frame, $node);
-        } catch (CouldNotResolveNode $couldNotResolveNode) {
-            return NodeContext::none()
-                ->withIssue($couldNotResolveNode->getMessage());
-        }
-    }
-
-    /**
-     * @param Node|Token $node
-     */
-    private function _resolveNode(Frame $frame, $node): NodeContext
-    {
-        $key = 'sc:'.spl_object_hash($node);
-
-        return $this->cache->getOrSet($key, function () use ($frame, $node) {
-            if (false === $node instanceof Node) {
-                throw new CouldNotResolveNode(sprintf(
-                    'Non-node class passed to resolveNode, got "%s"',
-                    get_class($node)
-                ));
-            }
-
-            $context = $this->__resolveNode($frame, $node);
-            $context = $context->withScope(new ReflectionScope($this->reflector, $node));
-
-            return $context;
-        });
     }
 
     private function resolveVariable(Frame $frame, ParserVariable $node): NodeContext
@@ -315,7 +316,7 @@ class SymbolContextResolver
 
     private function resolveMemberAccessExpression(Frame $frame, MemberAccessExpression $node): NodeContext
     {
-        $class = $this->_resolveNode($frame, $node->dereferencableExpression);
+        $class = $this->doResolveNodeWithCache($frame, $node->dereferencableExpression);
 
         return $this->_infoFromMemberAccess($frame, $class->type(), $node);
     }
@@ -323,7 +324,7 @@ class SymbolContextResolver
     private function resolveCallExpression(Frame $frame, CallExpression $node): NodeContext
     {
         $resolvableNode = $node->callableExpression;
-        return $this->_resolveNode($frame, $resolvableNode);
+        return $this->doResolveNodeWithCache($frame, $resolvableNode);
     }
 
     private function resolveQualfiedNameList(Frame $frame, QualifiedNameList $node): NodeContext
@@ -419,7 +420,7 @@ class SymbolContextResolver
 
         $value = null;
         if ($node->default) {
-            $value = $this->_resolveNode($frame, $node->default)->value();
+            $value = $this->doResolveNodeWithCache($frame, $node->default)->value();
         }
 
         return NodeContextFactory::create(
@@ -593,9 +594,9 @@ class SymbolContextResolver
         }
 
         foreach ($node->arrayElements->getElements() as $element) {
-            $value = $this->_resolveNode($frame, $element->elementValue)->value();
+            $value = $this->doResolveNodeWithCache($frame, $element->elementValue)->value();
             if ($element->elementKey) {
-                $key = $this->_resolveNode($frame, $element->elementKey)->value();
+                $key = $this->doResolveNodeWithCache($frame, $element->elementKey)->value();
                 $array[$key] = $value;
                 continue;
             }
@@ -652,7 +653,7 @@ class SymbolContextResolver
         }
 
         if ($node instanceof StringLiteral) {
-            $string = $this->_resolveNode($frame, $node);
+            $string = $this->doResolveNodeWithCache($frame, $node);
 
             if (array_key_exists($string->value(), $subjectValue)) {
                 $value = $subjectValue[$string->value()];
@@ -694,14 +695,14 @@ class SymbolContextResolver
             throw new CouldNotResolveNode(sprintf('Could not create object from "%s"', get_class($node)));
         }
 
-        return $this->_resolveNode($frame, $node->classTypeDesignator);
+        return $this->doResolveNodeWithCache($frame, $node->classTypeDesignator);
     }
 
     private function resolveTernaryExpression(Frame $frame, TernaryExpression $node): NodeContext
     {
         // @phpstan-ignore-next-line
         if ($node->ifExpression) {
-            $ifValue = $this->_resolveNode($frame, $node->ifExpression);
+            $ifValue = $this->doResolveNodeWithCache($frame, $node->ifExpression);
 
             if (!$ifValue->type() instanceof MissingType) {
                 return $ifValue;
@@ -709,7 +710,7 @@ class SymbolContextResolver
         }
 
         // if expression was not defined, fallback to condition
-        $conditionValue = $this->_resolveNode($frame, $node->condition);
+        $conditionValue = $this->doResolveNodeWithCache($frame, $node->condition);
 
         if (!$conditionValue->type() instanceof MissingType) {
             return $conditionValue;
@@ -721,7 +722,7 @@ class SymbolContextResolver
     private function resolveMethodDeclaration(Frame $frame, MethodDeclaration $node): NodeContext
     {
         $classNode = $this->getClassLikeAncestor($node);
-        $classSymbolContext = $this->_resolveNode($frame, $classNode);
+        $classSymbolContext = $this->doResolveNodeWithCache($frame, $classNode);
 
         return NodeContextFactory::create(
             (string)$node->name->getText($node->getFileContents()),
@@ -742,7 +743,7 @@ class SymbolContextResolver
         $memberType = $node->getParent() instanceof CallExpression ? Symbol::METHOD : Symbol::PROPERTY;
 
         if ($node->memberName instanceof Node) {
-            $memberNameInfo = $this->_resolveNode($frame, $node->memberName);
+            $memberNameInfo = $this->doResolveNodeWithCache($frame, $node->memberName);
             if (is_string($memberNameInfo->value())) {
                 $memberName = $memberNameInfo->value();
             }
@@ -810,7 +811,7 @@ class SymbolContextResolver
 
     private function resolveParenthesizedExpression(Frame $frame, ParenthesizedExpression $node): NodeContext
     {
-        return $this->__resolveNode($frame, $node->expression);
+        return $this->doResolveNode($frame, $node->expression);
     }
 
     private function resolveVariableName(string $name, Node $node, Frame $frame): NodeContext
@@ -856,7 +857,7 @@ class SymbolContextResolver
 
     private function resolveCloneExpression(Frame $frame, CloneExpression $node): NodeContext
     {
-        return $this->__resolveNode($frame, $node->expression);
+        return $this->doResolveNode($frame, $node->expression);
     }
 
     /**

--- a/lib/WorseReflection/Core/Type/GenericClassType.php
+++ b/lib/WorseReflection/Core/Type/GenericClassType.php
@@ -13,7 +13,7 @@ class GenericClassType extends ReflectedClassType implements IterableType
     /**
      * @var Type[]
      */
-    private array $arguments;
+    public array $arguments;
 
     /**
      * @param Type[] $arguments

--- a/lib/WorseReflection/Tests/Unit/TypeUtilTest.php
+++ b/lib/WorseReflection/Tests/Unit/TypeUtilTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Phpactor\WorseReflection\Tests\Unit;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use Phpactor\WorseReflection\Core\ClassName;
+use Phpactor\WorseReflection\Core\Type;
+use Phpactor\WorseReflection\Core\TypeFactory;
+use Phpactor\WorseReflection\Core\Type\GenericClassType;
+use Phpactor\WorseReflection\ReflectorBuilder;
+use Phpactor\WorseReflection\TypeUtil;
+
+class TypeUtilTest extends TestCase
+{
+    /**
+     * @dataProvider provideToLocalType
+     */
+    public function testToLocalType(string $source, Type $type, string $expected): void
+    {
+        $reflector = ReflectorBuilder::create()->addSource($source)->build();
+        $class = $reflector->reflectClassLike('Foo');
+        self::assertEquals(
+            $expected,
+            (string)TypeUtil::toLocalType($class->scope(), $type)
+        );
+    }
+
+    public function provideToLocalType(): Generator
+    {
+        $reflector = ReflectorBuilder::create()->build();
+        yield [
+            '<?php class Foo{}',
+            TypeFactory::string(),
+            'string',
+        ];
+
+        yield [
+            '<?php class Foo{}',
+            TypeFactory::class('Foo\Baz'),
+            'Baz',
+        ];
+
+        yield [
+            '<?php use Foo\Baz as Boo; class Foo{}',
+            TypeFactory::class('Foo\Baz'),
+            'Boo',
+        ];
+
+        yield [
+            '<?php use Foo\Baz as Boo; class Foo{}',
+            TypeFactory::array('Foo\Baz'),
+            'Boo[]',
+        ];
+
+        yield [
+            '<?php use Foo\Baz as Boo; class Foo{}',
+            new GenericClassType($reflector, ClassName::fromString('Foo'), [
+                TypeFactory::fromString('string'),
+                TypeFactory::fromString('Foo\Baz'),
+            ]),
+            'Foo<string,Boo>',
+        ];
+    }
+}

--- a/lib/WorseReflection/TypeUtil.php
+++ b/lib/WorseReflection/TypeUtil.php
@@ -2,7 +2,10 @@
 
 namespace Phpactor\WorseReflection;
 
+use Phpactor\WorseReflection\Core\ClassName;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionScope;
 use Phpactor\WorseReflection\Core\Type;
+use Phpactor\WorseReflection\Core\Type\ArrayType;
 use Phpactor\WorseReflection\Core\Type\ClassType;
 use Phpactor\WorseReflection\Core\Type\MissingType;
 use Phpactor\WorseReflection\Core\Type\NullableType;
@@ -69,5 +72,26 @@ class TypeUtil
         }
 
         return $type->type;
+    }
+
+    public static function toLocalType(ReflectionScope $scope, Type $type): Type
+    {
+        if ($type instanceof NullableType) {
+            return new NullableType(self::toLocalType($scope, $type->type));
+        }
+        if ($type instanceof ClassType) {
+            $typeName = $scope->resolveLocalName($type->name());
+            $type = clone $type;
+            $type->name = ClassName::fromString($typeName);
+            return $type;
+        }
+        if ($type instanceof ArrayType) {
+            $type = clone $type;
+            $type->keyType = self::toLocalType($scope, $type->keyType);
+            $type->valueType = self::toLocalType($scope, $type->valueType);
+            return $type;
+        }
+
+        return $type;
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -851,11 +851,6 @@ parameters:
 			path: lib/CodeBuilder/Adapter/Twig/TwigRenderer.php
 
 		-
-			message: "#^Call to an undefined method Phpactor\\\\CodeBuilder\\\\Domain\\\\Builder\\\\ClassLikeBuilder\\:\\:property\\(\\)\\.$#"
-			count: 1
-			path: lib/CodeBuilder/Adapter/WorseReflection/WorseBuilderFactory.php
-
-		-
 			message: "#^Call to an undefined method Phpactor\\\\WorseReflection\\\\Core\\\\ClassName\\|Phpactor\\\\WorseReflection\\\\Reflector\\:\\:reflectClassesIn\\(\\)\\.$#"
 			count: 1
 			path: lib/CodeBuilder/Adapter/WorseReflection/WorseBuilderFactory.php
@@ -967,11 +962,6 @@ parameters:
 
 		-
 			message: "#^Method Phpactor\\\\CodeBuilder\\\\Domain\\\\Builder\\\\PropertyBuilder\\:\\:childNames\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/CodeBuilder/Domain/Builder/PropertyBuilder.php
-
-		-
-			message: "#^Method Phpactor\\\\CodeBuilder\\\\Domain\\\\Builder\\\\PropertyBuilder\\:\\:defaultValue\\(\\) has parameter \\$value with no type specified\\.$#"
 			count: 1
 			path: lib/CodeBuilder/Domain/Builder/PropertyBuilder.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6586,56 +6586,6 @@ parameters:
 			path: lib/WorseReflection/Core/Inference/PropertyAssignments.php
 
 		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: lib/WorseReflection/Core/Inference/SymbolContextResolver.php
-
-		-
-			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\SymbolContextResolver\\:\\:_resolveNode\\(\\) has parameter \\$node with no type specified\\.$#"
-			count: 1
-			path: lib/WorseReflection/Core/Inference/SymbolContextResolver.php
-
-		-
-			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\SymbolContextResolver\\:\\:classTypeFromNode\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: lib/WorseReflection/Core/Inference/SymbolContextResolver.php
-
-		-
-			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\SymbolContextResolver\\:\\:getClassLikeAncestor\\(\\) should return Microsoft\\\\PhpParser\\\\Node\\\\Statement\\\\ClassDeclaration\\|Microsoft\\\\PhpParser\\\\Node\\\\Statement\\\\InterfaceDeclaration\\|Microsoft\\\\PhpParser\\\\Node\\\\Statement\\\\TraitDeclaration but returns Microsoft\\\\PhpParser\\\\Node\\|null\\.$#"
-			count: 1
-			path: lib/WorseReflection/Core/Inference/SymbolContextResolver.php
-
-		-
-			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\SymbolContextResolver\\:\\:resolveNode\\(\\) has parameter \\$node with no type specified\\.$#"
-			count: 1
-			path: lib/WorseReflection/Core/Inference/SymbolContextResolver.php
-
-		-
-			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\SymbolContextResolver\\:\\:resolveObjectCreationExpression\\(\\) has parameter \\$node with no type specified\\.$#"
-			count: 1
-			path: lib/WorseReflection/Core/Inference/SymbolContextResolver.php
-
-		-
-			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\SymbolContextResolver\\:\\:resolveParenthesizedExpression\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: lib/WorseReflection/Core/Inference/SymbolContextResolver.php
-
-		-
-			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\SymbolContextResolver\\:\\:resolvePropertyVariable\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: lib/WorseReflection/Core/Inference/SymbolContextResolver.php
-
-		-
-			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\SymbolContextResolver\\:\\:resolveVariableName\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: lib/WorseReflection/Core/Inference/SymbolContextResolver.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between null and Microsoft\\\\PhpParser\\\\Node\\\\Statement\\\\ClassDeclaration\\|Microsoft\\\\PhpParser\\\\Node\\\\Statement\\\\InterfaceDeclaration\\|Microsoft\\\\PhpParser\\\\Node\\\\Statement\\\\TraitDeclaration will always evaluate to false\\.$#"
-			count: 2
-			path: lib/WorseReflection/Core/Inference/SymbolContextResolver.php
-
-		-
 			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\Variable\\:\\:isNamed\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: lib/WorseReflection/Core/Inference/Variable.php

--- a/templates/code/7.4/Property.php.twig
+++ b/templates/code/7.4/Property.php.twig
@@ -1,5 +1,10 @@
+{% if prototype.docTypeAddsAdditionalInfo %}
+/**
+ * @var {{ prototype.docType }}
+ */
+{% endif %}
 {{ prototype.visibility }}
 {%- if prototype.type.notNone %}
- {{ prototype.type.nullable ? '?' : '' }}{{ prototype.type }} 
+ {{ prototype.type }} 
 {%- endif %}
  ${{ prototype.name}}{% if prototype.defaultValue.notNone %} = {{ prototype.defaultValue.export }}{% endif %};

--- a/templates/code/Method.php.twig
+++ b/templates/code/Method.php.twig
@@ -6,4 +6,4 @@
  */
 {% endif %}
 {% if prototype.isAbstract %}abstract {%endif %}{{ prototype.visibility }} {% if prototype.isStatic %}static {%endif %}function {{ prototype.name}}({% spaceless %}
-{% for parameter in prototype.parameters %}{{ generator.render(parameter, variant)|raw }}{% if not loop.last %}, {% endif %}{% endfor %}{% endspaceless %}){% if prototype.returnType.notNone %}: {{ prototype.returnType.nullable ? '?' : '' }}{{ prototype.returnType }}{% endif %}
+{% for parameter in prototype.parameters %}{{ generator.render(parameter, variant)|raw }}{% if not loop.last %}, {% endif %}{% endfor %}{% endspaceless %}){% if prototype.returnType.notNone %}: {{ prototype.returnType }}{% endif %}

--- a/templates/code/Parameter.php.twig
+++ b/templates/code/Parameter.php.twig
@@ -1,3 +1,3 @@
-{% if prototype.type.notNone %}{{ prototype.type.nullable ? '?' : '' }}{{ prototype.type }} {% endif %}
+{% if prototype.type.notNone %}{{ prototype.type }} {% endif %}
 {% if prototype.byReference %}&{% endif %}{% if true %}${{ prototype.name }}{% endif %}
 {% if prototype.defaultValue.notNone %} = {{ prototype.defaultValue.export|raw }}{% endif %}

--- a/templates/code/Property.php.twig
+++ b/templates/code/Property.php.twig
@@ -1,6 +1,6 @@
-{% if prototype.type.notNone %}
+{% if prototype.docTypeOrType.notNone %}
 /**
- * @var {{ prototype.type }}{{ prototype.type.nullable ? '|null' }}
+ * @var {{ prototype.docTypeOrType }}
  */
 {% endif %}
 {{ prototype.visibility }} ${{ prototype.name}}{% if prototype.defaultValue.notNone %} = {{ prototype.defaultValue.export }}{% endif %};


### PR DESCRIPTION
- When generating properties (complete constructor, add missing properties) use the documented type if available:

```
    /**
     * @var array<string,Resolver>
     */
    private array $resolverMap;
```

- Do not HTML-escape generated code (!)
- Various refactoring