### PR TITLE
Variable Refactor

### DIFF
--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseExtractMethod.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseExtractMethod.php
@@ -225,7 +225,7 @@ class WorseExtractMethod implements ExtractMethod
             throw new TransformException('Cannot extract method, not in class scope');
         }
 
-        $type = TypeUtil::unwrapNullableType($thisVariable->last()->symbolContext()->type());
+        $type = TypeUtil::unwrapNullableType($thisVariable->last()->type());
 
         if (!$type instanceof ClassType) {
             throw new TransformException('Cannot extract method, not in class scope');
@@ -260,7 +260,7 @@ class WorseExtractMethod implements ExtractMethod
             }
 
             $parameterBuilder = $methodBuilder->parameter($freeVariable->name());
-            $variableType = $freeVariable->symbolContext()->types()->best();
+            $variableType = $freeVariable->types()->best();
             if (TypeUtil::isDefined($variableType)) {
                 $parameterBuilder->type(TypeUtil::short($variableType));
                 foreach (TypeUtil::unwrapClassTypes($variableType) as $classType) {
@@ -324,7 +324,7 @@ class WorseExtractMethod implements ExtractMethod
         });
 
         $returnVariables = array_filter($returnVariables, function (Variable $variable) use ($args) {
-            if (TypeUtil::isPrimitive($variable->symbolContext()->type())) {
+            if (TypeUtil::isPrimitive($variable->type())) {
                 return true;
             }
 
@@ -339,7 +339,7 @@ class WorseExtractMethod implements ExtractMethod
             /** @var Variable $variable */
             $variable = reset($returnVariables);
             $methodBuilder->body()->line('return $' . $variable->name() . ';');
-            $type = $variable->symbolContext()->types()->best();
+            $type = $variable->types()->best();
             if (TypeUtil::isDefined($type)) {
                 $methodBuilder->returnType(TypeUtil::short($type));
                 $type = TypeUtil::unwrapNullableType($type);
@@ -418,7 +418,7 @@ class WorseExtractMethod implements ExtractMethod
     {
         $newMethodBody = 'return ' . $newMethodBody .';';
         $offset = $this->reflector->reflectOffset($source->__toString(), $offsetEnd);
-        $expressionTypes = $offset->symbolContext()->types();
+        $expressionTypes = $offset->types();
         if ($expressionTypes->count() === 1) {
             $type = $expressionTypes->best();
             if (TypeUtil::isDefined($type)) {

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseExtractMethod.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseExtractMethod.php
@@ -418,7 +418,7 @@ class WorseExtractMethod implements ExtractMethod
     {
         $newMethodBody = 'return ' . $newMethodBody .';';
         $offset = $this->reflector->reflectOffset($source->__toString(), $offsetEnd);
-        $expressionTypes = $offset->types();
+        $expressionTypes = $offset->symbolContext()->types();
         if ($expressionTypes->count() === 1) {
             $type = $expressionTypes->best();
             if (TypeUtil::isDefined($type)) {

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseGenerateMethod.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseGenerateMethod.php
@@ -79,7 +79,7 @@ class WorseGenerateMethod implements GenerateMethod
          * @var Variable $variable
          */
         foreach ($reflectionOffset->frame()->locals()->byName('$this') as $variable) {
-            return $variable->symbolContext()->type();
+            return $variable->type();
         }
 
         return null;

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/AbstractParameterCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/AbstractParameterCompletor.php
@@ -56,7 +56,7 @@ abstract class AbstractParameterCompletor
 
         foreach ($variables as $variable) {
             if (
-                $variable->symbolContext()->types()->count() &&
+                $variable->types()->count() &&
                 false === $this->isVariableValidForParameter($variable, $parameter)
             ) {
                 // parameter has no types and is not valid for this position, ignore it
@@ -70,7 +70,7 @@ abstract class AbstractParameterCompletor
                     'priority' => Suggestion::PRIORITY_HIGH,
                     'short_description' => sprintf(
                         '%s => param #%d %s',
-                        $this->formatter->format($variable->symbolContext()->types()),
+                        $this->formatter->format($variable->types()),
                         $paramIndex,
                         $this->formatter->format($parameter)
                     )
@@ -121,7 +121,7 @@ abstract class AbstractParameterCompletor
         }
 
         /** @var Type $variableType */
-        foreach ($variable->symbolContext()->types() as $variableType) {
+        foreach ($variable->types() as $variableType) {
             $variableType = TypeUtil::unwrapNullableType($variableType);
 
             foreach ($parameter->inferredTypes() as $parameterType) {

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseParameterCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseParameterCompletor.php
@@ -117,7 +117,7 @@ class WorseParameterCompletor extends AbstractParameterCompletor implements Tole
         $valid = false;
 
         /** @var Type $variableType */
-        foreach ($variable->symbolContext()->types() as $variableType) {
+        foreach ($variable->types() as $variableType) {
             $variableTypeClass = null;
             foreach ($parameter->inferredTypes() as $parameterType) {
                 if ($parameterType->accepts($variableType)->isTrue()) {

--- a/lib/Completion/Bridge/WorseReflection/Formatter/VariableFormatter.php
+++ b/lib/Completion/Bridge/WorseReflection/Formatter/VariableFormatter.php
@@ -17,6 +17,6 @@ class VariableFormatter implements Formatter
     {
         assert($object instanceof Variable);
 
-        return $formatter->format($object->symbolContext()->types());
+        return $formatter->format($object->types());
     }
 }

--- a/lib/Extension/WorseReflection/Tests/Unit/TestExtension.php
+++ b/lib/Extension/WorseReflection/Tests/Unit/TestExtension.php
@@ -40,6 +40,7 @@ class TestFrameWalker implements Walker
         }
 
         $frame->locals()->add(
+            $node->getStartPosition(),
             Variable::fromSymbolContext(
                 NodeContext::for(Symbol::fromTypeNameAndPosition('variable', 'test_variable', Position::fromFullStartStartAndEnd(0, 1, 10)))
             )

--- a/lib/Extension/WorseReflectionExtra/Rpc/OffsetInfoHandler.php
+++ b/lib/Extension/WorseReflectionExtra/Rpc/OffsetInfoHandler.php
@@ -70,15 +70,16 @@ class OffsetInfoHandler implements Handler
         $frame = [];
 
         foreach (['locals', 'properties'] as $assignmentType) {
-            foreach ($reflectionOffset->frame()->$assignmentType() as $local) {
+            $assignments = $reflectionOffset->frame()->$assignmentType();
+            foreach ($assignments as $local) {
                 $info = sprintf(
                     '%s = (%s) %s',
                     $local->name(),
-                    $local->symbolContext()->type(),
-                    str_replace(PHP_EOL, '', var_export($local->symbolContext()->value(), true))
+                    $local->type(),
+                    str_replace(PHP_EOL, '', var_export($local->value(), true))
                 );
 
-                $frame[$assignmentType][$local->offset()->toInt()] = $info;
+                $frame[$assignmentType][$assignments->offsetFor($local)] = $info;
             }
         }
         $return['frame'] = $frame;

--- a/lib/WorseReferenceFinder/WorseReflectionDefinitionLocator.php
+++ b/lib/WorseReferenceFinder/WorseReflectionDefinitionLocator.php
@@ -216,8 +216,12 @@ class WorseReflectionDefinitionLocator implements DefinitionLocator
             throw new CouldNotLocateDefinition(sprintf('Could not find variable "%s" in scope', $name));
         }
 
-        $variable = $variables->first();
+        $offset = $variables->offsetFor($variables->first());
 
-        return new DefinitionLocation($uri, ByteOffset::fromInt($variable->offset()->toInt()));
+        if (null === $offset) {
+            throw new CouldNotLocateDefinition(sprintf('Could not find variable "%s" in scope', $name));
+        }
+
+        return new DefinitionLocation($uri, ByteOffset::fromInt($offset));
     }
 }

--- a/lib/WorseReflection/Core/Inference/Assignments.php
+++ b/lib/WorseReflection/Core/Inference/Assignments.php
@@ -8,28 +8,28 @@ use RuntimeException;
 use ArrayIterator;
 
 /**
- * @implements IteratorAggregate<int,Variable>
+ * @implements IteratorAggregate<array-key,array{int,Variable}>
  */
 abstract class Assignments implements Countable, IteratorAggregate
 {
     /**
-     * @var Variable[]
+     * @var array<array-key,array{int,Variable}>
      */
-    private array $variables = [];
+    private array $variables;
 
     /**
-     * @param Variable[] $variables
+     * @param array<array-key, array{int, Variable}> $variables
      */
-    protected function __construct(array $variables)
+    final function __construct(array $variables)
     {
-        foreach ($variables as $variable) {
-            $this->add($variable);
-        }
+        $this->variables = $variables;
     }
 
-    public function add(Variable $variable): void
+    public function add(int $offset, Variable $variable): void
     {
-        $this->variables[] = $variable;
+        $this->variables[] = [
+            $offset, $variable
+        ];
     }
 
     /**
@@ -37,36 +37,36 @@ abstract class Assignments implements Countable, IteratorAggregate
      */
     public function byName(string $name): Assignments
     {
-        return new static(array_filter($this->variables, function (Variable $variable) use ($name) {
-            return $variable->isNamed($name);
+        return new static(array_filter($this->variables, function (array $pair) use ($name) {
+            return $pair[1]->isNamed($name);
         }));
     }
 
     public function lessThanOrEqualTo(int $offset): Assignments
     {
-        return new static(array_filter($this->variables, function (Variable $variable) use ($offset) {
-            return $variable->offset()->toInt() <= $offset;
+        return new static(array_filter($this->variables, function (array $pair) use ($offset) {
+            return $pair[0] <= $offset;
         }));
     }
 
     public function lessThan(int $offset): Assignments
     {
-        return new static(array_filter($this->variables, function (Variable $variable) use ($offset) {
-            return $variable->offset()->toInt() < $offset;
+        return new static(array_filter($this->variables, function (array $pair) use ($offset) {
+            return $pair[0] < $offset;
         }));
     }
 
     public function greaterThan(int $offset): Assignments
     {
-        return new static(array_filter($this->variables, function (Variable $variable) use ($offset) {
-            return $variable->offset()->toInt() > $offset;
+        return new static(array_filter($this->variables, function (array $pair) use ($offset) {
+            return $pair[0] > $offset;
         }));
     }
 
     public function greaterThanOrEqualTo(int $offset): Assignments
     {
-        return new static(array_filter($this->variables, function (Variable $variable) use ($offset) {
-            return $variable->offset()->toInt() >= $offset;
+        return new static(array_filter($this->variables, function (array $pair) use ($offset) {
+            return $pair[0] >= $offset;
         }));
     }
 
@@ -80,7 +80,7 @@ abstract class Assignments implements Countable, IteratorAggregate
             );
         }
 
-        return $first;
+        return $first[1];
     }
 
     public function atIndex(int $index): Variable
@@ -92,7 +92,7 @@ abstract class Assignments implements Countable, IteratorAggregate
             ));
         }
 
-        return $this->variables[$index];
+        return array_values($this->variables)[$index][1];
     }
 
     public function last(): Variable
@@ -105,7 +105,7 @@ abstract class Assignments implements Countable, IteratorAggregate
             );
         }
 
-        return $last;
+        return $last[1];
     }
     
     public function count(): int
@@ -113,6 +113,9 @@ abstract class Assignments implements Countable, IteratorAggregate
         return count($this->variables);
     }
 
+    /**
+     * @return ArrayIterator<array-key,array{int,Variable}>
+     */
     public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->variables);
@@ -120,8 +123,8 @@ abstract class Assignments implements Countable, IteratorAggregate
 
     public function merge(Assignments $variables): Assignments
     {
-        foreach ($variables as $variable) {
-            $this->variables[] = $variable;
+        foreach ($variables->variables as $pair) {
+            $this->variables[] = $pair;
         }
 
         return $this;
@@ -129,18 +132,18 @@ abstract class Assignments implements Countable, IteratorAggregate
 
     public function replace(Variable $existing, Variable $replacement): void
     {
-        foreach ($this->variables as $index => $variable) {
+        foreach ($this->variables as $index => [$offset, $variable]) {
             if ($variable !== $existing) {
                 continue;
             }
-            $this->variables[$index] = $replacement;
+            $this->variables[$index] = [$offset, $replacement];
         }
     }
 
     public function equalTo(int $offset): Assignments
     {
-        return new static(array_filter($this->variables, function (Variable $variable) use ($offset) {
-            return $variable->offset()->toInt() === $offset;
+        return new static(array_filter($this->variables, function (array $pair) use ($offset) {
+            return $pair[0] === $offset;
         }));
     }
 }

--- a/lib/WorseReflection/Core/Inference/Assignments.php
+++ b/lib/WorseReflection/Core/Inference/Assignments.php
@@ -20,7 +20,7 @@ abstract class Assignments implements Countable, IteratorAggregate
     /**
      * @param array<array-key, array{int, Variable}> $variables
      */
-    final function __construct(array $variables)
+    final public function __construct(array $variables)
     {
         foreach ($variables as [$offset, $variable]) {
             $this->variables[] = [ $offset, $variable ];
@@ -121,7 +121,7 @@ abstract class Assignments implements Countable, IteratorAggregate
      */
     public function getIterator(): ArrayIterator
     {
-        return new ArrayIterator(array_map(fn(array $pair) => $pair[1], $this->variables));
+        return new ArrayIterator(array_map(fn (array $pair) => $pair[1], $this->variables));
     }
 
     public function merge(Assignments $variables): Assignments
@@ -148,5 +148,16 @@ abstract class Assignments implements Countable, IteratorAggregate
         return new static(array_filter($this->variables, function (array $pair) use ($offset) {
             return $pair[0] === $offset;
         }));
+    }
+
+    public function offsetFor(Variable $target): ?int
+    {
+        foreach ($this->variables as [$offset, $variable]) {
+            if ($target === $variable) {
+                return $offset;
+            }
+        }
+
+        return null;
     }
 }

--- a/lib/WorseReflection/Core/Inference/Assignments.php
+++ b/lib/WorseReflection/Core/Inference/Assignments.php
@@ -8,21 +8,23 @@ use RuntimeException;
 use ArrayIterator;
 
 /**
- * @implements IteratorAggregate<array-key,array{int,Variable}>
+ * @implements IteratorAggregate<array-key,Variable>
  */
 abstract class Assignments implements Countable, IteratorAggregate
 {
     /**
      * @var array<array-key,array{int,Variable}>
      */
-    private array $variables;
+    private array $variables = [];
 
     /**
      * @param array<array-key, array{int, Variable}> $variables
      */
     final function __construct(array $variables)
     {
-        $this->variables = $variables;
+        foreach ($variables as [$offset, $variable]) {
+            $this->variables[] = [ $offset, $variable ];
+        }
     }
 
     public function add(int $offset, Variable $variable): void
@@ -85,14 +87,15 @@ abstract class Assignments implements Countable, IteratorAggregate
 
     public function atIndex(int $index): Variable
     {
-        if (!isset($this->variables[$index])) {
+        $variables = array_values($this->variables);
+        if (!isset($variables[$index])) {
             throw new RuntimeException(sprintf(
                 'No variable at index "%s"',
                 $index
             ));
         }
 
-        return array_values($this->variables)[$index][1];
+        return $variables[$index][1];
     }
 
     public function last(): Variable
@@ -114,11 +117,11 @@ abstract class Assignments implements Countable, IteratorAggregate
     }
 
     /**
-     * @return ArrayIterator<array-key,array{int,Variable}>
+     * @return ArrayIterator<array-key,Variable>
      */
     public function getIterator(): ArrayIterator
     {
-        return new ArrayIterator($this->variables);
+        return new ArrayIterator(array_map(fn(array $pair) => $pair[1], $this->variables));
     }
 
     public function merge(Assignments $variables): Assignments

--- a/lib/WorseReflection/Core/Inference/ExpressionTypeResolver.php
+++ b/lib/WorseReflection/Core/Inference/ExpressionTypeResolver.php
@@ -4,7 +4,6 @@ namespace Phpactor\WorseReflection\Core\Inference;
 
 use Microsoft\PhpParser\Node;
 use Phpactor\WorseReflection\Core\Type;
-use Phpactor\WorseReflection\Core\Type\MissingType;
 
 final class ExpressionTypeResolver
 {

--- a/lib/WorseReflection/Core/Inference/ExpressionTypeResolver.php
+++ b/lib/WorseReflection/Core/Inference/ExpressionTypeResolver.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Phpactor\WorseReflection\Core\Inference;
+
+use Microsoft\PhpParser\Node;
+use Phpactor\WorseReflection\Core\Type;
+use Phpactor\WorseReflection\Core\Type\MissingType;
+
+final class ExpressionTypeResolver
+{
+    /**
+     * @return array<string,Type>
+     */
+    public function resolve(Frame $frame, Node $node): array
+    {
+        return [
+        ];
+    }
+}

--- a/lib/WorseReflection/Core/Inference/NodeContextFactory.php
+++ b/lib/WorseReflection/Core/Inference/NodeContextFactory.php
@@ -75,7 +75,17 @@ class NodeContextFactory
             )->withIssue(sprintf('Variable "%s" is undefined', $varName));
         }
 
-        return $variables->last()->symbolContext();
+        $variable = $variables->last();
+        return NodeContextFactory::create(
+            $name,
+            $start,
+            $end,
+            [
+                'type' => $variable->type(),
+                'symbol_type' => Symbol::VARIABLE,
+                'value' => $variable->value(),
+            ]
+        )->withIssue(sprintf('Variable "%s" is undefined', $varName));
     }
 
     /**

--- a/lib/WorseReflection/Core/Inference/Resolver/MemberAccessExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/MemberAccessExpressionResolver.php
@@ -102,10 +102,6 @@ class MemberAccessExpressionResolver implements Resolver
         foreach ($assignments as $variable) {
             $containerType = $variable->classType();
 
-            if (!$containerType) {
-                continue;
-            }
-
             if (!$containerType instanceof ClassType) {
                 continue;
             }

--- a/lib/WorseReflection/Core/Inference/Resolver/MemberAccessExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/MemberAccessExpressionResolver.php
@@ -100,8 +100,7 @@ class MemberAccessExpressionResolver implements Resolver
         }
 
         foreach ($assignments as $variable) {
-            $symbolContext = $variable->symbolContext();
-            $containerType = $symbolContext->containerType();
+            $containerType = $variable->classType();
 
             if (!$containerType) {
                 continue;

--- a/lib/WorseReflection/Core/Inference/Resolver/MemberAccessExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/MemberAccessExpressionResolver.php
@@ -114,7 +114,7 @@ class MemberAccessExpressionResolver implements Resolver
                 continue;
             }
 
-            yield $symbolContext->types();
+            yield $variable->types();
         }
     }
 }

--- a/lib/WorseReflection/Core/Inference/Variable.php
+++ b/lib/WorseReflection/Core/Inference/Variable.php
@@ -2,9 +2,7 @@
 
 namespace Phpactor\WorseReflection\Core\Inference;
 
-use Phpactor\WorseReflection\Core\Offset;
 use Phpactor\WorseReflection\Core\Type;
-use Phpactor\WorseReflection\Core\Type\ClassType;
 use Phpactor\WorseReflection\Core\Type\MissingType;
 use Phpactor\WorseReflection\Core\Types;
 

--- a/lib/WorseReflection/Core/Inference/Variable.php
+++ b/lib/WorseReflection/Core/Inference/Variable.php
@@ -9,14 +9,11 @@ final class Variable
 {
     private string $name;
     
-    private Offset $offset;
-    
     private NodeContext $symbolContext;
 
-    private function __construct(string $name, Offset $offset, NodeContext $symbolContext)
+    private function __construct(string $name, NodeContext $symbolContext)
     {
         $this->name = $name;
-        $this->offset = $offset;
         $this->symbolContext = $symbolContext;
     }
 
@@ -29,14 +26,8 @@ final class Variable
     {
         return new self(
             $symbolContext->symbol()->name(),
-            Offset::fromInt($symbolContext->symbol()->position()->start()),
             $symbolContext
         );
-    }
-
-    public function offset(): Offset
-    {
-        return $this->offset;
     }
 
     public function name(): string
@@ -49,20 +40,15 @@ final class Variable
         return $this->symbolContext;
     }
 
-    public function isNamed(string $name)
+    public function isNamed(string $name): bool
     {
         $name = ltrim($name, '$');
 
         return $this->name == $name;
     }
 
-    public function withTypes(Types $types)
+    public function withTypes(Types $types): self
     {
-        return new self($this->name, $this->offset, $this->symbolContext->withTypes($types));
-    }
-
-    public function withOffset($offset): Variable
-    {
-        return new self($this->name, Offset::fromUnknown($offset), $this->symbolContext);
+        return new self($this->name, $this->symbolContext->withTypes($types));
     }
 }

--- a/lib/WorseReflection/Core/Inference/Variable.php
+++ b/lib/WorseReflection/Core/Inference/Variable.php
@@ -3,18 +3,25 @@
 namespace Phpactor\WorseReflection\Core\Inference;
 
 use Phpactor\WorseReflection\Core\Offset;
+use Phpactor\WorseReflection\Core\Type;
 use Phpactor\WorseReflection\Core\Types;
 
 final class Variable
 {
     private string $name;
-    
-    private NodeContext $symbolContext;
 
-    private function __construct(string $name, NodeContext $symbolContext)
+    private Type $type;
+
+    /**
+     * @var mixed
+     */
+    private $value;
+
+    private function __construct(string $name, Type $type, $value = null)
     {
         $this->name = $name;
-        $this->symbolContext = $symbolContext;
+        $this->type = $type;
+        $this->value = $value;
     }
 
     public function __toString()
@@ -26,7 +33,8 @@ final class Variable
     {
         return new self(
             $symbolContext->symbol()->name(),
-            $symbolContext
+            $symbolContext->type(),
+            $symbolContext->value(),
         );
     }
 
@@ -35,9 +43,9 @@ final class Variable
         return $this->name;
     }
 
-    public function symbolContext(): NodeContext
+    public function type(): Type
     {
-        return $this->symbolContext;
+        return $this->type;
     }
 
     public function isNamed(string $name): bool

--- a/lib/WorseReflection/Core/Inference/Walker/AbstractInstanceOfWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/AbstractInstanceOfWalker.php
@@ -162,7 +162,7 @@ abstract class AbstractInstanceOfWalker extends AbstractWalker
         Frame $frame,
         WorseVariable $variable
     ): Assignments {
-        if (Symbol::PROPERTY === $variable->symbolContext()->symbol()->symbolType()) {
+        if ($variable->isProperty()) {
             return $frame->properties();
         }
 

--- a/lib/WorseReflection/Core/Inference/Walker/AbstractInstanceOfWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/AbstractInstanceOfWalker.php
@@ -134,7 +134,7 @@ abstract class AbstractInstanceOfWalker extends AbstractWalker
             ;
         }
 
-        $classType = $assignments->first()->symbolContext()->types()->best();
+        $classType = $assignments->first()->types()->best();
 
         return $symbolContext->withContainerType($classType);
     }

--- a/lib/WorseReflection/Core/Inference/Walker/AssertFrameWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/AssertFrameWalker.php
@@ -47,7 +47,7 @@ class AssertFrameWalker extends AbstractInstanceOfWalker implements Walker
 
             foreach ($variables as $variable) {
                 $this->getAssignmentsMatchingVariableType($frame, $variable)
-                    ->add($variable)
+                    ->add($node->getStartPosition(), $variable)
                 ;
             }
         }

--- a/lib/WorseReflection/Core/Inference/Walker/AssignmentWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/AssignmentWalker.php
@@ -97,7 +97,7 @@ class AssignmentWalker extends AbstractWalker
             ]
         );
 
-        $frame->locals()->add(WorseVariable::fromSymbolContext($context));
+        $frame->locals()->add($leftOperand->getStartPosition(), WorseVariable::fromSymbolContext($context));
     }
 
     private function walkMemberAccessExpression(
@@ -142,7 +142,7 @@ class AssignmentWalker extends AbstractWalker
             ]
         );
 
-        $frame->properties()->add(WorseVariable::fromSymbolContext($context));
+        $frame->properties()->add($leftOperand->getStartPosition(), WorseVariable::fromSymbolContext($context));
     }
 
     private function walkArrayCreation(Frame $frame, ArrayCreationExpression $leftOperand, NodeContext $symbolContext): void
@@ -231,7 +231,7 @@ class AssignmentWalker extends AbstractWalker
                 $variableContext = $variableContext->withType(TypeFactory::fromString(gettype($value[$index])));
             }
         
-            $frame->locals()->add(WorseVariable::fromSymbolContext($variableContext));
+            $frame->locals()->add($element->getStartPosition(), WorseVariable::fromSymbolContext($variableContext));
         }
     }
 }

--- a/lib/WorseReflection/Core/Inference/Walker/CatchWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/CatchWalker.php
@@ -45,7 +45,7 @@ class CatchWalker extends AbstractWalker
             ]
         );
 
-        $frame->locals()->add(Variable::fromSymbolContext($context));
+        $frame->locals()->add($variableName->getStartPosition(), Variable::fromSymbolContext($context));
 
         return $frame;
     }

--- a/lib/WorseReflection/Core/Inference/Walker/ForeachWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/ForeachWalker.php
@@ -31,6 +31,7 @@ class ForeachWalker extends AbstractWalker
     {
         assert($node instanceof ForeachStatement);
         $collection = $resolver->resolveNode($frame, $node->forEachCollectionName);
+
         $this->processKey($node, $frame, $collection);
         $this->processValue($resolver, $node, $frame, $collection);
 
@@ -87,7 +88,7 @@ class ForeachWalker extends AbstractWalker
             ]
         );
         
-        $frame->locals()->add(WorseVariable::fromSymbolContext($context));
+        $frame->locals()->add($node->getStartPosition(), WorseVariable::fromSymbolContext($context));
     }
 
     private function valueFromVariable(Variable $expression, ForeachStatement $node, NodeContext $collection, Frame $frame): void
@@ -116,7 +117,7 @@ class ForeachWalker extends AbstractWalker
             $context = $context->withType($collectionType->valueType);
         }
         
-        $frame->locals()->add(WorseVariable::fromSymbolContext($context));
+        $frame->locals()->add($context->symbol()->position()->start(), WorseVariable::fromSymbolContext($context));
     }
 
     private function valueFromArrayCreation(
@@ -148,7 +149,7 @@ class ForeachWalker extends AbstractWalker
                 $context = $context->withValue($values[$index]);
             }
 
-            $frame->locals()->add(WorseVariable::fromSymbolContext($context));
+            $frame->locals()->add($context->symbol()->position()->start(), WorseVariable::fromSymbolContext($context));
             $index++;
         }
     }

--- a/lib/WorseReflection/Core/Inference/Walker/FunctionLikeWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/FunctionLikeWalker.php
@@ -71,7 +71,7 @@ class FunctionLikeWalker extends AbstractWalker
 
             // add this and self
             // TODO: self is NOT added here - does it work?
-            $frame->locals()->add(Variable::fromSymbolContext($context));
+            $frame->locals()->add($node->getStartPosition(), Variable::fromSymbolContext($context));
         }
 
         if ($node instanceof AnonymousFunctionCreationExpression) {
@@ -99,7 +99,7 @@ class FunctionLikeWalker extends AbstractWalker
                 ]
             );
 
