### PR TITLE
Remove `Types` Part 2

### DIFF
--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseExtractMethod.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseExtractMethod.php
@@ -260,7 +260,7 @@ class WorseExtractMethod implements ExtractMethod
             }
 
             $parameterBuilder = $methodBuilder->parameter($freeVariable->name());
-            $variableType = $freeVariable->types()->best();
+            $variableType = $freeVariable->type();
             if (TypeUtil::isDefined($variableType)) {
                 $parameterBuilder->type(TypeUtil::short($variableType));
                 foreach (TypeUtil::unwrapClassTypes($variableType) as $classType) {
@@ -339,7 +339,7 @@ class WorseExtractMethod implements ExtractMethod
             /** @var Variable $variable */
             $variable = reset($returnVariables);
             $methodBuilder->body()->line('return $' . $variable->name() . ';');
-            $type = $variable->types()->best();
+            $type = $variable->type();
             if (TypeUtil::isDefined($type)) {
                 $methodBuilder->returnType(TypeUtil::short($type));
                 $type = TypeUtil::unwrapNullableType($type);
@@ -418,17 +418,16 @@ class WorseExtractMethod implements ExtractMethod
     {
         $newMethodBody = 'return ' . $newMethodBody .';';
         $offset = $this->reflector->reflectOffset($source->__toString(), $offsetEnd);
-        $expressionTypes = $offset->symbolContext()->types();
-        if ($expressionTypes->count() === 1) {
-            $type = $expressionTypes->best();
-            if (TypeUtil::isDefined($type)) {
-                $methodBuilder->returnType(TypeUtil::short($type));
-            }
-            $type = TypeUtil::unwrapNullableType($type);
-            if ($type instanceof ClassType) {
-                $methodBuilder->end()->end()->use($type->name()->full());
-            }
+        $expressionType = $offset->symbolContext()->type();
+
+        if (TypeUtil::isDefined($expressionType)) {
+            $methodBuilder->returnType(TypeUtil::short($expressionType));
         }
+        $type = TypeUtil::unwrapNullableType($expressionType);
+        if ($type instanceof ClassType) {
+            $methodBuilder->end()->end()->use($type->name()->full());
+        }
+
         return $newMethodBody;
     }
 

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/AbstractParameterCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/AbstractParameterCompletor.php
@@ -39,6 +39,9 @@ abstract class AbstractParameterCompletor
         $this->variableCompletionHelper = $variableCompletionHelper ?: new VariableCompletionHelper($reflector);
     }
 
+    /**
+     * @param WorseVariable[] $variables
+     */
     protected function populateResponse(Node $callableExpression, ReflectionFunctionLike $functionLikeReflection, array $variables): Generator
     {
         // function has no parameters, return empty handed
@@ -56,7 +59,7 @@ abstract class AbstractParameterCompletor
 
         foreach ($variables as $variable) {
             if (
-                $variable->types()->count() &&
+                TypeUtil::isDefined($variable->type()) &&
                 false === $this->isVariableValidForParameter($variable, $parameter)
             ) {
                 // parameter has no types and is not valid for this position, ignore it
@@ -70,7 +73,7 @@ abstract class AbstractParameterCompletor
                     'priority' => Suggestion::PRIORITY_HIGH,
                     'short_description' => sprintf(
                         '%s => param #%d %s',
-                        $this->formatter->format($variable->types()),
+                        $this->formatter->format($variable->type()),
                         $paramIndex,
                         $this->formatter->format($parameter)
                     )
@@ -120,8 +123,7 @@ abstract class AbstractParameterCompletor
             return true;
         }
 
-        /** @var Type $variableType */
-        foreach ($variable->types() as $variableType) {
+        foreach (TypeUtil::unwrapUnion($variable->type()) as $variableType) {
             $variableType = TypeUtil::unwrapNullableType($variableType);
 
             if ($parameter->inferredType()->accepts($variableType)->isTrue()) {

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/AbstractParameterCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/AbstractParameterCompletor.php
@@ -20,7 +20,6 @@ use Phpactor\Completion\Core\Suggestion;
 use Phpactor\WorseReflection\Core\Inference\Variable as WorseVariable;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionFunctionLike;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionParameter;
-use Phpactor\WorseReflection\Core\Type;
 use Phpactor\WorseReflection\Reflector;
 use Phpactor\WorseReflection\TypeUtil;
 

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletor.php
@@ -81,10 +81,10 @@ class WorseClassMemberCompletor implements TolerantCompletor, TolerantQualifiabl
         $reflectionOffset = $this->reflector->reflectOffset($source, $memberStartOffset);
 
         $symbolContext = $reflectionOffset->symbolContext();
-        $types = $symbolContext->types();
+        $type = $symbolContext->type();
         $static = $node instanceof ScopedPropertyAccessExpression;
 
-        foreach ($types as $type) {
+        foreach (TypeUtil::unwrapUnion($type) as $type) {
             foreach ($this->populateSuggestions($symbolContext, $type, $static, $shouldCompleteOnlyName) as $suggestion) {
                 if ($partialMatch && 0 !== mb_strpos($suggestion->name(), $partialMatch)) {
                     continue;

--- a/lib/Completion/Bridge/WorseReflection/Formatter/VariableFormatter.php
+++ b/lib/Completion/Bridge/WorseReflection/Formatter/VariableFormatter.php
@@ -17,6 +17,6 @@ class VariableFormatter implements Formatter
     {
         assert($object instanceof Variable);
 
-        return $formatter->format($object->types());
+        return $formatter->format($object->type());
     }
 }

--- a/lib/Extension/CompletionExtra/Rpc/HoverHandler.php
+++ b/lib/Extension/CompletionExtra/Rpc/HoverHandler.php
@@ -5,6 +5,7 @@ namespace Phpactor\Extension\CompletionExtra\Rpc;
 use Phpactor\Completion\Core\Exception\CouldNotFormat;
 use Phpactor\Completion\Core\Formatter\ObjectFormatter;
 use Phpactor\Extension\Rpc\Handler;
+use Phpactor\Extension\Rpc\Response;
 use Phpactor\Extension\Rpc\Response\EchoResponse;
 use Phpactor\MapResolver\Resolver;
 use Phpactor\WorseReflection\Core\Exception\NotFound;
@@ -43,11 +44,14 @@ class HoverHandler implements Handler
         ]);
     }
 
-    public function handle(array $arguments)
+    /**
+     * @param array<string,mixed> $arguments
+     */
+    public function handle(array $arguments): Response
     {
         $offset = $this->reflector->reflectOffset($arguments[self::PARAM_SOURCE], $arguments[self::PARAM_OFFSET]);
 
-        $types = $offset->symbolContext()->types();
+        $type = $offset->symbolContext()->type();
         $symbolContext = $offset->symbolContext();
 
         $info = $this->messageFromSymbolContext($symbolContext);
@@ -122,7 +126,7 @@ class HoverHandler implements Handler
 
     private function renderVariable(NodeContext $symbolContext)
     {
-        return $this->formatter->format($symbolContext->types());
+        return $this->formatter->format($symbolContext->type());
     }
 
     private function renderClass(Type $type)

--- a/lib/Extension/LanguageServerCompletion/Tests/Integration/expected/offset1.md
+++ b/lib/Extension/LanguageServerCompletion/Tests/Integration/expected/offset1.md
@@ -1,2 +1,2 @@
 <unknown>: __<unknown>__
-type: ____
+type: __<missing>__

--- a/lib/WorseReflection/Core/Inference/NodeContext.php
+++ b/lib/WorseReflection/Core/Inference/NodeContext.php
@@ -4,6 +4,7 @@ namespace Phpactor\WorseReflection\Core\Inference;
 
 use Phpactor\WorseReflection\Core\Type;
 use Phpactor\WorseReflection\Core\TypeFactory;
+use Phpactor\WorseReflection\Core\Type\MissingType;
 use Phpactor\WorseReflection\Core\Types;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionScope;
 
@@ -14,7 +15,7 @@ final class NodeContext
      */
     private $value;
     
-    private Types $types;
+    private Type $type;
     
     private Symbol $symbol;
 
@@ -36,18 +37,18 @@ final class NodeContext
     /**
      * @param mixed $value
      */
-    private function __construct(Symbol $symbol, Types $types, $value = null, Type $containerType = null, ReflectionScope $scope = null)
+    private function __construct(Symbol $symbol, Type $type, $value = null, Type $containerType = null, ReflectionScope $scope = null)
     {
         $this->value = $value;
         $this->symbol = $symbol;
         $this->containerType = $containerType;
-        $this->types = $types;
+        $this->type = $type;
         $this->scope = $scope;
     }
 
     public static function for(Symbol $symbol): NodeContext
     {
-        return new self($symbol, Types::fromTypes([ TypeFactory::unknown() ]));
+        return new self($symbol, TypeFactory::unknown());
     }
 
     /**
@@ -56,7 +57,7 @@ final class NodeContext
      */
     public static function fromTypeAndValue(Type $type, $value): NodeContext
     {
-        return new self(Symbol::unknown(), Types::fromTypes([ $type ]), $value);
+        return new self(Symbol::unknown(), $type, $value);
     }
 
     /**
@@ -64,12 +65,12 @@ final class NodeContext
      */
     public static function fromType(Type $type): NodeContext
     {
-        return new self(Symbol::unknown(), Types::fromTypes([ $type ]));
+        return new self(Symbol::unknown(), $type);
     }
 
     public static function none(): NodeContext
     {
-        return new self(Symbol::unknown(), Types::empty());
+        return new self(Symbol::unknown(), new MissingType());
     }
 
     /**
@@ -97,15 +98,7 @@ final class NodeContext
     public function withType(Type $type): NodeContext
     {
         $new = clone $this;
-        $new->types = Types::fromTypes([ $type ]);
-
-        return $new;
-    }
-
-    public function withTypes(Types $types): NodeContext
-    {
-        $new = clone $this;
-        $new->types = $types;
+        $new->type = $type;
 
         return $new;
     }
@@ -131,16 +124,7 @@ final class NodeContext
      */
     public function type(): Type
     {
-        foreach ($this->types() as $type) {
-            return $type;
-        }
-
-        return TypeFactory::unknown();
-    }
-
-    public function types(): Types
-    {
-        return $this->types;
+        return $this->type ?? new MissingType();
     }
 
     /**

--- a/lib/WorseReflection/Core/Inference/NodeContextFactory.php
+++ b/lib/WorseReflection/Core/Inference/NodeContextFactory.php
@@ -5,6 +5,7 @@ namespace Phpactor\WorseReflection\Core\Inference;
 use Phpactor\WorseReflection\Core\Name;
 use Phpactor\WorseReflection\Core\Position;
 use Phpactor\WorseReflection\Core\Type;
+use Phpactor\WorseReflection\Core\TypeFactory;
 use Phpactor\WorseReflection\Core\Types;
 use RuntimeException;
 
@@ -14,7 +15,6 @@ class NodeContextFactory
      * @param array{
      *     container_type?: Type|null,
      *     type?: Type|null,
-     *     types?: Types|null,
      *     symbol_type?: Symbol::*|null,
      *     name?: Name|null,
      *     value?: mixed|null,
@@ -25,8 +25,7 @@ class NodeContextFactory
         $defaultConfig = [
             'symbol_type' => Symbol::UNKNOWN,
             'container_type' => null,
-            'type' => null,
-            'types' => null,
+            'type' => TypeFactory::unknown(),
             'value' => null,
         ];
 
@@ -47,13 +46,9 @@ class NodeContextFactory
             $position
         );
 
-        if ($config['type'] && !$config['types']) {
-            $config['types'] = Types::fromTypes([$config['type']]);
-        }
-
         return self::contextFromParameters(
             $symbol,
-            $config['types'],
+            $config['type'],
             $config['container_type'],
             $config['value'],
         );
@@ -93,14 +88,14 @@ class NodeContextFactory
      */
     private static function contextFromParameters(
         Symbol $symbol,
-        Types $types = null,
+        Type $type = null,
         Type $containerType = null,
         $value = null
     ): NodeContext {
         $context = NodeContext::for($symbol);
 
-        if ($types) {
-            $context = $context->withTypes($types);
+        if ($type) {
+            $context = $context->withType($type);
         }
 
         if ($containerType) {

--- a/lib/WorseReflection/Core/Inference/NodeContextFactory.php
+++ b/lib/WorseReflection/Core/Inference/NodeContextFactory.php
@@ -6,7 +6,6 @@ use Phpactor\WorseReflection\Core\Name;
 use Phpactor\WorseReflection\Core\Position;
 use Phpactor\WorseReflection\Core\Type;
 use Phpactor\WorseReflection\Core\TypeFactory;
-use Phpactor\WorseReflection\Core\Types;
 use RuntimeException;
 
 class NodeContextFactory

--- a/lib/WorseReflection/Core/Inference/Resolver/MemberAccessExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/MemberAccessExpressionResolver.php
@@ -17,6 +17,7 @@ use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
 use Phpactor\WorseReflection\Core\Type;
 use Phpactor\WorseReflection\Core\Type\ClassType;
 use Phpactor\WorseReflection\Core\Util\NodeUtil;
+use Phpactor\WorseReflection\TypeUtil;
 
 class MemberAccessExpressionResolver implements Resolver
 {
@@ -74,9 +75,9 @@ class MemberAccessExpressionResolver implements Resolver
                 $node->getEndPosition(),
             );
 
-            foreach ($frameTypes as $types) {
-                $info = $info->withTypes(
-                    $info->types()->merge($types),
+            foreach ($frameTypes as $type) {
+                $info = $info->withType(
+                    TypeUtil::combine($info->type(), $type)
                 );
             }
         }
@@ -110,7 +111,7 @@ class MemberAccessExpressionResolver implements Resolver
                 continue;
             }
 
-            yield $variable->types();
+            yield $variable->type();
         }
     }
 }

--- a/lib/WorseReflection/Core/Inference/Resolver/QualifiedNameListResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/QualifiedNameListResolver.php
@@ -11,6 +11,7 @@ use Phpactor\WorseReflection\Core\Inference\NodeContextFactory;
 use Phpactor\WorseReflection\Core\Inference\Resolver;
 use Phpactor\WorseReflection\Core\Inference\Symbol;
 use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
+use Phpactor\WorseReflection\Core\Type\UnionType;
 use Phpactor\WorseReflection\Core\Types;
 
 class QualifiedNameListResolver implements Resolver
@@ -30,14 +31,13 @@ class QualifiedNameListResolver implements Resolver
             $types[] = $resolver->resolveNode($frame, $child)->type();
         }
 
-        $types = Types::fromTypes($types);
+        $type = new UnionType(...$types);
         return NodeContextFactory::create(
             $node->getText(),
             $node->getStartPosition(),
             $node->getEndPosition(),
             [
-                'type' => $types->best(),
-                'types' => $types,
+                'type' => $type->reduce(),
                 'symbol_type' => Symbol::CLASS_,
             ]
         );

--- a/lib/WorseReflection/Core/Inference/Resolver/QualifiedNameListResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/QualifiedNameListResolver.php
@@ -12,7 +12,6 @@ use Phpactor\WorseReflection\Core\Inference\Resolver;
 use Phpactor\WorseReflection\Core\Inference\Symbol;
 use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
 use Phpactor\WorseReflection\Core\Type\UnionType;
-use Phpactor\WorseReflection\Core\Types;
 
 class QualifiedNameListResolver implements Resolver
 {

--- a/lib/WorseReflection/Core/Inference/Variable.php
+++ b/lib/WorseReflection/Core/Inference/Variable.php
@@ -4,13 +4,12 @@ namespace Phpactor\WorseReflection\Core\Inference;
 
 use Phpactor\WorseReflection\Core\Type;
 use Phpactor\WorseReflection\Core\Type\MissingType;
-use Phpactor\WorseReflection\Core\Types;
 
 final class Variable
 {
     private string $name;
 
-    private Types $types;
+    private Type $type;
 
     /**
      * @var mixed
@@ -22,10 +21,10 @@ final class Variable
     /**
      * @param mixed $value
      */
-    private function __construct(string $name, Types $types, ?Type $classType = null, $value = null)
+    private function __construct(string $name, Type $type, ?Type $classType = null, $value = null)
     {
         $this->name = $name;
-        $this->types = $types;
+        $this->type = $type;
         $this->value = $value;
         $this->classType = $classType;
     }
@@ -39,7 +38,7 @@ final class Variable
     {
         return new self(
             $symbolContext->symbol()->name(),
-            $symbolContext->types(),
+            $symbolContext->type(),
             $symbolContext->symbol()->symbolType() === Symbol::PROPERTY ? $symbolContext->containerType() : null,
             $symbolContext->value(),
         );
@@ -57,19 +56,14 @@ final class Variable
         return $this->name == $name;
     }
 
-    public function withTypes(Types $types): self
+    public function withType(Type $type): self
     {
-        return new self($this->name, $types, $this->classType, $this->value);
+        return new self($this->name, $type, $this->classType, $this->value);
     }
 
     public function type(): Type
     {
-        return $this->types->best();
-    }
-
-    public function types(): Types
-    {
-        return $this->types;
+        return $this->type;
     }
 
     /**

--- a/lib/WorseReflection/Core/Inference/Walker/AbstractInstanceOfWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/AbstractInstanceOfWalker.php
@@ -134,7 +134,7 @@ abstract class AbstractInstanceOfWalker extends AbstractWalker
             ;
         }
 
-        $classType = $assignments->first()->types()->best();
+        $classType = $assignments->first()->type();
 
         return $symbolContext->withContainerType($classType);
     }

--- a/lib/WorseReflection/Core/Inference/Walker/CatchWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/CatchWalker.php
@@ -28,7 +28,7 @@ class CatchWalker extends AbstractWalker
         }
 
         /** @phpstan-ignore-next-line Lies */
-        $types = $resolver->resolveNode($frame, $node->qualifiedNameList)->types();
+        $type = $resolver->resolveNode($frame, $node->qualifiedNameList)->type();
         $variableName = $node->variableName;
 
         if (null === $variableName) {
@@ -41,7 +41,7 @@ class CatchWalker extends AbstractWalker
             $variableName->getEndPosition(),
             [
                 'symbol_type' => Symbol::VARIABLE,
-                'types' => $types,
+                'type' => $type,
             ]
         );
 

--- a/lib/WorseReflection/Core/Inference/Walker/ForeachWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/ForeachWalker.php
@@ -77,7 +77,7 @@ class ForeachWalker extends AbstractWalker
             return;
         }
         
-        $collectionType = $collection->types()->best();
+        $collectionType = $collection->type();
         
         $context = NodeContextFactory::create(
             $itemName,
@@ -99,7 +99,7 @@ class ForeachWalker extends AbstractWalker
             return;
         }
 
-        $collectionType = $collection->types()->best();
+        $collectionType = $collection->type();
 
         $context = NodeContextFactory::create(
             $itemName,

--- a/lib/WorseReflection/Core/Inference/Walker/FunctionLikeWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/FunctionLikeWalker.php
@@ -94,7 +94,7 @@ class FunctionLikeWalker extends AbstractWalker
                 $parameterNode->getEndPosition(),
                 [
                     'symbol_type' => Symbol::VARIABLE,
-                    'type' => $symbolContext->types()->best(),
+                    'type' => $symbolContext->type(),
                     'value' => $symbolContext->value(),
                 ]
             );

--- a/lib/WorseReflection/Core/Inference/Walker/IncludeWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/IncludeWalker.php
@@ -101,7 +101,7 @@ class IncludeWalker implements Walker
         foreach ($frame->locals()->byName((string)$name) as $variable) {
             $frame->locals()->replace(
                 $variable,
-                $variable->withTypes($returnValueContext->types())
+                $variable->withType($returnValueContext->type())
             );
             return $frame;
         }

--- a/lib/WorseReflection/Core/Inference/Walker/InstanceOfWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/InstanceOfWalker.php
@@ -13,7 +13,6 @@ use Phpactor\WorseReflection\Core\Inference\Variable as WorseVariable;
 use Microsoft\PhpParser\Node\Statement\ReturnStatement;
 use Microsoft\PhpParser\Node\Expression;
 use Phpactor\WorseReflection\Core\TypeFactory;
-use Phpactor\WorseReflection\Core\Types;
 use Microsoft\PhpParser\Node\Statement\CompoundStatementNode;
 use Microsoft\PhpParser\Node\Statement\BreakOrContinueStatement;
 use Phpactor\WorseReflection\TypeUtil;

--- a/lib/WorseReflection/Core/Inference/Walker/VariableWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/VariableWalker.php
@@ -75,12 +75,12 @@ class VariableWalker extends AbstractWalker
             unset($this->injectedTypes[$symbolName]);
         }
 
-        $context = $context->withTypes($docblockTypes);
+        $context = $context->withType($docblockTypes->best());
         $locals = $frame->locals();
         foreach ($locals->byName($symbolName)->equalTo($context->symbol()->position()->start()) as $existing) {
             assert($existing instanceof PhpactorVariable);
             // TODO: not sure this will work as expected
-            $locals->replace($existing, $existing->withTypes($context->types()));
+            $locals->replace($existing, $existing->withType($context->type()));
             return $frame;
         }
         $frame->locals()->add($context->symbol()->position()->start(), WorseVariable::fromSymbolContext($context));

--- a/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/AssertWalkerTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/AssertWalkerTest.php
@@ -20,7 +20,7 @@ class AssertWalkerTest extends FrameWalkerTestCase
         ,
             function (Frame $frame): void {
                 $this->assertCount(1, $frame->locals());
-                $this->assertEquals('Foobar', (string) $frame->locals()->first()->types()->best());
+                $this->assertEquals('Foobar', (string) $frame->locals()->first()->type());
             }
         ];
 
@@ -55,7 +55,7 @@ class AssertWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame, int $offset): void {
             $this->assertCount(1, $frame->locals());
-            $this->assertEquals('Foo', $frame->locals()->atIndex(0)->types()->best()->__toString());
+            $this->assertEquals('Foo', $frame->locals()->atIndex(0)->type()->__toString());
             $this->assertCount(1, $frame->properties());
             $this->assertEquals('Foo', $frame->properties()->atIndex(0)->classType()->__toString());
             $this->assertEquals('Bar', $frame->properties()->atIndex(0)->type()->__toString());

--- a/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/AssignmentWalkerTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/AssignmentWalkerTest.php
@@ -247,9 +247,9 @@ class AssignmentWalkerTest extends FrameWalkerTestCase
                 $this->assertCount(3, $frame->locals());
                 $this->assertEquals(
                     'Foobar\Listy<Foobar\Collection>',
-                    (string) $frame->locals()->byName('bar')->first()->types()->best()
+                    (string) $frame->locals()->byName('bar')->first()->type()
                 );
-                $type = $frame->locals()->byName('bar')->first()->types()->best();
+                $type = $frame->locals()->byName('bar')->first()->type();
                 $this->assertEquals(
                     'Foobar\Collection',
                     $type->iterableValueType()->__toString()
@@ -276,7 +276,7 @@ class AssignmentWalkerTest extends FrameWalkerTestCase
         ,
             function (Frame $frame): void {
                 $this->assertCount(1, $frame->locals()->byName('barfoo'));
-                $type = $frame->locals()->byName('barfoo')->first()->types()->best();
+                $type = $frame->locals()->byName('barfoo')->first()->type();
                 assert($type instanceof ClassType);
                 $this->assertEquals('Barfoo', $type->name->short());
             }

--- a/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/CatchWalkerTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/CatchWalkerTest.php
@@ -28,9 +28,7 @@ class CatchWalkerTest extends FrameWalkerTestCase
                 $this->assertCount(1, $frame->locals()->byName('$exception'));
                 $exception = $frame->locals()->byName('$exception')->first();
                 self::assertTrinaryTrue(
-                    TypeFactory::class('\Exception')->is(
-                        $exception->type()
-                    )
+                    TypeFactory::class('\Exception')->is($exception->type())
                 );
             }
         ];
@@ -48,7 +46,7 @@ class CatchWalkerTest extends FrameWalkerTestCase
             function (Frame $frame): void {
                 $this->assertCount(1, $frame->locals()->byName('$exception'));
                 $exception = $frame->locals()->byName('$exception')->first();
-                self::assertEquals('Foo|Bar', $exception->types()->__toString());
+                self::assertEquals('Foo|Bar', $exception->type()->__toString());
             }
         ];
     }

--- a/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/ForeachWalkerTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/ForeachWalkerTest.php
@@ -25,7 +25,7 @@ class ForeachWalkerTest extends FrameWalkerTestCase
             function (Frame $frame): void {
                 $this->assertCount(2, $frame->locals());
                 $this->assertCount(1, $frame->locals()->byName('item'));
-                $this->assertEquals('int', (string) $frame->locals()->byName('item')->first()->types()->best());
+                $this->assertEquals('int', (string) $frame->locals()->byName('item')->first()->type());
             }
         ];
 
@@ -43,7 +43,7 @@ class ForeachWalkerTest extends FrameWalkerTestCase
             function (Frame $frame): void {
                 $this->assertCount(3, $frame->locals());
                 $this->assertCount(1, $frame->locals()->byName('key'));
-                $this->assertEquals(TypeFactory::unknown(), $frame->locals()->byName('key')->first()->types()->best());
+                $this->assertEquals(TypeFactory::unknown(), $frame->locals()->byName('key')->first()->type());
                 $this->assertEquals(false, $frame->locals()->byName('key')->first()->isProperty());
             }
         ];
@@ -66,7 +66,7 @@ class ForeachWalkerTest extends FrameWalkerTestCase
             function (Frame $frame): void {
                 $this->assertCount(2, $frame->locals());
                 $this->assertCount(1, $frame->locals()->byName('item'));
-                $this->assertEquals('Foobar\\Barfoo', (string) $frame->locals()->byName('item')->first()->types()->best());
+                $this->assertEquals('Foobar\\Barfoo', (string) $frame->locals()->byName('item')->first()->type());
             }
         ];
 
@@ -96,11 +96,11 @@ class ForeachWalkerTest extends FrameWalkerTestCase
                 $this->assertCount(1, $frame->locals()->byName('item'));
                 $this->assertEquals(
                     'Foobar\\Collection<Foobar\Item>',
-                    (string) $frame->locals()->byName('items')->first()->types()->best()
+                    (string) $frame->locals()->byName('items')->first()->type()
                 );
                 $this->assertEquals(
                     'Foobar\\Item',
-                    (string) $frame->locals()->byName('item')->first()->types()->best()
+                    (string) $frame->locals()->byName('item')->first()->type()
                 );
             }
         ];

