### PR TITLE
Array literals

### DIFF
--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionConstant.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionConstant.php
@@ -12,6 +12,7 @@ use Phpactor\WorseReflection\Core\Reflection\ReflectionConstant as CoreReflectio
 use Phpactor\WorseReflection\Core\Reflection\ReflectionClassLike;
 use Phpactor\WorseReflection\Core\TypeFactory;
 use Microsoft\PhpParser\Node\ClassConstDeclaration;
+use Phpactor\WorseReflection\TypeUtil;
 
 class ReflectionConstant extends AbstractReflectionClassMember implements CoreReflectionConstant
 {
@@ -67,12 +68,12 @@ class ReflectionConstant extends AbstractReflectionClassMember implements CoreRe
     
     public function value()
     {
-        return $this->serviceLocator()
+        return TypeUtil::valueOrNull($this->serviceLocator()
                     ->symbolContextResolver()
                     ->resolveNode(
                         new Frame('_'),
                         $this->node->assignment
-                    )->value();
+                    )->type());
     }
 
     public function memberType(): string

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionParameter.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionParameter.php
@@ -13,6 +13,7 @@ use Phpactor\WorseReflection\Core\Reflection\ReflectionParameter as CoreReflecti
 use Phpactor\WorseReflection\Bridge\TolerantParser\Reflection\TypeResolver\DeclaredMemberTypeResolver;
 use Phpactor\WorseReflection\Core\TypeFactory;
 use Phpactor\WorseReflection\Core\Reflection\TypeResolver\ParameterTypeResolver;
+use Phpactor\WorseReflection\TypeUtil;
 
 class ReflectionParameter extends AbstractReflectedNode implements CoreReflectionParameter
 {
@@ -73,9 +74,9 @@ class ReflectionParameter extends AbstractReflectedNode implements CoreReflectio
         if (null === $this->parameter->default) {
             return DefaultValue::undefined();
         }
-        $value = $this->serviceLocator->symbolContextResolver()->resolveNode(new Frame('test'), $this->parameter->default)->value();
+        $value = $this->serviceLocator->symbolContextResolver()->resolveNode(new Frame('test'), $this->parameter->default)->type();
 
-        return DefaultValue::fromValue($value);
+        return DefaultValue::fromValue(TypeUtil::valueOrNull($value));
     }
 
     public function byReference(): bool