-            $frame->locals()->add(Variable::fromSymbolContext($context));
+            $frame->locals()->add($parameterNode->getStartPosition(), Variable::fromSymbolContext($context));
         }
     }
 
@@ -139,7 +139,7 @@ class FunctionLikeWalker extends AbstractWalker
             // add it with above context and continue
             // TODO: Do we infer the type hint??
             if (0 === $parentVars->byName($varName)->count()) {
-                $frame->locals()->add(Variable::fromSymbolContext($variableContext));
+                $frame->locals()->add($element->getStartPosition(), Variable::fromSymbolContext($variableContext));
                 continue;
             }
 
@@ -149,7 +149,7 @@ class FunctionLikeWalker extends AbstractWalker
                 ->withType($variable->symbolContext()->type())
                 ->withValue($variable->symbolContext()->value());
 
-            $frame->locals()->add(Variable::fromSymbolContext($variableContext));
+            $frame->locals()->add($element->getStartPosition(), Variable::fromSymbolContext($variableContext));
         }
     }
 

--- a/lib/WorseReflection/Core/Inference/Walker/FunctionLikeWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/FunctionLikeWalker.php
@@ -146,8 +146,8 @@ class FunctionLikeWalker extends AbstractWalker
             $variable = $parentVars->byName($varName)->last();
 
             $variableContext = $variableContext