--- a/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/FunctionLikeWalkerTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/FunctionLikeWalkerTest.php
@@ -84,11 +84,11 @@ class FunctionLikeWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame): void {
             $this->assertCount(1, $frame->locals()->byName('many'));
-            $this->assertEquals('string', (string) $frame->locals()->byName('many')->first()->types()->best());
+            $this->assertEquals('string', (string) $frame->locals()->byName('many')->first()->type());
 
             $this->assertCount(1, $frame->locals()->byName('worlds'));
-            $this->assertEquals('Foobar\Barfoo\World[]', (string) $frame->locals()->byName('worlds')->first()->types()->best());
-            $type = $frame->locals()->byName('worlds')->first()->types()->best();
+            $this->assertEquals('Foobar\Barfoo\World[]', (string) $frame->locals()->byName('worlds')->first()->type());
+            $type = $frame->locals()->byName('worlds')->first()->type();
             assert($type instanceof IterableType);
             $this->assertEquals('Foobar\Barfoo\World', (string) $type->valueType);
         }];

--- a/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/InstanceOfWalkerTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/InstanceOfWalkerTest.php
@@ -21,8 +21,8 @@ class InstanceOfWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame): void {
             $this->assertCount(2, $frame->locals());
-            $this->assertEquals('Foobar', (string) $frame->locals()->first()->types()->best());
-            $this->assertEquals(TypeFactory::unknown(), $frame->locals()->atIndex(1)->types()->best());
+            $this->assertEquals('Foobar', (string) $frame->locals()->first()->type());
+            $this->assertEquals(TypeFactory::unknown(), $frame->locals()->atIndex(1)->type());
         }
         ];
 
