### PR TITLE
Keywords

### DIFF
--- a/doc/reference/configuration.rst
+++ b/doc/reference/configuration.rst
@@ -518,7 +518,7 @@ Enable or disable the ``keyword`` completor.
 Completion for keywords (not very accurate).
 
 
-**Default**: ``false``
+**Default**: ``true``
 
 
 .. _param_completion_worse.completor.docblock.enabled:

--- a/lib/Completion/Bridge/TolerantParser/CompletionContext.php
+++ b/lib/Completion/Bridge/TolerantParser/CompletionContext.php
@@ -2,19 +2,24 @@
 
 namespace Phpactor\Completion\Bridge\TolerantParser;
 
+use Microsoft\PhpParser\ClassLike;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\ArrayElement;
 use Microsoft\PhpParser\Node\ClassBaseClause;
 use Microsoft\PhpParser\Node\ClassInterfaceClause;
+use Microsoft\PhpParser\Node\ClassMembersNode;
 use Microsoft\PhpParser\Node\DelimitedList\QualifiedNameList;
 use Microsoft\PhpParser\Node\Expression;
 use Microsoft\PhpParser\Node\InterfaceBaseClause;
+use Microsoft\PhpParser\Node\MethodDeclaration;
 use Microsoft\PhpParser\Node\NamespaceUseClause;
 use Microsoft\PhpParser\Node\Parameter;
+use Microsoft\PhpParser\Node\Statement\CompoundStatementNode;
 use Microsoft\PhpParser\Node\Statement\ExpressionStatement;
 use Microsoft\PhpParser\Node\Statement\IfStatementNode;
 use Microsoft\PhpParser\Node\Statement\ReturnStatement;
 use Microsoft\PhpParser\Node\TraitUseClause;
+use Phpactor\WorseReflection\Core\Util\NodeUtil;
 
 class CompletionContext
 {
@@ -24,6 +29,29 @@ class CompletionContext
 
         if (null === $parent) {
             return false;
+        }
+
+        $prefix = substr($node->getFileContents(), 0, $node->getStartPosition());
+
+
+        $nodeBeforeOffset = NodeUtil::firstDescendantNodeBeforeOffset($node->getRoot(), $node->parent->getStartPosition());
+
+        if ($nodeBeforeOffset->getFirstAncestor(ClassLike::class)) {
+            if ($nodeBeforeOffset instanceof ClassMembersNode) {
+                return false;
+            }
+
+            if ($nodeBeforeOffset instanceof CompoundStatementNode && $node->getStartPosition() < $nodeBeforeOffset->getEndPosition()) {
+                return true;
+            }
+
+            $methodDeclaration = $nodeBeforeOffset->getFirstAncestor(MethodDeclaration::class);
+            if (!$methodDeclaration) {
+                return false;
+            }
+            if ($methodDeclaration->getEndPosition() < $node->getStartPosition()) {
+                return false;
+            }
         }
 
         return

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/KeywordCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/KeywordCompletor.php
@@ -6,20 +6,11 @@ namespace Phpactor\Completion\Bridge\TolerantParser\WorseReflection;
 
 use Generator;
 use Microsoft\PhpParser\Node;
-use Microsoft\PhpParser\Node\ClassMembersNode;
-use Microsoft\PhpParser\Node\Expression\AnonymousFunctionCreationExpression;
-use Microsoft\PhpParser\Node\Expression\MemberAccessExpression;
-use Microsoft\PhpParser\Node\Expression\ScopedPropertyAccessExpression;
-use Microsoft\PhpParser\Node\Expression\Variable;
-use Microsoft\PhpParser\Node\Statement\CompoundStatementNode;
-use Microsoft\PhpParser\Node\StringLiteral;
-use Microsoft\PhpParser\TokenStringMaps;
 use Phpactor\Completion\Bridge\TolerantParser\CompletionContext;
 use Phpactor\Completion\Bridge\TolerantParser\TolerantCompletor;
 use Phpactor\Completion\Core\Suggestion;
 use Phpactor\TextDocument\ByteOffset;
 use Phpactor\TextDocument\TextDocument;
-use Phpactor\WorseReflection\Core\Util\NodeUtil;
 
 class KeywordCompletor implements TolerantCompletor
 {
@@ -30,16 +21,18 @@ class KeywordCompletor implements TolerantCompletor
             return true;
         }
 
-        if (CompletionContext::classMembersBody($node)) {
-            yield from $this->keywords(['private', 'protected', 'public']);
-            return true;
-        }
-
-        if (CompletionContext::classMembersBody($node->parent)) {
+        if (
+            CompletionContext::classMembersBody($node->parent)
+        ) {
             yield from $this->keywords([
                 'function',
                 'const',
             ]);
+            return true;
+        }
+
+        if (CompletionContext::classMembersBody($node)) {
+            yield from $this->keywords(['private', 'protected', 'public']);
             return true;
         }
 
@@ -55,6 +48,7 @@ class KeywordCompletor implements TolerantCompletor
         foreach ($keywords as $keyword) {
             yield Suggestion::createWithOptions($keyword, [
                 'type' => Suggestion::TYPE_KEYWORD,
+                'priority' => Suggestion::PRIORITY_HIGH,
             ]);
         }
     }

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/KeywordCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/KeywordCompletor.php
@@ -27,10 +27,12 @@ class KeywordCompletor implements TolerantCompletor
     {
         if (CompletionContext::classClause($node, $offset)) {
             yield from $this->keywords(['implements', 'extends']);
+            return true;
         }
 
         if (CompletionContext::classMembersBody($node)) {
             yield from $this->keywords(['private', 'protected', 'public']);
+            return true;
         }
 
         if (CompletionContext::classMembersBody($node->parent)) {
@@ -38,6 +40,7 @@ class KeywordCompletor implements TolerantCompletor
                 'function',
                 'const',
             ]);
+            return true;
         }
 
         return true;

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/KeywordCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/KeywordCompletor.php
@@ -14,118 +14,45 @@ use Microsoft\PhpParser\Node\Expression\Variable;
 use Microsoft\PhpParser\Node\Statement\CompoundStatementNode;
 use Microsoft\PhpParser\Node\StringLiteral;
 use Microsoft\PhpParser\TokenStringMaps;
