### PR TITLE
Use shutdown middleware

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "phpactor/amp-fswatch": "^0.2.0",
         "thecodingmachine/safe": "^1.0",
         "phpactor/phly-event-dispatcher": "^2.0.0",
-        "phpactor/language-server": "^2.0.0",
+        "phpactor/language-server": "^2.1.0",
         "dantleech/object-renderer": "^0.1.1",
         "phpactor/language-server-protocol": "~0.3.0",
         "monolog/monolog": "^1.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6f9368afd6a593a4af54ba26c3a3f68d",
+    "content-hash": "29dc5e6fdce8b352ef6b60a60d69f03e",
     "packages": [
         {
             "name": "amphp/amp",
@@ -1680,16 +1680,16 @@
         },
         {
             "name": "phpactor/language-server",
-            "version": "2.0.0",
+            "version": "dev-shutdown-middleware",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/language-server.git",
-                "reference": "555756be8f6875da1ef03a20e7248524b251d4e2"
+                "reference": "f4604f3c18d4b979ce19ef221f8044e874cea5c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/language-server/zipball/555756be8f6875da1ef03a20e7248524b251d4e2",
-                "reference": "555756be8f6875da1ef03a20e7248524b251d4e2",
+                "url": "https://api.github.com/repos/phpactor/language-server/zipball/f4604f3c18d4b979ce19ef221f8044e874cea5c5",
+                "reference": "f4604f3c18d4b979ce19ef221f8044e874cea5c5",
                 "shasum": ""
             },
             "require": {
@@ -1740,9 +1740,9 @@
             "description": "Generic Language Server Platform",
             "support": {
                 "issues": "https://github.com/phpactor/language-server/issues",
-                "source": "https://github.com/phpactor/language-server/tree/2.0.0"
+                "source": "https://github.com/phpactor/language-server/tree/shutdown-middleware"
             },
-            "time": "2022-04-20T21:08:10+00:00"
+            "time": "2022-04-21T20:38:00+00:00"
         },
         {
             "name": "phpactor/language-server-protocol",
@@ -7624,6 +7624,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "phpactor/language-server": 20,
         "jetbrains/phpstorm-stubs": 20,
         "dms/phpunit-arraysubset-asserts": 20
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "29dc5e6fdce8b352ef6b60a60d69f03e",
+    "content-hash": "657b3348581591928a5615350961e496",
     "packages": [
         {
             "name": "amphp/amp",
@@ -1680,16 +1680,16 @@
         },
         {
             "name": "phpactor/language-server",
-            "version": "dev-shutdown-middleware",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/language-server.git",
-                "reference": "f4604f3c18d4b979ce19ef221f8044e874cea5c5"
+                "reference": "f9656685f2ad9a083b8a4b09949ef7abb56ea164"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/language-server/zipball/f4604f3c18d4b979ce19ef221f8044e874cea5c5",
-                "reference": "f4604f3c18d4b979ce19ef221f8044e874cea5c5",
+                "url": "https://api.github.com/repos/phpactor/language-server/zipball/f9656685f2ad9a083b8a4b09949ef7abb56ea164",
+                "reference": "f9656685f2ad9a083b8a4b09949ef7abb56ea164",
                 "shasum": ""
             },
             "require": {
@@ -1740,9 +1740,9 @@
             "description": "Generic Language Server Platform",
             "support": {
                 "issues": "https://github.com/phpactor/language-server/issues",
-                "source": "https://github.com/phpactor/language-server/tree/shutdown-middleware"
+                "source": "https://github.com/phpactor/language-server/tree/2.1.0"
             },
-            "time": "2022-04-21T20:38:00+00:00"
+            "time": "2022-04-21T21:05:09+00:00"
         },
         {
             "name": "phpactor/language-server-protocol",
@@ -7624,7 +7624,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "phpactor/language-server": 20,
         "jetbrains/phpstorm-stubs": 20,
         "dms/phpunit-arraysubset-asserts": 20
     },

--- a/lib/Extension/LanguageServer/LanguageServerExtension.php
+++ b/lib/Extension/LanguageServer/LanguageServerExtension.php
@@ -52,6 +52,7 @@ use Phpactor\LanguageServer\Listener\WorkspaceListener;
 use Phpactor\LanguageServer\Core\Workspace\Workspace;
 use Phpactor\LanguageServer\LanguageServerBuilder;
 use Phpactor\LanguageServer\Core\Server\ServerStats;
+use Phpactor\LanguageServer\Middleware\ShutdownMiddleware;
 use Phpactor\LanguageServer\Service\DiagnosticsService;
 use Phpactor\MapResolver\Resolver;
 use Phpactor\MapResolver\ResolverErrors;
@@ -303,6 +304,7 @@ class LanguageServerExtension implements Extension
                 $container->get(EventDispatcherInterface::class)
             );
 
+            $stack[] = new ShutdownMiddleware($container->get(EventDispatcherInterface::class));
             $stack[] = new CancellationMiddleware(
                 $container->get(MethodRunner::class)
             );
@@ -313,6 +315,7 @@ class LanguageServerExtension implements Extension
             $stack[] = new HandlerMiddleware(
                 $container->get(MethodRunner::class)
             );
+
 
             return new MiddlewareDispatcher(...$stack);
         });