@@ -37,7 +37,7 @@ class InstanceOfWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame, int $offset): void {
             $this->assertCount(2, $frame->locals());
-            $this->assertEquals(TypeFactory::unknown(), $frame->locals()->atIndex(1)->types()->best());
+            $this->assertEquals(TypeFactory::unknown(), $frame->locals()->atIndex(1)->type());
         }
         ];
 
@@ -52,7 +52,7 @@ class InstanceOfWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame, int $offset): void {
             $this->assertCount(2, $frame->locals());
-            $this->assertEquals(TypeFactory::unknown(), $frame->locals()->atIndex(1)->types()->best());
+            $this->assertEquals(TypeFactory::unknown(), $frame->locals()->atIndex(1)->type());
         }
         ];
 
@@ -70,7 +70,7 @@ class InstanceOfWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame, int $offset): void {
             $this->assertCount(2, $frame->locals()->byName('foobar'));
-            $this->assertEquals('Foobar', $frame->locals()->last()->types()->best()->__toString());
+            $this->assertEquals('Foobar', $frame->locals()->last()->type()->__toString());
         }
         ];
 
@@ -88,7 +88,7 @@ class InstanceOfWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame, int $offset): void {
             $this->assertCount(2, $frame->locals()->byName('foobar'));
-            $this->assertEquals('Foobar', $frame->locals()->last()->types()->best()->__toString());
+            $this->assertEquals('Foobar', $frame->locals()->last()->type()->__toString());
         }
         ];
 