-                ->withType($variable->symbolContext()->type())
-                ->withValue($variable->symbolContext()->value());
+                ->withType($variable->type())
+                ->withValue($variable->value());
 
             $frame->locals()->add($element->getStartPosition(), Variable::fromSymbolContext($variableContext));
         }

--- a/lib/WorseReflection/Core/Inference/Walker/IncludeWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/IncludeWalker.php
@@ -99,7 +99,8 @@ class IncludeWalker implements Walker
         $name = $name->getText($node->getFileContents());
         
         foreach ($frame->locals()->byName((string)$name) as $variable) {
-            $frame->locals()->add(
+            $frame->locals()->replace(
+                $variable,
                 $variable->withTypes($returnValueContext->types())
             );
             return $frame;

--- a/lib/WorseReflection/Core/Inference/Walker/InstanceOfWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/InstanceOfWalker.php
@@ -50,11 +50,11 @@ class InstanceOfWalker extends AbstractInstanceOfWalker implements Walker
 
                 // reset variables after the if branch
                 if ($expressionsAreTrue) {
-                    $assignments->add($variable);
+                    $assignments->add($node->getStartPosition(), $variable);
 
                     // restore
                     $restoredVariable = $this->existingOrStripType($node, $frame, $variable);
-                    $assignments->add($restoredVariable);
+                    $assignments->add($node->getEndPosition(), $restoredVariable);
                     continue;
                 }
 
@@ -68,14 +68,14 @@ class InstanceOfWalker extends AbstractInstanceOfWalker implements Walker
             }
 
             if ($expressionsAreTrue) {
-                $assignments->add($variable);
+                $assignments->add($node->getStartPosition(), $variable);
                 $restoredVariable = $this->existingOrStripType($node, $frame, $variable);
-                $assignments->add($restoredVariable);
+                $assignments->add($node->getEndPosition(), $restoredVariable);
             }
 
             if (false === $expressionsAreTrue) {
                 $variable = $variable->withTypes(Types::empty());
-                $assignments->add($variable);
+                $assignments->add($node->getStartPosition(), $variable);
             }
         }
 

