### PR TITLE
Fix virtual method resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 
 Bug fixes:
 
+  - [wr] Fix resolutin of virtual method
   - [ct] Fix missing properties refactor does not import class #1534
   - [ct] Fix false diagnostic for missing method #1500
   - [dl] Fix docblock definition location at class level docblocks

--- a/lib/WorseReflection/Core/Inference/Resolver/MemberAccessExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/MemberAccessExpressionResolver.php
@@ -82,6 +82,7 @@ class MemberAccessExpressionResolver implements Resolver
             } catch (NotFound $e) {
                 continue;
             }
+
             foreach ($reflection->members()->byMemberType($memberType)->byName($memberName) as $member) {
                 $declaringClass = TypeFactory::reflectedClass($resolver->reflector(), $member->declaringClass()->name());
 
@@ -97,7 +98,6 @@ class MemberAccessExpressionResolver implements Resolver
                         return $information->withContainerType($subType)->withType($type);
                     }
                 }
-
                 $types[] = $declaringClass;
                 $memberTypes[] = $member->inferredType();
             }
@@ -112,7 +112,7 @@ class MemberAccessExpressionResolver implements Resolver
         return $information->withContainerType(
             $containerType
         )->withType(
-            UnionType::fromTypes(...$memberTypes)->reduce()
+            (new UnionType(...$memberTypes))->clean()->reduce()
         );
     }
 

--- a/lib/WorseReflection/Core/Virtual/VirtualReflectionClassDecorator.php
+++ b/lib/WorseReflection/Core/Virtual/VirtualReflectionClassDecorator.php
@@ -91,7 +91,8 @@ class VirtualReflectionClassDecorator extends VirtualReflectionClassLikeDecorato
     public function members(): ReflectionMemberCollection
     {
         $members = $this->class->members();
-        $members->merge($this->virtualMethods());
+        $members = $members->merge($this->virtualMethods());
+
         assert($members instanceof ReflectionMemberCollection);
         return $members;
     }
@@ -117,7 +118,6 @@ class VirtualReflectionClassDecorator extends VirtualReflectionClassLikeDecorato
             $virtualMethods = $virtualMethods->merge(
                 $memberProvider->provideMembers($this->serviceLocator, $this->class)->methods()
             );
-
             foreach ($this->traits() as $trait) {
                 $virtualMethods = $virtualMethods->merge(
                     $memberProvider->provideMembers($this->serviceLocator, $trait)->methods()

--- a/lib/WorseReflection/Core/Virtual/VirtualReflectionMethod.php
+++ b/lib/WorseReflection/Core/Virtual/VirtualReflectionMethod.php
@@ -104,6 +104,6 @@ class VirtualReflectionMethod extends VirtualReflectionMember implements Reflect
 
     public function memberType(): string
     {
-        return ReflectionMember::TYPE_PROPERTY;
+        return ReflectionMember::TYPE_METHOD;
     }
 }

--- a/lib/WorseReflection/Tests/Inference/virtual_member/method.test
+++ b/lib/WorseReflection/Tests/Inference/virtual_member/method.test
@@ -1,0 +1,38 @@
+<?php
+
+namespace Wr;
+
+interface ReflectionClass {
+    public function methods(): MethodCollection;
+}
+
+class ReflectionMethod {}
+
+class MemberCollection
+{
+    public function get(string $name);
+}
+
+/**
+ * @method ReflectionMethod get(string $name)
+ */
+class MethodCollection extends MemberCollection
+{
+}
+
+class Reflector
+{
+    public function reflectClass(string $name): ReflectionClass;
+}
+
+/** @var Reflector $reflector */
+$reflector;
+
+$reflection = $reflector->reflectClass('ClassOne');
+$methods = $reflection->methods();
+$method = $methods->get('foobar');
+wrAssertType('Wr\Reflector', $reflector);
+wrAssertType('Wr\ReflectionClass', $reflection);
+wrAssertType('Wr\MethodCollection', $methods);
+wrAssertType('Wr\ReflectionMethod', $method);
+


### PR DESCRIPTION
It turns out there was a couple of issues with virtual methods:

- The VirtualMethod returned it's type as "property"
- The decorator didn't include the virtual methods when calling members()