@@ -102,7 +102,7 @@ class InstanceOfWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame, int $offset): void {
             $this->assertCount(1, $frame->locals());
-            $this->assertEquals(TypeFactory::unknown(), $frame->locals()->atIndex(0)->types()->best());
+            $this->assertEquals(TypeFactory::unknown(), $frame->locals()->atIndex(0)->type());
         }
     ];
 
@@ -116,7 +116,7 @@ class InstanceOfWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame, int $offset): void {
             $this->assertCount(1, $frame->locals());
-            $this->assertEquals(TypeFactory::unknown(), $frame->locals()->atIndex(0)->types()->best());
+            $this->assertEquals(TypeFactory::unknown(), $frame->locals()->atIndex(0)->type());
         }
         ];
 
@@ -133,8 +133,8 @@ class InstanceOfWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame, int $offset): void {
             $this->assertCount(2, $frame->locals());
-            $this->assertEquals(TypeFactory::unknown(), $frame->locals()->atIndex(0)->types()->best());
-            $this->assertEquals('Foobar', (string) $frame->locals()->atIndex(1)->types()->best());
+            $this->assertEquals(TypeFactory::unknown(), $frame->locals()->atIndex(0)->type());
+            $this->assertEquals('Foobar', (string) $frame->locals()->atIndex(1)->type());
         }
                 ];
 