--- a/lib/WorseReflection/Core/Inference/Walker/InstanceOfWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/InstanceOfWalker.php
@@ -131,10 +131,9 @@ class InstanceOfWalker extends AbstractInstanceOfWalker implements Walker
             if (isset($vars[$variable->name()])) {
                 $originalVariable = $vars[$variable->name()];
                 $variable = $originalVariable->withTypes(
-                    $originalVariable->symbolContext()
-                        ->types()
+                    $originalVariable->types()
                         ->merge(
-                            $variable->symbolContext()->types()
+                            $variable->types()
                         )
                 );
             }

--- a/lib/WorseReflection/Core/Inference/Walker/InstanceOfWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/InstanceOfWalker.php
@@ -61,9 +61,8 @@ class InstanceOfWalker extends AbstractInstanceOfWalker implements Walker
                 // create new variables after the if branch
                 if (false === $expressionsAreTrue) {
                     $detypedVariable = $variable->withTypes(Types::empty());
-                    $assignments->add($detypedVariable);
-                    $variable = $variable->withOffset($node->getEndPosition());
-                    $assignments->add($variable);
+                    $assignments->add($node->getStartPosition(), $detypedVariable);
+                    $assignments->add($node->getEndPosition(), $variable);
                     continue;
                 }
             }

--- a/lib/WorseReflection/Core/Inference/Walker/InstanceOfWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/InstanceOfWalker.php
@@ -154,9 +154,9 @@ class InstanceOfWalker extends AbstractInstanceOfWalker implements Walker
         ;
 
         if (0 === $previousAssignments->count()) {
-            return $variable->withTypes(Types::empty())->withOffset($node->getEndPosition());
+            return $variable->withTypes(Types::empty());
         }
 
-        return $previousAssignments->last()->withOffset($node->getEndPosition());
+        return $previousAssignments->last();
     }
 }

--- a/lib/WorseReflection/Core/Inference/Walker/VariableWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/VariableWalker.php
@@ -79,10 +79,11 @@ class VariableWalker extends AbstractWalker
         $locals = $frame->locals();
         foreach ($locals->byName($symbolName)->equalTo($context->symbol()->position()->start()) as $existing) {
             assert($existing instanceof PhpactorVariable);
+            // TODO: not sure this will work as expected
             $locals->replace($existing, $existing->withTypes($context->types()));
             return $frame;
         }
-        $frame->locals()->add(WorseVariable::fromSymbolContext($context));
+        $frame->locals()->add($context->symbol()->position()->start(), WorseVariable::fromSymbolContext($context));
 
         return $frame;
     }

--- a/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/AssertWalkerTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/AssertWalkerTest.php
@@ -20,7 +20,7 @@ class AssertWalkerTest extends FrameWalkerTestCase
         ,
             function (Frame $frame): void {
                 $this->assertCount(1, $frame->locals());
-                $this->assertEquals('Foobar', (string) $frame->locals()->first()->symbolContext()->types()->best());
+                $this->assertEquals('Foobar', (string) $frame->locals()->first()->types()->best());
             }
         ];
 
@@ -55,10 +55,10 @@ class AssertWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame, int $offset): void {
             $this->assertCount(1, $frame->locals());
-            $this->assertEquals('Foo', $frame->locals()->atIndex(0)->symbolContext()->types()->best()->__toString());
+            $this->assertEquals('Foo', $frame->locals()->atIndex(0)->types()->best()->__toString());
             $this->assertCount(1, $frame->properties());
             $this->assertEquals('Foo', $frame->properties()->atIndex(0)->symbolContext()->containerType()->__toString());
-            $this->assertEquals('Bar', $frame->properties()->atIndex(0)->symbolContext()->types()->best()->__toString());
+            $this->assertEquals('Bar', $frame->properties()->atIndex(0)->types()->best()->__toString());
         }];
     }
 }

--- a/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/AssertWalkerTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/AssertWalkerTest.php
@@ -57,8 +57,8 @@ class AssertWalkerTest extends FrameWalkerTestCase
             $this->assertCount(1, $frame->locals());
             $this->assertEquals('Foo', $frame->locals()->atIndex(0)->types()->best()->__toString());
             $this->assertCount(1, $frame->properties());
-            $this->assertEquals('Foo', $frame->properties()->atIndex(0)->symbolContext()->containerType()->__toString());
-            $this->assertEquals('Bar', $frame->properties()->atIndex(0)->types()->best()->__toString());
+            $this->assertEquals('Foo', $frame->properties()->atIndex(0)->classType()->__toString());
+            $this->assertEquals('Bar', $frame->properties()->atIndex(0)->type()->__toString());
         }];
     }
 }

--- a/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/AssignmentWalkerTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/AssignmentWalkerTest.php
@@ -28,9 +28,9 @@ class AssignmentWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame): void {
             $this->assertCount(1, $frame->locals()->byName('foobar'));
-            $symbolInformation = $frame->locals()->byName('foobar')->first()->symbolContext();
-            $this->assertEquals('string', (string) $symbolInformation->type());
-            $this->assertEquals('foobar', (string) $symbolInformation->value());
+            $var = $frame->locals()->byName('foobar')->first();
+            $this->assertEquals('string', (string) $var->type());
+            $this->assertEquals('foobar', (string) $var->value());
         }];
         yield 'It returns types for reassigned variables' => [
             <<<'EOT'
@@ -49,9 +49,9 @@ class AssignmentWalkerTest extends FrameWalkerTestCase
         , function (Frame $frame): void {
             $vars = $frame->locals()->byName('foobar');
             $this->assertCount(1, $vars);
-            $symbolInformation = $vars->first()->symbolContext();
-            $this->assertEquals('World', (string) $symbolInformation->type());
-            $this->assertEquals('test', (string) $symbolInformation->value());
+            $var = $vars->first();
+            $this->assertEquals('World', (string) $var->type());
+            $this->assertEquals('test', (string) $var->value());
         }];
 
         yield 'It returns type for $this' => [
@@ -70,8 +70,8 @@ class AssignmentWalkerTest extends FrameWalkerTestCase
         , function (Frame $frame): void {
             $vars = $frame->locals()->byName('this');
             $this->assertCount(1, $vars);
-            $symbolInformation = $vars->first()->symbolContext();
-            $this->assertEquals('Foobar', (string) $symbolInformation->type());
+            $var = $vars->first();
+            $this->assertEquals('Foobar', (string) $var->type());
         }];
 
         yield 'It tracks assigned properties' => [
@@ -90,9 +90,9 @@ class AssignmentWalkerTest extends FrameWalkerTestCase
         , function (Frame $frame): void {
             $vars = $frame->properties()->byName('foobar');
             $this->assertCount(1, $vars);
-            $symbolInformation = $vars->first()->symbolContext();
-            $this->assertEquals('string', (string) $symbolInformation->type());
-            $this->assertEquals('foobar', (string) $symbolInformation->value());
+            $var = $vars->first();
+            $this->assertEquals('string', (string) $var->type());
+            $this->assertEquals('foobar', (string) $var->value());
         }];
 
         yield 'It assigns property values to assignments' => [
@@ -114,11 +114,11 @@ class AssignmentWalkerTest extends FrameWalkerTestCase
         , function (Frame $frame): void {
             $vars = $frame->locals()->byName('foobar');
             $this->assertCount(1, $vars);
-            $symbolInformation = $vars->first()->symbolContext();
-            $type = $symbolInformation->type();
+            $var = $vars->first();
+            $type = $var->type();
             assert($type instanceof IterableType);
             $this->assertEquals('Foobar[]', (string) $type);
-            $this->assertEquals('Foobar', (string) $symbolInformation->type()->valueType);
+            $this->assertEquals('Foobar', (string) $var->type()->valueType);
         }];
 
 
