### PR TITLE
Enable disable completors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Improvements:
 
 Features:
 
+  - [cmp] Explicitly enable/disable completors and disable `keyword` completor by default.
   - [wr] Support `iterator_to_array`
   - [wr] Handle constant glob to union types (`@return Foo::BAR_*`).
   - [lsp] show class category in offset hover info 

--- a/doc/reference/completion.rst
+++ b/doc/reference/completion.rst
@@ -13,7 +13,7 @@ Completors
 
 .. note::
 
-    Completors can be disabled using the :ref:`param_completion_worse.disabled_completors` configuration.
+    Completors can be enabled or disabled in configuration f.e. :ref:`param_completion_worse.completor.worse_parameter.enabled` configuration.
 
 ``worse_parameter``
 ~~~~~~~~~~~~~~~~~~~

--- a/doc/reference/configuration.rst
+++ b/doc/reference/configuration.rst
@@ -1172,6 +1172,9 @@ Register to recieve file events
 
 
 
+Logs timing information for incoming LSP requests
+
+
 **Default**: ``false``
 
 

--- a/doc/reference/configuration.rst
+++ b/doc/reference/configuration.rst
@@ -234,6 +234,210 @@ CompletionWorseExtension
 ------------------------
 
 
+.. _param_completion_worse.completor.worse_parameter.enabled:
+
+
+``completion_worse.completor.worse_parameter.enabled``
+""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+
+
+
+Enable or disable the ``worse_parameter`` completor.
+
+Completion for method or function parameters
+
+
+**Default**: ``true``
+
+
+.. _param_completion_worse.completor.named_parameter.enabled:
+
+
+``completion_worse.completor.named_parameter.enabled``
+""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+
+
+
+Enable or disable the ``named_parameter`` completor.
+
+Completion for named parameters
+
+
+**Default**: ``true``
+
+
+.. _param_completion_worse.completor.constructor.enabled:
+
+
+``completion_worse.completor.constructor.enabled``
+""""""""""""""""""""""""""""""""""""""""""""""""""
+
+
+
+
+Enable or disable the ``constructor`` completor.
+
+Completion for constructors
+
+
+**Default**: ``true``
+
+
+.. _param_completion_worse.completor.class_member.enabled:
+
+
+``completion_worse.completor.class_member.enabled``
+"""""""""""""""""""""""""""""""""""""""""""""""""""
+
+
+
+
+Enable or disable the ``class_member`` completor.
+
+Completion for class members
+
+
+**Default**: ``true``
+
+
+.. _param_completion_worse.completor.scf_class.enabled:
+
+
+``completion_worse.completor.scf_class.enabled``
+""""""""""""""""""""""""""""""""""""""""""""""""
+
+
+
+
+Enable or disable the ``scf_class`` completor.
+
+Brute force completion for class names (not recommended)
+
+
+**Default**: ``true``
+
+
+.. _param_completion_worse.completor.local_variable.enabled:
+
+
+``completion_worse.completor.local_variable.enabled``
+"""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+
+
+
+Enable or disable the ``local_variable`` completor.
+
+Completion for local variables
+
+
+**Default**: ``true``
+
+
+.. _param_completion_worse.completor.declared_function.enabled:
+
+
+``completion_worse.completor.declared_function.enabled``
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+
+
+
+Enable or disable the ``declared_function`` completor.
+
+Completion for functions defined in the Phpactor runtime
+
+
+**Default**: ``true``
+
+
+.. _param_completion_worse.completor.constant.enabled:
+
+
+``completion_worse.completor.constant.enabled``
+"""""""""""""""""""""""""""""""""""""""""""""""
+
+
+
+
+Enable or disable the ``constant`` completor.
+
+Completion for constants
+
+
+**Default**: ``true``
+
+
+.. _param_completion_worse.completor.class_alias.enabled:
+
+
+``completion_worse.completor.class_alias.enabled``
+""""""""""""""""""""""""""""""""""""""""""""""""""
+
+
+
+
+Enable or disable the ``class_alias`` completor.
+
+Completion for class aliases
+
+
+**Default**: ``true``
+
+
+.. _param_completion_worse.completor.declared_class.enabled:
+
+
+``completion_worse.completor.declared_class.enabled``
+"""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+
+
+
+Enable or disable the ``declared_class`` completor.
+
+Completion for classes defined in the Phpactor runtime
+
+
+**Default**: ``true``
+
+
+.. _param_completion_worse.completor.name_search.enabled:
+
+
+``completion_worse.completor.name_search.enabled``
+""""""""""""""""""""""""""""""""""""""""""""""""""
+
+
+
+
+Enable or disable the ``name_search`` completor.
+
+Completion for class names, constants and functions located in the index
+
+
+**Default**: ``true``
+
+
+.. _param_completion_worse.completor.keyword.enabled:
+
+
+``completion_worse.completor.keyword.enabled``
+""""""""""""""""""""""""""""""""""""""""""""""
+
+
+
+
+Enable or disable the ``keyword`` completor.
+
+Completion for keywords (not very accurate)
+
+
+**Default**: ``false``
+
+
 .. _param_completion_worse.completor.class.limit:
 
 
@@ -247,21 +451,6 @@ Suggestion limit for the filesystem based SCF class_completor
 
 
 **Default**: ``100``
-
-
-.. _param_completion_worse.disabled_completors:
-
-
-``completion_worse.disabled_completors``
-""""""""""""""""""""""""""""""""""""""""
-
-
-
-
-List of completors to disable (e.g. ``scf_class`` and ``declared_function``)
-
-
-**Default**: ``[]``
 
 
 .. _param_completion_worse.name_completion_priority:
@@ -972,6 +1161,18 @@ Register to recieve file events
 
 
 **Default**: ``["**\/*.php"]``
+
+
+.. _param_language_server.profile:
+
+
+``language_server.profile``
+"""""""""""""""""""""""""""
+
+
+
+
+**Default**: ``false``
 
 
 .. _LanguageServerCompletionExtension:

--- a/doc/reference/configuration.rst
+++ b/doc/reference/configuration.rst
@@ -245,7 +245,7 @@ CompletionWorseExtension
 
 Enable or disable the ``worse_parameter`` completor.
 
-Completion for method or function parameters
+Completion for method or function parameters.
 
 
 **Default**: ``true``
@@ -262,7 +262,7 @@ Completion for method or function parameters
 
 Enable or disable the ``named_parameter`` completor.
 
-Completion for named parameters
+Completion for named parameters.
 
 
 **Default**: ``true``
@@ -279,7 +279,7 @@ Completion for named parameters
 
 Enable or disable the ``constructor`` completor.
 
-Completion for constructors
+Completion for constructors.
 
 
 **Default**: ``true``
@@ -296,7 +296,7 @@ Completion for constructors
 
 Enable or disable the ``class_member`` completor.
 
-Completion for class members
+Completion for class members.
 
 
 **Default**: ``true``
@@ -313,7 +313,7 @@ Completion for class members
 
 Enable or disable the ``scf_class`` completor.
 
-Brute force completion for class names (not recommended)
+Brute force completion for class names (not recommended).
 
 
 **Default**: ``true``
@@ -330,7 +330,7 @@ Brute force completion for class names (not recommended)
 
 Enable or disable the ``local_variable`` completor.
 
-Completion for local variables
+Completion for local variables.
 
 
 **Default**: ``true``
@@ -347,7 +347,7 @@ Completion for local variables
 
 Enable or disable the ``declared_function`` completor.
 
-Completion for functions defined in the Phpactor runtime
+Completion for functions defined in the Phpactor runtime.
 
 
 **Default**: ``true``
@@ -364,7 +364,7 @@ Completion for functions defined in the Phpactor runtime
 
 Enable or disable the ``constant`` completor.
 
-Completion for constants
+Completion for constants.
 
 
 **Default**: ``true``
@@ -381,7 +381,7 @@ Completion for constants
 
 Enable or disable the ``class_alias`` completor.
 
-Completion for class aliases
+Completion for class aliases.
 
 
 **Default**: ``true``
@@ -398,7 +398,7 @@ Completion for class aliases
 
 Enable or disable the ``declared_class`` completor.
 
-Completion for classes defined in the Phpactor runtime
+Completion for classes defined in the Phpactor runtime.
 
 
 **Default**: ``true``
@@ -415,7 +415,7 @@ Completion for classes defined in the Phpactor runtime
 
 Enable or disable the ``name_search`` completor.
 
-Completion for class names, constants and functions located in the index
+Completion for class names, constants and functions located in the index.
 
 
 **Default**: ``true``
@@ -432,7 +432,7 @@ Completion for class names, constants and functions located in the index
 
 Enable or disable the ``keyword`` completor.
 
-Completion for keywords (not very accurate)
+Completion for keywords (not very accurate).
 
 
 **Default**: ``false``

--- a/lib/Extension/CompletionWorse/CompletionWorseExtension.php
+++ b/lib/Extension/CompletionWorse/CompletionWorseExtension.php
@@ -246,7 +246,7 @@ class CompletionWorseExtension implements Extension
                         $container->get(WorseReflectionExtension::SERVICE_REFLECTOR),
                         $container->get(CompletionExtension::SERVICE_SHORT_DESC_FORMATTER)
                     );
-                }, 
+                },
             ],
             'named_parameter' => [
                 'Completion for named parameters',

--- a/lib/Extension/CompletionWorse/Tests/Unit/CompletionWorseExtensionTest.php
+++ b/lib/Extension/CompletionWorse/Tests/Unit/CompletionWorseExtensionTest.php
@@ -39,25 +39,11 @@ class CompletionWorseExtensionTest extends TestCase
     public function testDisableCompletors(): void
     {
         $container = $this->buildContainer([
-            CompletionWorseExtension::PARAM_DISABLED_COMPLETORS => [
-                'worse_constructor',
-            ],
+            'completion_worse.completor.worse_parameter.enabled' => false,
         ]);
         $completors = $container->get('completion_worse.completor_map');
 
         self::assertFalse(in_array('completion_worse.completor.constructor', $completors), 'Completor disabled');
-    }
-
-    public function testExceptionWhenDisabledCompletorNotExisting(): void
-    {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unknown completors');
-        $container = $this->buildContainer([
-            CompletionWorseExtension::PARAM_DISABLED_COMPLETORS => [
-                'foobar',
-            ],
-        ]);
-        $container->get('completion_worse.completor_map');
     }
 
     public function testExceptionWhenSelectingUnknownSearchPriotityStrategy(): void
@@ -70,6 +56,9 @@ class CompletionWorseExtensionTest extends TestCase
         $container->get(DocumentPrioritizer::class);
     }
 
+    /**
+     * @param array<string,mixed> $config
+     */
     private function buildContainer(array $config = []): Container
     {
         return PhpactorContainer::fromExtensions(

--- a/lib/Extension/LanguageServer/LanguageServerExtension.php
+++ b/lib/Extension/LanguageServer/LanguageServerExtension.php
@@ -101,6 +101,7 @@ class LanguageServerExtension implements Extension
             self::PARAM_PROFILE => false,
         ]);
         $schema->setDescriptions([
+            self::PARAM_PROFILE => 'Logs timing information for incoming LSP requests',
             self::PARAM_METHOD_ALIAS_MAP => 'Allow method names to be re-mapped. Useful for maintaining backwards compatibility',
             self::PARAM_SESSION_PARAMETERS => 'Phpactor parameters (config) that apply only to the language server session',
             self::PARAM_ENABLE_WORKPACE => <<<'EOT'

--- a/lib/Extension/LanguageServer/Middleware/ProfilerMiddleware.php
+++ b/lib/Extension/LanguageServer/Middleware/ProfilerMiddleware.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServer\Middleware;
+
+use Amp\Promise;
+use Phpactor\LanguageServer\Core\Middleware\Middleware;
+use Phpactor\LanguageServer\Core\Middleware\RequestHandler;
+use Phpactor\LanguageServer\Core\Rpc\Message;
+use Phpactor\LanguageServer\Core\Rpc\NotificationMessage;
+use Phpactor\LanguageServer\Core\Rpc\RequestMessage;
+use Psr\Log\LoggerInterface;
+use function Amp\call;
+
+class ProfilerMiddleware implements Middleware
+{
+    private LoggerInterface $logger;
+
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    public function process(Message $request, RequestHandler $handler): Promise
+    {
+        return call(function () use ($request, $handler) {
+            if ($request instanceof NotificationMessage) {
+                $this->logger->info(sprintf('PROFILER >> notification [%s]', $request->method));
+            }
+
+            if ($request instanceof RequestMessage) {
+                $this->logger->info(sprintf(
+                    'PROFILER >> request #%d [%s]',
+                    $request->id,
+                    $request->method,
+                ));
+            }
+
+            $start = microtime(true);
+            $response = yield $handler->handle($request);
+            $elapsed = microtime(true) - $start;
+
+            if ($request instanceof NotificationMessage) {
+                $this->logger->info(sprintf('PROFILER << notification [%s] %ss', $request->method, number_format($elapsed, 4)));
+            }
+
+            if ($request instanceof RequestMessage) {
+                $this->logger->info(sprintf(
+                    'PROFILER << request #%d [%s] %ss',
+                    $request->id,
+                    $request->method,
+                    number_format($elapsed, 4)
+                ));
+            }
+
+            return $response;
+        });
+    }
+}

--- a/lib/Phpactor.php
+++ b/lib/Phpactor.php
@@ -271,11 +271,14 @@ class Phpactor
             ],
             WorseReflectionExtension::PARAM_ENABLE_CONTEXT_LOCATION => false,
             ClassToFileExtension::PARAM_BRUTE_FORCE_CONVERSION => false,
-            CompletionWorseExtension::PARAM_DISABLED_COMPLETORS => [
-                'scf_class',
-                'declared_class',
-                'declared_function',
-            ],
+
+            // these completors are not appropriate for the language server SCF
+            // is a brute force, blocking completor. the declared completors
+            // use the functions declared in the Phpactor runtime and not the
+            // project.
+            'completion_worse.completor.scf_class.enabled' => false,
+            'completion_worse.completor.declared_class.enabled' => false,
+            'completion_worse.completor.declared_function.enabled' => false,
         ];
 
         return $config;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -81,11 +81,6 @@ parameters:
 			path: lib/ClassMover/Adapter/WorseTolerant/WorseTolerantMemberFinder.php
 
 		-
-			message: "#^Method Phpactor\\\\ClassMover\\\\Adapter\\\\WorseTolerant\\\\WorseTolerantMemberFinder\\:\\:attachClassInfoToReference\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: lib/ClassMover/Adapter/WorseTolerant/WorseTolerantMemberFinder.php
-
-		-
 			message: "#^Method Phpactor\\\\ClassMover\\\\Adapter\\\\WorseTolerant\\\\WorseTolerantMemberFinder\\:\\:collectMemberReferences\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: lib/ClassMover/Adapter/WorseTolerant/WorseTolerantMemberFinder.php
@@ -386,11 +381,6 @@ parameters:
 			path: lib/ClassMover/Domain/Reference/ImportedNameReference.php
 
 		-
-			message: "#^Method Phpactor\\\\ClassMover\\\\Domain\\\\Reference\\\\MemberReference\\:\\:withClass\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: lib/ClassMover/Domain/Reference/MemberReference.php
-
-		-
 			message: "#^Class Phpactor\\\\ClassMover\\\\Domain\\\\Reference\\\\MemberReferences implements generic interface IteratorAggregate but does not specify its types\\: TKey, TValue$#"
 			count: 1
 			path: lib/ClassMover/Domain/Reference/MemberReferences.php
@@ -424,31 +414,6 @@ parameters:
 			message: "#^Property Phpactor\\\\ClassMover\\\\Domain\\\\Reference\\\\NamespaceReference\\:\\:\\$position has no type specified\\.$#"
 			count: 1
 			path: lib/ClassMover/Domain/Reference/NamespaceReference.php
-
-		-
-			message: "#^Class Phpactor\\\\ClassMover\\\\Domain\\\\Reference\\\\NamespacedClassReferences implements generic interface IteratorAggregate but does not specify its types\\: TKey, TValue$#"
-			count: 1
-			path: lib/ClassMover/Domain/Reference/NamespacedClassReferences.php
-
-		-
-			message: "#^Method Phpactor\\\\ClassMover\\\\Domain\\\\Reference\\\\NamespacedClassReferences\\:\\:__construct\\(\\) has parameter \\$classRefs with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/ClassMover/Domain/Reference/NamespacedClassReferences.php
-
-		-
-			message: "#^Method Phpactor\\\\ClassMover\\\\Domain\\\\Reference\\\\NamespacedClassReferences\\:\\:empty\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: lib/ClassMover/Domain/Reference/NamespacedClassReferences.php
-
-		-
-			message: "#^Method Phpactor\\\\ClassMover\\\\Domain\\\\Reference\\\\NamespacedClassReferences\\:\\:fromNamespaceAndClassRefs\\(\\) has parameter \\$classRefs with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/ClassMover/Domain/Reference/NamespacedClassReferences.php
-
-		-
-			message: "#^Property Phpactor\\\\ClassMover\\\\Domain\\\\Reference\\\\NamespacedClassReferences\\:\\:\\$classRefs has no type specified\\.$#"
-			count: 1
-			path: lib/ClassMover/Domain/Reference/NamespacedClassReferences.php
 
 		-
 			message: "#^Method Phpactor\\\\ClassMover\\\\Domain\\\\Reference\\\\Position\\:\\:fromStartAndEnd\\(\\) has no return type specified\\.$#"
@@ -2916,11 +2881,6 @@ parameters:
 			path: lib/Extension/ClassMover/Rpc/ReferencesHandler.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Rpc\\\\ReferencesHandler\\:\\:defaultReplacement\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Rpc/ReferencesHandler.php
-
-		-
 			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Rpc\\\\ReferencesHandler\\:\\:doPerformFindOrReplaceReferences\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: lib/Extension/ClassMover/Rpc/ReferencesHandler.php
@@ -3449,16 +3409,6 @@ parameters:
 			message: "#^Property Phpactor\\\\Extension\\\\CompletionRpc\\\\Tests\\\\Unit\\\\Handler\\\\CompleteHandlerTest\\:\\:\\$completor with generic class Prophecy\\\\Prophecy\\\\ObjectProphecy does not specify its types\\: T$#"
 			count: 1
 			path: lib/Extension/CompletionRpc/Tests/Unit/Handler/CompleteHandlerTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$callback of function array_map expects \\(callable\\(int\\|string, string\\)\\: mixed\\)\\|null, Closure\\(string, string\\)\\: string\\|false given\\.$#"
-			count: 1
-			path: lib/Extension/CompletionWorse/CompletionWorseExtension.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\CompletionWorse\\\\Tests\\\\Unit\\\\CompletionWorseExtensionTest\\:\\:buildContainer\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Extension/CompletionWorse/Tests/Unit/CompletionWorseExtensionTest.php
 
 		-
 			message: "#^Method Phpactor\\\\Extension\\\\ComposerAutoloader\\\\ClassLoaderFactory\\:\\:resolveMap\\(\\) return type has no value type specified in iterable type array\\.$#"
@@ -5581,11 +5531,6 @@ parameters:
 			path: lib/WorseReferenceFinder/Tests/DefinitionLocatorTestCase.php
 
 		-
-			message: "#^Method Phpactor\\\\WorseReferenceFinder\\\\Tests\\\\Unit\\\\WorsePlainTextDefinitionLocatorTest\\:\\:provideGotoWord\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: lib/WorseReferenceFinder/Tests/Unit/WorsePlainTextDefinitionLocatorTest.php
-
-		-
 			message: "#^Parameter \\#1 \\$offset of static method Phpactor\\\\TextDocument\\\\ByteOffset\\:\\:fromInt\\(\\) expects int, string given\\.$#"
 			count: 2
 			path: lib/WorseReferenceFinder/Tests/Unit/WorseReflectionDefinitionLocatorTest.php
@@ -5689,11 +5634,6 @@ parameters:
 			message: "#^Variable \\$resolvedName on left side of \\?\\? always exists and is always null\\.$#"
 			count: 2
 			path: lib/WorseReflection/Bridge/TolerantParser/Patch/TolerantQualifiedNameResolver.php
-
-		-
-			message: "#^Parameter \\#1 \\$method of method Phpactor\\\\WorseReflection\\\\Core\\\\Util\\\\OriginalMethodResolver\\:\\:resolveOriginalMember\\(\\) expects Phpactor\\\\WorseReflection\\\\Core\\\\Reflection\\\\ReflectionMember, \\$this\\(Phpactor\\\\WorseReflection\\\\Bridge\\\\TolerantParser\\\\Reflection\\\\AbstractReflectionClassMember\\) given\\.$#"
-			count: 1
-			path: lib/WorseReflection/Bridge/TolerantParser/Reflection/AbstractReflectionClassMember.php
 
 		-
 			message: "#^Strict comparison using \\=\\=\\= between null and Microsoft\\\\PhpParser\\\\ResolvedName will always evaluate to false\\.$#"


### PR DESCRIPTION
Add explicit options for enabling or disabing completors:
```
    "completion_worse.completor.worse_parameter.enabled": true,
    "completion_worse.completor.named_parameter.enabled": true,
    "completion_worse.completor.constructor.enabled": true,
    "completion_worse.completor.class_member.enabled": true,
    "completion_worse.completor.scf_class.enabled": false,
    "completion_worse.completor.local_variable.enabled": true,
    "completion_worse.completor.declared_function.enabled": false,
    "completion_worse.completor.constant.enabled": true,
    "completion_worse.completor.class_alias.enabled": true,
    "completion_worse.completor.declared_class.enabled": false,
    "completion_worse.completor.name_search.enabled": true,
    "completion_worse.completor.keyword.enabled": false,
```

and disables the `keyword` completor by default as it is often inappropriate.