@@ -152,7 +152,7 @@ class InstanceOfWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame, int $offset): void {
             $this->assertCount(3, $frame->locals());
-            $this->assertEquals('Foobar', (string) $frame->locals()->atIndex(2)->types()->best());
+            $this->assertEquals('Foobar', (string) $frame->locals()->atIndex(2)->type());
         }
         ];
 
@@ -168,8 +168,8 @@ class InstanceOfWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame, int $offset): void {
             $this->assertCount(2, $frame->locals());
-            $this->assertEquals('Foobar', (string) $frame->locals()->atIndex(1)->types()->best());
-            $this->assertEquals(TypeFactory::unknown(), $frame->locals()->atIndex(0)->types()->best());
+            $this->assertEquals('Foobar', (string) $frame->locals()->atIndex(1)->type());
+            $this->assertEquals(TypeFactory::unknown(), $frame->locals()->atIndex(0)->type());
         }
         ];
 
@@ -184,7 +184,7 @@ class InstanceOfWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame, int $offset): void {
             $this->assertCount(2, $frame->locals());
-            $this->assertEquals('Foobar|Barfoo', $frame->locals()->atIndex(0)->types()->__toString());
+            $this->assertEquals('Foobar|Barfoo', $frame->locals()->atIndex(0)->type()->__toString());
         }
         ];
 