@@ -138,9 +138,9 @@ class AssignmentWalkerTest extends FrameWalkerTestCase
         , function (Frame $frame): void {
             $vars = $frame->properties()->byName('foobar');
             $this->assertCount(1, $vars);
-            $symbolInformation = $vars->first()->symbolContext();
-            $this->assertEquals('array', (string) $symbolInformation->type());
-            $this->assertEquals('foobar', (string) $symbolInformation->value());
+            $var = $vars->first();
+            $this->assertEquals('array', (string) $var->type());
+            $this->assertEquals('foobar', (string) $var->value());
         }];
 
         yield 'It tracks assigned from variable' => [
@@ -160,9 +160,9 @@ class AssignmentWalkerTest extends FrameWalkerTestCase
         , function (Frame $frame): void {
             $vars = $frame->properties()->byName('foobar');
             $this->assertCount(1, $vars);
-            $symbolInformation = $vars->first()->symbolContext();
-            $this->assertEquals('string', (string) $symbolInformation->type());
-            $this->assertEquals('foobar', (string) $symbolInformation->value());
+            $var = $vars->first();
+            $this->assertEquals('string', (string) $var->type());
+            $this->assertEquals('foobar', (string) $var->value());
         }];
 
         yield 'Handles array assignments' => [
@@ -176,9 +176,9 @@ class AssignmentWalkerTest extends FrameWalkerTestCase
             function (Frame $frame): void {
                 $this->assertCount(2, $frame->locals());
                 $this->assertEquals('array', (string) $frame->locals()->first()->type());
-                $this->assertEquals(['foo' => 'bar'], $frame->locals()->first()->symbolContext()->value());
+                $this->assertEquals(['foo' => 'bar'], $frame->locals()->first()->value());
                 $this->assertEquals('string', (string) $frame->locals()->last()->type());
-                $this->assertEquals('bar', (string) $frame->locals()->last()->symbolContext()->value());
+                $this->assertEquals('bar', (string) $frame->locals()->last()->value());
             }
         ];
 
@@ -191,7 +191,7 @@ class AssignmentWalkerTest extends FrameWalkerTestCase
         ,
             function (Frame $frame): void {
                 $this->assertCount(2, $frame->locals());
-                $this->assertEquals('foo', $frame->locals()->first()->symbolContext()->value());
+                $this->assertEquals('foo', $frame->locals()->first()->value());
                 $this->assertEquals('string', (string) $frame->locals()->first()->type());
             }
         ];
@@ -205,8 +205,8 @@ class AssignmentWalkerTest extends FrameWalkerTestCase
         ,
             function (Frame $frame): void {
                 $this->assertCount(2, $frame->locals());
-                $this->assertEquals('foo', $frame->locals()->atIndex(0)->symbolContext()->value());
-                $this->assertEquals('bar', $frame->locals()->atIndex(1)->symbolContext()->value());
+                $this->assertEquals('foo', $frame->locals()->atIndex(0)->value());
+                $this->assertEquals('bar', $frame->locals()->atIndex(1)->value());
             }
         ];
 

--- a/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/AssignmentWalkerTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/AssignmentWalkerTest.php
@@ -175,9 +175,9 @@ class AssignmentWalkerTest extends FrameWalkerTestCase
         ,
             function (Frame $frame): void {
                 $this->assertCount(2, $frame->locals());
-                $this->assertEquals('array', (string) $frame->locals()->first()->symbolContext()->type());
+                $this->assertEquals('array', (string) $frame->locals()->first()->type());
                 $this->assertEquals(['foo' => 'bar'], $frame->locals()->first()->symbolContext()->value());
-                $this->assertEquals('string', (string) $frame->locals()->last()->symbolContext()->type());
+                $this->assertEquals('string', (string) $frame->locals()->last()->type());
                 $this->assertEquals('bar', (string) $frame->locals()->last()->symbolContext()->value());
             }
         ];
@@ -192,7 +192,7 @@ class AssignmentWalkerTest extends FrameWalkerTestCase
             function (Frame $frame): void {
                 $this->assertCount(2, $frame->locals());
                 $this->assertEquals('foo', $frame->locals()->first()->symbolContext()->value());
-                $this->assertEquals('string', (string) $frame->locals()->first()->symbolContext()->type());
+                $this->assertEquals('string', (string) $frame->locals()->first()->type());
             }
         ];
 
@@ -247,9 +247,9 @@ class AssignmentWalkerTest extends FrameWalkerTestCase
                 $this->assertCount(3, $frame->locals());
                 $this->assertEquals(
                     'Foobar\Listy<Foobar\Collection>',
-                    (string) $frame->locals()->byName('bar')->first()->symbolContext()->types()->best()
+                    (string) $frame->locals()->byName('bar')->first()->types()->best()
                 );
-                $type = $frame->locals()->byName('bar')->first()->symbolContext()->types()->best();
+                $type = $frame->locals()->byName('bar')->first()->types()->best();
                 $this->assertEquals(
                     'Foobar\Collection',
                     $type->iterableValueType()->__toString()
@@ -276,7 +276,7 @@ class AssignmentWalkerTest extends FrameWalkerTestCase
         ,
             function (Frame $frame): void {
                 $this->assertCount(1, $frame->locals()->byName('barfoo'));
-                $type = $frame->locals()->byName('barfoo')->first()->symbolContext()->types()->best();
+                $type = $frame->locals()->byName('barfoo')->first()->types()->best();
                 assert($type instanceof ClassType);
                 $this->assertEquals('Barfoo', $type->name->short());
             }

--- a/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/CatchWalkerTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/CatchWalkerTest.php
@@ -29,7 +29,7 @@ class CatchWalkerTest extends FrameWalkerTestCase
                 $exception = $frame->locals()->byName('$exception')->first();
                 self::assertTrinaryTrue(
                     TypeFactory::class('\Exception')->is(
-                        $exception->symbolContext()->type()
+                        $exception->type()
                     )
                 );
             }
@@ -48,7 +48,7 @@ class CatchWalkerTest extends FrameWalkerTestCase
             function (Frame $frame): void {
                 $this->assertCount(1, $frame->locals()->byName('$exception'));
                 $exception = $frame->locals()->byName('$exception')->first();
-                self::assertEquals('Foo|Bar', $exception->symbolContext()->types()->__toString());
+                self::assertEquals('Foo|Bar', $exception->types()->__toString());
             }
         ];
     }

--- a/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/ForeachWalkerTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/ForeachWalkerTest.php
@@ -2,7 +2,6 @@
 
 namespace Phpactor\WorseReflection\Tests\Integration\Core\Inference\FrameWalker;
 
-use Phpactor\WorseReflection\Core\Inference\Symbol;
 use Phpactor\WorseReflection\Core\TypeFactory;
 use Phpactor\WorseReflection\Tests\Integration\Core\Inference\FrameWalkerTestCase;
 use Phpactor\WorseReflection\Core\Inference\Frame;

--- a/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/ForeachWalkerTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/ForeachWalkerTest.php
@@ -26,7 +26,7 @@ class ForeachWalkerTest extends FrameWalkerTestCase
             function (Frame $frame): void {
                 $this->assertCount(2, $frame->locals());
                 $this->assertCount(1, $frame->locals()->byName('item'));
-                $this->assertEquals('int', (string) $frame->locals()->byName('item')->first()->symbolContext()->types()->best());
+                $this->assertEquals('int', (string) $frame->locals()->byName('item')->first()->types()->best());
             }
         ];
 
@@ -44,8 +44,8 @@ class ForeachWalkerTest extends FrameWalkerTestCase
             function (Frame $frame): void {
                 $this->assertCount(3, $frame->locals());
                 $this->assertCount(1, $frame->locals()->byName('key'));
-                $this->assertEquals(TypeFactory::unknown(), $frame->locals()->byName('key')->first()->symbolContext()->types()->best());
-                $this->assertEquals(Symbol::VARIABLE, $frame->locals()->byName('key')->first()->symbolContext()->symbol()->symbolType());
+                $this->assertEquals(TypeFactory::unknown(), $frame->locals()->byName('key')->first()->types()->best());
+                $this->assertEquals(false, $frame->locals()->byName('key')->first()->isProperty());
             }
         ];
 
@@ -67,7 +67,7 @@ class ForeachWalkerTest extends FrameWalkerTestCase
             function (Frame $frame): void {
                 $this->assertCount(2, $frame->locals());
                 $this->assertCount(1, $frame->locals()->byName('item'));
-                $this->assertEquals('Foobar\\Barfoo', (string) $frame->locals()->byName('item')->first()->symbolContext()->types()->best());
+                $this->assertEquals('Foobar\\Barfoo', (string) $frame->locals()->byName('item')->first()->types()->best());
             }
         ];
 
@@ -97,11 +97,11 @@ class ForeachWalkerTest extends FrameWalkerTestCase
                 $this->assertCount(1, $frame->locals()->byName('item'));
                 $this->assertEquals(
                     'Foobar\\Collection<Foobar\Item>',
-                    (string) $frame->locals()->byName('items')->first()->symbolContext()->types()->best()
+                    (string) $frame->locals()->byName('items')->first()->types()->best()
                 );
                 $this->assertEquals(
                     'Foobar\\Item',
-                    (string) $frame->locals()->byName('item')->first()->symbolContext()->types()->best()
+                    (string) $frame->locals()->byName('item')->first()->types()->best()
                 );
             }
         ];
@@ -125,8 +125,8 @@ class ForeachWalkerTest extends FrameWalkerTestCase
         , function (Frame $frame): void {
             $vars = $frame->locals()->byName('foobar');
             $this->assertCount(2, $vars);
-            $symbolInformation = $vars->atIndex(1)->symbolContext();
-            $this->assertEquals('Foobar', (string) $symbolInformation->type());
+            $var = $vars->atIndex(1);
+            $this->assertEquals('Foobar', (string) $var->type());
         }];
 
         yield 'List assignment in foreach' => [
@@ -143,11 +143,11 @@ class ForeachWalkerTest extends FrameWalkerTestCase
                 $this->assertEquals('bar', $frame->locals()->atIndex(1)->name());
                 $this->assertEquals(
                     'foo',
-                    $frame->locals()->byName('foo')->first()->symbolContext()->value()
+                    $frame->locals()->byName('foo')->first()->value()
                 );
                 $this->assertEquals(
                     'bar',
-                    $frame->locals()->byName('bar')->first()->symbolContext()->value()
+                    $frame->locals()->byName('bar')->first()->value()
                 );
             }
         ];