@@ -355,10 +358,6 @@ class LanguageServerExtension implements Extension
                 $container->get(ClientApi::class),
                 $container->get(ServerStats::class)
             );
-        }, [ self::TAG_METHOD_HANDLER => []]);
-
-        $container->register(ExitHandler::class, function (Container $container) {
-            return new ExitHandler($container->get(EventDispatcherInterface::class));
         }, [ self::TAG_METHOD_HANDLER => []]);
 
         $container->register(CodeActionHandler::class, function (Container $container) {

--- a/lib/Extension/LanguageServer/LanguageServerExtension.php
+++ b/lib/Extension/LanguageServer/LanguageServerExtension.php
@@ -20,7 +20,6 @@ use Phpactor\LanguageServer\Core\Command\CommandDispatcher;
 use Phpactor\LanguageServer\Core\Diagnostics\AggregateDiagnosticsProvider;
 use Phpactor\LanguageServer\Core\Diagnostics\DiagnosticsEngine;
 use Phpactor\LanguageServer\Diagnostics\CodeActionDiagnosticsProvider;
-use Phpactor\LanguageServer\Handler\System\ExitHandler;
 use Phpactor\LanguageServer\Handler\System\StatsHandler;
 use Phpactor\LanguageServer\Handler\TextDocument\CodeActionHandler;
 use Phpactor\LanguageServer\Handler\TextDocument\TextDocumentHandler;

--- a/lib/Extension/LanguageServer/Tests/Unit/LanguageServerExtensionTest.php
+++ b/lib/Extension/LanguageServer/Tests/Unit/LanguageServerExtensionTest.php
@@ -64,7 +64,7 @@ class LanguageServerExtensionTest extends LanguageServerTestCase
         $this->expectException(ExitSession::class);
 
         $serverTester = $this->createTester();
-        $serverTester->requestAndWait('exit', []);
+        $serverTester->notifyAndWait('exit', []);
     }
 
     public function testDebug(): void
@@ -72,7 +72,7 @@ class LanguageServerExtensionTest extends LanguageServerTestCase
         $this->expectException(ExitSession::class);
 
         $serverTester = $this->createTester();
-        $serverTester->requestAndWait('exit', []);
+        $serverTester->notifyAndWait('exit', []);
     }
 
     public function testRegistersCommands(): void

--- a/lib/WorseReflection/Tests/Inference/qualified-name/function-fallback-to-global.test
+++ b/lib/WorseReflection/Tests/Inference/qualified-name/function-fallback-to-global.test
@@ -7,5 +7,6 @@ function in_array(): array
 namespace Foo {
     wrAssertType('array', in_array());
     wrAssertSymbolName('in_array', in_array());
+
 }
 


### PR DESCRIPTION
Instead of ExitHandler use Middleware. According to the spec once the server recieves the `shutdown` request it should not respond to any further requests save the `exit` request.

Neovim was, for some reason, sending a `didOpen` notification after sending the `shutdown` notification, which possibly confused things.