@@ -199,7 +199,7 @@ class InstanceOfWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame, int $offset): void {
             $this->assertCount(2, $frame->locals());
-            $this->assertEquals('Foobar|Barfoo', $frame->locals()->atIndex(0)->types()->__toString());
+            $this->assertEquals('Foobar|Barfoo', $frame->locals()->atIndex(0)->type()->__toString());
         }
         ];
 
@@ -215,7 +215,7 @@ class InstanceOfWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame, int $offset): void {
             $this->assertCount(3, $frame->locals());
-            $this->assertEquals('stdClass', $frame->locals()->atIndex(2)->types()->best());
+            $this->assertEquals('stdClass', $frame->locals()->atIndex(2)->type());
         }
         ];
 
@@ -231,7 +231,7 @@ class InstanceOfWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame, int $offset): void {
             $this->assertCount(2, $frame->locals());
-            $this->assertEquals('Foobar\Barfoo', (string) $frame->locals()->atIndex(0)->types()->best());
+            $this->assertEquals('Foobar\Barfoo', (string) $frame->locals()->atIndex(0)->type());
         }
         ];
 
@@ -302,12 +302,12 @@ class InstanceOfWalkerTest extends FrameWalkerTestCase
                 EOT
         , function (Frame $frame, int $offset): void {
             $this->assertCount(1, $frame->locals());
-            $this->assertEquals('Foo', $frame->locals()->atIndex(0)->types()->best()->__toString());
+            $this->assertEquals('Foo', $frame->locals()->atIndex(0)->type()->__toString());
             $this->assertCount(2, $frame->properties());
             $this->assertEquals('Foo', $frame->properties()->atIndex(0)->classType()->__toString());
-            $this->assertEquals(TypeFactory::unknown(), $frame->properties()->atIndex(0)->types()->best()->__toString());
+            $this->assertEquals(TypeFactory::unknown(), $frame->properties()->atIndex(0)->type()->__toString());
             $this->assertEquals('Foo', $frame->properties()->atIndex(1)->classType());
-            $this->assertEquals('Bar', $frame->properties()->atIndex(1)->types()->best()->__toString());
+            $this->assertEquals('Bar', $frame->properties()->atIndex(1)->type()->__toString());
         }
         ];
     }