--- a/lib/WorseReflection/Core/Inference/Resolver/ArrayCreationExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/ArrayCreationExpressionResolver.php
@@ -25,14 +25,14 @@ class ArrayCreationExpressionResolver implements Resolver
                 $node->getStartPosition(),
                 $node->getEndPosition(),
                 [
-                    'type' => TypeFactory::array(),
+                    'type' => TypeFactory::arrayLiteral([]),
                     'value' => []
                 ]
             );
         }
 
         foreach ($node->arrayElements->getElements() as $element) {
-            $value = $resolver->resolveNode($frame, $element->elementValue)->value();
+            $value = $resolver->resolveNode($frame, $element->elementValue)->type();
             if ($element->elementKey) {
                 $key = $resolver->resolveNode($frame, $element->elementKey)->value();
                 $array[$key] = $value;
@@ -47,7 +47,7 @@ class ArrayCreationExpressionResolver implements Resolver
             $node->getStartPosition(),
             $node->getEndPosition(),
             [
-                'type' => TypeFactory::array(),
+                'type' => TypeFactory::arrayLiteral($array),
                 'value' => $array
             ]
         );

--- a/lib/WorseReflection/Core/Inference/Walker/AssignmentWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/AssignmentWalker.php
@@ -205,7 +205,6 @@ class AssignmentWalker extends AbstractWalker
         
             $index++;
             $elementValue = $element->elementValue;
-        
             if (!$elementValue instanceof Variable) {
                 continue;
             }
@@ -228,7 +227,7 @@ class AssignmentWalker extends AbstractWalker
         
             if (is_array($value) && isset($value[$index])) {
                 $variableContext = $variableContext->withValue($value[$index]);
-                $variableContext = $variableContext->withType(TypeFactory::fromString(gettype($value[$index])));
+                $variableContext = $variableContext->withType($value[$index]);
             }
         
             $frame->locals()->add($element->getStartPosition(), WorseVariable::fromSymbolContext($variableContext));

--- a/lib/WorseReflection/Core/Type/ArrayLiteral.php
+++ b/lib/WorseReflection/Core/Type/ArrayLiteral.php
@@ -25,6 +25,16 @@ class ArrayLiteral extends ArrayType implements Literal, Generalizable
 
     public function __toString(): string
     {
+        if (range(0, count($this->typeMap) - 1) === array_keys($this->typeMap)) {
+            return sprintf(
+                'array{%s}',
+                implode(',', array_map(
+                    fn (Type $type) => sprintf('%s', $type->__toString()),
+                    array_values($this->typeMap),
+                ))
+            );
+        }
+
         return sprintf(
             'array{%s}',
             implode(',', array_map(

--- a/lib/WorseReflection/Core/Type/ArrayLiteral.php
+++ b/lib/WorseReflection/Core/Type/ArrayLiteral.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Phpactor\WorseReflection\Core\Type;
+
+use Phpactor\WorseReflection\Core\Type;
+use Phpactor\WorseReflection\TypeUtil;
+
+class ArrayLiteral extends ArrayType implements Literal, Generalizable
+{
+    /**
+     * @var array<array-key,Type>
+     */
+    private array $typeMap;
+
+    /**
+     * @param array<array-key,Type> $typeMap
+     */
+    public function __construct(array $typeMap)
+    {
+        $this->typeMap = $typeMap;
+    }
+
+    public function __toString(): string
+    {
+        return sprintf(
+            'array{%s}',
+            implode(',', array_map(
+                fn ($key, Type $type) => sprintf('%s:%s', $key, $type->__toString()),
+                array_keys($this->typeMap),
+                array_values($this->typeMap),
+            ))
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function value()
+    {
+        return array_map(
+            fn (Type $type) => TypeUtil::valueOrNull($type),
+            $this->typeMap
+        );
+    }
+
+    public function generalize(): Type
+    {
+        return new ArrayType(new ArrayKeyType(), new MixedType());
+    }
+}

--- a/lib/WorseReflection/Core/TypeFactory.php
+++ b/lib/WorseReflection/Core/TypeFactory.php
@@ -3,6 +3,7 @@
 namespace Phpactor\WorseReflection\Core;
 
 use Phpactor\WorseReflection\Core\Reflector\ClassReflector;
+use Phpactor\WorseReflection\Core\Type\ArrayLiteral;
 use Phpactor\WorseReflection\Core\Type\ArrayType;
 use Phpactor\WorseReflection\Core\Type\BinLiteralType;
 use Phpactor\WorseReflection\Core\Type\BooleanLiteralType;
@@ -222,6 +223,14 @@ class TypeFactory
     public static function boolLiteral(bool $value): BooleanLiteralType
     {
         return new BooleanLiteralType($value);
+    }
+
+    /**
+     * @param array<array-key,Type> $elements
+     */
+    public static function arrayLiteral(array $elements): ArrayLiteral
+    {
+        return new ArrayLiteral($elements);
     }
 
     public static function fromNumericString(string $value): Type

--- a/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Reflection/ReflectionParameterTest.php
+++ b/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Reflection/ReflectionParameterTest.php
@@ -2,6 +2,7 @@
 
 namespace Phpactor\WorseReflection\Tests\Integration\Bridge\TolerantParser\Reflection;
 
+use Phpactor\WorseReflection\Core\Reflection\ReflectionMethod;
 use Phpactor\WorseReflection\Core\TypeFactory;
 use Phpactor\WorseReflection\Core\Type\MissingType;
 use Phpactor\WorseReflection\Tests\Integration\IntegrationTestCase;
@@ -25,14 +26,14 @@ class ReflectionParameterTest extends IntegrationTestCase
     {
         yield 'It reflects a an empty list with no parameters' => [
             '',
-            function ($method): void {
+            function (ReflectionMethod $method): void {
                 $this->assertCount(0, $method->parameters());
             },
         ];
 
         yield 'It reflects a single parameter' => [
             '$foobar',
-            function ($method): void {
+            function (ReflectionMethod $method): void {
                 $this->assertCount(1, $method->parameters());
                 $parameter = $method->parameters()->get('foobar');
                 $this->assertInstanceOf(ReflectionParameter::class, $parameter);
@@ -42,7 +43,7 @@ class ReflectionParameterTest extends IntegrationTestCase
 
         yield 'It returns false if the parameter has no type' => [
             '$foobar',
-            function ($method): void {
+            function (ReflectionMethod $method): void {
                 $this->assertTrue(
                     $method->parameters()->get('foobar')->type() instanceof MissingType
                 );
@@ -51,21 +52,21 @@ class ReflectionParameterTest extends IntegrationTestCase
 
         yield 'It returns the parameter type' => [
             'Foobar $foobar',
-            function ($method): void {
+            function (ReflectionMethod $method): void {
                 $this->assertEquals('Acme\Foobar', $method->parameters()->get('foobar')->type()->__toString());
             },
         ];
 
         yield 'It returns false if the parameter has no default' => [
             '$foobar',
-            function ($method): void {
+            function (ReflectionMethod $method): void {
                 $this->assertFalse($method->parameters()->get('foobar')->default()->isDefined());
             },
         ];
 
         yield 'It returns the default value for a string' => [
             '$foobar = "foo"',
-            function ($method): void {
+            function (ReflectionMethod $method): void {
                 $this->assertTrue($method->parameters()->get('foobar')->default()->isDefined());
                 $this->assertEquals(
                     'foo',
@@ -76,7 +77,7 @@ class ReflectionParameterTest extends IntegrationTestCase
 
         yield 'It returns the default value for a number' => [
             '$foobar = 1234',
-            function ($method): void {
+            function (ReflectionMethod $method): void {
                 $this->assertEquals(
                     1234,
                     $method->parameters()->get('foobar')->default()->value()
@@ -86,7 +87,7 @@ class ReflectionParameterTest extends IntegrationTestCase
 
         yield 'It returns the default value for an array' => [
             '$foobar = [ "foobar" ]',
-            function ($method): void {
+            function (ReflectionMethod $method): void {
                 $this->assertEquals(
                     ['foobar'],
                     $method->parameters()->get('foobar')->default()->value()
@@ -96,7 +97,7 @@ class ReflectionParameterTest extends IntegrationTestCase
 
         yield 'It returns the default value for null' => [
             '$foobar = null',
-            function ($method): void {
+            function (ReflectionMethod $method): void {
                 $this->assertEquals(
                     null,
                     $method->parameters()->get('foobar')->default()->value()
@@ -106,7 +107,7 @@ class ReflectionParameterTest extends IntegrationTestCase
 
         yield 'It returns the default value for empty array' => [
             '$foobar = []',
-            function ($method): void {
+            function (ReflectionMethod $method): void {
                 $foobar = $method->parameters()->get('foobar');
                 $this->assertEquals(
                     [],
@@ -117,7 +118,7 @@ class ReflectionParameterTest extends IntegrationTestCase
 
         yield 'It returns the default value for a boolean' => [
             '$foobar = false',
-            function ($method): void {
+            function (ReflectionMethod $method): void {
                 $this->assertEquals(
                     false,
                     $method->parameters()->get('foobar')->default()->value()
@@ -127,7 +128,7 @@ class ReflectionParameterTest extends IntegrationTestCase
 
         yield 'Passed by reference' => [
             '&$foobar',
-            function ($method): void {
+            function (ReflectionMethod $method): void {
                 $this->assertTrue(
                     $method->parameters()->get('foobar')->byReference()
                 );
@@ -136,7 +137,7 @@ class ReflectionParameterTest extends IntegrationTestCase
 
         yield 'Not passed by reference' => [
             '$foobar',
-            function ($method): void {
+            function (ReflectionMethod $method): void {
                 $this->assertFalse(
                     $method->parameters()->get('foobar')->byReference()
                 );
@@ -145,7 +146,7 @@ class ReflectionParameterTest extends IntegrationTestCase
 
         yield 'It reflects iterable type properly' => [
             'iterable $foobar',
-            function ($method): void {
+            function (ReflectionMethod $method): void {
                 $this->assertEquals(
                     TypeFactory::fromString('iterable'),
                     $method->parameters()->get('foobar')->type()
@@ -155,7 +156,7 @@ class ReflectionParameterTest extends IntegrationTestCase
 
         yield 'It reflects resource type properly' => [
             'resource $foobar',
-            function ($method): void {
+            function (ReflectionMethod $method): void {
                 $this->assertEquals(
                     TypeFactory::fromString('resource'),
                     $method->parameters()->get('foobar')->type()
@@ -165,7 +166,7 @@ class ReflectionParameterTest extends IntegrationTestCase
 
         yield 'It reflects callable type properly' => [
             'callable $foobar',
-            function ($method): void {
+            function (ReflectionMethod $method): void {
                 $this->assertEquals(
                     TypeFactory::fromString('callable'),
                     $method->parameters()->get('foobar')->type()
@@ -175,7 +176,7 @@ class ReflectionParameterTest extends IntegrationTestCase
 
         yield 'It reflects a nullable parameter' => [
             '?string $foobar',
-            function ($method): void {
+            function (ReflectionMethod $method): void {
                 $this->assertEquals(
                     TypeFactory::nullable(TypeFactory::string()),
                     $method->parameters()->get('foobar')->type()
@@ -185,7 +186,7 @@ class ReflectionParameterTest extends IntegrationTestCase
 
         yield 'It reflects a promoted parameter' => [
             'private string $foobar',
-            function ($method): void {
+            function (ReflectionMethod $method): void {
                 $this->assertTrue(
                     $method->parameters()->get('foobar')->isPromoted()
                 );
@@ -194,7 +195,7 @@ class ReflectionParameterTest extends IntegrationTestCase
 
         yield 'It reflects a (not) promoted parameter' => [
             'string $foobar',
-            function ($method): void {
+            function (ReflectionMethod $method): void {
                 $this->assertFalse(
                     $method->parameters()->get('foobar')->isPromoted()
                 );
@@ -217,7 +218,7 @@ class ReflectionParameterTest extends IntegrationTestCase
         yield 'It returns docblock parameter type' => [
             '$foobar',
             '/** @param Foobar $foobar */',
-            function ($method): void {
+            function (ReflectionMethod $method): void {
                 $this->assertCount(1, $method->parameters());
                 $this->assertEquals('Acme\Foobar', (string) $method->parameters()->get('foobar')->inferredType());
             },
@@ -226,7 +227,7 @@ class ReflectionParameterTest extends IntegrationTestCase
         yield 'It returns unknown type when no type hinting is available' => [
             '$foobar',
             '/** */',
-            function ($method): void {
+            function (ReflectionMethod $method): void {
                 $this->assertCount(1, $method->parameters());
                 $this->assertEquals(TypeFactory::unknown(), $method->parameters()->get('foobar')->inferredType());
             },

--- a/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/AssignmentWalkerTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/AssignmentWalkerTest.php
@@ -175,10 +175,8 @@ class AssignmentWalkerTest extends FrameWalkerTestCase
         ,
             function (Frame $frame): void {
                 $this->assertCount(2, $frame->locals());
-                $this->assertEquals('array', (string) $frame->locals()->first()->type());
-                $this->assertEquals(['foo' => 'bar'], $frame->locals()->first()->value());
+                $this->assertEquals('array{foo:"bar"}', (string) $frame->locals()->first()->type());
                 $this->assertEquals('"foo"', (string) $frame->locals()->last()->type());
-                $this->assertEquals('bar', (string) $frame->locals()->last()->value());
             }
         ];
 
@@ -191,8 +189,10 @@ class AssignmentWalkerTest extends FrameWalkerTestCase
         ,
             function (Frame $frame): void {
                 $this->assertCount(2, $frame->locals());
-                $this->assertEquals('foo', $frame->locals()->first()->value());
-                $this->assertEquals('string', (string) $frame->locals()->first()->type());
+                $this->assertEquals('foo', $frame->locals()->first()->name());
+                $this->assertEquals('"foo"', (string)$frame->locals()->first()->type());
+                $this->assertEquals('bar', $frame->locals()->atIndex(1)->name());
+                $this->assertEquals('"bar"', (string)$frame->locals()->atIndex(1)->type());
             }
         ];
 
@@ -205,8 +205,8 @@ class AssignmentWalkerTest extends FrameWalkerTestCase
         ,
             function (Frame $frame): void {
                 $this->assertCount(2, $frame->locals());
-                $this->assertEquals('foo', $frame->locals()->atIndex(0)->value());
-                $this->assertEquals('bar', $frame->locals()->atIndex(1)->value());
+                $this->assertEquals('"foo"', (string)$frame->locals()->atIndex(0)->type());
+                $this->assertEquals('"bar"', (string)$frame->locals()->atIndex(1)->type());
             }
         ];
 

--- a/lib/WorseReflection/Tests/SelfTest/SelfTest.php
+++ b/lib/WorseReflection/Tests/SelfTest/SelfTest.php
@@ -27,6 +27,7 @@ class SelfTest extends IntegrationTestCase
     public function provideSelf(): Generator
     {
         foreach ([
+            'assignment',
             'flow',
             'generics',
         ] as $topic) {

--- a/lib/WorseReflection/Tests/SelfTest/assignment/array1.test
+++ b/lib/WorseReflection/Tests/SelfTest/assignment/array1.test
@@ -1,0 +1,18 @@
+<?php
+
+$foo = [];
+
+wrAssertType('array{}', $foo);
+
+$foo = [
+     'foo' => [
+          'hello' => 'world',
+     ],
+     'bar' => 'baz',
+];
+
+wrAssertType('array{foo:array{hello:"world"},bar:"baz"}', $foo);
+
+$foo = [1, 2, 3, 4, 5];
+
+wrAssertType('array{1,2,3,4,5}', $foo);

--- a/lib/WorseReflection/TypeUtil.php
+++ b/lib/WorseReflection/TypeUtil.php
@@ -10,6 +10,7 @@ use Phpactor\WorseReflection\Core\Type\ArrayType;
 use Phpactor\WorseReflection\Core\Type\ClassType;
 use Phpactor\WorseReflection\Core\Type\Generalizable;
 use Phpactor\WorseReflection\Core\Type\GenericClassType;
+use Phpactor\WorseReflection\Core\Type\Literal;
 use Phpactor\WorseReflection\Core\Type\MissingType;
 use Phpactor\WorseReflection\Core\Type\NullableType;
 use Phpactor\WorseReflection\Core\Type\PrimitiveType;
@@ -168,5 +169,17 @@ class TypeUtil
         }
 
         return $type;
+    }
+
+    /**
+     * @return mixed
+     */
+    public static function valueOrNull(Type $value)
+    {
+        if ($value instanceof Literal) {
+            return $value->value();
+        }
+
+        return null;
     }
 }

--- a/lib/WorseReflection/TypeUtil.php
+++ b/lib/WorseReflection/TypeUtil.php
@@ -174,10 +174,10 @@ class TypeUtil
     /**
      * @return mixed
      */
-    public static function valueOrNull(Type $value)
+    public static function valueOrNull(Type $type)
     {
-        if ($value instanceof Literal) {
-            return $value->value();
+        if ($type instanceof Literal) {
+            return $type->value();
         }
 
         return null;


### PR DESCRIPTION
This PR is introducing support for array literals and will try and remove `value()` on variables and the node context (as this can now be determined from literal types)