@@ -166,12 +166,12 @@ class ForeachWalkerTest extends FrameWalkerTestCase
             function (Frame $frame): void {
                 $this->assertEquals(
                     TypeFactory::string(),
-                    $frame->locals()->byName('foo')->atIndex(0)->symbolContext()->type(),
+                    $frame->locals()->byName('foo')->atIndex(0)->type(),
                     'Type'
                 );
                 $this->assertEquals(
                     'one',
-                    $frame->locals()->byName('foo')->first()->symbolContext()->value(),
+                    $frame->locals()->byName('foo')->first()->value(),
                     'Value'
                 );
             }

--- a/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/FunctionLikeWalkerTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/FunctionLikeWalkerTest.php
@@ -5,7 +5,6 @@ namespace Phpactor\WorseReflection\Tests\Integration\Core\Inference\FrameWalker;
 use Phpactor\WorseReflection\Core\Type\IterableType;
 use Phpactor\WorseReflection\Tests\Integration\Core\Inference\FrameWalkerTestCase;
 use Generator;
-use Phpactor\WorseReflection\Core\Inference\Symbol;
 use Phpactor\WorseReflection\Core\Inference\Frame;
 
 class FunctionLikeWalkerTest extends FrameWalkerTestCase

--- a/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/FunctionLikeWalkerTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/FunctionLikeWalkerTest.php
@@ -31,7 +31,7 @@ class FunctionLikeWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame): void {
             $this->assertCount(1, $frame->locals()->byName('this'));
-            $this->assertEquals('Foobar\Barfoo\Foobar', $frame->locals()->byName('this')->first()->symbolContext()->type()->__toString());
+            $this->assertEquals('Foobar\Barfoo\Foobar', $frame->locals()->byName('this')->first()->type()->__toString());
             $this->assertEquals(Symbol::VARIABLE, $frame->locals()->byName('this')->first()->symbolContext()->symbol()->symbolType());
         }];
 
@@ -57,7 +57,7 @@ class FunctionLikeWalkerTest extends FrameWalkerTestCase
             $this->assertCount(1, $frame->locals()->byName('this'));
             $this->assertEquals(
                 'Foobar\Barfoo\Foobar',
-                $frame->locals()->byName('this')->first()->symbolContext()->type()->__toString()
+                $frame->locals()->byName('this')->first()->type()->__toString()
             );
         }];
 
@@ -85,11 +85,11 @@ class FunctionLikeWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame): void {
             $this->assertCount(1, $frame->locals()->byName('many'));
-            $this->assertEquals('string', (string) $frame->locals()->byName('many')->first()->symbolContext()->types()->best());
+            $this->assertEquals('string', (string) $frame->locals()->byName('many')->first()->types()->best());
 
             $this->assertCount(1, $frame->locals()->byName('worlds'));
-            $this->assertEquals('Foobar\Barfoo\World[]', (string) $frame->locals()->byName('worlds')->first()->symbolContext()->types()->best());
-            $type = $frame->locals()->byName('worlds')->first()->symbolContext()->types()->best();
+            $this->assertEquals('Foobar\Barfoo\World[]', (string) $frame->locals()->byName('worlds')->first()->types()->best());
+            $type = $frame->locals()->byName('worlds')->first()->types()->best();
             assert($type instanceof IterableType);
             $this->assertEquals('Foobar\Barfoo\World', (string) $type->valueType);
         }];
@@ -115,7 +115,7 @@ class FunctionLikeWalkerTest extends FrameWalkerTestCase
         , function (Frame $frame): void {
             $this->assertCount(1, $frame->locals()->byName('hellos'));
             $variable = $frame->locals()->byName('hellos')->first();
-            $type = $variable->symbolContext()->type();
+            $type = $variable->type();
             assert($type instanceof IterableType);
             $this->assertEquals('string', (string)$type->valueType);
         }];
@@ -150,7 +150,7 @@ class FunctionLikeWalkerTest extends FrameWalkerTestCase
             function (Frame $frame): void {
                 $this->assertCount(1, $frame->locals()->byName('$foo'));
                 $variable = $frame->locals()->byName('$foo')->first();
-                $this->assertEquals('Foobar', $variable->symbolContext()->type()->__toString());
+                $this->assertEquals('Foobar', $variable->type()->__toString());
             }
         ];
 
@@ -168,7 +168,7 @@ class FunctionLikeWalkerTest extends FrameWalkerTestCase
             function (Frame $frame): void {
                 $this->assertCount(1, $frame->locals()->byName('$zed'));
                 $zed = $frame->locals()->byName('$zed')->first();
-                $this->assertEquals('string', (string) $zed->symbolContext()->type());
+                $this->assertEquals('string', (string) $zed->type());
                 $this->assertEquals(Symbol::VARIABLE, $zed->symbolContext()->symbol()->symbolType());
             }
         ];
@@ -194,7 +194,7 @@ class FunctionLikeWalkerTest extends FrameWalkerTestCase
         ,
             function (Frame $frame): void {
                 $this->assertCount(1, $frame->locals()->byName('$zed'));
-                $this->assertEquals('string', (string) $frame->locals()->byName('$zed')->last()->symbolContext()->type());
+                $this->assertEquals('string', (string) $frame->locals()->byName('$zed')->last()->type());
             }
         ];
     }

--- a/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/FunctionLikeWalkerTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/FunctionLikeWalkerTest.php
@@ -32,7 +32,7 @@ class FunctionLikeWalkerTest extends FrameWalkerTestCase
         , function (Frame $frame): void {
             $this->assertCount(1, $frame->locals()->byName('this'));
             $this->assertEquals('Foobar\Barfoo\Foobar', $frame->locals()->byName('this')->first()->type()->__toString());
-            $this->assertEquals(Symbol::VARIABLE, $frame->locals()->byName('this')->first()->symbolContext()->symbol()->symbolType());
+            $this->assertEquals(false, $frame->locals()->byName('this')->first()->isProperty());
         }];
 
         yield 'It returns method arguments' => [
@@ -169,7 +169,6 @@ class FunctionLikeWalkerTest extends FrameWalkerTestCase
                 $this->assertCount(1, $frame->locals()->byName('$zed'));
                 $zed = $frame->locals()->byName('$zed')->first();
                 $this->assertEquals('string', (string) $zed->type());
-                $this->assertEquals(Symbol::VARIABLE, $zed->symbolContext()->symbol()->symbolType());
             }
         ];
 

--- a/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/IncludeWalkerTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/IncludeWalkerTest.php
@@ -71,7 +71,7 @@ class IncludeWalkerTest extends FrameWalkerTestCase
             function (Frame $frame): void {
                 $this->assertCount(1, $frame->locals());
                 $this->assertEquals('foo', $frame->locals()->last()->__toString());
-                $this->assertEquals('string', (string) $frame->locals()->last()->symbolContext()->type());
+                $this->assertEquals('string', (string) $frame->locals()->last()->type());
             }
         ];
 
@@ -86,7 +86,7 @@ class IncludeWalkerTest extends FrameWalkerTestCase
             function (Frame $frame): void {
                 $this->assertCount(1, $frame->locals());
                 $this->assertEquals('foo', $frame->locals()->last()->__toString());
-                $this->assertEquals('string', (string) $frame->locals()->last()->symbolContext()->type());
+                $this->assertEquals('string', (string) $frame->locals()->last()->type());
             }
         ];
     }

--- a/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/IncludeWalkerTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/IncludeWalkerTest.php
@@ -69,7 +69,7 @@ class IncludeWalkerTest extends FrameWalkerTestCase
                 EOT
         ,
             function (Frame $frame): void {
-                $this->assertCount(2, $frame->locals());
+                $this->assertCount(1, $frame->locals());
                 $this->assertEquals('foo', $frame->locals()->last()->__toString());
                 $this->assertEquals('string', (string) $frame->locals()->last()->symbolContext()->type());
             }
@@ -84,7 +84,7 @@ class IncludeWalkerTest extends FrameWalkerTestCase
                 EOT
         ,
             function (Frame $frame): void {
-                $this->assertCount(2, $frame->locals());
+                $this->assertCount(1, $frame->locals());
                 $this->assertEquals('foo', $frame->locals()->last()->__toString());
                 $this->assertEquals('string', (string) $frame->locals()->last()->symbolContext()->type());
             }

--- a/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/InstanceOfWalkerTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/InstanceOfWalkerTest.php
@@ -21,8 +21,8 @@ class InstanceOfWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame): void {
             $this->assertCount(2, $frame->locals());
-            $this->assertEquals('Foobar', (string) $frame->locals()->first()->symbolContext()->types()->best());
-            $this->assertEquals(TypeFactory::unknown(), $frame->locals()->atIndex(1)->symbolContext()->types()->best());
+            $this->assertEquals('Foobar', (string) $frame->locals()->first()->types()->best());
+            $this->assertEquals(TypeFactory::unknown(), $frame->locals()->atIndex(1)->types()->best());
         }
         ];
 
@@ -37,7 +37,7 @@ class InstanceOfWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame, int $offset): void {
             $this->assertCount(2, $frame->locals());
-            $this->assertEquals(TypeFactory::unknown(), $frame->locals()->atIndex(1)->symbolContext()->types()->best());
+            $this->assertEquals(TypeFactory::unknown(), $frame->locals()->atIndex(1)->types()->best());
         }
         ];
 
@@ -52,7 +52,7 @@ class InstanceOfWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame, int $offset): void {
             $this->assertCount(2, $frame->locals());
-            $this->assertEquals(TypeFactory::unknown(), $frame->locals()->atIndex(1)->symbolContext()->types()->best());
+            $this->assertEquals(TypeFactory::unknown(), $frame->locals()->atIndex(1)->types()->best());
         }
         ];
 
@@ -70,7 +70,7 @@ class InstanceOfWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame, int $offset): void {
             $this->assertCount(2, $frame->locals()->byName('foobar'));
-            $this->assertEquals('Foobar', $frame->locals()->last()->symbolContext()->types()->best()->__toString());
+            $this->assertEquals('Foobar', $frame->locals()->last()->types()->best()->__toString());
         }
         ];
 