--- a/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/VariableWalkerTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/VariableWalkerTest.php
@@ -117,7 +117,7 @@ class VariableWalkerTest extends FrameWalkerTestCase
         ,
             function (Frame $frame): void {
                 $this->assertCount(1, $frame->locals()->byName('$zed'));
-                $this->assertEquals('Bar|Baz', $frame->locals()->byName('$zed')->last()->types()->__toString());
+                $this->assertEquals('Bar|Baz', $frame->locals()->byName('$zed')->last()->type()->__toString());
             }
         ];
 

--- a/lib/WorseReflection/Tests/Integration/Core/Inference/SymbolContextResolverTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/Inference/SymbolContextResolverTest.php
@@ -18,6 +18,7 @@ use Phpactor\WorseReflection\Core\Inference\Symbol;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Position;
 use Phpactor\TestUtils\ExtractOffset;
+use Phpactor\WorseReflection\TypeUtil;
 use RuntimeException;
 
 class SymbolContextResolverTest extends IntegrationTestCase
@@ -1190,8 +1191,8 @@ class SymbolContextResolverTest extends IntegrationTestCase
                     continue 2;
                 case 'types':
                     $this->assertEquals(
-                        Types::fromTypes($value)->__toString(),
-                        $information->types()->__toString(),
+                        TypeUtil::combine(...$value)->__toString(),
+                        $information->type()->__toString(),
                         $name,
                     );
                     continue 2;

