### PR TITLE
improvement: Support "class-string" type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Improvements:
   - [templates] Include templates for creating new interfaces, traits and enums
   - [wr] Resolve type from array access
   - [cb] Preserve `?` operator as distinct from a union type
+  - [wr] Support for class-string type (not for type inference however)
 
 Features:
 

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Transformer/CompleteConstructorTest.php
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Transformer/CompleteConstructorTest.php
@@ -279,7 +279,7 @@ class CompleteConstructorTest extends WorseTestCase
                 class Foobar
                 {
                     /**
-                     * @param Foo<string,Bar> $foo
+                     * @param Foo<class-string,Bar> $foo
                      */
                     public function __construct(array $foo)
                     {
@@ -293,12 +293,12 @@ class CompleteConstructorTest extends WorseTestCase
                 class Foobar
                 {
                     /**
-                     * @var Foo<string,Bar>
+                     * @var Foo<class-string,Bar>
                      */
                     private $foo;
 
                     /**
-                     * @param Foo<string,Bar> $foo
+                     * @param Foo<class-string,Bar> $foo
                      */
                     public function __construct(array $foo)
                     {

--- a/lib/DocblockParser/Lexer.php
+++ b/lib/DocblockParser/Lexer.php
@@ -25,7 +25,7 @@ final class Lexer
         '=', // equals
         '(', ')', '\{', '\}', '\[', '\]', '<', '>', // brackets
         '\$[a-zA-Z0-9_\x80-\xff]+', // variable
-        '[a-zA-Z0-9_\\\]+', // label
+        '[a-zA-Z\\\][-a-zA-Z0-9_\\\]*', // label
     ];
     private const TOKEN_VALUE_MAP = [
         ']' => Token::T_BRACKET_SQUARE_CLOSE,

--- a/lib/DocblockParser/Parser.php
+++ b/lib/DocblockParser/Parser.php
@@ -43,7 +43,7 @@ final class Parser
      * TODO Callable is not a scalar.
      */
     private const SCALAR_TYPES = [
-        'int', 'float', 'bool', 'string', 'mixed', 'callable',
+        'int', 'float', 'bool', 'class-string', 'string', 'mixed', 'callable',
     ];
     
     private Tokens $tokens;

--- a/lib/DocblockParser/Tests/Unit/Printer/examples/class-string.test
+++ b/lib/DocblockParser/Tests/Unit/Printer/examples/class-string.test
@@ -1,0 +1,11 @@
+/**
+ * @var class-string
+ */
+---
+Docblock: = 
+ ElementList: = /**
+ * 
+  VarTag: = @var
+   ScalarNode: = class-string
+ */
+

--- a/lib/WorseReflection/Bridge/Phpactor/DocblockParser/TypeConverter.php
+++ b/lib/WorseReflection/Bridge/Phpactor/DocblockParser/TypeConverter.php
@@ -20,6 +20,7 @@ use Phpactor\WorseReflection\Core\Type;
 use Phpactor\WorseReflection\Core\Type\ArrayType;
 use Phpactor\WorseReflection\Core\Type\BooleanType;
 use Phpactor\WorseReflection\Core\Type\CallableType;
+use Phpactor\WorseReflection\Core\Type\ClassStringType;
 use Phpactor\WorseReflection\Core\Type\ClassType;
 use Phpactor\WorseReflection\Core\Type\FloatType;
 use Phpactor\WorseReflection\Core\Type\GenericClassType;
@@ -88,6 +89,9 @@ class TypeConverter
         }
         if ($type === 'string') {
             return new StringType();
+        }
+        if ($type === 'class-string') {
+            return new ClassStringType();
         }
         if ($type === 'float') {
             return new FloatType();

--- a/lib/WorseReflection/Core/Type/ClassStringType.php
+++ b/lib/WorseReflection/Core/Type/ClassStringType.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Phpactor\WorseReflection\Core\Type;
+
+class ClassStringType extends StringType
+{
+    public function __toString(): string
+    {
+        return 'class-string';
+    }
+
+    public function toPhpString(): string
+    {
+        return 'string';
+    }
+}

--- a/lib/WorseReflection/Core/Type/StringType.php
+++ b/lib/WorseReflection/Core/Type/StringType.php
@@ -2,7 +2,7 @@
 
 namespace Phpactor\WorseReflection\Core\Type;
 
-final class StringType extends ScalarType
+class StringType extends ScalarType
 {
     public ?string $value;
 

--- a/lib/WorseReflection/Core/TypeFactory.php
+++ b/lib/WorseReflection/Core/TypeFactory.php
@@ -6,6 +6,7 @@ use Phpactor\WorseReflection\Core\Reflector\ClassReflector;
 use Phpactor\WorseReflection\Core\Type\ArrayType;
 use Phpactor\WorseReflection\Core\Type\BooleanType;
 use Phpactor\WorseReflection\Core\Type\CallableType;
+use Phpactor\WorseReflection\Core\Type\ClassStringType;
 use Phpactor\WorseReflection\Core\Type\ClassType;
 use Phpactor\WorseReflection\Core\Type\FloatType;
 use Phpactor\WorseReflection\Core\Type\GenericClassType;
@@ -256,6 +257,10 @@ class TypeFactory
 
         if ($type === 'static') {
             return new StaticType();
+        }
+
+        if ($type === 'class-string') {
+            return new ClassStringType();
         }
 
         if ($type === '$this') {

--- a/lib/WorseReflection/Tests/Unit/Core/TypeFactoryTest.php
+++ b/lib/WorseReflection/Tests/Unit/Core/TypeFactoryTest.php
@@ -31,6 +31,12 @@ class TypeFactoryTest extends TestCase
         ];
 
         yield [
+            TypeFactory::fromString('class-string'),
+            'class-string',
+            'string',
+        ];
+
+        yield [
             TypeFactory::fromString('float'),
             'float',
             'float',
@@ -118,6 +124,12 @@ class TypeFactoryTest extends TestCase
             TypeFactory::fromString('resource'),
             'resource',
             'resource'
+        ];
+
+        yield 'class-string' => [
+            TypeFactory::fromString('class-string'),
+            'class-string',
+            'string',
         ];
     }
 


### PR DESCRIPTION
Adds docblock-level support for `class-string` and adds a dedicated type for it (not used for type inference yet though)