### PR TITLE
Fix import globals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Bug fixes:
 
 Improvements:
 
+  - [ct] Add option to disable importing global functions
   - [wr] reset,array_shift and array_pop stubs
   - [wr] improved ternary support
   - [log] Include a channel prefxi in log messages

--- a/doc/reference/configuration.rst
+++ b/doc/reference/configuration.rst
@@ -227,11 +227,43 @@ If the first letter of a generated accessor should be made uppercase
 **Default**: ``false``
 
 
+.. _param_code_transform.import_globals:
+
+
+``code_transform.import_globals``
+"""""""""""""""""""""""""""""""""
+
+
+
+
+Import functions even if they are in the global namespace
+
+
+**Default**: ``false``
+
+
 .. _CompletionWorseExtension:
 
 
 CompletionWorseExtension
 ------------------------
+
+
+.. _param_completion_worse.completor.class_alias.enabled:
+
+
+``completion_worse.completor.class_alias.enabled``
+""""""""""""""""""""""""""""""""""""""""""""""""""
+
+
+
+
+Enable or disable the ``class_alias`` completor.
+
+Completion for class aliases.
+
+
+**Default**: ``true``
 
 
 .. _param_completion_worse.completor.worse_parameter.enabled:
@@ -365,23 +397,6 @@ Completion for functions defined in the Phpactor runtime.
 Enable or disable the ``constant`` completor.
 
 Completion for constants.
-
-
-**Default**: ``true``
-
-
-.. _param_completion_worse.completor.class_alias.enabled:
-
-
-``completion_worse.completor.class_alias.enabled``
-""""""""""""""""""""""""""""""""""""""""""""""""""
-
-
-
-
-Enable or disable the ``class_alias`` completor.
-
-Completion for class aliases.
 
 
 **Default**: ``true``

--- a/lib/CodeTransform/Adapter/TolerantParser/Refactor/TolerantImportName.php
+++ b/lib/CodeTransform/Adapter/TolerantParser/Refactor/TolerantImportName.php
@@ -43,9 +43,10 @@ class TolerantImportName implements ImportName
 
     public function importName(SourceCode $source, ByteOffset $offset, NameImport $nameImport): TextEdits
     {
-        if ($this->importGlobals === false && $nameImport->isFunction() && $nameImport->name()->count() === 1) {
+        if ($this->isGlobalFunction($nameImport)) {
             return TextEdits::none();
         }
+
         $sourceNode = $this->parser->parseSourceFile($source);
         $node = $this->getLastNodeAtPosition($sourceNode, $offset);
 
@@ -62,6 +63,10 @@ class TolerantImportName implements ImportName
 
     public function importNameOnly(SourceCode $source, ByteOffset $offset, NameImport $nameImport): TextEdits
     {
+        if ($this->isGlobalFunction($nameImport)) {
+            return TextEdits::none();
+        }
+
         $sourceNode = $this->parser->parseSourceFile($source);
         $node = $this->getLastNodeAtPosition($sourceNode, $offset);
 
@@ -230,5 +235,10 @@ class TolerantImportName implements ImportName
         }
 
         return $node;
+    }
+
+    private function isGlobalFunction(NameImport $nameImport): bool
+    {
+        return $this->importGlobals === false && $nameImport->isFunction() && $nameImport->name()->count() === 1;
     }
 }

--- a/lib/CodeTransform/Adapter/TolerantParser/Refactor/TolerantImportName.php
+++ b/lib/CodeTransform/Adapter/TolerantParser/Refactor/TolerantImportName.php
@@ -31,11 +31,14 @@ class TolerantImportName implements ImportName
 
     private Updater $updater;
 
-    public function __construct(Updater $updater, Parser $parser = null)
+    private bool $importGlobals;
+
+    public function __construct(Updater $updater, Parser $parser = null, bool $importGlobals = false)
     {
         $this->parser = $parser ?: new Parser();
         ;
         $this->updater = $updater;
+        $this->importGlobals = $importGlobals;
     }
 
     public function importName(SourceCode $source, ByteOffset $offset, NameImport $nameImport): TextEdits

--- a/lib/CodeTransform/Adapter/TolerantParser/Refactor/TolerantImportName.php
+++ b/lib/CodeTransform/Adapter/TolerantParser/Refactor/TolerantImportName.php
@@ -43,6 +43,9 @@ class TolerantImportName implements ImportName
 
     public function importName(SourceCode $source, ByteOffset $offset, NameImport $nameImport): TextEdits
     {
+        if ($this->importGlobals === false && $nameImport->isFunction() && $nameImport->name()->count() === 1) {
+            return TextEdits::none();
+        }
         $sourceNode = $this->parser->parseSourceFile($source);
         $node = $this->getLastNodeAtPosition($sourceNode, $offset);
 

--- a/lib/CodeTransform/Domain/Helper/UnresolvableClassNameFinder/TestUnresolvableClassNameFinder.php
+++ b/lib/CodeTransform/Domain/Helper/UnresolvableClassNameFinder/TestUnresolvableClassNameFinder.php
@@ -3,7 +3,6 @@
 namespace Phpactor\CodeTransform\Domain\Helper\UnresolvableClassNameFinder;
 
 use Phpactor\CodeTransform\Domain\Helper\UnresolvableClassNameFinder;
-use Phpactor\CodeTransform\Domain\NameWithByteOffset;
 use Phpactor\CodeTransform\Domain\NameWithByteOffsets;
 use Phpactor\TextDocument\TextDocument;
 

--- a/lib/CodeTransform/Domain/Helper/UnresolvableClassNameFinder/TestUnresolvableClassNameFinder.php
+++ b/lib/CodeTransform/Domain/Helper/UnresolvableClassNameFinder/TestUnresolvableClassNameFinder.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Phpactor\CodeTransform\Domain\Helper\UnresolvableClassNameFinder;
+
+use Phpactor\CodeTransform\Domain\Helper\UnresolvableClassNameFinder;
+use Phpactor\CodeTransform\Domain\NameWithByteOffset;
+use Phpactor\CodeTransform\Domain\NameWithByteOffsets;
+use Phpactor\TextDocument\TextDocument;
+
+class TestUnresolvableClassNameFinder implements UnresolvableClassNameFinder
+{
+    private NameWithByteOffsets $result;
+
+    public function __construct(NameWithByteOffsets $result)
+    {
+        $this->result = $result;
+    }
+
+    public function find(TextDocument $sourceCode): NameWithByteOffsets
+    {
+        return $this->result;
+    }
+}

--- a/lib/CodeTransform/Tests/Adapter/TolerantParser/Refactor/AbstractTolerantImportNameTest.php
+++ b/lib/CodeTransform/Tests/Adapter/TolerantParser/Refactor/AbstractTolerantImportNameTest.php
@@ -202,7 +202,7 @@ abstract class AbstractTolerantImportNameTest extends TolerantTestCase
 
     abstract public function provideImportFunction(): Generator;
 
-    abstract protected function importName(string $source, int $offset, NameImport $nameImport): TextEdits;
+    abstract protected function importName(string $source, int $offset, NameImport $nameImport, bool $importGlobals = true): TextEdits;
 
     private function importNameFromTestFile(string $type, string $test, string $name, string $alias = null)
     {

--- a/lib/CodeTransform/Tests/Adapter/TolerantParser/Refactor/AbstractTolerantImportNameTest.php
+++ b/lib/CodeTransform/Tests/Adapter/TolerantParser/Refactor/AbstractTolerantImportNameTest.php
@@ -202,7 +202,7 @@ abstract class AbstractTolerantImportNameTest extends TolerantTestCase
 
     abstract public function provideImportFunction(): Generator;
 
-    abstract protected function importName($source, int $offset, NameImport $nameImport): TextEdits;
+    abstract protected function importName(string $source, int $offset, NameImport $nameImport): TextEdits;
 
     private function importNameFromTestFile(string $type, string $test, string $name, string $alias = null)
     {

--- a/lib/CodeTransform/Tests/Adapter/TolerantParser/Refactor/TolerantImportNameOnlyTest.php
+++ b/lib/CodeTransform/Tests/Adapter/TolerantParser/Refactor/TolerantImportNameOnlyTest.php
@@ -76,9 +76,9 @@ class TolerantImportNameOnlyTest extends AbstractTolerantImportNameTest
         ];
     }
 
-    protected function importName($source, int $offset, NameImport $nameImport): TextEdits
+    protected function importName($source, int $offset, NameImport $nameImport, bool $importGlobals = true): TextEdits
     {
-        $importClass = (new TolerantImportName($this->updater(), $this->parser()));
+        $importClass = (new TolerantImportName($this->updater(), $this->parser(), $importGlobals));
         return $importClass->importNameOnly(SourceCode::fromString($source), ByteOffset::fromInt($offset), $nameImport);
     }
 }

--- a/lib/CodeTransform/Tests/Adapter/TolerantParser/Refactor/TolerantImportNameTest.php
+++ b/lib/CodeTransform/Tests/Adapter/TolerantParser/Refactor/TolerantImportNameTest.php
@@ -90,7 +90,14 @@ class TolerantImportNameTest extends AbstractTolerantImportNameTest
         self::assertStringNotContainsString('array_map', $edits->apply($source));
     }
 
-    protected function importName($source, int $offset, NameImport $nameImport, bool $importGlobals = false): TextEdits
+    public function testImportNotGlobalWhenDisabled(): void
+    {
+        $source = '<?php namespace Foobar;';
+        $edits = $this->importName($source, 10, NameImport::forFunction('Bar\array_map', null), false);
+        self::assertStringContainsString('Bar\array_map', $edits->apply($source));
+    }
+
+    protected function importName(string $source, int $offset, NameImport $nameImport, bool $importGlobals = true): TextEdits
     {
         $importClass = (new TolerantImportName($this->updater(), $this->parser(), $importGlobals));
         return $importClass->importName(SourceCode::fromString($source), ByteOffset::fromInt($offset), $nameImport);

--- a/lib/CodeTransform/Tests/Adapter/TolerantParser/Refactor/TolerantImportNameTest.php
+++ b/lib/CodeTransform/Tests/Adapter/TolerantParser/Refactor/TolerantImportNameTest.php
@@ -76,9 +76,23 @@ class TolerantImportNameTest extends AbstractTolerantImportNameTest
         ];
     }
 
-    protected function importName($source, int $offset, NameImport $nameImport): TextEdits
+    public function testImportsGlobal(): void
     {
-        $importClass = (new TolerantImportName($this->updater(), $this->parser()));
+        $source = '<?php namespace Foobar;';
+        $edits = $this->importName($source, 10, NameImport::forFunction('array_map', null), true);
+        self::assertStringContainsString('array_map', $edits->apply($source));
+    }
+
+    public function testNotImportGlobalWhenDisabled(): void
+    {
+        $source = '<?php namespace Foobar;';
+        $edits = $this->importName($source, 10, NameImport::forFunction('array_map', null), false);
+        self::assertStringNotContainsString('array_map', $edits->apply($source));
+    }
+
+    protected function importName($source, int $offset, NameImport $nameImport, bool $importGlobals = false): TextEdits
+    {
+        $importClass = (new TolerantImportName($this->updater(), $this->parser(), $importGlobals));
         return $importClass->importName(SourceCode::fromString($source), ByteOffset::fromInt($offset), $nameImport);
     }
 }

--- a/lib/Extension/CodeTransform/CodeTransformExtension.php
+++ b/lib/Extension/CodeTransform/CodeTransformExtension.php
@@ -75,6 +75,7 @@ class CodeTransformExtension implements Extension
     public const PARAM_INDENTATION = 'code_transform.indentation';
     public const PARAM_GENERATE_ACCESSOR_PREFIX = 'code_transform.refactor.generate_accessor.prefix';
     public const PARAM_GENERATE_ACCESSOR_UPPER_CASE_FIRST = 'code_transform.refactor.generate_accessor.upper_case_first';
+    public const PARAM_IMPORT_GLOBALS = 'code_transform.import_globals';
     private const APP_TEMPLATE_PATH = '%application_root%/templates/code';
     private const SERVICE_TOLERANT_PARSER = 'code_transform.tolerant_parser';
 
@@ -90,6 +91,7 @@ class CodeTransformExtension implements Extension
             self::PARAM_INDENTATION => '    ',
             self::PARAM_GENERATE_ACCESSOR_PREFIX => '',
             self::PARAM_GENERATE_ACCESSOR_UPPER_CASE_FIRST => false,
+            self::PARAM_IMPORT_GLOBALS => false,
         ]);
         $schema->setDescriptions([
             self::PARAM_NEW_CLASS_VARIANTS => 'Variants which should be suggested when class-create is invoked',
@@ -97,6 +99,7 @@ class CodeTransformExtension implements Extension
             self::PARAM_INDENTATION => 'Indentation chars to use in code generation and transformation',
             self::PARAM_GENERATE_ACCESSOR_PREFIX => 'Prefix to use for generated accessors',
             self::PARAM_GENERATE_ACCESSOR_UPPER_CASE_FIRST => 'If the first letter of a generated accessor should be made uppercase',
+            self::PARAM_IMPORT_GLOBALS => 'Import functions even if they are in the global namespace',
         ]);
     }
 
@@ -218,7 +221,9 @@ class CodeTransformExtension implements Extension
 
         $container->register(ImportName::class, function (Container $container) {
             return new TolerantImportName(
-                $container->get(Updater::class)
+                $container->get(Updater::class),
+                null,
+                $container->getParameter(self::PARAM_IMPORT_GLOBALS),
             );
         });
 


### PR DESCRIPTION
This PR adds a new option to dsiable importing global functions on completion.

The existing option is for diagnostics and if functions should be included as candidates when importing non-existing names.

The new option `code_transform.import_globals` will prevent these anmes being imported at all.