@@ -88,7 +88,7 @@ class InstanceOfWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame, int $offset): void {
             $this->assertCount(2, $frame->locals()->byName('foobar'));
-            $this->assertEquals('Foobar', $frame->locals()->last()->symbolContext()->types()->best()->__toString());
+            $this->assertEquals('Foobar', $frame->locals()->last()->types()->best()->__toString());
         }
         ];
 
@@ -102,7 +102,7 @@ class InstanceOfWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame, int $offset): void {
             $this->assertCount(1, $frame->locals());
-            $this->assertEquals(TypeFactory::unknown(), $frame->locals()->atIndex(0)->symbolContext()->types()->best());
+            $this->assertEquals(TypeFactory::unknown(), $frame->locals()->atIndex(0)->types()->best());
         }
     ];
 
@@ -116,7 +116,7 @@ class InstanceOfWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame, int $offset): void {
             $this->assertCount(1, $frame->locals());
-            $this->assertEquals(TypeFactory::unknown(), $frame->locals()->atIndex(0)->symbolContext()->types()->best());
+            $this->assertEquals(TypeFactory::unknown(), $frame->locals()->atIndex(0)->types()->best());
         }
         ];
 
@@ -133,8 +133,8 @@ class InstanceOfWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame, int $offset): void {
             $this->assertCount(2, $frame->locals());
-            $this->assertEquals(TypeFactory::unknown(), $frame->locals()->atIndex(0)->symbolContext()->types()->best());
-            $this->assertEquals('Foobar', (string) $frame->locals()->atIndex(1)->symbolContext()->types()->best());
+            $this->assertEquals(TypeFactory::unknown(), $frame->locals()->atIndex(0)->types()->best());
+            $this->assertEquals('Foobar', (string) $frame->locals()->atIndex(1)->types()->best());
         }
                 ];
 
@@ -152,7 +152,7 @@ class InstanceOfWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame, int $offset): void {
             $this->assertCount(3, $frame->locals());
-            $this->assertEquals('Foobar', (string) $frame->locals()->atIndex(2)->symbolContext()->types()->best());
+            $this->assertEquals('Foobar', (string) $frame->locals()->atIndex(2)->types()->best());
         }
         ];
 
@@ -168,8 +168,8 @@ class InstanceOfWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame, int $offset): void {
             $this->assertCount(2, $frame->locals());
-            $this->assertEquals('Foobar', (string) $frame->locals()->atIndex(1)->symbolContext()->types()->best());
-            $this->assertEquals(TypeFactory::unknown(), $frame->locals()->atIndex(0)->symbolContext()->types()->best());
+            $this->assertEquals('Foobar', (string) $frame->locals()->atIndex(1)->types()->best());
+            $this->assertEquals(TypeFactory::unknown(), $frame->locals()->atIndex(0)->types()->best());
         }
         ];
 
@@ -184,7 +184,7 @@ class InstanceOfWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame, int $offset): void {
             $this->assertCount(2, $frame->locals());
-            $this->assertEquals('Foobar|Barfoo', $frame->locals()->atIndex(0)->symbolContext()->types()->__toString());
+            $this->assertEquals('Foobar|Barfoo', $frame->locals()->atIndex(0)->types()->__toString());
         }
         ];
 
@@ -199,7 +199,7 @@ class InstanceOfWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame, int $offset): void {
             $this->assertCount(2, $frame->locals());
-            $this->assertEquals('Foobar|Barfoo', $frame->locals()->atIndex(0)->symbolContext()->types()->__toString());
+            $this->assertEquals('Foobar|Barfoo', $frame->locals()->atIndex(0)->types()->__toString());
         }
         ];
 
@@ -215,7 +215,7 @@ class InstanceOfWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame, int $offset): void {
             $this->assertCount(3, $frame->locals());
-            $this->assertEquals('stdClass', $frame->locals()->atIndex(2)->symbolContext()->types()->best());
+            $this->assertEquals('stdClass', $frame->locals()->atIndex(2)->types()->best());
         }
         ];
 
@@ -231,7 +231,7 @@ class InstanceOfWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame, int $offset): void {
             $this->assertCount(2, $frame->locals());
-            $this->assertEquals('Foobar\Barfoo', (string) $frame->locals()->atIndex(0)->symbolContext()->types()->best());
+            $this->assertEquals('Foobar\Barfoo', (string) $frame->locals()->atIndex(0)->types()->best());
         }
         ];
 
@@ -302,12 +302,12 @@ class InstanceOfWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame, int $offset): void {
             $this->assertCount(1, $frame->locals());
-            $this->assertEquals('Foo', $frame->locals()->atIndex(0)->symbolContext()->types()->best()->__toString());
+            $this->assertEquals('Foo', $frame->locals()->atIndex(0)->types()->best()->__toString());
             $this->assertCount(2, $frame->properties());
             $this->assertEquals('Foo', $frame->properties()->atIndex(0)->symbolContext()->containerType()->__toString());
-            $this->assertEquals(TypeFactory::unknown(), $frame->properties()->atIndex(0)->symbolContext()->types()->best()->__toString());
+            $this->assertEquals(TypeFactory::unknown(), $frame->properties()->atIndex(0)->types()->best()->__toString());
             $this->assertEquals('Foo', $frame->properties()->atIndex(1)->symbolContext()->containerType());
-            $this->assertEquals('Bar', $frame->properties()->atIndex(1)->symbolContext()->types()->best()->__toString());
+            $this->assertEquals('Bar', $frame->properties()->atIndex(1)->types()->best()->__toString());
         }
         ];
     }

--- a/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/InstanceOfWalkerTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/InstanceOfWalkerTest.php
@@ -304,9 +304,9 @@ class InstanceOfWalkerTest extends FrameWalkerTestCase
             $this->assertCount(1, $frame->locals());
             $this->assertEquals('Foo', $frame->locals()->atIndex(0)->types()->best()->__toString());
             $this->assertCount(2, $frame->properties());
-            $this->assertEquals('Foo', $frame->properties()->atIndex(0)->symbolContext()->containerType()->__toString());
+            $this->assertEquals('Foo', $frame->properties()->atIndex(0)->classType()->__toString());
             $this->assertEquals(TypeFactory::unknown(), $frame->properties()->atIndex(0)->types()->best()->__toString());
-            $this->assertEquals('Foo', $frame->properties()->atIndex(1)->symbolContext()->containerType());
+            $this->assertEquals('Foo', $frame->properties()->atIndex(1)->classType());
             $this->assertEquals('Bar', $frame->properties()->atIndex(1)->types()->best()->__toString());
         }
         ];

--- a/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/VariableWalkerTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/VariableWalkerTest.php
@@ -27,8 +27,8 @@ class VariableWalkerTest extends FrameWalkerTestCase
         , function (Frame $frame): void {
             $vars = $frame->locals()->byName('$foobar');
             $this->assertCount(2, $vars);
-            $this->assertEquals('Foobar', (string) $vars->first()->symbolContext()->type());
-            $this->assertEquals('stdClass', (string) $vars->last()->symbolContext()->type());
+            $this->assertEquals('Foobar', (string) $vars->first()->type());
+            $this->assertEquals('stdClass', (string) $vars->last()->type());
         }];
 
         yield 'Injects variables with @var (standard)' => [
@@ -41,7 +41,7 @@ class VariableWalkerTest extends FrameWalkerTestCase
         ,
             function (Frame $frame): void {
                 $this->assertCount(1, $frame->locals()->byName('$zed'));
-                $this->assertEquals('string', (string) $frame->locals()->byName('$zed')->last()->symbolContext()->type());
+                $this->assertEquals('string', (string) $frame->locals()->byName('$zed')->last()->type());
             }
         ];
 
@@ -56,7 +56,7 @@ class VariableWalkerTest extends FrameWalkerTestCase
         ,
             function (Frame $frame): void {
                 $this->assertCount(1, $frame->locals()->byName('$zed'));
-                $this->assertEquals('Foo\\Bar', (string) $frame->locals()->byName('$zed')->last()->symbolContext()->type());
+                $this->assertEquals('Foo\\Bar', (string) $frame->locals()->byName('$zed')->last()->type());
             }
         ];
 
@@ -71,7 +71,7 @@ class VariableWalkerTest extends FrameWalkerTestCase
         ,
             function (Frame $frame): void {
                 $this->assertCount(1, $frame->locals()->byName('$zed'));
-                $this->assertEquals('Foo\\Bar\\Baz', (string) $frame->locals()->byName('$zed')->last()->symbolContext()->type());
+                $this->assertEquals('Foo\\Bar\\Baz', (string) $frame->locals()->byName('$zed')->last()->type());
             }
         ];
 
@@ -86,7 +86,7 @@ class VariableWalkerTest extends FrameWalkerTestCase
         ,
             function (Frame $frame): void {
                 $this->assertCount(1, $frame->locals()->byName('$zed'));
-                $this->assertEquals('Bar\\Baz', (string) $frame->locals()->byName('$zed')->last()->symbolContext()->type());
+                $this->assertEquals('Bar\\Baz', (string) $frame->locals()->byName('$zed')->last()->type());
             }
         ];
 
@@ -102,7 +102,7 @@ class VariableWalkerTest extends FrameWalkerTestCase
         ,
             function (Frame $frame): void {
                 $this->assertCount(1, $frame->locals()->byName('$zed'));
-                $this->assertEquals('Foo\Bar\Zed\Baz', (string) $frame->locals()->byName('$zed')->last()->symbolContext()->type());
+                $this->assertEquals('Foo\Bar\Zed\Baz', (string) $frame->locals()->byName('$zed')->last()->type());
             }
         ];
 
