### PR TITLE
regression: fully qualified names used ingenerated methods

### DIFF
--- a/lib/WorseReflection/Tests/Unit/TypeUtilTest.php
+++ b/lib/WorseReflection/Tests/Unit/TypeUtilTest.php
@@ -62,4 +62,45 @@ class TypeUtilTest extends TestCase
             'Foo<string,Boo>',
         ];
     }
+
+    /**
+     * @dataProvider provideShort
+     */
+    public function testShort(Type $type, string $expected): void
+    {
+        self::assertEquals(
+            $expected,
+            TypeUtil::short($type),
+        );
+    }
+
+    public function provideShort(): Generator
+    {
+        yield 'scalar' => [
+            TypeFactory::string(),
+            'string',
+        ];
+
+        yield 'Root class' => [
+            TypeFactory::class('Foo'),
+            'Foo',
+        ];
+        yield 'Namespaced class' => [
+            TypeFactory::class('\Foo\Bar'),
+            'Bar',
+        ];
+        yield 'Union' => [
+            TypeFactory::union(
+                TypeFactory::class('\Foo\Bar'),
+            ),
+            'Bar',
+        ];
+        yield 'Union with two elements' => [
+            TypeFactory::union(
+                TypeFactory::class('\Foo\Bar'),
+                TypeFactory::class('\Foo\Baz'),
+            ),
+            'Bar|Baz',
+        ];
+    }
 }

--- a/lib/WorseReflection/TypeUtil.php
+++ b/lib/WorseReflection/TypeUtil.php
@@ -35,6 +35,14 @@ class TypeUtil
 
     public static function short(Type $type): string
     {
+        if ($type instanceof UnionType) {
+            $type = $type->reduce();
+        }
+
+        if ($type instanceof UnionType) {
+            return implode('|', array_map(fn (Type $t) => self::short($t), $type->types));
+        }
+
         if ($type instanceof NullableType) {
             return '?' . self::short($type->type);
         }


### PR DESCRIPTION
ensure that union types are shortened

fixes #1426