+use Phpactor\Completion\Bridge\TolerantParser\CompletionContext;
 use Phpactor\Completion\Bridge\TolerantParser\TolerantCompletor;
 use Phpactor\Completion\Core\Suggestion;
 use Phpactor\TextDocument\ByteOffset;
 use Phpactor\TextDocument\TextDocument;
+use Phpactor\WorseReflection\Core\Util\NodeUtil;
 
 class KeywordCompletor implements TolerantCompletor
 {
-    public const MEMBER_ACCESS = 'member_access';
-    public const CLASS_MEMBERS = 'class_members';
-    public const STRING_LITERAL = 'string_literal';
-    public const VARIABLE = 'variable';
-    public const AFTER_ANONYMOUS_FUNC_PARAMS = 'after_anonymous_func_params';
-    public const SPECIAL_SCOPES = [
-        self::MEMBER_ACCESS => [ ],
-        self::STRING_LITERAL => [ ],
-        self::VARIABLE => [ ],
-        // https://github.com/php/php-langspec/blob/master/spec/10-expressions.md#anonymous-function-creation
-        self::AFTER_ANONYMOUS_FUNC_PARAMS => [
-            'use'
-        ],
-        // https://github.com/php/php-langspec/blob/master/spec/14-classes.md#grammar-class-member-declaration
-        self::CLASS_MEMBERS => [
-            // visibility
-            'public',
-            'private',
-            'protected',
-            // scope
-            'static',
-            // property
-            'var',
-            // const
-            'const',
-            // method
-            'function',
-            // trait use
-            'use',
-        ],
-    ];
-
-    /**
-     * @var null|string[]
-     */
-    private ?array $allKeywords = null;
-    
-    public function initKeywords(): void
-    {
-        if ($this->allKeywords === null) {
-            $this->allKeywords = array_merge(
-                array_keys(TokenStringMaps::RESERVED_WORDS),
-                array_keys(TokenStringMaps::KEYWORDS)
-            );
-        }
-    }
-    
     public function complete(Node $node, TextDocument $source, ByteOffset $offset): Generator
     {
-        $this->initKeywords();
-
-        $scopeName = $this->getScopeName($node, $offset);
-
-        $keywords =
-            (isset(self::SPECIAL_SCOPES[$scopeName])) ?
-                self::SPECIAL_SCOPES[$scopeName] :
-                $this->allKeywords;
-
-        foreach ($keywords as $keyword) {
-            yield Suggestion::createWithOptions(
-                $keyword,
-                [
-                    'type' => Suggestion::TYPE_KEYWORD
-                ]
-            );
+        if (CompletionContext::classClause($node, $offset)) {
+            yield from $this->keywords(['implements', 'extends']);
         }
+
+        if (CompletionContext::classMembersBody($node)) {
+            yield from $this->keywords(['private', 'protected', 'public']);
+        }
+
+        if (CompletionContext::classMembersBody($node->parent)) {
+            yield from $this->keywords([
+                'function',
+                'const',
+            ]);
+        }
+
         return true;
     }
 
-    private function getScopeName(Node $node, ByteOffset $offset): ?string
+    /**
+     * @return Generator<Suggestion>
+     * @param string[] $keywords
+     */
+    private function keywords(array $keywords): Generator
     {
-        if (
-            ($node instanceof MemberAccessExpression || $node instanceof ScopedPropertyAccessExpression)
-            && ($node->memberName->getEndPosition() == $offset->toInt())
-        ) {
-            return self::MEMBER_ACCESS;
+        foreach ($keywords as $keyword) {
+            yield Suggestion::createWithOptions($keyword, [
+                'type' => Suggestion::TYPE_KEYWORD,
+            ]);
         }
-        
-        if ($node instanceof ClassMembersNode) {
-            return self::CLASS_MEMBERS;
-        }
-        
-        if ($node instanceof StringLiteral) {
-            return self::STRING_LITERAL;
-        }
-        
-        if (
-            $node instanceof Variable
-            && ($node->name->getEndPosition() == $offset->toInt())
-        ) {
-            return self::VARIABLE;
-        }
-        
-        if (
-            $node instanceof CompoundStatementNode
-            && $node->getParent() instanceof AnonymousFunctionCreationExpression
-            && $node->getParent()->closeParen->getEndPosition() == ($offset->toInt() - 1)
-            && (
-                $node->getParent()->colonToken == null
-                || $node->getParent()->colonToken->getStartPosition() > $offset->toInt()
-            )
-        ) {
-            return self::AFTER_ANONYMOUS_FUNC_PARAMS;
-        }
-
-        return null;
     }
 }

--- a/lib/Completion/Tests/Integration/Bridge/TolerantParser/WorseReflection/KeywordCompletorTest.php
+++ b/lib/Completion/Tests/Integration/Bridge/TolerantParser/WorseReflection/KeywordCompletorTest.php
@@ -38,11 +38,11 @@ class KeywordCompletorTest extends TolerantCompletorTestCase
 
         yield 'class implements 1' => [
             '<?php class Foobar <>',
-            $this->expect(['implements', 'extends']),
+            $this->expect(['extends', 'implements']),
         ];
         yield 'class implements 2' => [
             '<?php class Foobar impl<>',
-            $this->expect(['implements', 'extends']),
+            $this->expect(['extends', 'implements']),
         ];
     }
 

--- a/lib/Completion/Tests/Integration/Bridge/TolerantParser/WorseReflection/KeywordCompletorTest.php
+++ b/lib/Completion/Tests/Integration/Bridge/TolerantParser/WorseReflection/KeywordCompletorTest.php
@@ -3,10 +3,8 @@
 namespace Phpactor\Completion\Tests\Integration\Bridge\TolerantParser\WorseReflection;
 
 use Generator;
-use Microsoft\PhpParser\TokenStringMaps;
 use Phpactor\Completion\Bridge\TolerantParser\TolerantCompletor;
 use Phpactor\Completion\Bridge\TolerantParser\WorseReflection\KeywordCompletor;
-use Phpactor\Completion\Core\Suggestion;
 use Phpactor\Completion\Tests\Integration\Bridge\TolerantParser\TolerantCompletorTestCase;
 use Phpactor\TextDocument\TextDocument;
 
@@ -33,6 +31,10 @@ class KeywordCompletorTest extends TolerantCompletorTestCase
 
         yield 'member keyword postfix' => [
             '<?php class Foobar { private <>',
+            $this->expect(['const', 'function']),
+        ];
+        yield 'member keyword postfix 2' => [
+            '<?php class Foobar { private func<>',
             $this->expect(['const', 'function']),
         ];
 

--- a/lib/Completion/Tests/Integration/Bridge/TolerantParser/WorseReflection/KeywordCompletorTest.php
+++ b/lib/Completion/Tests/Integration/Bridge/TolerantParser/WorseReflection/KeywordCompletorTest.php
@@ -14,76 +14,35 @@ class KeywordCompletorTest extends TolerantCompletorTestCase
 {
     /**
      * @dataProvider provideComplete
+     * @param array{string,array<string,mixed>[]} $expected
      */
     public function testComplete(string $source, array $expected): void
     {
         $this->assertComplete($source, $expected);
     }
-    
+
+    /**
+     * @return Generator<string,array{string,array<string,mixed>[]}>
+     */
     public function provideComplete(): Generator
     {
-        $keywords = array_merge(array_keys(TokenStringMaps::RESERVED_WORDS), array_keys(TokenStringMaps::KEYWORDS));
-        $allKeywords = $this->createExpectedKeywords($keywords);
+        yield 'member keywords' => [
+            '<?php class Foobar { <>',
+            $this->expect(['private', 'protected', 'public']),
+        ];
 
-        yield 'all keywords' => [
-            '<?php <>',
-            $allKeywords
+        yield 'member keyword postfix' => [
+            '<?php class Foobar { private <>',
+            $this->expect(['const', 'function']),
         ];
-        yield 'member' => [
-            '<?php class C { <>',
-            $this->createExpectedKeywords(KeywordCompletor::SPECIAL_SCOPES[KeywordCompletor::CLASS_MEMBERS])
+
+        yield 'class implements 1' => [
+            '<?php class Foobar <>',
+            $this->expect(['implements', 'extends']),
         ];
-        yield 'member access' => [
-            '<?php function F(){ $v-><>',
-            $this->createExpectedKeywords(KeywordCompletor::SPECIAL_SCOPES[KeywordCompletor::MEMBER_ACCESS])
-        ];
-        yield 'member access with partial name' => [
-            '<?php function F(){ $v->p<>',
-            $this->createExpectedKeywords(KeywordCompletor::SPECIAL_SCOPES[KeywordCompletor::MEMBER_ACCESS])
-        ];
-        yield 'member access after name' => [
-            '<?php function F(){ $v->p <>',
-            $allKeywords
-        ];
-        yield 'scoped member access' => [
-            '<?php function F(){ joe::<>',
-            $this->createExpectedKeywords(KeywordCompletor::SPECIAL_SCOPES[KeywordCompletor::MEMBER_ACCESS])
-        ];
-        yield 'scoped member access with partial name' => [
-            '<?php function F(){ joe::me<>',
-            $this->createExpectedKeywords(KeywordCompletor::SPECIAL_SCOPES[KeywordCompletor::MEMBER_ACCESS])
-        ];
-        yield 'scoped member access after name' => [
-            '<?php function F(){ joe::me <>',
-            $allKeywords
-        ];
-        yield 'scoped member access after name and brace' => [
-            '<?php function F(){ joe::me(<>',
-            $allKeywords
-        ];
-        yield 'inside string' => [
-            '<?php $var ="<> ',
-            $this->createExpectedKeywords(KeywordCompletor::SPECIAL_SCOPES[KeywordCompletor::STRING_LITERAL])
-        ];
-        yield 'inside string expression' => [
-            '<?php $var ="{$var->n<> ',
-            $this->createExpectedKeywords(KeywordCompletor::SPECIAL_SCOPES[KeywordCompletor::MEMBER_ACCESS])
-        ];
-        yield 'var' => [
-            '<?php $var<> ',
-            $this->createExpectedKeywords(KeywordCompletor::SPECIAL_SCOPES[KeywordCompletor::VARIABLE])
-        ];
-        yield 'after var' => [
-            '<?php $var <> ',
-            $allKeywords
-        ];
-        yield 'after function braces' => [
-            '<?php $func = function() <> ',
-            $this->createExpectedKeywords(KeywordCompletor::SPECIAL_SCOPES[KeywordCompletor::AFTER_ANONYMOUS_FUNC_PARAMS])
-        ];
-        yield 'after function braces before return statement' => [
-            '<?php $func = function() <> :string ',
-            $this->createExpectedKeywords(KeywordCompletor::SPECIAL_SCOPES[KeywordCompletor::AFTER_ANONYMOUS_FUNC_PARAMS])
+        yield 'class implements 2' => [
+            '<?php class Foobar impl<>',
+            $this->expect(['implements', 'extends']),
         ];
     }
 
@@ -92,16 +51,14 @@ class KeywordCompletorTest extends TolerantCompletorTestCase
         return new KeywordCompletor();
     }
 
-    private function createExpectedKeywords(array $list): array
+    /**
+     * @return array<array<string,mixed>>
+     * @param array<string> $array
+     */
+    private function expect(array $array): array
     {
-        sort($list);
-        $keywords = [];
-        foreach ($list as $keyword) {
-            $keywords[] = [
-                'type' => Suggestion::TYPE_KEYWORD,
-                'name' => $keyword,
-            ];
-        }
-        return $keywords;
+        return array_map(fn (string $keyword) => [
+            'name' => $keyword,
+        ], $array);
     }
 }

--- a/lib/Completion/Tests/Unit/Bridge/TolerantParser/CompletionContextTest.php
+++ b/lib/Completion/Tests/Unit/Bridge/TolerantParser/CompletionContextTest.php
@@ -7,6 +7,7 @@ use Microsoft\PhpParser\Parser;
 use PHPUnit\Framework\TestCase;
 use Phpactor\Completion\Bridge\TolerantParser\CompletionContext;
 use Phpactor\TestUtils\ExtractOffset;
+use Phpactor\TextDocument\ByteOffset;
 
 class CompletionContextTest extends TestCase
 {
@@ -46,6 +47,76 @@ class CompletionContextTest extends TestCase
         yield 'not class clause on new line' => [
             "<?php class Foo \ni<>",
             false,
+        ];
+
+        yield 'not class member body' => [
+            "<?php class Foo { A<>",
+            false,
+        ];
+
+        yield 'not class member body after property' => [
+            "<?php class Foo { private \$foo; A<>",
+            false,
+        ];
+        yield 'not after method 1' => [
+            "<?php class Foo { public function bar() {} A<> }",
+            false,
+        ];
+        yield 'not after method 2' => [
+            "<?php class Foo { private \$foo; public function bar() {} public function boo() {} A<> public functoin baz() {}}",
+            false,
+        ];
+        yield 'not after method 3' => [
+            "<?php class Foo { public function bar() {\necho 'hello world'; \$bar = 12;} A<> }",
+            false,
+        ];
+
+        yield 'in class method body 1' => [
+            "<?php class Foo { public function foo() { A<> }",
+            true
+        ];
+        yield 'in class method body 2' => [
+            "<?php class Foo { public function bar() { if (true) { return false; } A<> } }",
+            true,
+        ];
+    }
+
+    /**
+     * @dataProvider provideClassClause
+     */
+    public function testClassClause(string $source, bool $expected): void
+    {
+        [$source, $offset] = ExtractOffset::fromSource($source);
+        $node = (new Parser())->parseSourceFile($source)->getDescendantNodeAtPosition((int)$offset);
+        self::assertEquals($expected, CompletionContext::classClause($node, ByteOffset::fromInt((int)$offset)));
+    }
+
+    /**
+     * @return Generator<string,array<int,mixed>>
+     */
+    public function provideClassClause(): Generator
+    {
+        yield 'clause' => [
+            '<?php class Foo i<>',
+            true,
+        ];
+
+        yield 'clause 2' => [
+            '<?php class Foo <>',
+            true,
+        ];
+        yield 'clause 3' => [
+            '<?php class Foo implements Foo <>',
+            true,
+        ];
+        yield 'class clause 4' => [
+            '<?php class Foo implements Foo,Bar <>',
+            true,
+        ];
+
+        yield 'class clause on new line' => [
+            "<?php class Foo \ni<>",
+            true,
         ];
 
         yield 'not class member body' => [

--- a/lib/Completion/Tests/Unit/Bridge/TolerantParser/CompletionContextTest.php
+++ b/lib/Completion/Tests/Unit/Bridge/TolerantParser/CompletionContextTest.php
@@ -50,20 +50,20 @@ class CompletionContextTest extends TestCase
         ];
 
         yield 'not class member body' => [
-            "<?php class Foo { A<>",
+            '<?php class Foo { A<>',
             false,
         ];
 
         yield 'not class member body after property' => [
-            "<?php class Foo { private \$foo; A<>",
+            '<?php class Foo { private $foo; A<>',
             false,
         ];
         yield 'not after method 1' => [
-            "<?php class Foo { public function bar() {} A<> }",
+            '<?php class Foo { public function bar() {} A<> }',
             false,
         ];
         yield 'not after method 2' => [
-            "<?php class Foo { private \$foo; public function bar() {} public function boo() {} A<> public functoin baz() {}}",
+            '<?php class Foo { private $foo; public function bar() {} public function boo() {} A<> public functoin baz() {}}',
             false,
         ];
         yield 'not after method 3' => [
@@ -72,11 +72,11 @@ class CompletionContextTest extends TestCase
         ];
 
         yield 'in class method body 1' => [
-            "<?php class Foo { public function foo() { A<> }",
+            '<?php class Foo { public function foo() { A<> }',
             true
         ];
         yield 'in class method body 2' => [
-            "<?php class Foo { public function bar() { if (true) { return false; } A<> } }",
+            '<?php class Foo { public function bar() { if (true) { return false; } A<> } }',
             true,
         ];
     }
@@ -97,29 +97,29 @@ class CompletionContextTest extends TestCase
     public function provideClassMemberBody(): Generator
     {
         yield 'property' => [
-            "<?php class Foo { pri<> }",
+            '<?php class Foo { pri<> }',
             true
         ];
         yield 'visibility 1' => [
-            "<?php class Foo { <> }",
+            '<?php class Foo { <> }',
             true
         ];
         yield 'visibility 2' => [
-            "<?php class Foo { private <> }",
+            '<?php class Foo { private <> }',
             true
         ];
         yield 'visibility 3' => [
-            "<?php class Foo { private Foob<> }",
+            '<?php class Foo { private Foob<> }',
             true,
         ];
 
         // todo...
         yield 'visibility 4' => [
-            "<?php class Foo { private Foobles <> }",
+            '<?php class Foo { private Foobles <> }',
             true,
         ];
         yield 'visibility 5' => [
-            "<?php class Foo { private Foobles $<> }",
+            '<?php class Foo { private Foobles $<> }',
             false,
         ];
     }

--- a/lib/Completion/Tests/Unit/Bridge/TolerantParser/CompletionContextTest.php
+++ b/lib/Completion/Tests/Unit/Bridge/TolerantParser/CompletionContextTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Phpactor\Completion\Tests\Unit\Bridge\TolerantParser;
+
+use Generator;
+use Microsoft\PhpParser\Parser;
+use PHPUnit\Framework\TestCase;
+use Phpactor\Completion\Bridge\TolerantParser\CompletionContext;
+use Phpactor\TestUtils\ExtractOffset;
+
+class CompletionContextTest extends TestCase
+{
+    /**
+     * @dataProvider provideExpression
+     */
+    public function testExpression(string $source, bool $expected): void
+    {
+        [$source, $offset] = ExtractOffset::fromSource($source);
+        $node = (new Parser())->parseSourceFile($source)->getDescendantNodeAtPosition((int)$offset);
+        self::assertEquals($expected, CompletionContext::expression($node));
+    }
+
+    /**
+     * @return Generator<string,array<int,mixed>>
+     */
+    public function provideExpression(): Generator
+    {
+        yield 'not class clause' => [
+            '<?php class Foo i<>',
+            false,
+        ];
+
+        yield 'not class clause 2' => [
+            '<?php class Foo <>',
+            false,
+        ];
+        yield 'not class clause 3' => [
+            '<?php class Foo implements Foo <>',
+            false,
+        ];
+        yield 'not class clause 4' => [
+            '<?php class Foo implements Foo,Bar <>',
+            false,
+        ];
+
+        yield 'not class clause on new line' => [
+            "<?php class Foo \ni<>",
+            false,
+        ];
+
+        yield 'not class member body' => [
+            "<?php class Foo { A<>",
+            false,
+        ];
+
+        yield 'not class member body after property' => [
+            "<?php class Foo { private \$foo; A<>",
+            false,
+        ];
+        yield 'not after method 1' => [
+            "<?php class Foo { public function bar() {} A<> }",
+            false,
+        ];
+        yield 'not after method 2' => [
+            "<?php class Foo { private \$foo; public function bar() {} public function boo() {} A<> public functoin baz() {}}",
+            false,
+        ];
+        yield 'not after method 3' => [
+            "<?php class Foo { public function bar() {\necho 'hello world'; \$bar = 12;} A<> }",
+            false,
+        ];
+
+        yield 'in class method body 1' => [
+            "<?php class Foo { public function foo() { A<> }",
+            true
+        ];
+        yield 'in class method body 2' => [
+            "<?php class Foo { public function bar() { if (true) { return false; } A<> } }",
+            true,
+        ];
+    }
+}

--- a/lib/Completion/Tests/Unit/Bridge/TolerantParser/CompletionContextTest.php
+++ b/lib/Completion/Tests/Unit/Bridge/TolerantParser/CompletionContextTest.php
@@ -82,6 +82,49 @@ class CompletionContextTest extends TestCase
     }
 
     /**
+     * @dataProvider provideClassMemberBody
+     */
+    public function testClassMemberBody(string $source, bool $expected): void
+    {
+        [$source, $offset] = ExtractOffset::fromSource($source);
+        $node = (new Parser())->parseSourceFile($source)->getDescendantNodeAtPosition((int)$offset);
+        self::assertEquals($expected, CompletionContext::classMembersBody($node));
+    }
+
+    /**
+     * @return Generator<string,array<int,mixed>>
+     */
+    public function provideClassMemberBody(): Generator
+    {
+        yield 'property' => [
+            "<?php class Foo { pri<> }",
+            true
+        ];
+        yield 'visibility 1' => [
+            "<?php class Foo { <> }",
+            true
+        ];
+        yield 'visibility 2' => [
+            "<?php class Foo { private <> }",
+            true
+        ];
+        yield 'visibility 3' => [
+            "<?php class Foo { private Foob<> }",
+            true,
+        ];
+
+        // todo...
+        yield 'visibility 4' => [
+            "<?php class Foo { private Foobles <> }",
+            true,
+        ];
+        yield 'visibility 5' => [
+            "<?php class Foo { private Foobles $<> }",
+            false,
+        ];
+    }
+
+    /**
      * @dataProvider provideClassClause
      */
     public function testClassClause(string $source, bool $expected): void
@@ -109,44 +152,12 @@ class CompletionContextTest extends TestCase
             '<?php class Foo implements Foo <>',
             true,
         ];
-        yield 'class clause 4' => [
-            '<?php class Foo implements Foo,Bar <>',
+        yield 'clause 4' => [
+            '<?php class Foo extends Foo <>',
             true,
         ];
-
-        yield 'class clause on new line' => [
-            "<?php class Foo \ni<>",
-            true,
-        ];
-
-        yield 'not class member body' => [
-            "<?php class Foo { A<>",
-            false,
-        ];
-
-        yield 'not class member body after property' => [
-            "<?php class Foo { private \$foo; A<>",
-            false,
-        ];
-        yield 'not after method 1' => [
-            "<?php class Foo { public function bar() {} A<> }",
-            false,
-        ];
-        yield 'not after method 2' => [
-            "<?php class Foo { private \$foo; public function bar() {} public function boo() {} A<> public functoin baz() {}}",
-            false,
-        ];
-        yield 'not after method 3' => [
-            "<?php class Foo { public function bar() {\necho 'hello world'; \$bar = 12;} A<> }",
-            false,
-        ];
-
-        yield 'in class method body 1' => [
-            "<?php class Foo { public function foo() { A<> }",
-            true
-        ];
-        yield 'in class method body 2' => [
-            "<?php class Foo { public function bar() { if (true) { return false; } A<> } }",
+        yield 'clause 5' => [
+            '<?php class Foo extends Foo, Bar <>',
             true,
         ];
     }

--- a/lib/Extension/CompletionWorse/CompletionWorseExtension.php
+++ b/lib/Extension/CompletionWorse/CompletionWorseExtension.php
@@ -88,7 +88,6 @@ class CompletionWorseExtension implements Extension
         ));
 
         /** @phpstan-ignore-next-line */