@@ -117,7 +117,7 @@ class VariableWalkerTest extends FrameWalkerTestCase
         ,
             function (Frame $frame): void {
                 $this->assertCount(1, $frame->locals()->byName('$zed'));
-                $this->assertEquals('Bar|Baz', $frame->locals()->byName('$zed')->last()->symbolContext()->types()->__toString());
+                $this->assertEquals('Bar|Baz', $frame->locals()->byName('$zed')->last()->types()->__toString());
             }
         ];
 
@@ -132,7 +132,7 @@ class VariableWalkerTest extends FrameWalkerTestCase
         ,
             function (Frame $frame): void {
                 $this->assertCount(1, $frame->locals()->byName('$zed'));
-                $this->assertEquals('Zed\Baz', (string) $frame->locals()->byName('$zed')->first()->symbolContext()->type());
+                $this->assertEquals('Zed\Baz', (string) $frame->locals()->byName('$zed')->first()->type());
             }
         ];
 
@@ -149,7 +149,7 @@ class VariableWalkerTest extends FrameWalkerTestCase
         ,
             function (Frame $frame): void {
                 $this->assertCount(1, $frame->locals()->byName('$zed'));
-                $this->assertEquals('Zed\Baz', (string) $frame->locals()->byName('$zed')->first()->symbolContext()->type());
+                $this->assertEquals('Zed\Baz', (string) $frame->locals()->byName('$zed')->first()->type());
             }
         ];
 
@@ -167,7 +167,7 @@ class VariableWalkerTest extends FrameWalkerTestCase
         ,
             function (Frame $frame): void {
                 $this->assertCount(1, $frame->locals()->byName('$zed'));
-                $this->assertEquals('string', (string) $frame->locals()->byName('$zed')->last()->symbolContext()->type());
+                $this->assertEquals('string', (string) $frame->locals()->byName('$zed')->last()->type());
             }
         ];
     }

--- a/lib/WorseReflection/Tests/Integration/Core/Inference/SymbolContextResolverTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/Inference/SymbolContextResolverTest.php
@@ -48,12 +48,12 @@ class SymbolContextResolverTest extends IntegrationTestCase
             $variable = Variable::fromSymbolContext($varSymbolInfo);
 
             if (Symbol::PROPERTY === $varSymbolInfo->symbol()->symbolType()) {
-                $properties[] = $variable;
+                $properties[] = [$varSymbolInfo->symbol()->position()->start(), $variable];
 
                 continue;
             }
 
-            $variables[] = $variable;
+            $variables[] = [$varSymbolInfo->symbol()->position()->start(), $variable];
         }
 
         $symbolInfo = $this->resolveNodeAtOffset(
@@ -88,13 +88,14 @@ class SymbolContextResolverTest extends IntegrationTestCase
     {
         $value = $this->resolveNodeAtOffset(
             LocalAssignments::fromArray([
-                Variable::fromSymbolContext(
+                [0, Variable::fromSymbolContext(
                     NodeContext::for(Symbol::fromTypeNameAndPosition(
                         Symbol::CLASS_,
                         'bar',
                         Position::fromStartAndEnd(0, 0)
                     ))->withType(TypeFactory::fromString('Foobar'))
                 ),
+                ]
             ]),
             PropertyAssignments::create(),
             $source

--- a/lib/WorseReflection/Tests/Integration/Core/SourceReflectorTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/SourceReflectorTest.php
@@ -58,8 +58,8 @@ class SourceReflectorTest extends IntegrationTestCase
         ;
 
         $offset = $this->createReflector($source)->reflectOffset($source, 27);
-        $this->assertEquals('string', (string) $offset->type());
-        $this->assertEquals('Hello', $offset->frame()->locals()->byName('$foobar')->first()->symbolContext()->value());
+        $this->assertEquals('string', (string) $offset->symbolContext()->type());
+        $this->assertEquals('Hello', $offset->frame()->locals()->byName('$foobar')->first()->value());
     }
 
     /**
@@ -79,6 +79,6 @@ class SourceReflectorTest extends IntegrationTestCase
         list($source, $offset) = ExtractOffset::fromSource($source);
 
         $offset = $this->createReflector($source)->reflectOffset($source, $offset);
-        $this->assertEquals('int', (string) $offset->type());
+        $this->assertEquals('int', (string) $offset->symbolContext()->type());
     }
 }

--- a/lib/WorseReflection/Tests/Integration/Core/SourceReflectorTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/SourceReflectorTest.php
@@ -58,7 +58,7 @@ class SourceReflectorTest extends IntegrationTestCase
         ;
 
         $offset = $this->createReflector($source)->reflectOffset($source, 27);
-        $this->assertEquals('string', (string) $offset->symbolContext()->type());
+        $this->assertEquals('string', (string) $offset->type());
         $this->assertEquals('Hello', $offset->frame()->locals()->byName('$foobar')->first()->symbolContext()->value());
     }
 
@@ -79,6 +79,6 @@ class SourceReflectorTest extends IntegrationTestCase
         list($source, $offset) = ExtractOffset::fromSource($source);
 
         $offset = $this->createReflector($source)->reflectOffset($source, $offset);
-        $this->assertEquals('int', (string) $offset->symbolContext()->type());
+        $this->assertEquals('int', (string) $offset->type());
     }
 }

--- a/lib/WorseReflection/Tests/Unit/Core/Inference/AssignmentstTestCase.php
+++ b/lib/WorseReflection/Tests/Unit/Core/Inference/AssignmentstTestCase.php
@@ -25,7 +25,7 @@ abstract class AssignmentstTestCase extends TestCase
             )
         );
 
-        $assignments->add(Variable::fromSymbolContext($information));
+        $assignments->add(0, Variable::fromSymbolContext($information));
 
         $this->assertEquals($information, $assignments->byName('hello')->first()->symbolContext());
     }
@@ -34,8 +34,8 @@ abstract class AssignmentstTestCase extends TestCase
     {
         $assignments = $this->assignments();
 
-        $assignments->add($this->createVariable('hello', 0, 0));
-        $assignments->add($this->createVariable('hello', 0, 0));
+        $assignments->add(0, $this->createVariable('hello', 0, 0));
+        $assignments->add(0, $this->createVariable('hello', 0, 0));
 
         $this->assertCount(2, $assignments->byName('hello'));
     }
@@ -44,9 +44,9 @@ abstract class AssignmentstTestCase extends TestCase
     {
         $assignments = $this->assignments();
 
-        $assignments->add($this->createVariable('hello', 0, 5));
-        $assignments->add($this->createVariable('hello', 5, 10));
-        $assignments->add($this->createVariable('hello', 10, 15));
+        $assignments->add(0, $this->createVariable('hello', 0, 5));
+        $assignments->add(5, $this->createVariable('hello', 5, 10));
+        $assignments->add(10, $this->createVariable('hello', 10, 15));
 
         $this->assertCount(2, $assignments->byName('hello')->lessThanOrEqualTo(5));
     }
@@ -55,9 +55,9 @@ abstract class AssignmentstTestCase extends TestCase
     {
         $assignments = $this->assignments();
 
-        $assignments->add($this->createVariable('hello', 0, 5));
-        $assignments->add($this->createVariable('hello', 5, 10));
-        $assignments->add($this->createVariable('hello', 10, 15));
+        $assignments->add(0, $this->createVariable('hello', 0, 5));
+        $assignments->add(5, $this->createVariable('hello', 5, 10));
+        $assignments->add(10, $this->createVariable('hello', 10, 15));
 
         $this->assertCount(1, $assignments->byName('hello')->lessThan(5));
     }
@@ -66,9 +66,9 @@ abstract class AssignmentstTestCase extends TestCase
     {
         $assignments = $this->assignments();
 
-        $assignments->add($this->createVariable('hello', 0, 5));
-        $assignments->add($this->createVariable('hello', 5, 10));
-        $assignments->add($this->createVariable('hello', 10, 15));
+        $assignments->add(0, $this->createVariable('hello', 0, 5));
+        $assignments->add(5, $this->createVariable('hello', 5, 10));
+        $assignments->add(10, $this->createVariable('hello', 10, 15));
 
         $this->assertCount(2, $assignments->byName('hello')->greaterThanOrEqualTo(5));
     }
@@ -77,9 +77,9 @@ abstract class AssignmentstTestCase extends TestCase
     {
         $assignments = $this->assignments();
 
-        $assignments->add($this->createVariable('hello', 0, 5));
-        $assignments->add($this->createVariable('hello', 5, 10));
-        $assignments->add($this->createVariable('hello', 10, 15));
+        $assignments->add(0, $this->createVariable('hello', 0, 5));
+        $assignments->add(5, $this->createVariable('hello', 5, 10));
+        $assignments->add(10, $this->createVariable('hello', 10, 15));
 
         $this->assertCount(1, $assignments->byName('hello')->greaterThan(5));
     }
@@ -90,7 +90,7 @@ abstract class AssignmentstTestCase extends TestCase
         $this->expectExceptionMessage('No variable at index "5"');
         $assignments = $this->assignments();
 
-        $assignments->add($this->createVariable('hello', 0, 5));
+        $assignments->add(0, $this->createVariable('hello', 0, 5));
 
         $this->assertCount(1, $assignments->atIndex(5));
     }

--- a/lib/WorseReflection/Tests/Unit/Core/Inference/AssignmentstTestCase.php
+++ b/lib/WorseReflection/Tests/Unit/Core/Inference/AssignmentstTestCase.php
@@ -27,7 +27,7 @@ abstract class AssignmentstTestCase extends TestCase
 
         $assignments->add(0, Variable::fromSymbolContext($information));
 
-        $this->assertEquals($information, $assignments->byName('hello')->first()->symbolContext());
+        $this->assertEquals('hello', $assignments->byName('hello')->first()->name());
     }
 
     public function testMultipleByName(): void


### PR DESCRIPTION
Refactor the Variable class:

- Remove the NodeContext: types and value[1] are properties of the Variable and the offset is tracked in the `Assignments` collection. 

This should provide a saner API for resolving variable types.