--- a/lib/WorseReflection/Tests/Integration/Core/Inference/SymbolContextResolverTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/Inference/SymbolContextResolverTest.php
@@ -8,7 +8,6 @@ use Phpactor\WorseReflection\Core\Inference\NodeToTypeConverter;
 use Phpactor\WorseReflection\Core\Inference\PropertyAssignments;
 use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
 use Phpactor\WorseReflection\Core\TypeFactory;
-use Phpactor\WorseReflection\Core\Types;
 use Phpactor\WorseReflection\Tests\Integration\IntegrationTestCase;
 use Phpactor\WorseReflection\Core\Type;
 use Phpactor\WorseReflection\Core\Inference\Frame;

--- a/lib/WorseReflection/TypeUtil.php
+++ b/lib/WorseReflection/TypeUtil.php
@@ -128,4 +128,16 @@ class TypeUtil
 
         return new UnionType(...$types);
     }
+
+    /**
+     * @return Type[]
+     */
+    public static function unwrapUnion(Type $type): array
+    {
+        if (!$type instanceof UnionType) {
+            return [$type];
+        }
+
+        return $type->types;
+    }
 }

--- a/lib/WorseReflection/TypeUtil.php
+++ b/lib/WorseReflection/TypeUtil.php
@@ -12,6 +12,7 @@ use Phpactor\WorseReflection\Core\Type\MissingType;
 use Phpactor\WorseReflection\Core\Type\NullableType;
 use Phpactor\WorseReflection\Core\Type\PrimitiveType;
 use Phpactor\WorseReflection\Core\Type\ReflectedClassType;
+use Phpactor\WorseReflection\Core\Type\UnionType;
 
 class TypeUtil
 {
@@ -114,5 +115,17 @@ class TypeUtil
         }
 
         return $type;
+    }
+
+    public static function combine(Type ...$types): Type
+    {
+        if (count($types) === 0) {
+            return new MissingType();
+        }
+        if (count($types) === 1) {
+            return $types[0];
+        }
+
+        return new UnionType(...$types);
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2111,11 +2111,6 @@ parameters:
 			path: lib/Completion/Bridge/TolerantParser/SourceCodeFilesystem/ScfClassCompletor.php
 
 		-
-			message: "#^Method Phpactor\\\\Completion\\\\Bridge\\\\TolerantParser\\\\WorseReflection\\\\AbstractParameterCompletor\\:\\:populateResponse\\(\\) has parameter \\$variables with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Completion/Bridge/TolerantParser/WorseReflection/AbstractParameterCompletor.php
-
-		-
 			message: "#^Method Phpactor\\\\Completion\\\\Bridge\\\\TolerantParser\\\\WorseReflection\\\\DoctrineAnnotationCompletor\\:\\:createSuggestionOptions\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: lib/Completion/Bridge/TolerantParser/WorseReflection/DoctrineAnnotationCompletor.php
@@ -3454,16 +3449,6 @@ parameters:
 			message: "#^Method Phpactor\\\\Extension\\\\CompletionExtra\\\\Application\\\\Complete\\:\\:complete\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: lib/Extension/CompletionExtra/Application/Complete.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\CompletionExtra\\\\Rpc\\\\HoverHandler\\:\\:handle\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: lib/Extension/CompletionExtra/Rpc/HoverHandler.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\CompletionExtra\\\\Rpc\\\\HoverHandler\\:\\:handle\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Extension/CompletionExtra/Rpc/HoverHandler.php
 
 		-
 			message: "#^Method Phpactor\\\\Extension\\\\CompletionExtra\\\\Rpc\\\\HoverHandler\\:\\:renderClass\\(\\) has no return type specified\\.$#"

--- a/templates/help/markdown/Phpactor/WorseReflection/Core/Inference/NodeContext.twig
+++ b/templates/help/markdown/Phpactor/WorseReflection/Core/Inference/NodeContext.twig
@@ -1,2 +1,2 @@
 {{ object.symbol.symbolType }}: __{{ object.symbol.name }}__
-type: __{{ render(object.types) }}__{% if object.value %} = {{ object.value|json_encode }}{% endif %}
+type: __{{ render(object.type) }}__{% if object.value %} = {{ object.value|json_encode }}{% endif %}


### PR DESCRIPTION
Removes `Types` from NodeContext and Variable, replace with UnionType where applicable. Now the only remaining thing using Types is are Docblocks.