-        $defaults['completion_worse.completor.keyword.enabled'] = true;
         $defaults['completion_worse.completor.constant.enabled'] = false;
 
         $schema->setDefaults(array_merge($defaults, [

--- a/lib/Extension/CompletionWorse/CompletionWorseExtension.php
+++ b/lib/Extension/CompletionWorse/CompletionWorseExtension.php
@@ -69,7 +69,6 @@ class CompletionWorseExtension implements Extension
     public const PARAM_SNIPPETS = 'completion_worse.snippets';
     public const PARAM_DEBUG = 'completion_worse.debug';
 
-    
     public function load(ContainerBuilder $container): void
     {
         $this->registerCompletion($container);
@@ -89,7 +88,7 @@ class CompletionWorseExtension implements Extension
         ));
 
         /** @phpstan-ignore-next-line */
-        $defaults['completion_worse.completor.keyword.enabled'] = false;
+        $defaults['completion_worse.completor.keyword.enabled'] = true;
         $defaults['completion_worse.completor.constant.enabled'] = false;
 
         $schema->setDefaults(array_merge($defaults, [

--- a/lib/WorseReflection/Core/Util/NodeUtil.php
+++ b/lib/WorseReflection/Core/Util/NodeUtil.php
@@ -137,7 +137,12 @@ class NodeUtil
     public static function dump(Node $node, int $level = 0): string
     {
         $out = [
-            str_repeat('  ', $level) . $node->getNodeKindName(),
+            sprintf(
+                '%s %d:%d',
+                str_repeat('  ', $level) . $node->getNodeKindName(),
+                $node->getStartPosition(),
+                $node->getEndPosition()
+            )
         ];
 
         $level++;
@@ -217,6 +222,18 @@ class NodeUtil
             if ($node->getStartPosition() > $offset) {
                 return $node;
             }
+        }
+
+        return $node;
+    }
+    public static function firstDescendantNodeBeforeOffset(Node $node, int $offset): Node
+    {
+        $lastNode = null;
+        foreach ($node->getDescendantNodes() as $node) {
+            if ($node->getStartPosition() >= $offset) {
+                return $lastNode ?? $node;
+            }
+            $lastNode = $node;
         }
 
         return $node;


### PR DESCRIPTION
Renables the keyword completor but it's much more restrictive:

- Complete class member visibility
- Complete implements, extends in class declaration

Getting the context from the AST is hit-and-miss as the document is often mal-formed due to the incompleteness