### PR TITLE
Imrove docblock performance by caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /**/Tests/Workspace
 /lib/Completion/cache
 /lib/Test.php
+/lib/WorseReflection/Tests/Cache
 /lib/Extension/WorseReflection/stubs
 
 # File frequently used for testing

--- a/lib/WorseReflection/Bridge/Phpactor/DocblockParser/CachedParserFactory.php
+++ b/lib/WorseReflection/Bridge/Phpactor/DocblockParser/CachedParserFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Phpactor\WorseReflection\Bridge\Phpactor\DocblockParser;
+
+use Phpactor\WorseReflection\Core\Cache;
+use Phpactor\WorseReflection\Core\DocBlock\DocBlock;
+use Phpactor\WorseReflection\Core\DocBlock\DocBlockFactory;
+use Phpactor\WorseReflection\Core\TypeResolver;
+
+class CachedParserFactory implements DocBlockFactory
+{
+    private Cache $cache;
+
+    private DocBlockFactory $innerFactory;
+
+    public function __construct(DocBlockFactory $innerFactory, Cache $cache)
+    {
+        $this->cache = $cache;
+        $this->innerFactory = $innerFactory;
+    }
+
+    public function create(TypeResolver $resolver, string $docblock): DocBlock
+    {
+        return $this->cache->getOrSet($docblock, function () use ($resolver, $docblock) {
+            return $this->innerFactory->create($resolver, $docblock);
+        });
+    }
+}

--- a/lib/WorseReflection/Core/ServiceLocator.php
+++ b/lib/WorseReflection/Core/ServiceLocator.php
@@ -2,6 +2,7 @@
 
 namespace Phpactor\WorseReflection\Core;
 
+use Phpactor\WorseReflection\Bridge\Phpactor\DocblockParser\CachedParserFactory;
 use Phpactor\WorseReflection\Bridge\Phpactor\DocblockParser\DocblockParserFactory;
 use Phpactor\WorseReflection\Core\Cache\NullCache;
 use Phpactor\WorseReflection\Core\Inference\Walker;
@@ -83,6 +84,9 @@ class ServiceLocator
 
         $this->sourceLocator = $sourceLocator;
         $this->docblockFactory = new DocblockParserFactory($this->reflector);
+        if (!$cache instanceof NullCache) {
+            $this->docblockFactory = new CachedParserFactory($this->docblockFactory, $cache);
+        }
         $this->logger = $logger;
 
         $nameResolver = new NodeToTypeConverter($this->reflector, $this->logger);

--- a/lib/WorseReflection/Tests/Benchmarks/BaseBenchCase.php
+++ b/lib/WorseReflection/Tests/Benchmarks/BaseBenchCase.php
@@ -19,12 +19,12 @@ abstract class BaseBenchCase
     {
         $composerLocator = new ComposerSourceLocator(include(__DIR__ . '/../../../../vendor/autoload.php'));
 
-        $workspace = new Workspace(__DIR__ . '/../Workspace');
+        $workspace = $this->workspace();
         $workspace->reset();
         $stubLocator = new StubSourceLocator(
             ReflectorBuilder::create()->build(),
             __DIR__ . '/../../../../vendor/jetbrains/phpstorm-stubs',
-            $workspace->path('/')
+            __DIR__ . '/../Cache',
         );
 
         $this->reflector = ReflectorBuilder::create()
@@ -36,8 +36,23 @@ abstract class BaseBenchCase
             ->build();
     }
 
+    public function loadFixture(string $name): void
+    {
+        foreach ((array)glob(sprintf('%s/%s/%s/*.php.test', __DIR__, 'fixtures', $name)) as $path) {
+            $this->workspace()->put(
+                substr(basename((string)$path), 0, -5),
+                (string)file_get_contents((string)$path)
+            );
+        }
+    }
+
     public function getReflector(): Reflector
     {
         return $this->reflector;
+    }
+
+    private function workspace(): Workspace
+    {
+        return new Workspace(__DIR__ . '/../Workspace');
     }
 }

--- a/lib/WorseReflection/Tests/Benchmarks/SelfReflectClassBench.php
+++ b/lib/WorseReflection/Tests/Benchmarks/SelfReflectClassBench.php
@@ -20,7 +20,7 @@ class SelfReflectClassBench extends BaseBenchCase
 
         foreach ($class->methods() as $method) {
             foreach ($method->parameters() as $parameter) {
-                $method->inferredReturnTypes();
+                $method->inferredType();
             }
         }
     }

--- a/lib/WorseReflection/Tests/Benchmarks/YiiBench.php
+++ b/lib/WorseReflection/Tests/Benchmarks/YiiBench.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Phpactor\WorseReflection\Tests\Benchmarks;
+
+/**
+ * @Iterations(5)
+ * @Revs(1)
+ * @Warmup(1)
+ */
+class YiiBench extends BaseBenchCase
+{
+    public function install(): void
+    {
+        $this->loadFixture('yii');
+    }
+
+    /**
+     * @BeforeMethods({"setUp", "install"})
+     */
+    public function benchMembers(): void
+    {
+        $reflection = $this->getReflector()->reflectClass('Phpactor\WorseReflection\Tests\Workspace\Record');
+        foreach ($reflection->members() as $method) {
+            $method->inferredType();
+        }
+    }
+}

--- a/lib/WorseReflection/Tests/Benchmarks/fixtures/yii/ActiveRecord.php.test
+++ b/lib/WorseReflection/Tests/Benchmarks/fixtures/yii/ActiveRecord.php.test
@@ -1,0 +1,799 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace Phpactor\WorseReflection\Tests\Workspace;
+
+use Yii;
+use yii\base\InvalidArgumentException;
+use yii\base\InvalidConfigException;
+use yii\helpers\ArrayHelper;
+use yii\helpers\Inflector;
+use yii\helpers\StringHelper;
+
+/**
+ * ActiveRecord is the base class for classes representing relational data in terms of objects.
+ *
+ * Active Record implements the [Active Record design pattern](http://en.wikipedia.org/wiki/Active_record).
+ * The premise behind Active Record is that an individual [[ActiveRecord]] object is associated with a specific
+ * row in a database table. The object's attributes are mapped to the columns of the corresponding table.
+ * Referencing an Active Record attribute is equivalent to accessing the corresponding table column for that record.
+ *
+ * As an example, say that the `Customer` ActiveRecord class is associated with the `customer` table.
+ * This would mean that the class's `name` attribute is automatically mapped to the `name` column in `customer` table.
+ * Thanks to Active Record, assuming the variable `$customer` is an object of type `Customer`, to get the value of
+ * the `name` column for the table row, you can use the expression `$customer->name`.
+ * In this example, Active Record is providing an object-oriented interface for accessing data stored in the database.
+ * But Active Record provides much more functionality than this.
+ *
+ * To declare an ActiveRecord class you need to extend [[\yii\db\ActiveRecord]] and
+ * implement the `tableName` method:
+ *
+ * ```php
+ * <?php
+ *
+ * class Customer extends \yii\db\ActiveRecord
+ * {
+ *     public static function tableName()
+ *     {
+ *         return 'customer';
+ *     }
+ * }
+ * ```
+ *
+ * The `tableName` method only has to return the name of the database table associated with the class.
+ *
+ * > Tip: You may also use the [Gii code generator](guide:start-gii) to generate ActiveRecord classes from your
+ * > database tables.
+ *
+ * Class instances are obtained in one of two ways:
+ *
+ * * Using the `new` operator to create a new, empty object
+ * * Using a method to fetch an existing record (or records) from the database
+ *
+ * Below is an example showing some typical usage of ActiveRecord:
+ *
+ * ```php
+ * $user = new User();
+ * $user->name = 'Qiang';
+ * $user->save();  // a new row is inserted into user table
+ *
+ * // the following will retrieve the user 'CeBe' from the database
+ * $user = User::find()->where(['name' => 'CeBe'])->one();
+ *
+ * // this will get related records from orders table when relation is defined
+ * $orders = $user->orders;
+ * ```
+ *
+ * For more details and usage information on ActiveRecord, see the [guide article on ActiveRecord](guide:db-active-record).
+ *
+ * @method ActiveQuery hasMany($class, array $link) see [[BaseActiveRecord::hasMany()]] for more info
+ * @method ActiveQuery hasOne($class, array $link) see [[BaseActiveRecord::hasOne()]] for more info
+ *
+ * @author Qiang Xue <qiang.xue@gmail.com>
+ * @author Carsten Brandt <mail@cebe.cc>
+ * @since 2.0
+ */
+class ActiveRecord extends BaseActiveRecord
+{
+    /**
+     * The insert operation. This is mainly used when overriding [[transactions()]] to specify which operations are transactional.
+     */
+    const OP_INSERT = 0x01;
+    /**
+     * The update operation. This is mainly used when overriding [[transactions()]] to specify which operations are transactional.
+     */
+    const OP_UPDATE = 0x02;
+    /**
+     * The delete operation. This is mainly used when overriding [[transactions()]] to specify which operations are transactional.
+     */
+    const OP_DELETE = 0x04;
+    /**
+     * All three operations: insert, update, delete.
+     * This is a shortcut of the expression: OP_INSERT | OP_UPDATE | OP_DELETE.
+     */
+    const OP_ALL = 0x07;
+
+
+    /**
+     * Loads default values from database table schema.
+     *
+     * You may call this method to load default values after creating a new instance:
+     *
+     * ```php
+     * // class Customer extends \yii\db\ActiveRecord
+     * $customer = new Customer();
+     * $customer->loadDefaultValues();
+     * ```
+     *
+     * @param bool $skipIfSet whether existing value should be preserved.
+     * This will only set defaults for attributes that are `null`.
+     * @return $this the model instance itself.
+     */
+    public function loadDefaultValues($skipIfSet = true)
+    {
+        foreach (static::getTableSchema()->columns as $column) {
+            if ($column->defaultValue !== null && (!$skipIfSet || $this->{$column->name} === null)) {
+                $this->{$column->name} = $column->defaultValue;
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Returns the database connection used by this AR class.
+     * By default, the "db" application component is used as the database connection.
+     * You may override this method if you want to use a different database connection.
+     * @return Connection the database connection used by this AR class.
+     */
+    public static function getDb()
+    {
+        return Yii::$app->getDb();
+    }
+
+    /**
+     * Creates an [[ActiveQuery]] instance with a given SQL statement.
+     *
+     * Note that because the SQL statement is already specified, calling additional
+     * query modification methods (such as `where()`, `order()`) on the created [[ActiveQuery]]
+     * instance will have no effect. However, calling `with()`, `asArray()` or `indexBy()` is
+     * still fine.
+     *
+     * Below is an example:
+     *
+     * ```php
+     * $customers = Customer::findBySql('SELECT * FROM customer')->all();
+     * ```
+     *
+     * @param string $sql the SQL statement to be executed
+     * @param array $params parameters to be bound to the SQL statement during execution.
+     * @return ActiveQuery the newly created [[ActiveQuery]] instance
+     */
+    public static function findBySql($sql, $params = [])
+    {
+        $query = static::find();
+        $query->sql = $sql;
+
+        return $query->params($params);
+    }
+
+    /**
+     * Finds ActiveRecord instance(s) by the given condition.
+     * This method is internally called by [[findOne()]] and [[findAll()]].
+     * @param mixed $condition please refer to [[findOne()]] for the explanation of this parameter
+     * @return ActiveQueryInterface the newly created [[ActiveQueryInterface|ActiveQuery]] instance.
+     * @throws InvalidConfigException if there is no primary key defined.
+     * @internal
+     */
+    protected static function findByCondition($condition)
+    {
+        $query = static::find();
+
+        if (!ArrayHelper::isAssociative($condition) && !$condition instanceof ExpressionInterface) {
+            // query by primary key
+            $primaryKey = static::primaryKey();
+            if (isset($primaryKey[0])) {
+                $pk = $primaryKey[0];
+                if (!empty($query->join) || !empty($query->joinWith)) {
+                    $pk = static::tableName() . '.' . $pk;
+                }
+                // if condition is scalar, search for a single primary key, if it is array, search for multiple primary key values
+                $condition = [$pk => is_array($condition) ? array_values($condition) : $condition];
+            } else {
+                throw new InvalidConfigException('"' . get_called_class() . '" must have a primary key.');
+            }
+        } elseif (is_array($condition)) {
+            $aliases = static::filterValidAliases($query);
+            $condition = static::filterCondition($condition, $aliases);
+        }
+
+        return $query->andWhere($condition);
+    }
+
+    /**
+     * Returns table aliases which are not the same as the name of the tables.
+     *
+     * @param Query $query
+     * @return array
+     * @throws InvalidConfigException
+     * @since 2.0.17
+     * @internal
+     */
+    protected static function filterValidAliases(Query $query)
+    {
+        $tables = $query->getTablesUsedInFrom();
+
+        $aliases = array_diff(array_keys($tables), $tables);
+
+        return array_map(function ($alias) {
+            return preg_replace('/{{([\w]+)}}/', '$1', $alias);
+        }, array_values($aliases));
+    }
+
+    /**
+     * Filters array condition before it is assiged to a Query filter.
+     *
+     * This method will ensure that an array condition only filters on existing table columns.
+     *
+     * @param array $condition condition to filter.
+     * @param array $aliases
+     * @return array filtered condition.
+     * @throws InvalidArgumentException in case array contains unsafe values.
+     * @throws InvalidConfigException
+     * @since 2.0.15
+     * @internal
+     */
+    protected static function filterCondition(array $condition, array $aliases = [])
+    {
+        $result = [];
+        $db = static::getDb();
+        $columnNames = static::filterValidColumnNames($db, $aliases);
+
+        foreach ($condition as $key => $value) {
+            if (is_string($key) && !in_array($db->quoteSql($key), $columnNames, true)) {
+                throw new InvalidArgumentException('Key "' . $key . '" is not a column name and can not be used as a filter');
+            }
+            $result[$key] = is_array($value) ? array_values($value) : $value;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Valid column names are table column names or column names prefixed with table name or table alias
+     *
+     * @param Connection $db
+     * @param array $aliases
+     * @return array
+     * @throws InvalidConfigException
+     * @since 2.0.17
+     * @internal
+     */
+    protected static function filterValidColumnNames($db, array $aliases)
+    {
+        $columnNames = [];
+        $tableName = static::tableName();
+        $quotedTableName = $db->quoteTableName($tableName);
+
+        foreach (static::getTableSchema()->getColumnNames() as $columnName) {
+            $columnNames[] = $columnName;
+            $columnNames[] = $db->quoteColumnName($columnName);
+            $columnNames[] = "$tableName.$columnName";
+            $columnNames[] = $db->quoteSql("$quotedTableName.[[$columnName]]");
+            foreach ($aliases as $tableAlias) {
+                $columnNames[] = "$tableAlias.$columnName";
+                $quotedTableAlias = $db->quoteTableName($tableAlias);
+                $columnNames[] = $db->quoteSql("$quotedTableAlias.[[$columnName]]");
+            }
+        }
+
+        return $columnNames;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function refresh()
+    {
+        $query = static::find();
+        $tableName = key($query->getTablesUsedInFrom());
+        $pk = [];
+        // disambiguate column names in case ActiveQuery adds a JOIN
+        foreach ($this->getPrimaryKey(true) as $key => $value) {
+            $pk[$tableName . '.' . $key] = $value;
+        }
+        $query->where($pk);
+
+        /* @var $record BaseActiveRecord */
+        $record = $query->one();
+        return $this->refreshInternal($record);
+    }
+
+    /**
+     * Updates the whole table using the provided attribute values and conditions.
+     *
+     * For example, to change the status to be 1 for all customers whose status is 2:
+     *
+     * ```php
+     * Customer::updateAll(['status' => 1], 'status = 2');
+     * ```
+     *
+     * > Warning: If you do not specify any condition, this method will update **all** rows in the table.
+     *
+     * Note that this method will not trigger any events. If you need [[EVENT_BEFORE_UPDATE]] or
+     * [[EVENT_AFTER_UPDATE]] to be triggered, you need to [[find()|find]] the models first and then
+     * call [[update()]] on each of them. For example an equivalent of the example above would be:
+     *
+     * ```php
+     * $models = Customer::find()->where('status = 2')->all();
+     * foreach ($models as $model) {
+     *     $model->status = 1;
+     *     $model->update(false); // skipping validation as no user input is involved
+     * }
+     * ```
+     *
+     * For a large set of models you might consider using [[ActiveQuery::each()]] to keep memory usage within limits.
+     *
+     * @param array $attributes attribute values (name-value pairs) to be saved into the table
+     * @param string|array $condition the conditions that will be put in the WHERE part of the UPDATE SQL.
+     * Please refer to [[Query::where()]] on how to specify this parameter.
+     * @param array $params the parameters (name => value) to be bound to the query.
+     * @return int the number of rows updated
+     */
+    public static function updateAll($attributes, $condition = '', $params = [])
+    {
+        $command = static::getDb()->createCommand();
+        $command->update(static::tableName(), $attributes, $condition, $params);
+
+        return $command->execute();
+    }
+
+    /**
+     * Updates the whole table using the provided counter changes and conditions.
+     *
+     * For example, to increment all customers' age by 1,
+     *
+     * ```php
+     * Customer::updateAllCounters(['age' => 1]);
+     * ```
+     *
+     * Note that this method will not trigger any events.
+     *
+     * @param array $counters the counters to be updated (attribute name => increment value).
+     * Use negative values if you want to decrement the counters.
+     * @param string|array $condition the conditions that will be put in the WHERE part of the UPDATE SQL.
+     * Please refer to [[Query::where()]] on how to specify this parameter.
+     * @param array $params the parameters (name => value) to be bound to the query.
+     * Do not name the parameters as `:bp0`, `:bp1`, etc., because they are used internally by this method.
+     * @return int the number of rows updated
+     */
+    public static function updateAllCounters($counters, $condition = '', $params = [])
+    {
+        $n = 0;
+        foreach ($counters as $name => $value) {
+            $counters[$name] = new Expression("[[$name]]+:bp{$n}", [":bp{$n}" => $value]);
+            $n++;
+        }
+        $command = static::getDb()->createCommand();
+        $command->update(static::tableName(), $counters, $condition, $params);
+
+        return $command->execute();
+    }
+
+    /**
+     * Deletes rows in the table using the provided conditions.
+     *
+     * For example, to delete all customers whose status is 3:
+     *
+     * ```php
+     * Customer::deleteAll('status = 3');
+     * ```
+     *
+     * > Warning: If you do not specify any condition, this method will delete **all** rows in the table.
+     *
+     * Note that this method will not trigger any events. If you need [[EVENT_BEFORE_DELETE]] or
+     * [[EVENT_AFTER_DELETE]] to be triggered, you need to [[find()|find]] the models first and then
+     * call [[delete()]] on each of them. For example an equivalent of the example above would be:
+     *
+     * ```php
+     * $models = Customer::find()->where('status = 3')->all();
+     * foreach ($models as $model) {
+     *     $model->delete();
+     * }
+     * ```
+     *
+     * For a large set of models you might consider using [[ActiveQuery::each()]] to keep memory usage within limits.
+     *
+     * @param string|array $condition the conditions that will be put in the WHERE part of the DELETE SQL.
+     * Please refer to [[Query::where()]] on how to specify this parameter.
+     * @param array $params the parameters (name => value) to be bound to the query.
+     * @return int the number of rows deleted
+     */
+    public static function deleteAll($condition = null, $params = [])
+    {
+        $command = static::getDb()->createCommand();
+        $command->delete(static::tableName(), $condition, $params);
+
+        return $command->execute();
+    }
+
+    /**
+     * {@inheritdoc}
+     * @return ActiveQuery the newly created [[ActiveQuery]] instance.
+     */
+    public static function find()
+    {
+        return Yii::createObject(ActiveQuery::className(), [get_called_class()]);
+    }
+
+    /**
+     * Declares the name of the database table associated with this AR class.
+     * By default this method returns the class name as the table name by calling [[Inflector::camel2id()]]
+     * with prefix [[Connection::tablePrefix]]. For example if [[Connection::tablePrefix]] is `tbl_`,
+     * `Customer` becomes `tbl_customer`, and `OrderItem` becomes `tbl_order_item`. You may override this method
+     * if the table is not named after this convention.
+     * @return string the table name
+     */
+    public static function tableName()
+    {
+        return '{{%' . Inflector::camel2id(StringHelper::basename(get_called_class()), '_') . '}}';
+    }
+
+    /**
+     * Returns the schema information of the DB table associated with this AR class.
+     * @return TableSchema the schema information of the DB table associated with this AR class.
+     * @throws InvalidConfigException if the table for the AR class does not exist.
+     */
+    public static function getTableSchema()
+    {
+        $tableSchema = static::getDb()
+            ->getSchema()
+            ->getTableSchema(static::tableName());
+
+        if ($tableSchema === null) {
+            throw new InvalidConfigException('The table does not exist: ' . static::tableName());
+        }
+
+        return $tableSchema;
+    }
+
+    /**
+     * Returns the primary key name(s) for this AR class.
+     * The default implementation will return the primary key(s) as declared
+     * in the DB table that is associated with this AR class.
+     *
+     * If the DB table does not declare any primary key, you should override
+     * this method to return the attributes that you want to use as primary keys
+     * for this AR class.
+     *
+     * Note that an array should be returned even for a table with single primary key.
+     *
+     * @return string[] the primary keys of the associated database table.
+     */
+    public static function primaryKey()
+    {
+        return static::getTableSchema()->primaryKey;
+    }
+
+    /**
+     * Returns the list of all attribute names of the model.
+     * The default implementation will return all column names of the table associated with this AR class.
+     * @return array list of attribute names.
+     */
+    public function attributes()
+    {
+        return array_keys(static::getTableSchema()->columns);
+    }
+
+    /**
+     * Declares which DB operations should be performed within a transaction in different scenarios.
+     * The supported DB operations are: [[OP_INSERT]], [[OP_UPDATE]] and [[OP_DELETE]],
+     * which correspond to the [[insert()]], [[update()]] and [[delete()]] methods, respectively.
+     * By default, these methods are NOT enclosed in a DB transaction.
+     *
+     * In some scenarios, to ensure data consistency, you may want to enclose some or all of them
+     * in transactions. You can do so by overriding this method and returning the operations
+     * that need to be transactional. For example,
+     *
+     * ```php
+     * return [
+     *     'admin' => self::OP_INSERT,
+     *     'api' => self::OP_INSERT | self::OP_UPDATE | self::OP_DELETE,
+     *     // the above is equivalent to the following:
+     *     // 'api' => self::OP_ALL,
+     *
+     * ];
+     * ```
+     *
+     * The above declaration specifies that in the "admin" scenario, the insert operation ([[insert()]])
+     * should be done in a transaction; and in the "api" scenario, all the operations should be done
+     * in a transaction.
+     *
+     * @return array the declarations of transactional operations. The array keys are scenarios names,
+     * and the array values are the corresponding transaction operations.
+     */
+    public function transactions()
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function populateRecord($record, $row)
+    {
+        $columns = static::getTableSchema()->columns;
+        foreach ($row as $name => $value) {
+            if (isset($columns[$name])) {
+                $row[$name] = $columns[$name]->phpTypecast($value);
+            }
+        }
+        parent::populateRecord($record, $row);
+    }
+
+    /**
+     * Inserts a row into the associated database table using the attribute values of this record.
+     *
+     * This method performs the following steps in order:
+     *
+     * 1. call [[beforeValidate()]] when `$runValidation` is `true`. If [[beforeValidate()]]
+     *    returns `false`, the rest of the steps will be skipped;
+     * 2. call [[afterValidate()]] when `$runValidation` is `true`. If validation
+     *    failed, the rest of the steps will be skipped;
+     * 3. call [[beforeSave()]]. If [[beforeSave()]] returns `false`,
+     *    the rest of the steps will be skipped;
+     * 4. insert the record into database. If this fails, it will skip the rest of the steps;
+     * 5. call [[afterSave()]];
+     *
+     * In the above step 1, 2, 3 and 5, events [[EVENT_BEFORE_VALIDATE]],
+     * [[EVENT_AFTER_VALIDATE]], [[EVENT_BEFORE_INSERT]], and [[EVENT_AFTER_INSERT]]
+     * will be raised by the corresponding methods.
+     *
+     * Only the [[dirtyAttributes|changed attribute values]] will be inserted into database.
+     *
+     * If the table's primary key is auto-incremental and is `null` during insertion,
+     * it will be populated with the actual value after insertion.
+     *
+     * For example, to insert a customer record:
+     *
+     * ```php
+     * $customer = new Customer;
+     * $customer->name = $name;
+     * $customer->email = $email;
+     * $customer->insert();
+     * ```
+     *
+     * @param bool $runValidation whether to perform validation (calling [[validate()]])
+     * before saving the record. Defaults to `true`. If the validation fails, the record
+     * will not be saved to the database and this method will return `false`.
+     * @param array $attributes list of attributes that need to be saved. Defaults to `null`,
+     * meaning all attributes that are loaded from DB will be saved.
+     * @return bool whether the attributes are valid and the record is inserted successfully.
+     * @throws \Exception|\Throwable in case insert failed.
+     */
+    public function insert($runValidation = true, $attributes = null)
+    {
+        if ($runValidation && !$this->validate($attributes)) {
+            Yii::info('Model not inserted due to validation error.', __METHOD__);
+            return false;
+        }
+
+        if (!$this->isTransactional(self::OP_INSERT)) {
+            return $this->insertInternal($attributes);
+        }
+
+        $transaction = static::getDb()->beginTransaction();
+        try {
+            $result = $this->insertInternal($attributes);
+            if ($result === false) {
+                $transaction->rollBack();
+            } else {
+                $transaction->commit();
+            }
+
+            return $result;
+        } catch (\Exception $e) {
+            $transaction->rollBack();
+            throw $e;
+        } catch (\Throwable $e) {
+            $transaction->rollBack();
+            throw $e;
+        }
+    }
+
+    /**
+     * Inserts an ActiveRecord into DB without considering transaction.
+     * @param array $attributes list of attributes that need to be saved. Defaults to `null`,
+     * meaning all attributes that are loaded from DB will be saved.
+     * @return bool whether the record is inserted successfully.
+     */
+    protected function insertInternal($attributes = null)
+    {
+        if (!$this->beforeSave(true)) {
+            return false;
+        }
+        $values = $this->getDirtyAttributes($attributes);
+        if (($primaryKeys = static::getDb()->schema->insert(static::tableName(), $values)) === false) {
+            return false;
+        }
+        foreach ($primaryKeys as $name => $value) {
+            $id = static::getTableSchema()->columns[$name]->phpTypecast($value);
+            $this->setAttribute($name, $id);
+            $values[$name] = $id;
+        }
+
+        $changedAttributes = array_fill_keys(array_keys($values), null);
+        $this->setOldAttributes($values);
+        $this->afterSave(true, $changedAttributes);
+
+        return true;
+    }
+
+    /**
+     * Saves the changes to this active record into the associated database table.
+     *
+     * This method performs the following steps in order:
+     *
+     * 1. call [[beforeValidate()]] when `$runValidation` is `true`. If [[beforeValidate()]]
+     *    returns `false`, the rest of the steps will be skipped;
+     * 2. call [[afterValidate()]] when `$runValidation` is `true`. If validation
+     *    failed, the rest of the steps will be skipped;
+     * 3. call [[beforeSave()]]. If [[beforeSave()]] returns `false`,
+     *    the rest of the steps will be skipped;
+     * 4. save the record into database. If this fails, it will skip the rest of the steps;
+     * 5. call [[afterSave()]];
+     *
+     * In the above step 1, 2, 3 and 5, events [[EVENT_BEFORE_VALIDATE]],
+     * [[EVENT_AFTER_VALIDATE]], [[EVENT_BEFORE_UPDATE]], and [[EVENT_AFTER_UPDATE]]
+     * will be raised by the corresponding methods.
+     *
+     * Only the [[dirtyAttributes|changed attribute values]] will be saved into database.
+     *
+     * For example, to update a customer record:
+     *
+     * ```php
+     * $customer = Customer::findOne($id);
+     * $customer->name = $name;
+     * $customer->email = $email;
+     * $customer->update();
+     * ```
+     *
+     * Note that it is possible the update does not affect any row in the table.
+     * In this case, this method will return 0. For this reason, you should use the following
+     * code to check if update() is successful or not:
+     *
+     * ```php
+     * if ($customer->update() !== false) {
+     *     // update successful
+     * } else {
+     *     // update failed
+     * }
+     * ```
+     *
+     * @param bool $runValidation whether to perform validation (calling [[validate()]])
+     * before saving the record. Defaults to `true`. If the validation fails, the record
+     * will not be saved to the database and this method will return `false`.
+     * @param array $attributeNames list of attributes that need to be saved. Defaults to `null`,
+     * meaning all attributes that are loaded from DB will be saved.
+     * @return int|false the number of rows affected, or false if validation fails
+     * or [[beforeSave()]] stops the updating process.
+     * @throws StaleObjectException if [[optimisticLock|optimistic locking]] is enabled and the data
+     * being updated is outdated.
+     * @throws \Exception|\Throwable in case update failed.
+     */
+    public function update($runValidation = true, $attributeNames = null)
+    {
+        if ($runValidation && !$this->validate($attributeNames)) {
+            Yii::info('Model not updated due to validation error.', __METHOD__);
+            return false;
+        }
+
+        if (!$this->isTransactional(self::OP_UPDATE)) {
+            return $this->updateInternal($attributeNames);
+        }
+
+        $transaction = static::getDb()->beginTransaction();
+        try {
+            $result = $this->updateInternal($attributeNames);
+            if ($result === false) {
+                $transaction->rollBack();
+            } else {
+                $transaction->commit();
+            }
+
+            return $result;
+        } catch (\Exception $e) {
+            $transaction->rollBack();
+            throw $e;
+        } catch (\Throwable $e) {
+            $transaction->rollBack();
+            throw $e;
+        }
+    }
+
+    /**
+     * Deletes the table row corresponding to this active record.
+     *
+     * This method performs the following steps in order:
+     *
+     * 1. call [[beforeDelete()]]. If the method returns `false`, it will skip the
+     *    rest of the steps;
+     * 2. delete the record from the database;
+     * 3. call [[afterDelete()]].
+     *
+     * In the above step 1 and 3, events named [[EVENT_BEFORE_DELETE]] and [[EVENT_AFTER_DELETE]]
+     * will be raised by the corresponding methods.
+     *
+     * @return int|false the number of rows deleted, or `false` if the deletion is unsuccessful for some reason.
+     * Note that it is possible the number of rows deleted is 0, even though the deletion execution is successful.
+     * @throws StaleObjectException if [[optimisticLock|optimistic locking]] is enabled and the data
+     * being deleted is outdated.
+     * @throws \Exception|\Throwable in case delete failed.
+     */
+    public function delete()
+    {
+        if (!$this->isTransactional(self::OP_DELETE)) {
+            return $this->deleteInternal();
+        }
+
+        $transaction = static::getDb()->beginTransaction();
+        try {
+            $result = $this->deleteInternal();
+            if ($result === false) {
+                $transaction->rollBack();
+            } else {
+                $transaction->commit();
+            }
+
+            return $result;
+        } catch (\Exception $e) {
+            $transaction->rollBack();
+            throw $e;
+        } catch (\Throwable $e) {
+            $transaction->rollBack();
+            throw $e;
+        }
+    }
+
+    /**
+     * Deletes an ActiveRecord without considering transaction.
+     * @return int|false the number of rows deleted, or `false` if the deletion is unsuccessful for some reason.
+     * Note that it is possible the number of rows deleted is 0, even though the deletion execution is successful.
+     * @throws StaleObjectException
+     */
+    protected function deleteInternal()
+    {
+        if (!$this->beforeDelete()) {
+            return false;
+        }
+
+        // we do not check the return value of deleteAll() because it's possible
+        // the record is already deleted in the database and thus the method will return 0
+        $condition = $this->getOldPrimaryKey(true);
+        $lock = $this->optimisticLock();
+        if ($lock !== null) {
+            $condition[$lock] = $this->$lock;
+        }
+        $result = static::deleteAll($condition);
+        if ($lock !== null && !$result) {
+            throw new StaleObjectException('The object being deleted is outdated.');
+        }
+        $this->setOldAttributes(null);
+        $this->afterDelete();
+
+        return $result;
+    }
+
+    /**
+     * Returns a value indicating whether the given active record is the same as the current one.
+     * The comparison is made by comparing the table names and the primary key values of the two active records.
+     * If one of the records [[isNewRecord|is new]] they are also considered not equal.
+     * @param ActiveRecord $record record to compare to
+     * @return bool whether the two active records refer to the same row in the same database table.
+     */
+    public function equals($record)
+    {
+        if ($this->isNewRecord || $record->isNewRecord) {
+            return false;
+        }
+
+        return static::tableName() === $record->tableName() && $this->getPrimaryKey() === $record->getPrimaryKey();
+    }
+
+    /**
+     * Returns a value indicating whether the specified operation is transactional in the current [[$scenario]].
+     * @param int $operation the operation to check. Possible values are [[OP_INSERT]], [[OP_UPDATE]] and [[OP_DELETE]].
+     * @return bool whether the specified operation is transactional in the current [[scenario]].
+     */
+    public function isTransactional($operation)
+    {
+        $scenario = $this->getScenario();
+        $transactions = $this->transactions();
+
+        return isset($transactions[$scenario]) && ($transactions[$scenario] & $operation);
+    }
+}

--- a/lib/WorseReflection/Tests/Benchmarks/fixtures/yii/ActiveRecordInterface.php.test
+++ b/lib/WorseReflection/Tests/Benchmarks/fixtures/yii/ActiveRecordInterface.php.test
@@ -1,0 +1,472 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace Phpactor\WorseReflection\Tests\Workspace;
+
+/**
+ * ActiveRecordInterface.
+ *
+ * @author Qiang Xue <qiang.xue@gmail.com>
+ * @author Carsten Brandt <mail@cebe.cc>
+ * @since 2.0
+ */
+interface ActiveRecordInterface extends StaticInstanceInterface
+{
+    /**
+     * Returns the primary key **name(s)** for this AR class.
+     *
+     * Note that an array should be returned even when the record only has a single primary key.
+     *
+     * For the primary key **value** see [[getPrimaryKey()]] instead.
+     *
+     * @return string[] the primary key name(s) for this AR class.
+     */
+    public static function primaryKey();
+
+    /**
+     * Returns the list of all attribute names of the record.
+     * @return array list of attribute names.
+     */
+    public function attributes();
+
+    /**
+     * Returns the named attribute value.
+     * If this record is the result of a query and the attribute is not loaded,
+     * `null` will be returned.
+     * @param string $name the attribute name
+     * @return mixed the attribute value. `null` if the attribute is not set or does not exist.
+     * @see hasAttribute()
+     */
+    public function getAttribute($name);
+
+    /**
+     * Sets the named attribute value.
+     * @param string $name the attribute name.
+     * @param mixed $value the attribute value.
+     * @see hasAttribute()
+     */
+    public function setAttribute($name, $value);
+
+    /**
+     * Returns a value indicating whether the record has an attribute with the specified name.
+     * @param string $name the name of the attribute
+     * @return bool whether the record has an attribute with the specified name.
+     */
+    public function hasAttribute($name);
+
+    /**
+     * Returns the primary key value(s).
+     * @param bool $asArray whether to return the primary key value as an array. If true,
+     * the return value will be an array with attribute names as keys and attribute values as values.
+     * Note that for composite primary keys, an array will always be returned regardless of this parameter value.
+     * @return mixed the primary key value. An array (attribute name => attribute value) is returned if the primary key
+     * is composite or `$asArray` is true. A string is returned otherwise (`null` will be returned if
+     * the key value is `null`).
+     */
+    public function getPrimaryKey($asArray = false);
+
+    /**
+     * Returns the old primary key value(s).
+     * This refers to the primary key value that is populated into the record
+     * after executing a find method (e.g. find(), findOne()).
+     * The value remains unchanged even if the primary key attribute is manually assigned with a different value.
+     * @param bool $asArray whether to return the primary key value as an array. If true,
+     * the return value will be an array with column name as key and column value as value.
+     * If this is `false` (default), a scalar value will be returned for non-composite primary key.
+     * @property mixed The old primary key value. An array (column name => column value) is
+     * returned if the primary key is composite. A string is returned otherwise (`null` will be
+     * returned if the key value is `null`).
+     * @return mixed the old primary key value. An array (column name => column value) is returned if the primary key
+     * is composite or `$asArray` is true. A string is returned otherwise (`null` will be returned if
+     * the key value is `null`).
+     */
+    public function getOldPrimaryKey($asArray = false);
+
+    /**
+     * Returns a value indicating whether the given set of attributes represents the primary key for this model.
+     * @param array $keys the set of attributes to check
+     * @return bool whether the given set of attributes represents the primary key for this model
+     */
+    public static function isPrimaryKey($keys);
+
+    /**
+     * Creates an [[ActiveQueryInterface]] instance for query purpose.
+     *
+     * The returned [[ActiveQueryInterface]] instance can be further customized by calling
+     * methods defined in [[ActiveQueryInterface]] before `one()` or `all()` is called to return
+     * populated ActiveRecord instances. For example,
+     *
+     * ```php
+     * // find the customer whose ID is 1
+     * $customer = Customer::find()->where(['id' => 1])->one();
+     *
+     * // find all active customers and order them by their age:
+     * $customers = Customer::find()
+     *     ->where(['status' => 1])
+     *     ->orderBy('age')
+     *     ->all();
+     * ```
+     *
+     * This method is also called by [[BaseActiveRecord::hasOne()]] and [[BaseActiveRecord::hasMany()]] to
+     * create a relational query.
+     *
+     * You may override this method to return a customized query. For example,
+     *
+     * ```php
+     * class Customer extends ActiveRecord
+     * {
+     *     public static function find()
+     *     {
+     *         // use CustomerQuery instead of the default ActiveQuery
+     *         return new CustomerQuery(get_called_class());
+     *     }
+     * }
+     * ```
+     *
+     * The following code shows how to apply a default condition for all queries:
+     *
+     * ```php
+     * class Customer extends ActiveRecord
+     * {
+     *     public static function find()
+     *     {
+     *         return parent::find()->where(['deleted' => false]);
+     *     }
+     * }
+     *
+     * // Use andWhere()/orWhere() to apply the default condition
+     * // SELECT FROM customer WHERE `deleted`=:deleted AND age>30
+     * $customers = Customer::find()->andWhere('age>30')->all();
+     *
+     * // Use where() to ignore the default condition
+     * // SELECT FROM customer WHERE age>30
+     * $customers = Customer::find()->where('age>30')->all();
+     *
+     * @return ActiveQueryInterface the newly created [[ActiveQueryInterface]] instance.
+     */
+    public static function find();
+
+    /**
+     * Returns a single active record model instance by a primary key or an array of column values.
+     *
+     * The method accepts:
+     *
+     *  - a scalar value (integer or string): query by a single primary key value and return the
+     *    corresponding record (or `null` if not found).
+     *  - a non-associative array: query by a list of primary key values and return the
+     *    first record (or `null` if not found).
+     *  - an associative array of name-value pairs: query by a set of attribute values and return a single record
+     *    matching all of them (or `null` if not found). Note that `['id' => 1, 2]` is treated as a non-associative array.
+     *    Column names are limited to current records table columns for SQL DBMS, or filtered otherwise to be limited to simple filter conditions.
+     *  - a yii\db\Expression: The expression will be used directly. (@since 2.0.37)
+     *
+     * That this method will automatically call the `one()` method and return an [[ActiveRecordInterface|ActiveRecord]]
+     * instance.
+     *
+     * > Note: As this is a short-hand method only, using more complex conditions, like ['!=', 'id', 1] will not work.
+     * > If you need to specify more complex conditions, use [[find()]] in combination with [[ActiveQuery::where()|where()]] instead.
+     *
+     * See the following code for usage examples:
+     *
+     * ```php
+     * // find a single customer whose primary key value is 10
+     * $customer = Customer::findOne(10);
+     *
+     * // the above code is equivalent to:
+     * $customer = Customer::find()->where(['id' => 10])->one();
+     *
+     * // find the customers whose primary key value is 10, 11 or 12.
+     * $customers = Customer::findOne([10, 11, 12]);
+     *
+     * // the above code is equivalent to:
+     * $customers = Customer::find()->where(['id' => [10, 11, 12]])->one();
+     *
+     * // find the first customer whose age is 30 and whose status is 1
+     * $customer = Customer::findOne(['age' => 30, 'status' => 1]);
+     *
+     * // the above code is equivalent to:
+     * $customer = Customer::find()->where(['age' => 30, 'status' => 1])->one();
+     * ```
+     *
+     * If you need to pass user input to this method, make sure the input value is scalar or in case of
+     * array condition, make sure the array structure can not be changed from the outside:
+     *
+     * ```php
+     * // yii\web\Controller ensures that $id is scalar
+     * public function actionView($id)
+     * {
+     *     $model = Post::findOne($id);
+     *     // ...
+     * }
+     *
+     * // explicitly specifying the colum to search, passing a scalar or array here will always result in finding a single record
+     * $model = Post::findOne(['id' => Yii::$app->request->get('id')]);
+     *
+     * // do NOT use the following code! it is possible to inject an array condition to filter by arbitrary column values!
+     * $model = Post::findOne(Yii::$app->request->get('id'));
+     * ```
+     *
+     * @param mixed $condition primary key value or a set of column values
+     * @return static|null ActiveRecord instance matching the condition, or `null` if nothing matches.
+     */
+    public static function findOne($condition);
+
+    /**
+     * Returns a list of active record models that match the specified primary key value(s) or a set of column values.
+     *
+     * The method accepts:
+     *
+     *  - a scalar value (integer or string): query by a single primary key value and return an array containing the
+     *    corresponding record (or an empty array if not found).
+     *  - a non-associative array: query by a list of primary key values and return the
+     *    corresponding records (or an empty array if none was found).
+     *    Note that an empty condition will result in an empty result as it will be interpreted as a search for
+     *    primary keys and not an empty `WHERE` condition.
+     *  - an associative array of name-value pairs: query by a set of attribute values and return an array of records
+     *    matching all of them (or an empty array if none was found). Note that `['id' => 1, 2]` is treated as
+     *    a non-associative array.
+     *    Column names are limited to current records table columns for SQL DBMS, or filtered otherwise to be limted to simple filter conditions.
+     *  - a yii\db\Expression: The expression will be used directly. (@since 2.0.37)
+     *
+     * This method will automatically call the `all()` method and return an array of [[ActiveRecordInterface|ActiveRecord]]
+     * instances.
+     *
+     * > Note: As this is a short-hand method only, using more complex conditions, like ['!=', 'id', 1] will not work.
+     * > If you need to specify more complex conditions, use [[find()]] in combination with [[ActiveQuery::where()|where()]] instead.
+     *
+     * See the following code for usage examples:
+     *
+     * ```php
+     * // find the customers whose primary key value is 10
+     * $customers = Customer::findAll(10);
+     *
+     * // the above code is equivalent to:
+     * $customers = Customer::find()->where(['id' => 10])->all();
+     *
+     * // find the customers whose primary key value is 10, 11 or 12.
+     * $customers = Customer::findAll([10, 11, 12]);
+     *
+     * // the above code is equivalent to:
+     * $customers = Customer::find()->where(['id' => [10, 11, 12]])->all();
+     *
+     * // find customers whose age is 30 and whose status is 1
+     * $customers = Customer::findAll(['age' => 30, 'status' => 1]);
+     *
+     * // the above code is equivalent to:
+     * $customers = Customer::find()->where(['age' => 30, 'status' => 1])->all();
+     * ```
+     *
+     * If you need to pass user input to this method, make sure the input value is scalar or in case of
+     * array condition, make sure the array structure can not be changed from the outside:
+     *
+     * ```php
+     * // yii\web\Controller ensures that $id is scalar
+     * public function actionView($id)
+     * {
+     *     $model = Post::findOne($id);
+     *     // ...
+     * }
+     *
+     * // explicitly specifying the colum to search, passing a scalar or array here will always result in finding a single record
+     * $model = Post::findOne(['id' => Yii::$app->request->get('id')]);
+     *
+     * // do NOT use the following code! it is possible to inject an array condition to filter by arbitrary column values!
+     * $model = Post::findOne(Yii::$app->request->get('id'));
+     * ```
+     *
+     * @param mixed $condition primary key value or a set of column values
+     * @return array an array of ActiveRecord instance, or an empty array if nothing matches.
+     */
+    public static function findAll($condition);
+
+    /**
+     * Updates records using the provided attribute values and conditions.
+     *
+     * For example, to change the status to be 1 for all customers whose status is 2:
+     *
+     * ```php
+     * Customer::updateAll(['status' => 1], ['status' => '2']);
+     * ```
+     *
+     * @param array $attributes attribute values (name-value pairs) to be saved for the record.
+     * Unlike [[update()]] these are not going to be validated.
+     * @param array $condition the condition that matches the records that should get updated.
+     * Please refer to [[QueryInterface::where()]] on how to specify this parameter.
+     * An empty condition will match all records.
+     * @return int the number of rows updated
+     */
+    public static function updateAll($attributes, $condition = null);
+
+    /**
+     * Deletes records using the provided conditions.
+     * WARNING: If you do not specify any condition, this method will delete ALL rows in the table.
+     *
+     * For example, to delete all customers whose status is 3:
+     *
+     * ```php
+     * Customer::deleteAll([status = 3]);
+     * ```
+     *
+     * @param array $condition the condition that matches the records that should get deleted.
+     * Please refer to [[QueryInterface::where()]] on how to specify this parameter.
+     * An empty condition will match all records.
+     * @return int the number of rows deleted
+     */
+    public static function deleteAll($condition = null);
+
+    /**
+     * Saves the current record.
+     *
+     * This method will call [[insert()]] when [[getIsNewRecord()|isNewRecord]] is true, or [[update()]]
+     * when [[getIsNewRecord()|isNewRecord]] is false.
+     *
+     * For example, to save a customer record:
+     *
+     * ```php
+     * $customer = new Customer; // or $customer = Customer::findOne($id);
+     * $customer->name = $name;
+     * $customer->email = $email;
+     * $customer->save();
+     * ```
+     *
+     * @param bool $runValidation whether to perform validation (calling [[\yii\base\Model::validate()|validate()]])
+     * before saving the record. Defaults to `true`. If the validation fails, the record
+     * will not be saved to the database and this method will return `false`.
+     * @param array $attributeNames list of attribute names that need to be saved. Defaults to `null`,
+     * meaning all attributes that are loaded from DB will be saved.
+     * @return bool whether the saving succeeded (i.e. no validation errors occurred).
+     */
+    public function save($runValidation = true, $attributeNames = null);
+
+    /**
+     * Inserts the record into the database using the attribute values of this record.
+     *
+     * Usage example:
+     *
+     * ```php
+     * $customer = new Customer;
+     * $customer->name = $name;
+     * $customer->email = $email;
+     * $customer->insert();
+     * ```
+     *
+     * @param bool $runValidation whether to perform validation (calling [[\yii\base\Model::validate()|validate()]])
+     * before saving the record. Defaults to `true`. If the validation fails, the record
+     * will not be saved to the database and this method will return `false`.
+     * @param array $attributes list of attributes that need to be saved. Defaults to `null`,
+     * meaning all attributes that are loaded from DB will be saved.
+     * @return bool whether the attributes are valid and the record is inserted successfully.
+     */
+    public function insert($runValidation = true, $attributes = null);
+
+    /**
+     * Saves the changes to this active record into the database.
+     *
+     * Usage example:
+     *
+     * ```php
+     * $customer = Customer::findOne($id);
+     * $customer->name = $name;
+     * $customer->email = $email;
+     * $customer->update();
+     * ```
+     *
+     * @param bool $runValidation whether to perform validation (calling [[\yii\base\Model::validate()|validate()]])
+     * before saving the record. Defaults to `true`. If the validation fails, the record
+     * will not be saved to the database and this method will return `false`.
+     * @param array $attributeNames list of attributes that need to be saved. Defaults to `null`,
+     * meaning all attributes that are loaded from DB will be saved.
+     * @return int|bool the number of rows affected, or `false` if validation fails
+     * or updating process is stopped for other reasons.
+     * Note that it is possible that the number of rows affected is 0, even though the
+     * update execution is successful.
+     */
+    public function update($runValidation = true, $attributeNames = null);
+
+    /**
+     * Deletes the record from the database.
+     *
+     * @return int|bool the number of rows deleted, or `false` if the deletion is unsuccessful for some reason.
+     * Note that it is possible that the number of rows deleted is 0, even though the deletion execution is successful.
+     */
+    public function delete();
+
+    /**
+     * Returns a value indicating whether the current record is new (not saved in the database).
+     * @return bool whether the record is new and should be inserted when calling [[save()]].
+     */
+    public function getIsNewRecord();
+
+    /**
+     * Returns a value indicating whether the given active record is the same as the current one.
+     * Two [[getIsNewRecord()|new]] records are considered to be not equal.
+     * @param static $record record to compare to
+     * @return bool whether the two active records refer to the same row in the same database table.
+     */
+    public function equals($record);
+
+    /**
+     * Returns the relation object with the specified name.
+     * A relation is defined by a getter method which returns an object implementing the [[ActiveQueryInterface]]
+     * (normally this would be a relational [[ActiveQuery]] object).
+     * It can be declared in either the ActiveRecord class itself or one of its behaviors.
+     * @param string $name the relation name, e.g. `orders` for a relation defined via `getOrders()` method (case-sensitive).
+     * @param bool $throwException whether to throw exception if the relation does not exist.
+     * @return ActiveQueryInterface the relational query object
+     */
+    public function getRelation($name, $throwException = true);
+
+    /**
+     * Populates the named relation with the related records.
+     * Note that this method does not check if the relation exists or not.
+     * @param string $name the relation name, e.g. `orders` for a relation defined via `getOrders()` method (case-sensitive).
+     * @param ActiveRecordInterface|array|null $records the related records to be populated into the relation.
+     * @since 2.0.8
+     */
+    public function populateRelation($name, $records);
+
+    /**
+     * Establishes the relationship between two records.
+     *
+     * The relationship is established by setting the foreign key value(s) in one record
+     * to be the corresponding primary key value(s) in the other record.
+     * The record with the foreign key will be saved into database without performing validation.
+     *
+     * If the relationship involves a junction table, a new row will be inserted into the
+     * junction table which contains the primary key values from both records.
+     *
+     * This method requires that the primary key value is not `null`.
+     *
+     * @param string $name the case sensitive name of the relationship, e.g. `orders` for a relation defined via `getOrders()` method.
+     * @param static $model the record to be linked with the current one.
+     * @param array $extraColumns additional column values to be saved into the junction table.
+     * This parameter is only meaningful for a relationship involving a junction table
+     * (i.e., a relation set with [[ActiveQueryInterface::via()]]).
+     */
+    public function link($name, $model, $extraColumns = []);
+
+    /**
+     * Destroys the relationship between two records.
+     *
+     * The record with the foreign key of the relationship will be deleted if `$delete` is true.
+     * Otherwise, the foreign key will be set `null` and the record will be saved without validation.
+     *
+     * @param string $name the case sensitive name of the relationship, e.g. `orders` for a relation defined via `getOrders()` method.
+     * @param static $model the model to be unlinked from the current one.
+     * @param bool $delete whether to delete the model that contains the foreign key.
+     * If false, the model's foreign key will be set `null` and saved.
+     * If true, the model containing the foreign key will be deleted.
+     */
+    public function unlink($name, $model, $delete = false);
+
+    /**
+     * Returns the connection used by this AR class.
+     * @return mixed the database connection used by this AR class.
+     */
+    public static function getDb();
+}
+

--- a/lib/WorseReflection/Tests/Benchmarks/fixtures/yii/Arrayable.php.test
+++ b/lib/WorseReflection/Tests/Benchmarks/fixtures/yii/Arrayable.php.test
@@ -1,0 +1,93 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace Phpactor\WorseReflection\Tests\Workspace;
+
+/**
+ * Arrayable is the interface that should be implemented by classes who want to support customizable representation of their instances.
+ *
+ * For example, if a class implements Arrayable, by calling [[toArray()]], an instance of this class
+ * can be turned into an array (including all its embedded objects) which can then be further transformed easily
+ * into other formats, such as JSON, XML.
+ *
+ * The methods [[fields()]] and [[extraFields()]] allow the implementing classes to customize how and which of their data
+ * should be formatted and put into the result of [[toArray()]].
+ *
+ * @author Qiang Xue <qiang.xue@gmail.com>
+ * @since 2.0
+ */
+interface Arrayable
+{
+    /**
+     * Returns the list of fields that should be returned by default by [[toArray()]] when no specific fields are specified.
+     *
+     * A field is a named element in the returned array by [[toArray()]].
+     *
+     * This method should return an array of field names or field definitions.
+     * If the former, the field name will be treated as an object property name whose value will be used
+     * as the field value. If the latter, the array key should be the field name while the array value should be
+     * the corresponding field definition which can be either an object property name or a PHP callable
+     * returning the corresponding field value. The signature of the callable should be:
+     *
+     * ```php
+     * function ($model, $field) {
+     *     // return field value
+     * }
+     * ```
+     *
+     * For example, the following code declares four fields:
+     *
+     * - `email`: the field name is the same as the property name `email`;
+     * - `firstName` and `lastName`: the field names are `firstName` and `lastName`, and their
+     *   values are obtained from the `first_name` and `last_name` properties;
+     * - `fullName`: the field name is `fullName`. Its value is obtained by concatenating `first_name`
+     *   and `last_name`.
+     *
+     * ```php
+     * return [
+     *     'email',
+     *     'firstName' => 'first_name',
+     *     'lastName' => 'last_name',
+     *     'fullName' => function ($model) {
+     *         return $model->first_name . ' ' . $model->last_name;
+     *     },
+     * ];
+     * ```
+     *
+     * @return array the list of field names or field definitions.
+     * @see toArray()
+     */
+    public function fields();
+
+    /**
+     * Returns the list of additional fields that can be returned by [[toArray()]] in addition to those listed in [[fields()]].
+     *
+     * This method is similar to [[fields()]] except that the list of fields declared
+     * by this method are not returned by default by [[toArray()]]. Only when a field in the list
+     * is explicitly requested, will it be included in the result of [[toArray()]].
+     *
+     * @return array the list of expandable field names or field definitions. Please refer
+     * to [[fields()]] on the format of the return value.
+     * @see toArray()
+     * @see fields()
+     */
+    public function extraFields();
+
+    /**
+     * Converts the object into an array.
+     *
+     * @param array $fields the fields that the output array should contain. Fields not specified
+     * in [[fields()]] will be ignored. If this parameter is empty, all fields as specified in [[fields()]] will be returned.
+     * @param array $expand the additional fields that the output array should contain.
+     * Fields not specified in [[extraFields()]] will be ignored. If this parameter is empty, no extra fields
+     * will be returned.
+     * @param bool $recursive whether to recursively return array representation of embedded objects.
+     * @return array the array representation of the object
+     */
+    public function toArray(array $fields = [], array $expand = [], $recursive = true);
+}
+

--- a/lib/WorseReflection/Tests/Benchmarks/fixtures/yii/ArrayableTrait.php
+++ b/lib/WorseReflection/Tests/Benchmarks/fixtures/yii/ArrayableTrait.php
@@ -1,0 +1,247 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace Phpactor\WorseReflection\Tests\Benchmarks\fixtures\yii;
+
+use Yii;
+use yii\helpers\ArrayHelper;
+use yii\web\Link;
+use yii\web\Linkable;
+use JsonSerializable;
+
+/**
+ * ArrayableTrait provides a common implementation of the [[Arrayable]] interface.
+ *
+ * ArrayableTrait implements [[toArray()]] by respecting the field definitions as declared
+ * in [[fields()]] and [[extraFields()]].
+ *
+ * @author Qiang Xue <qiang.xue@gmail.com>
+ * @since 2.0
+ */
+trait ArrayableTrait
+{
+    /**
+     * Returns the list of fields that should be returned by default by [[toArray()]] when no specific fields are specified.
+     *
+     * A field is a named element in the returned array by [[toArray()]].
+     *
+     * This method should return an array of field names or field definitions.
+     * If the former, the field name will be treated as an object property name whose value will be used
+     * as the field value. If the latter, the array key should be the field name while the array value should be
+     * the corresponding field definition which can be either an object property name or a PHP callable
+     * returning the corresponding field value. The signature of the callable should be:
+     *
+     * ```php
+     * function ($model, $field) {
+     *     // return field value
+     * }
+     * ```
+     *
+     * For example, the following code declares four fields:
+     *
+     * - `email`: the field name is the same as the property name `email`;
+     * - `firstName` and `lastName`: the field names are `firstName` and `lastName`, and their
+     *   values are obtained from the `first_name` and `last_name` properties;
+     * - `fullName`: the field name is `fullName`. Its value is obtained by concatenating `first_name`
+     *   and `last_name`.
+     *
+     * ```php
+     * return [
+     *     'email',
+     *     'firstName' => 'first_name',
+     *     'lastName' => 'last_name',
+     *     'fullName' => function () {
+     *         return $this->first_name . ' ' . $this->last_name;
+     *     },
+     * ];
+     * ```
+     *
+     * In this method, you may also want to return different lists of fields based on some context
+     * information. For example, depending on the privilege of the current application user,
+     * you may return different sets of visible fields or filter out some fields.
+     *
+     * The default implementation of this method returns the public object member variables indexed by themselves.
+     *
+     * @return array the list of field names or field definitions.
+     * @see toArray()
+     */
+    public function fields()
+    {
+        $fields = array_keys(Yii::getObjectVars($this));
+        return array_combine($fields, $fields);
+    }
+
+    /**
+     * Returns the list of fields that can be expanded further and returned by [[toArray()]].
+     *
+     * This method is similar to [[fields()]] except that the list of fields returned
+     * by this method are not returned by default by [[toArray()]]. Only when field names
+     * to be expanded are explicitly specified when calling [[toArray()]], will their values
+     * be exported.
+     *
+     * The default implementation returns an empty array.
+     *
+     * You may override this method to return a list of expandable fields based on some context information
+     * (e.g. the current application user).
+     *
+     * @return array the list of expandable field names or field definitions. Please refer
+     * to [[fields()]] on the format of the return value.
+     * @see toArray()
+     * @see fields()
+     */
+    public function extraFields()
+    {
+        return [];
+    }
+
+    /**
+     * Converts the model into an array.
+     *
+     * This method will first identify which fields to be included in the resulting array by calling [[resolveFields()]].
+     * It will then turn the model into an array with these fields. If `$recursive` is true,
+     * any embedded objects will also be converted into arrays.
+     * When embeded objects are [[Arrayable]], their respective nested fields will be extracted and passed to [[toArray()]].
+     *
+     * If the model implements the [[Linkable]] interface, the resulting array will also have a `_link` element
+     * which refers to a list of links as specified by the interface.
+     *
+     * @param array $fields the fields being requested.
+     * If empty or if it contains '*', all fields as specified by [[fields()]] will be returned.
+     * Fields can be nested, separated with dots (.). e.g.: item.field.sub-field
+     * `$recursive` must be true for nested fields to be extracted. If `$recursive` is false, only the root fields will be extracted.
+     * @param array $expand the additional fields being requested for exporting. Only fields declared in [[extraFields()]]
+     * will be considered.
+     * Expand can also be nested, separated with dots (.). e.g.: item.expand1.expand2
+     * `$recursive` must be true for nested expands to be extracted. If `$recursive` is false, only the root expands will be extracted.
+     * @param bool $recursive whether to recursively return array representation of embedded objects.
+     * @return array the array representation of the object
+     */
+    public function toArray(array $fields = [], array $expand = [], $recursive = true)
+    {
+        $data = [];
+        foreach ($this->resolveFields($fields, $expand) as $field => $definition) {
+            $attribute = is_string($definition) ? $this->$definition : $definition($this, $field);
+
+            if ($recursive) {
+                $nestedFields = $this->extractFieldsFor($fields, $field);
+                $nestedExpand = $this->extractFieldsFor($expand, $field);
+                if ($attribute instanceof JsonSerializable) {
+                    $attribute = $attribute->jsonSerialize();
+                } elseif ($attribute instanceof Arrayable) {
+                    $attribute = $attribute->toArray($nestedFields, $nestedExpand);
+                } elseif (is_array($attribute)) {
+                    $attribute = array_map(
+                        function ($item) use ($nestedFields, $nestedExpand) {
+                            if ($item instanceof JsonSerializable) {
+                                return $item->jsonSerialize();
+                            } elseif ($item instanceof Arrayable) {
+                                return $item->toArray($nestedFields, $nestedExpand);
+                            }
+                            return $item;
+                        },
+                        $attribute
+                    );
+                }
+            }
+            $data[$field] = $attribute;
+        }
+
+        if ($this instanceof Linkable) {
+            $data['_links'] = Link::serialize($this->getLinks());
+        }
+
+        return $recursive ? ArrayHelper::toArray($data) : $data;
+    }
+
+    /**
+     * Extracts the root field names from nested fields.
+     * Nested fields are separated with dots (.). e.g: "item.id"
+     * The previous example would extract "item".
+     *
+     * @param array $fields The fields requested for extraction
+     * @return array root fields extracted from the given nested fields
+     * @since 2.0.14
+     */
+    protected function extractRootFields(array $fields)
+    {
+        $result = [];
+
+        foreach ($fields as $field) {
+            $result[] = current(explode('.', $field, 2));
+        }
+
+        if (in_array('*', $result, true)) {
+            $result = [];
+        }
+
+        return array_unique($result);
+    }
+
+    /**
+     * Extract nested fields from a fields collection for a given root field
+     * Nested fields are separated with dots (.). e.g: "item.id"
+     * The previous example would extract "id".
+     *
+     * @param array $fields The fields requested for extraction
+     * @param string $rootField The root field for which we want to extract the nested fields
+     * @return array nested fields extracted for the given field
+     * @since 2.0.14
+     */
+    protected function extractFieldsFor(array $fields, $rootField)
+    {
+        $result = [];
+
+        foreach ($fields as $field) {
+            if (0 === strpos($field, "{$rootField}.")) {
+                $result[] = preg_replace('/^' . preg_quote($rootField, '/') . '\./i', '', $field);
+            }
+        }
+
+        return array_unique($result);
+    }
+
+    /**
+     * Determines which fields can be returned by [[toArray()]].
+     * This method will first extract the root fields from the given fields.
+     * Then it will check the requested root fields against those declared in [[fields()]] and [[extraFields()]]
+     * to determine which fields can be returned.
+     * @param array $fields the fields being requested for exporting
+     * @param array $expand the additional fields being requested for exporting
+     * @return array the list of fields to be exported. The array keys are the field names, and the array values
+     * are the corresponding object property names or PHP callables returning the field values.
+     */
+    protected function resolveFields(array $fields, array $expand)
+    {
+        $fields = $this->extractRootFields($fields);
+        $expand = $this->extractRootFields($expand);
+        $result = [];
+
+        foreach ($this->fields() as $field => $definition) {
+            if (is_int($field)) {
+                $field = $definition;
+            }
+            if (empty($fields) || in_array($field, $fields, true)) {
+                $result[$field] = $definition;
+            }
+        }
+
+        if (empty($expand)) {
+            return $result;
+        }
+
+        foreach ($this->extraFields() as $field => $definition) {
+            if (is_int($field)) {
+                $field = $definition;
+            }
+            if (in_array($field, $expand, true)) {
+                $result[$field] = $definition;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/lib/WorseReflection/Tests/Benchmarks/fixtures/yii/ArrayableTrait.php.test
+++ b/lib/WorseReflection/Tests/Benchmarks/fixtures/yii/ArrayableTrait.php.test
@@ -5,7 +5,7 @@
  * @license http://www.yiiframework.com/license/
  */
 
-namespace Phpactor\WorseReflection\Tests\Benchmarks\fixtures\yii;
+namespace Phpactor\WorseReflection\Tests\Workspace;
 
 use Yii;
 use yii\helpers\ArrayHelper;

--- a/lib/WorseReflection/Tests/Benchmarks/fixtures/yii/BaseActiveRecord.php.test
+++ b/lib/WorseReflection/Tests/Benchmarks/fixtures/yii/BaseActiveRecord.php.test
@@ -1,0 +1,1755 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace Phpactor\WorseReflection\Tests\Workspace;
+
+use Yii;
+use yii\base\InvalidArgumentException;
+use yii\base\InvalidCallException;
+use yii\base\InvalidConfigException;
+use yii\base\InvalidParamException;
+use yii\base\ModelEvent;
+use yii\base\NotSupportedException;
+use yii\base\UnknownMethodException;
+use yii\helpers\ArrayHelper;
+
+/**
+ * ActiveRecord is the base class for classes representing relational data in terms of objects.
+ *
+ * See [[\yii\db\ActiveRecord]] for a concrete implementation.
+ *
+ * @property array $dirtyAttributes The changed attribute values (name-value pairs). This property is
+ * read-only.
+ * @property bool $isNewRecord Whether the record is new and should be inserted when calling [[save()]].
+ * @property array $oldAttributes The old attribute values (name-value pairs). Note that the type of this
+ * property differs in getter and setter. See [[getOldAttributes()]] and [[setOldAttributes()]] for details.
+ * @property mixed $oldPrimaryKey The old primary key value. An array (column name => column value) is
+ * returned if the primary key is composite. A string is returned otherwise (null will be returned if the key
+ * value is null). This property is read-only.
+ * @property mixed $primaryKey The primary key value. An array (column name => column value) is returned if
+ * the primary key is composite. A string is returned otherwise (null will be returned if the key value is null).
+ * This property is read-only.
+ * @property array $relatedRecords An array of related records indexed by relation names. This property is
+ * read-only.
+ *
+ * @author Qiang Xue <qiang.xue@gmail.com>
+ * @author Carsten Brandt <mail@cebe.cc>
+ * @since 2.0
+ */
+abstract class BaseActiveRecord extends Model implements ActiveRecordInterface
+{
+    /**
+     * @event Event an event that is triggered when the record is initialized via [[init()]].
+     */
+    const EVENT_INIT = 'init';
+    /**
+     * @event Event an event that is triggered after the record is created and populated with query result.
+     */
+    const EVENT_AFTER_FIND = 'afterFind';
+    /**
+     * @event ModelEvent an event that is triggered before inserting a record.
+     * You may set [[ModelEvent::isValid]] to be `false` to stop the insertion.
+     */
+    const EVENT_BEFORE_INSERT = 'beforeInsert';
+    /**
+     * @event AfterSaveEvent an event that is triggered after a record is inserted.
+     */
+    const EVENT_AFTER_INSERT = 'afterInsert';
+    /**
+     * @event ModelEvent an event that is triggered before updating a record.
+     * You may set [[ModelEvent::isValid]] to be `false` to stop the update.
+     */
+    const EVENT_BEFORE_UPDATE = 'beforeUpdate';
+    /**
+     * @event AfterSaveEvent an event that is triggered after a record is updated.
+     */
+    const EVENT_AFTER_UPDATE = 'afterUpdate';
+    /**
+     * @event ModelEvent an event that is triggered before deleting a record.
+     * You may set [[ModelEvent::isValid]] to be `false` to stop the deletion.
+     */
+    const EVENT_BEFORE_DELETE = 'beforeDelete';
+    /**
+     * @event Event an event that is triggered after a record is deleted.
+     */
+    const EVENT_AFTER_DELETE = 'afterDelete';
+    /**
+     * @event Event an event that is triggered after a record is refreshed.
+     * @since 2.0.8
+     */
+    const EVENT_AFTER_REFRESH = 'afterRefresh';
+
+    /**
+     * @var array attribute values indexed by attribute names
+     */
+    private $_attributes = [];
+    /**
+     * @var array|null old attribute values indexed by attribute names.
+     * This is `null` if the record [[isNewRecord|is new]].
+     */
+    private $_oldAttributes;
+    /**
+     * @var array related models indexed by the relation names
+     */
+    private $_related = [];
+    /**
+     * @var array relation names indexed by their link attributes
+     */
+    private $_relationsDependencies = [];
+
+
+    /**
+     * {@inheritdoc}
+     * @return static|null ActiveRecord instance matching the condition, or `null` if nothing matches.
+     */
+    public static function findOne($condition)
+    {
+        return static::findByCondition($condition)->one();
+    }
+
+    /**
+     * {@inheritdoc}
+     * @return static[] an array of ActiveRecord instances, or an empty array if nothing matches.
+     */
+    public static function findAll($condition)
+    {
+        return static::findByCondition($condition)->all();
+    }
+
+    /**
+     * Finds ActiveRecord instance(s) by the given condition.
+     * This method is internally called by [[findOne()]] and [[findAll()]].
+     * @param mixed $condition please refer to [[findOne()]] for the explanation of this parameter
+     * @return ActiveQueryInterface the newly created [[ActiveQueryInterface|ActiveQuery]] instance.
+     * @throws InvalidConfigException if there is no primary key defined
+     * @internal
+     */
+    protected static function findByCondition($condition)
+    {
+        $query = static::find();
+
+        if (!ArrayHelper::isAssociative($condition) && !$condition instanceof ExpressionInterface) {
+            // query by primary key
+            $primaryKey = static::primaryKey();
+            if (isset($primaryKey[0])) {
+                // if condition is scalar, search for a single primary key, if it is array, search for multiple primary key values
+                $condition = [$primaryKey[0] => is_array($condition) ? array_values($condition) : $condition];
+            } else {
+                throw new InvalidConfigException('"' . get_called_class() . '" must have a primary key.');
+            }
+        }
+
+        return $query->andWhere($condition);
+    }
+
+    /**
+     * Updates the whole table using the provided attribute values and conditions.
+     *
+     * For example, to change the status to be 1 for all customers whose status is 2:
+     *
+     * ```php
+     * Customer::updateAll(['status' => 1], 'status = 2');
+     * ```
+     *
+     * @param array $attributes attribute values (name-value pairs) to be saved into the table
+     * @param string|array $condition the conditions that will be put in the WHERE part of the UPDATE SQL.
+     * Please refer to [[Query::where()]] on how to specify this parameter.
+     * @return int the number of rows updated
+     * @throws NotSupportedException if not overridden
+     */
+    public static function updateAll($attributes, $condition = '')
+    {
+        throw new NotSupportedException(__METHOD__ . ' is not supported.');
+    }
+
+    /**
+     * Updates the whole table using the provided counter changes and conditions.
+     *
+     * For example, to increment all customers' age by 1,
+     *
+     * ```php
+     * Customer::updateAllCounters(['age' => 1]);
+     * ```
+     *
+     * @param array $counters the counters to be updated (attribute name => increment value).
+     * Use negative values if you want to decrement the counters.
+     * @param string|array $condition the conditions that will be put in the WHERE part of the UPDATE SQL.
+     * Please refer to [[Query::where()]] on how to specify this parameter.
+     * @return int the number of rows updated
+     * @throws NotSupportedException if not overrided
+     */
+    public static function updateAllCounters($counters, $condition = '')
+    {
+        throw new NotSupportedException(__METHOD__ . ' is not supported.');
+    }
+
+    /**
+     * Deletes rows in the table using the provided conditions.
+     * WARNING: If you do not specify any condition, this method will delete ALL rows in the table.
+     *
+     * For example, to delete all customers whose status is 3:
+     *
+     * ```php
+     * Customer::deleteAll('status = 3');
+     * ```
+     *
+     * @param string|array $condition the conditions that will be put in the WHERE part of the DELETE SQL.
+     * Please refer to [[Query::where()]] on how to specify this parameter.
+     * @return int the number of rows deleted
+     * @throws NotSupportedException if not overridden.
+     */
+    public static function deleteAll($condition = null)
+    {
+        throw new NotSupportedException(__METHOD__ . ' is not supported.');
+    }
+
+    /**
+     * Returns the name of the column that stores the lock version for implementing optimistic locking.
+     *
+     * Optimistic locking allows multiple users to access the same record for edits and avoids
+     * potential conflicts. In case when a user attempts to save the record upon some staled data
+     * (because another user has modified the data), a [[StaleObjectException]] exception will be thrown,
+     * and the update or deletion is skipped.
+     *
+     * Optimistic locking is only supported by [[update()]] and [[delete()]].
+     *
+     * To use Optimistic locking:
+     *
+     * 1. Create a column to store the version number of each row. The column type should be `BIGINT DEFAULT 0`.
+     *    Override this method to return the name of this column.
+     * 2. Ensure the version value is submitted and loaded to your model before any update or delete.
+     *    Or add [[\yii\behaviors\OptimisticLockBehavior|OptimisticLockBehavior]] to your model
+     *    class in order to automate the process.
+     * 3. In the Web form that collects the user input, add a hidden field that stores
+     *    the lock version of the recording being updated.
+     * 4. In the controller action that does the data updating, try to catch the [[StaleObjectException]]
+     *    and implement necessary business logic (e.g. merging the changes, prompting stated data)
+     *    to resolve the conflict.
+     *
+     * @return string the column name that stores the lock version of a table row.
+     * If `null` is returned (default implemented), optimistic locking will not be supported.
+     */
+    public function optimisticLock()
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function canGetProperty($name, $checkVars = true, $checkBehaviors = true)
+    {
+        if (parent::canGetProperty($name, $checkVars, $checkBehaviors)) {
+            return true;
+        }
+
+        try {
+            return $this->hasAttribute($name);
+        } catch (\Exception $e) {
+            // `hasAttribute()` may fail on base/abstract classes in case automatic attribute list fetching used
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function canSetProperty($name, $checkVars = true, $checkBehaviors = true)
+    {
+        if (parent::canSetProperty($name, $checkVars, $checkBehaviors)) {
+            return true;
+        }
+
+        try {
+            return $this->hasAttribute($name);
+        } catch (\Exception $e) {
+            // `hasAttribute()` may fail on base/abstract classes in case automatic attribute list fetching used
+            return false;
+        }
+    }
+
+    /**
+     * PHP getter magic method.
+     * This method is overridden so that attributes and related objects can be accessed like properties.
+     *
+     * @param string $name property name
+     * @throws InvalidArgumentException if relation name is wrong
+     * @return mixed property value
+     * @see getAttribute()
+     */
+    public function __get($name)
+    {
+        if (isset($this->_attributes[$name]) || array_key_exists($name, $this->_attributes)) {
+            return $this->_attributes[$name];
+        }
+
+        if ($this->hasAttribute($name)) {
+            return null;
+        }
+
+        if (isset($this->_related[$name]) || array_key_exists($name, $this->_related)) {
+            return $this->_related[$name];
+        }
+        $value = parent::__get($name);
+        if ($value instanceof ActiveQueryInterface) {
+            $this->setRelationDependencies($name, $value);
+            return $this->_related[$name] = $value->findFor($name, $this);
+        }
+
+        return $value;
+    }
+
+    /**
+     * PHP setter magic method.
+     * This method is overridden so that AR attributes can be accessed like properties.
+     * @param string $name property name
+     * @param mixed $value property value
+     */
+    public function __set($name, $value)
+    {
+        if ($this->hasAttribute($name)) {
+            if (
+                !empty($this->_relationsDependencies[$name])
+                && (!array_key_exists($name, $this->_attributes) || $this->_attributes[$name] !== $value)
+            ) {
+                $this->resetDependentRelations($name);
+            }
+            $this->_attributes[$name] = $value;
+        } else {
+            parent::__set($name, $value);
+        }
+    }
+
+    /**
+     * Checks if a property value is null.
+     * This method overrides the parent implementation by checking if the named attribute is `null` or not.
+     * @param string $name the property name or the event name
+     * @return bool whether the property value is null
+     */
+    public function __isset($name)
+    {
+        try {
+            return $this->__get($name) !== null;
+        } catch (\Throwable $t) {
+            return false;
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+
+    /**
+     * Sets a component property to be null.
+     * This method overrides the parent implementation by clearing
+     * the specified attribute value.
+     * @param string $name the property name or the event name
+     */
+    public function __unset($name)
+    {
+        if ($this->hasAttribute($name)) {
+            unset($this->_attributes[$name]);
+            if (!empty($this->_relationsDependencies[$name])) {
+                $this->resetDependentRelations($name);
+            }
+        } elseif (array_key_exists($name, $this->_related)) {
+            unset($this->_related[$name]);
+        } elseif ($this->getRelation($name, false) === null) {
+            parent::__unset($name);
+        }
+    }
+
+    /**
+     * Declares a `has-one` relation.
+     * The declaration is returned in terms of a relational [[ActiveQuery]] instance
+     * through which the related record can be queried and retrieved back.
+     *
+     * A `has-one` relation means that there is at most one related record matching
+     * the criteria set by this relation, e.g., a customer has one country.
+     *
+     * For example, to declare the `country` relation for `Customer` class, we can write
+     * the following code in the `Customer` class:
+     *
+     * ```php
+     * public function getCountry()
+     * {
+     *     return $this->hasOne(Country::className(), ['id' => 'country_id']);
+     * }
+     * ```
+     *
+     * Note that in the above, the 'id' key in the `$link` parameter refers to an attribute name
+     * in the related class `Country`, while the 'country_id' value refers to an attribute name
+     * in the current AR class.
+     *
+     * Call methods declared in [[ActiveQuery]] to further customize the relation.
+     *
+     * @param string $class the class name of the related record
+     * @param array $link the primary-foreign key constraint. The keys of the array refer to
+     * the attributes of the record associated with the `$class` model, while the values of the
+     * array refer to the corresponding attributes in **this** AR class.
+     * @return ActiveQueryInterface the relational query object.
+     */
+    public function hasOne($class, $link)
+    {
+        return $this->createRelationQuery($class, $link, false);
+    }
+
+    /**
+     * Declares a `has-many` relation.
+     * The declaration is returned in terms of a relational [[ActiveQuery]] instance
+     * through which the related record can be queried and retrieved back.
+     *
+     * A `has-many` relation means that there are multiple related records matching
+     * the criteria set by this relation, e.g., a customer has many orders.
+     *
+     * For example, to declare the `orders` relation for `Customer` class, we can write
+     * the following code in the `Customer` class:
+     *
+     * ```php
+     * public function getOrders()
+     * {
+     *     return $this->hasMany(Order::className(), ['customer_id' => 'id']);
+     * }
+     * ```
+     *
+     * Note that in the above, the 'customer_id' key in the `$link` parameter refers to
+     * an attribute name in the related class `Order`, while the 'id' value refers to
+     * an attribute name in the current AR class.
+     *
+     * Call methods declared in [[ActiveQuery]] to further customize the relation.
+     *
+     * @param string $class the class name of the related record
+     * @param array $link the primary-foreign key constraint. The keys of the array refer to
+     * the attributes of the record associated with the `$class` model, while the values of the
+     * array refer to the corresponding attributes in **this** AR class.
+     * @return ActiveQueryInterface the relational query object.
+     */
+    public function hasMany($class, $link)
+    {
+        return $this->createRelationQuery($class, $link, true);
+    }
+
+    /**
+     * Creates a query instance for `has-one` or `has-many` relation.
+     * @param string $class the class name of the related record.
+     * @param array $link the primary-foreign key constraint.
+     * @param bool $multiple whether this query represents a relation to more than one record.
+     * @return ActiveQueryInterface the relational query object.
+     * @since 2.0.12
+     * @see hasOne()
+     * @see hasMany()
+     */
+    protected function createRelationQuery($class, $link, $multiple)
+    {
+        /* @var $class ActiveRecordInterface */
+        /* @var $query ActiveQuery */
+        $query = $class::find();
+        $query->primaryModel = $this;
+        $query->link = $link;
+        $query->multiple = $multiple;
+        return $query;
+    }
+
+    /**
+     * Populates the named relation with the related records.
+     * Note that this method does not check if the relation exists or not.
+     * @param string $name the relation name, e.g. `orders` for a relation defined via `getOrders()` method (case-sensitive).
+     * @param ActiveRecordInterface|array|null $records the related records to be populated into the relation.
+     * @see getRelation()
+     */
+    public function populateRelation($name, $records)
+    {
+        foreach ($this->_relationsDependencies as &$relationNames) {
+            unset($relationNames[$name]);
+        }
+
+        $this->_related[$name] = $records;
+    }
+
+    /**
+     * Check whether the named relation has been populated with records.
+     * @param string $name the relation name, e.g. `orders` for a relation defined via `getOrders()` method (case-sensitive).
+     * @return bool whether relation has been populated with records.
+     * @see getRelation()
+     */
+    public function isRelationPopulated($name)
+    {
+        return array_key_exists($name, $this->_related);
+    }
+
+    /**
+     * Returns all populated related records.
+     * @return array an array of related records indexed by relation names.
+     * @see getRelation()
+     */
+    public function getRelatedRecords()
+    {
+        return $this->_related;
+    }
+
+    /**
+     * Returns a value indicating whether the model has an attribute with the specified name.
+     * @param string $name the name of the attribute
+     * @return bool whether the model has an attribute with the specified name.
+     */
+    public function hasAttribute($name)
+    {
+        return isset($this->_attributes[$name]) || in_array($name, $this->attributes(), true);
+    }
+
+    /**
+     * Returns the named attribute value.
+     * If this record is the result of a query and the attribute is not loaded,
+     * `null` will be returned.
+     * @param string $name the attribute name
+     * @return mixed the attribute value. `null` if the attribute is not set or does not exist.
+     * @see hasAttribute()
+     */
+    public function getAttribute($name)
+    {
+        return isset($this->_attributes[$name]) ? $this->_attributes[$name] : null;
+    }
+
+    /**
+     * Sets the named attribute value.
+     * @param string $name the attribute name
+     * @param mixed $value the attribute value.
+     * @throws InvalidArgumentException if the named attribute does not exist.
+     * @see hasAttribute()
+     */
+    public function setAttribute($name, $value)
+    {
+        if ($this->hasAttribute($name)) {
+            if (
+                !empty($this->_relationsDependencies[$name])
+                && (!array_key_exists($name, $this->_attributes) || $this->_attributes[$name] !== $value)
+            ) {
+                $this->resetDependentRelations($name);
+            }
+            $this->_attributes[$name] = $value;
+        } else {
+            throw new InvalidArgumentException(get_class($this) . ' has no attribute named "' . $name . '".');
+        }
+    }
+
+    /**
+     * Returns the old attribute values.
+     * @return array the old attribute values (name-value pairs)
+     */
+    public function getOldAttributes()
+    {
+        return $this->_oldAttributes === null ? [] : $this->_oldAttributes;
+    }
+
+    /**
+     * Sets the old attribute values.
+     * All existing old attribute values will be discarded.
+     * @param array|null $values old attribute values to be set.
+     * If set to `null` this record is considered to be [[isNewRecord|new]].
+     */
+    public function setOldAttributes($values)
+    {
+        $this->_oldAttributes = $values;
+    }
+
+    /**
+     * Returns the old value of the named attribute.
+     * If this record is the result of a query and the attribute is not loaded,
+     * `null` will be returned.
+     * @param string $name the attribute name
+     * @return mixed the old attribute value. `null` if the attribute is not loaded before
+     * or does not exist.
+     * @see hasAttribute()
+     */
+    public function getOldAttribute($name)
+    {
+        return isset($this->_oldAttributes[$name]) ? $this->_oldAttributes[$name] : null;
+    }
+
+    /**
+     * Sets the old value of the named attribute.
+     * @param string $name the attribute name
+     * @param mixed $value the old attribute value.
+     * @throws InvalidArgumentException if the named attribute does not exist.
+     * @see hasAttribute()
+     */
+    public function setOldAttribute($name, $value)
+    {
+        if (isset($this->_oldAttributes[$name]) || $this->hasAttribute($name)) {
+            $this->_oldAttributes[$name] = $value;
+        } else {
+            throw new InvalidArgumentException(get_class($this) . ' has no attribute named "' . $name . '".');
+        }
+    }
+
+    /**
+     * Marks an attribute dirty.
+     * This method may be called to force updating a record when calling [[update()]],
+     * even if there is no change being made to the record.
+     * @param string $name the attribute name
+     */
+    public function markAttributeDirty($name)
+    {
+        unset($this->_oldAttributes[$name]);
+    }
+
+    /**
+     * Returns a value indicating whether the named attribute has been changed.
+     * @param string $name the name of the attribute.
+     * @param bool $identical whether the comparison of new and old value is made for
+     * identical values using `===`, defaults to `true`. Otherwise `==` is used for comparison.
+     * This parameter is available since version 2.0.4.
+     * @return bool whether the attribute has been changed
+     */
+    public function isAttributeChanged($name, $identical = true)
+    {
+        if (isset($this->_attributes[$name], $this->_oldAttributes[$name])) {
+            if ($identical) {
+                return $this->_attributes[$name] !== $this->_oldAttributes[$name];
+            }
+
+            return $this->_attributes[$name] != $this->_oldAttributes[$name];
+        }
+
+        return isset($this->_attributes[$name]) || isset($this->_oldAttributes[$name]);
+    }
+
+    /**
+     * Returns the attribute values that have been modified since they are loaded or saved most recently.
+     *
+     * The comparison of new and old values is made for identical values using `===`.
+     *
+     * @param string[]|null $names the names of the attributes whose values may be returned if they are
+     * changed recently. If null, [[attributes()]] will be used.
+     * @return array the changed attribute values (name-value pairs)
+     */
+    public function getDirtyAttributes($names = null)
+    {
+        if ($names === null) {
+            $names = $this->attributes();
+        }
+        $names = array_flip($names);
+        $attributes = [];
+        if ($this->_oldAttributes === null) {
+            foreach ($this->_attributes as $name => $value) {
+                if (isset($names[$name])) {
+                    $attributes[$name] = $value;
+                }
+            }
+        } else {
+            foreach ($this->_attributes as $name => $value) {
+                if (isset($names[$name]) && (!array_key_exists($name, $this->_oldAttributes) || $value !== $this->_oldAttributes[$name])) {
+                    $attributes[$name] = $value;
+                }
+            }
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * Saves the current record.
+     *
+     * This method will call [[insert()]] when [[isNewRecord]] is `true`, or [[update()]]
+     * when [[isNewRecord]] is `false`.
+     *
+     * For example, to save a customer record:
+     *
+     * ```php
+     * $customer = new Customer; // or $customer = Customer::findOne($id);
+     * $customer->name = $name;
+     * $customer->email = $email;
+     * $customer->save();
+     * ```
+     *
+     * @param bool $runValidation whether to perform validation (calling [[validate()]])
+     * before saving the record. Defaults to `true`. If the validation fails, the record
+     * will not be saved to the database and this method will return `false`.
+     * @param array $attributeNames list of attribute names that need to be saved. Defaults to null,
+     * meaning all attributes that are loaded from DB will be saved.
+     * @return bool whether the saving succeeded (i.e. no validation errors occurred).
+     */
+    public function save($runValidation = true, $attributeNames = null)
+    {
+        if ($this->getIsNewRecord()) {
+            return $this->insert($runValidation, $attributeNames);
+        }
+
+        return $this->update($runValidation, $attributeNames) !== false;
+    }
+
+    /**
+     * Saves the changes to this active record into the associated database table.
+     *
+     * This method performs the following steps in order:
+     *
+     * 1. call [[beforeValidate()]] when `$runValidation` is `true`. If [[beforeValidate()]]
+     *    returns `false`, the rest of the steps will be skipped;
+     * 2. call [[afterValidate()]] when `$runValidation` is `true`. If validation
+     *    failed, the rest of the steps will be skipped;
+     * 3. call [[beforeSave()]]. If [[beforeSave()]] returns `false`,
+     *    the rest of the steps will be skipped;
+     * 4. save the record into database. If this fails, it will skip the rest of the steps;
+     * 5. call [[afterSave()]];
+     *
+     * In the above step 1, 2, 3 and 5, events [[EVENT_BEFORE_VALIDATE]],
+     * [[EVENT_AFTER_VALIDATE]], [[EVENT_BEFORE_UPDATE]], and [[EVENT_AFTER_UPDATE]]
+     * will be raised by the corresponding methods.
+     *
+     * Only the [[dirtyAttributes|changed attribute values]] will be saved into database.
+     *
+     * For example, to update a customer record:
+     *
+     * ```php
+     * $customer = Customer::findOne($id);
+     * $customer->name = $name;
+     * $customer->email = $email;
+     * $customer->update();
+     * ```
+     *
+     * Note that it is possible the update does not affect any row in the table.
+     * In this case, this method will return 0. For this reason, you should use the following
+     * code to check if update() is successful or not:
+     *
+     * ```php
+     * if ($customer->update() !== false) {
+     *     // update successful
+     * } else {
+     *     // update failed
+     * }
+     * ```
+     *
+     * @param bool $runValidation whether to perform validation (calling [[validate()]])
+     * before saving the record. Defaults to `true`. If the validation fails, the record
+     * will not be saved to the database and this method will return `false`.
+     * @param array $attributeNames list of attribute names that need to be saved. Defaults to null,
+     * meaning all attributes that are loaded from DB will be saved.
+     * @return int|false the number of rows affected, or `false` if validation fails
+     * or [[beforeSave()]] stops the updating process.
+     * @throws StaleObjectException if [[optimisticLock|optimistic locking]] is enabled and the data
+     * being updated is outdated.
+     * @throws Exception in case update failed.
+     */
+    public function update($runValidation = true, $attributeNames = null)
+    {
+        if ($runValidation && !$this->validate($attributeNames)) {
+            return false;
+        }
+
+        return $this->updateInternal($attributeNames);
+    }
+
+    /**
+     * Updates the specified attributes.
+     *
+     * This method is a shortcut to [[update()]] when data validation is not needed
+     * and only a small set attributes need to be updated.
+     *
+     * You may specify the attributes to be updated as name list or name-value pairs.
+     * If the latter, the corresponding attribute values will be modified accordingly.
+     * The method will then save the specified attributes into database.
+     *
+     * Note that this method will **not** perform data validation and will **not** trigger events.
+     *
+     * @param array $attributes the attributes (names or name-value pairs) to be updated
+     * @return int the number of rows affected.
+     */
+    public function updateAttributes($attributes)
+    {
+        $attrs = [];
+        foreach ($attributes as $name => $value) {
+            if (is_int($name)) {
+                $attrs[] = $value;
+            } else {
+                $this->$name = $value;
+                $attrs[] = $name;
+            }
+        }
+
+        $values = $this->getDirtyAttributes($attrs);
+        if (empty($values) || $this->getIsNewRecord()) {
+            return 0;
+        }
+
+        $rows = static::updateAll($values, $this->getOldPrimaryKey(true));
+
+        foreach ($values as $name => $value) {
+            $this->_oldAttributes[$name] = $this->_attributes[$name];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @see update()
+     * @param array $attributes attributes to update
+     * @return int|false the number of rows affected, or false if [[beforeSave()]] stops the updating process.
+     * @throws StaleObjectException
+     */
+    protected function updateInternal($attributes = null)
+    {
+        if (!$this->beforeSave(false)) {
+            return false;
+        }
+        $values = $this->getDirtyAttributes($attributes);
+        if (empty($values)) {
+            $this->afterSave(false, $values);
+            return 0;
+        }
+        $condition = $this->getOldPrimaryKey(true);
+        $lock = $this->optimisticLock();
+        if ($lock !== null) {
+            $values[$lock] = $this->$lock + 1;
+            $condition[$lock] = $this->$lock;
+        }
+        // We do not check the return value of updateAll() because it's possible
+        // that the UPDATE statement doesn't change anything and thus returns 0.
+        $rows = static::updateAll($values, $condition);
+
+        if ($lock !== null && !$rows) {
+            throw new StaleObjectException('The object being updated is outdated.');
+        }
+
+        if (isset($values[$lock])) {
+            $this->$lock = $values[$lock];
+        }
+
+        $changedAttributes = [];
+        foreach ($values as $name => $value) {
+            $changedAttributes[$name] = isset($this->_oldAttributes[$name]) ? $this->_oldAttributes[$name] : null;
+            $this->_oldAttributes[$name] = $value;
+        }
+        $this->afterSave(false, $changedAttributes);
+
+        return $rows;
+    }
+
+    /**
+     * Updates one or several counter columns for the current AR object.
+     * Note that this method differs from [[updateAllCounters()]] in that it only
+     * saves counters for the current AR object.
+     *
+     * An example usage is as follows:
+     *
+     * ```php
+     * $post = Post::findOne($id);
+     * $post->updateCounters(['view_count' => 1]);
+     * ```
+     *
+     * @param array $counters the counters to be updated (attribute name => increment value)
+     * Use negative values if you want to decrement the counters.
+     * @return bool whether the saving is successful
+     * @see updateAllCounters()
+     */
+    public function updateCounters($counters)
+    {
+        if (static::updateAllCounters($counters, $this->getOldPrimaryKey(true)) > 0) {
+            foreach ($counters as $name => $value) {
+                if (!isset($this->_attributes[$name])) {
+                    $this->_attributes[$name] = $value;
+                } else {
+                    $this->_attributes[$name] += $value;
+                }
+                $this->_oldAttributes[$name] = $this->_attributes[$name];
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Deletes the table row corresponding to this active record.
+     *
+     * This method performs the following steps in order:
+     *
+     * 1. call [[beforeDelete()]]. If the method returns `false`, it will skip the
+     *    rest of the steps;
+     * 2. delete the record from the database;
+     * 3. call [[afterDelete()]].
+     *
+     * In the above step 1 and 3, events named [[EVENT_BEFORE_DELETE]] and [[EVENT_AFTER_DELETE]]
+     * will be raised by the corresponding methods.
+     *
+     * @return int|false the number of rows deleted, or `false` if the deletion is unsuccessful for some reason.
+     * Note that it is possible the number of rows deleted is 0, even though the deletion execution is successful.
+     * @throws StaleObjectException if [[optimisticLock|optimistic locking]] is enabled and the data
+     * being deleted is outdated.
+     * @throws Exception in case delete failed.
+     */
+    public function delete()
+    {
+        $result = false;
+        if ($this->beforeDelete()) {
+            // we do not check the return value of deleteAll() because it's possible
+            // the record is already deleted in the database and thus the method will return 0
+            $condition = $this->getOldPrimaryKey(true);
+            $lock = $this->optimisticLock();
+            if ($lock !== null) {
+                $condition[$lock] = $this->$lock;
+            }
+            $result = static::deleteAll($condition);
+            if ($lock !== null && !$result) {
+                throw new StaleObjectException('The object being deleted is outdated.');
+            }
+            $this->_oldAttributes = null;
+            $this->afterDelete();
+        }
+
+        return $result;
+    }
+
+    /**
+     * Returns a value indicating whether the current record is new.
+     * @return bool whether the record is new and should be inserted when calling [[save()]].
+     */
+    public function getIsNewRecord()
+    {
+        return $this->_oldAttributes === null;
+    }
+
+    /**
+     * Sets the value indicating whether the record is new.
+     * @param bool $value whether the record is new and should be inserted when calling [[save()]].
+     * @see getIsNewRecord()
+     */
+    public function setIsNewRecord($value)
+    {
+        $this->_oldAttributes = $value ? null : $this->_attributes;
+    }
+
+    /**
+     * Initializes the object.
+     * This method is called at the end of the constructor.
+     * The default implementation will trigger an [[EVENT_INIT]] event.
+     */
+    public function init()
+    {
+        parent::init();
+        $this->trigger(self::EVENT_INIT);
+    }
+
+    /**
+     * This method is called when the AR object is created and populated with the query result.
+     * The default implementation will trigger an [[EVENT_AFTER_FIND]] event.
+     * When overriding this method, make sure you call the parent implementation to ensure the
+     * event is triggered.
+     */
+    public function afterFind()
+    {
+        $this->trigger(self::EVENT_AFTER_FIND);
+    }
+
+    /**
+     * This method is called at the beginning of inserting or updating a record.
+     *
+     * The default implementation will trigger an [[EVENT_BEFORE_INSERT]] event when `$insert` is `true`,
+     * or an [[EVENT_BEFORE_UPDATE]] event if `$insert` is `false`.
+     * When overriding this method, make sure you call the parent implementation like the following:
+     *
+     * ```php
+     * public function beforeSave($insert)
+     * {
+     *     if (!parent::beforeSave($insert)) {
+     *         return false;
+     *     }
+     *
+     *     // ...custom code here...
+     *     return true;
+     * }
+     * ```
+     *
+     * @param bool $insert whether this method called while inserting a record.
+     * If `false`, it means the method is called while updating a record.
+     * @return bool whether the insertion or updating should continue.
+     * If `false`, the insertion or updating will be cancelled.
+     */
+    public function beforeSave($insert)
+    {
+        $event = new ModelEvent();
+        $this->trigger($insert ? self::EVENT_BEFORE_INSERT : self::EVENT_BEFORE_UPDATE, $event);
+
+        return $event->isValid;
+    }
+
+    /**
+     * This method is called at the end of inserting or updating a record.
+     * The default implementation will trigger an [[EVENT_AFTER_INSERT]] event when `$insert` is `true`,
+     * or an [[EVENT_AFTER_UPDATE]] event if `$insert` is `false`. The event class used is [[AfterSaveEvent]].
+     * When overriding this method, make sure you call the parent implementation so that
+     * the event is triggered.
+     * @param bool $insert whether this method called while inserting a record.
+     * If `false`, it means the method is called while updating a record.
+     * @param array $changedAttributes The old values of attributes that had changed and were saved.
+     * You can use this parameter to take action based on the changes made for example send an email
+     * when the password had changed or implement audit trail that tracks all the changes.
+     * `$changedAttributes` gives you the old attribute values while the active record (`$this`) has
+     * already the new, updated values.
+     *
+     * Note that no automatic type conversion performed by default. You may use
+     * [[\yii\behaviors\AttributeTypecastBehavior]] to facilitate attribute typecasting.
+     * See http://www.yiiframework.com/doc-2.0/guide-db-active-record.html#attributes-typecasting.
+     */
+    public function afterSave($insert, $changedAttributes)
+    {
+        $this->trigger($insert ? self::EVENT_AFTER_INSERT : self::EVENT_AFTER_UPDATE, new AfterSaveEvent([
+            'changedAttributes' => $changedAttributes,
+        ]));
+    }
+
+    /**
+     * This method is invoked before deleting a record.
+     *
+     * The default implementation raises the [[EVENT_BEFORE_DELETE]] event.
+     * When overriding this method, make sure you call the parent implementation like the following:
+     *
+     * ```php
+     * public function beforeDelete()
+     * {
+     *     if (!parent::beforeDelete()) {
+     *         return false;
+     *     }
+     *
+     *     // ...custom code here...
+     *     return true;
+     * }
+     * ```
+     *
+     * @return bool whether the record should be deleted. Defaults to `true`.
+     */
+    public function beforeDelete()
+    {
+        $event = new ModelEvent();
+        $this->trigger(self::EVENT_BEFORE_DELETE, $event);
+
+        return $event->isValid;
+    }
+
+    /**
+     * This method is invoked after deleting a record.
+     * The default implementation raises the [[EVENT_AFTER_DELETE]] event.
+     * You may override this method to do postprocessing after the record is deleted.
+     * Make sure you call the parent implementation so that the event is raised properly.
+     */
+    public function afterDelete()
+    {
+        $this->trigger(self::EVENT_AFTER_DELETE);
+    }
+
+    /**
+     * Repopulates this active record with the latest data.
+     *
+     * If the refresh is successful, an [[EVENT_AFTER_REFRESH]] event will be triggered.
+     * This event is available since version 2.0.8.
+     *
+     * @return bool whether the row still exists in the database. If `true`, the latest data
+     * will be populated to this active record. Otherwise, this record will remain unchanged.
+     */
+    public function refresh()
+    {
+        /* @var $record BaseActiveRecord */
+        $record = static::findOne($this->getPrimaryKey(true));
+        return $this->refreshInternal($record);
+    }
+
+    /**
+     * Repopulates this active record with the latest data from a newly fetched instance.
+     * @param BaseActiveRecord $record the record to take attributes from.
+     * @return bool whether refresh was successful.
+     * @see refresh()
+     * @since 2.0.13
+     */
+    protected function refreshInternal($record)
+    {
+        if ($record === null) {
+            return false;
+        }
+        foreach ($this->attributes() as $name) {
+            $this->_attributes[$name] = isset($record->_attributes[$name]) ? $record->_attributes[$name] : null;
+        }
+        $this->_oldAttributes = $record->_oldAttributes;
+        $this->_related = [];
+        $this->_relationsDependencies = [];
+        $this->afterRefresh();
+
+        return true;
+    }
+
+    /**
+     * This method is called when the AR object is refreshed.
+     * The default implementation will trigger an [[EVENT_AFTER_REFRESH]] event.
+     * When overriding this method, make sure you call the parent implementation to ensure the
+     * event is triggered.
+     * @since 2.0.8
+     */
+    public function afterRefresh()
+    {
+        $this->trigger(self::EVENT_AFTER_REFRESH);
+    }
+
+    /**
+     * Returns a value indicating whether the given active record is the same as the current one.
+     * The comparison is made by comparing the table names and the primary key values of the two active records.
+     * If one of the records [[isNewRecord|is new]] they are also considered not equal.
+     * @param ActiveRecordInterface $record record to compare to
+     * @return bool whether the two active records refer to the same row in the same database table.
+     */
+    public function equals($record)
+    {
+        if ($this->getIsNewRecord() || $record->getIsNewRecord()) {
+            return false;
+        }
+
+        return get_class($this) === get_class($record) && $this->getPrimaryKey() === $record->getPrimaryKey();
+    }
+
+    /**
+     * Returns the primary key value(s).
+     * @param bool $asArray whether to return the primary key value as an array. If `true`,
+     * the return value will be an array with column names as keys and column values as values.
+     * Note that for composite primary keys, an array will always be returned regardless of this parameter value.
+     * @property mixed The primary key value. An array (column name => column value) is returned if
+     * the primary key is composite. A string is returned otherwise (null will be returned if
+     * the key value is null).
+     * @return mixed the primary key value. An array (column name => column value) is returned if the primary key
+     * is composite or `$asArray` is `true`. A string is returned otherwise (null will be returned if
+     * the key value is null).
+     */
+    public function getPrimaryKey($asArray = false)
+    {
+        $keys = $this->primaryKey();
+        if (!$asArray && count($keys) === 1) {
+            return isset($this->_attributes[$keys[0]]) ? $this->_attributes[$keys[0]] : null;
+        }
+
+        $values = [];
+        foreach ($keys as $name) {
+            $values[$name] = isset($this->_attributes[$name]) ? $this->_attributes[$name] : null;
+        }
+
+        return $values;
+    }
+
+    /**
+     * Returns the old primary key value(s).
+     * This refers to the primary key value that is populated into the record
+     * after executing a find method (e.g. find(), findOne()).
+     * The value remains unchanged even if the primary key attribute is manually assigned with a different value.
+     * @param bool $asArray whether to return the primary key value as an array. If `true`,
+     * the return value will be an array with column name as key and column value as value.
+     * If this is `false` (default), a scalar value will be returned for non-composite primary key.
+     * @property mixed The old primary key value. An array (column name => column value) is
+     * returned if the primary key is composite. A string is returned otherwise (null will be
+     * returned if the key value is null).
+     * @return mixed the old primary key value. An array (column name => column value) is returned if the primary key
+     * is composite or `$asArray` is `true`. A string is returned otherwise (null will be returned if
+     * the key value is null).
+     * @throws Exception if the AR model does not have a primary key
+     */
+    public function getOldPrimaryKey($asArray = false)
+    {
+        $keys = $this->primaryKey();
+        if (empty($keys)) {
+            throw new Exception(get_class($this) . ' does not have a primary key. You should either define a primary key for the corresponding table or override the primaryKey() method.');
+        }
+        if (!$asArray && count($keys) === 1) {
+            return isset($this->_oldAttributes[$keys[0]]) ? $this->_oldAttributes[$keys[0]] : null;
+        }
+
+        $values = [];
+        foreach ($keys as $name) {
+            $values[$name] = isset($this->_oldAttributes[$name]) ? $this->_oldAttributes[$name] : null;
+        }
+
+        return $values;
+    }
+
+    /**
+     * Populates an active record object using a row of data from the database/storage.
+     *
+     * This is an internal method meant to be called to create active record objects after
+     * fetching data from the database. It is mainly used by [[ActiveQuery]] to populate
+     * the query results into active records.
+     *
+     * When calling this method manually you should call [[afterFind()]] on the created
+     * record to trigger the [[EVENT_AFTER_FIND|afterFind Event]].
+     *
+     * @param BaseActiveRecord $record the record to be populated. In most cases this will be an instance
+     * created by [[instantiate()]] beforehand.
+     * @param array $row attribute values (name => value)
+     */
+    public static function populateRecord($record, $row)
+    {
+        $columns = array_flip($record->attributes());
+        foreach ($row as $name => $value) {
+            if (isset($columns[$name])) {
+                $record->_attributes[$name] = $value;
+            } elseif ($record->canSetProperty($name)) {
+                $record->$name = $value;
+            }
+        }
+        $record->_oldAttributes = $record->_attributes;
+        $record->_related = [];
+        $record->_relationsDependencies = [];
+    }
+
+    /**
+     * Creates an active record instance.
+     *
+     * This method is called together with [[populateRecord()]] by [[ActiveQuery]].
+     * It is not meant to be used for creating new records directly.
+     *
+     * You may override this method if the instance being created
+     * depends on the row data to be populated into the record.
+     * For example, by creating a record based on the value of a column,
+     * you may implement the so-called single-table inheritance mapping.
+     * @param array $row row data to be populated into the record.
+     * @return static the newly created active record
+     */
+    public static function instantiate($row)
+    {
+        return new static();
+    }
+
+    /**
+     * Returns whether there is an element at the specified offset.
+     * This method is required by the interface [[\ArrayAccess]].
+     * @param mixed $offset the offset to check on
+     * @return bool whether there is an element at the specified offset.
+     */
+    public function offsetExists($offset)
+    {
+        return $this->__isset($offset);
+    }
+
+    /**
+     * Returns the relation object with the specified name.
+     * A relation is defined by a getter method which returns an [[ActiveQueryInterface]] object.
+     * It can be declared in either the Active Record class itself or one of its behaviors.
+     * @param string $name the relation name, e.g. `orders` for a relation defined via `getOrders()` method (case-sensitive).
+     * @param bool $throwException whether to throw exception if the relation does not exist.
+     * @return ActiveQueryInterface|ActiveQuery the relational query object. If the relation does not exist
+     * and `$throwException` is `false`, `null` will be returned.
+     * @throws InvalidArgumentException if the named relation does not exist.
+     */
+    public function getRelation($name, $throwException = true)
+    {
+        $getter = 'get' . $name;
+        try {
+            // the relation could be defined in a behavior
+            $relation = $this->$getter();
+        } catch (UnknownMethodException $e) {
+            if ($throwException) {
+                throw new InvalidArgumentException(get_class($this) . ' has no relation named "' . $name . '".', 0, $e);
+            }
+
+            return null;
+        }
+        if (!$relation instanceof ActiveQueryInterface) {
+            if ($throwException) {
+                throw new InvalidArgumentException(get_class($this) . ' has no relation named "' . $name . '".');
+            }
+
+            return null;
+        }
+
+        if (method_exists($this, $getter)) {
+            // relation name is case sensitive, trying to validate it when the relation is defined within this class
+            $method = new \ReflectionMethod($this, $getter);
+            $realName = lcfirst(substr($method->getName(), 3));
+            if ($realName !== $name) {
+                if ($throwException) {
+                    throw new InvalidArgumentException('Relation names are case sensitive. ' . get_class($this) . " has a relation named \"$realName\" instead of \"$name\".");
+                }
+
+                return null;
+            }
+        }
+
+        return $relation;
+    }
+
+    /**
+     * Establishes the relationship between two models.
+     *
+     * The relationship is established by setting the foreign key value(s) in one model
+     * to be the corresponding primary key value(s) in the other model.
+     * The model with the foreign key will be saved into database without performing validation.
+     *
+     * If the relationship involves a junction table, a new row will be inserted into the
+     * junction table which contains the primary key values from both models.
+     *
+     * Note that this method requires that the primary key value is not null.
+     *
+     * @param string $name the case sensitive name of the relationship, e.g. `orders` for a relation defined via `getOrders()` method.
+     * @param ActiveRecordInterface $model the model to be linked with the current one.
+     * @param array $extraColumns additional column values to be saved into the junction table.
+     * This parameter is only meaningful for a relationship involving a junction table
+     * (i.e., a relation set with [[ActiveRelationTrait::via()]] or [[ActiveQuery::viaTable()]].)
+     * @throws InvalidCallException if the method is unable to link two models.
+     */
+    public function link($name, $model, $extraColumns = [])
+    {
+        $relation = $this->getRelation($name);
+
+        if ($relation->via !== null) {
+            if ($this->getIsNewRecord() || $model->getIsNewRecord()) {
+                throw new InvalidCallException('Unable to link models: the models being linked cannot be newly created.');
+            }
+            if (is_array($relation->via)) {
+                /* @var $viaRelation ActiveQuery */
+                list($viaName, $viaRelation) = $relation->via;
+                $viaClass = $viaRelation->modelClass;
+                // unset $viaName so that it can be reloaded to reflect the change
+                unset($this->_related[$viaName]);
+            } else {
+                $viaRelation = $relation->via;
+                $viaTable = reset($relation->via->from);
+            }
+            $columns = [];
+            foreach ($viaRelation->link as $a => $b) {
+                $columns[$a] = $this->$b;
+            }
+            foreach ($relation->link as $a => $b) {
+                $columns[$b] = $model->$a;
+            }
+            foreach ($extraColumns as $k => $v) {
+                $columns[$k] = $v;
+            }
+            if (is_array($relation->via)) {
+                /* @var $viaClass ActiveRecordInterface */
+                /* @var $record ActiveRecordInterface */
+                $record = Yii::createObject($viaClass);
+                foreach ($columns as $column => $value) {
+                    $record->$column = $value;
+                }
+                $record->insert(false);
+            } else {
+                /* @var $viaTable string */
+                static::getDb()->createCommand()
+                    ->insert($viaTable, $columns)->execute();
+            }
+        } else {
+            $p1 = $model->isPrimaryKey(array_keys($relation->link));
+            $p2 = static::isPrimaryKey(array_values($relation->link));
+            if ($p1 && $p2) {
+                if ($this->getIsNewRecord() && $model->getIsNewRecord()) {
+                    throw new InvalidCallException('Unable to link models: at most one model can be newly created.');
+                } elseif ($this->getIsNewRecord()) {
+                    $this->bindModels(array_flip($relation->link), $this, $model);
+                } else {
+                    $this->bindModels($relation->link, $model, $this);
+                }
+            } elseif ($p1) {
+                $this->bindModels(array_flip($relation->link), $this, $model);
+            } elseif ($p2) {
+                $this->bindModels($relation->link, $model, $this);
+            } else {
+                throw new InvalidCallException('Unable to link models: the link defining the relation does not involve any primary key.');
+            }
+        }
+
+        // update lazily loaded related objects
+        if (!$relation->multiple) {
+            $this->_related[$name] = $model;
+        } elseif (isset($this->_related[$name])) {
+            if ($relation->indexBy !== null) {
+                if ($relation->indexBy instanceof \Closure) {
+                    $index = call_user_func($relation->indexBy, $model);
+                } else {
+                    $index = $model->{$relation->indexBy};
+                }
+                $this->_related[$name][$index] = $model;
+            } else {
+                $this->_related[$name][] = $model;
+            }
+        }
+    }
+
+    /**
+     * Destroys the relationship between two models.
+     *
+     * The model with the foreign key of the relationship will be deleted if `$delete` is `true`.
+     * Otherwise, the foreign key will be set `null` and the model will be saved without validation.
+     *
+     * @param string $name the case sensitive name of the relationship, e.g. `orders` for a relation defined via `getOrders()` method.
+     * @param ActiveRecordInterface $model the model to be unlinked from the current one.
+     * You have to make sure that the model is really related with the current model as this method
+     * does not check this.
+     * @param bool $delete whether to delete the model that contains the foreign key.
+     * If `false`, the model's foreign key will be set `null` and saved.
+     * If `true`, the model containing the foreign key will be deleted.
+     * @throws InvalidCallException if the models cannot be unlinked
+     */
+    public function unlink($name, $model, $delete = false)
+    {
+        $relation = $this->getRelation($name);
+
+        if ($relation->via !== null) {
+            if (is_array($relation->via)) {
+                /* @var $viaRelation ActiveQuery */
+                list($viaName, $viaRelation) = $relation->via;
+                $viaClass = $viaRelation->modelClass;
+                unset($this->_related[$viaName]);
+            } else {
+                $viaRelation = $relation->via;
+                $viaTable = reset($relation->via->from);
+            }
+            $columns = [];
+            foreach ($viaRelation->link as $a => $b) {
+                $columns[$a] = $this->$b;
+            }
+            foreach ($relation->link as $a => $b) {
+                $columns[$b] = $model->$a;
+            }
+            $nulls = [];
+            foreach (array_keys($columns) as $a) {
+                $nulls[$a] = null;
+            }
+            if (is_array($relation->via)) {
+                /* @var $viaClass ActiveRecordInterface */
+                if ($delete) {
+                    $viaClass::deleteAll($columns);
+                } else {
+                    $viaClass::updateAll($nulls, $columns);
+                }
+            } else {
+                /* @var $viaTable string */
+                /* @var $command Command */
+                $command = static::getDb()->createCommand();
+                if ($delete) {
+                    $command->delete($viaTable, $columns)->execute();
+                } else {
+                    $command->update($viaTable, $nulls, $columns)->execute();
+                }
+            }
+        } else {
+            $p1 = $model->isPrimaryKey(array_keys($relation->link));
+            $p2 = static::isPrimaryKey(array_values($relation->link));
+            if ($p2) {
+                if ($delete) {
+                    $model->delete();
+                } else {
+                    foreach ($relation->link as $a => $b) {
+                        $model->$a = null;
+                    }
+                    $model->save(false);
+                }
+            } elseif ($p1) {
+                foreach ($relation->link as $a => $b) {
+                    if (is_array($this->$b)) { // relation via array valued attribute
+                        if (($key = array_search($model->$a, $this->$b, false)) !== false) {
+                            $values = $this->$b;
+                            unset($values[$key]);
+                            $this->$b = array_values($values);
+                        }
+                    } else {
+                        $this->$b = null;
+                    }
+                }
+                $delete ? $this->delete() : $this->save(false);
+            } else {
+                throw new InvalidCallException('Unable to unlink models: the link does not involve any primary key.');
+            }
+        }
+
+        if (!$relation->multiple) {
+            unset($this->_related[$name]);
+        } elseif (isset($this->_related[$name])) {
+            /* @var $b ActiveRecordInterface */
+            foreach ($this->_related[$name] as $a => $b) {
+                if ($model->getPrimaryKey() === $b->getPrimaryKey()) {
+                    unset($this->_related[$name][$a]);
+                }
+            }
+        }
+    }
+
+    /**
+     * Destroys the relationship in current model.
+     *
+     * The model with the foreign key of the relationship will be deleted if `$delete` is `true`.
+     * Otherwise, the foreign key will be set `null` and the model will be saved without validation.
+     *
+     * Note that to destroy the relationship without removing records make sure your keys can be set to null
+     *
+     * @param string $name the case sensitive name of the relationship, e.g. `orders` for a relation defined via `getOrders()` method.
+     * @param bool $delete whether to delete the model that contains the foreign key.
+     *
+     * Note that the deletion will be performed using [[deleteAll()]], which will not trigger any events on the related models.
+     * If you need [[EVENT_BEFORE_DELETE]] or [[EVENT_AFTER_DELETE]] to be triggered, you need to [[find()|find]] the models first
+     * and then call [[delete()]] on each of them.
+     */
+    public function unlinkAll($name, $delete = false)
+    {
+        $relation = $this->getRelation($name);
+
+        if ($relation->via !== null) {
+            if (is_array($relation->via)) {
+                /* @var $viaRelation ActiveQuery */
+                list($viaName, $viaRelation) = $relation->via;
+                $viaClass = $viaRelation->modelClass;
+                unset($this->_related[$viaName]);
+            } else {
+                $viaRelation = $relation->via;
+                $viaTable = reset($relation->via->from);
+            }
+            $condition = [];
+            $nulls = [];
+            foreach ($viaRelation->link as $a => $b) {
+                $nulls[$a] = null;
+                $condition[$a] = $this->$b;
+            }
+            if (!empty($viaRelation->where)) {
+                $condition = ['and', $condition, $viaRelation->where];
+            }
+            if (!empty($viaRelation->on)) {
+                $condition = ['and', $condition, $viaRelation->on];
+            }
+            if (is_array($relation->via)) {
+                /* @var $viaClass ActiveRecordInterface */
+                if ($delete) {
+                    $viaClass::deleteAll($condition);
+                } else {
+                    $viaClass::updateAll($nulls, $condition);
+                }
+            } else {
+                /* @var $viaTable string */
+                /* @var $command Command */
+                $command = static::getDb()->createCommand();
+                if ($delete) {
+                    $command->delete($viaTable, $condition)->execute();
+                } else {
+                    $command->update($viaTable, $nulls, $condition)->execute();
+                }
+            }
+        } else {
+            /* @var $relatedModel ActiveRecordInterface */
+            $relatedModel = $relation->modelClass;
+            if (!$delete && count($relation->link) === 1 && is_array($this->{$b = reset($relation->link)})) {
+                // relation via array valued attribute
+                $this->$b = [];
+                $this->save(false);
+            } else {
+                $nulls = [];
+                $condition = [];
+                foreach ($relation->link as $a => $b) {
+                    $nulls[$a] = null;
+                    $condition[$a] = $this->$b;
+                }
+                if (!empty($relation->where)) {
+                    $condition = ['and', $condition, $relation->where];
+                }
+                if (!empty($relation->on)) {
+                    $condition = ['and', $condition, $relation->on];
+                }
+                if ($delete) {
+                    $relatedModel::deleteAll($condition);
+                } else {
+                    $relatedModel::updateAll($nulls, $condition);
+                }
+            }
+        }
+
+        unset($this->_related[$name]);
+    }
+
+    /**
+     * @param array $link
+     * @param ActiveRecordInterface $foreignModel
+     * @param ActiveRecordInterface $primaryModel
+     * @throws InvalidCallException
+     */
+    private function bindModels($link, $foreignModel, $primaryModel)
+    {
+        foreach ($link as $fk => $pk) {
+            $value = $primaryModel->$pk;
+            if ($value === null) {
+                throw new InvalidCallException('Unable to link models: the primary key of ' . get_class($primaryModel) . ' is null.');
+            }
+            if (is_array($foreignModel->$fk)) { // relation via array valued attribute
+                $foreignModel->{$fk}[] = $value;
+            } else {
+                $foreignModel->{$fk} = $value;
+            }
+        }
+        $foreignModel->save(false);
+    }
+
+    /**
+     * Returns a value indicating whether the given set of attributes represents the primary key for this model.
+     * @param array $keys the set of attributes to check
+     * @return bool whether the given set of attributes represents the primary key for this model
+     */
+    public static function isPrimaryKey($keys)
+    {
+        $pks = static::primaryKey();
+        if (count($keys) === count($pks)) {
+            return count(array_intersect($keys, $pks)) === count($pks);
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns the text label for the specified attribute.
+     * If the attribute looks like `relatedModel.attribute`, then the attribute will be received from the related model.
+     * @param string $attribute the attribute name
+     * @return string the attribute label
+     * @see generateAttributeLabel()
+     * @see attributeLabels()
+     */
+    public function getAttributeLabel($attribute)
+    {
+        $labels = $this->attributeLabels();
+        if (isset($labels[$attribute])) {
+            return $labels[$attribute];
+        } elseif (strpos($attribute, '.')) {
+            $attributeParts = explode('.', $attribute);
+            $neededAttribute = array_pop($attributeParts);
+
+            $relatedModel = $this;
+            foreach ($attributeParts as $relationName) {
+                if ($relatedModel->isRelationPopulated($relationName) && $relatedModel->$relationName instanceof self) {
+                    $relatedModel = $relatedModel->$relationName;
+                } else {
+                    try {
+                        $relation = $relatedModel->getRelation($relationName);
+                    } catch (InvalidParamException $e) {
+                        return $this->generateAttributeLabel($attribute);
+                    }
+                    /* @var $modelClass ActiveRecordInterface */
+                    $modelClass = $relation->modelClass;
+                    $relatedModel = $modelClass::instance();
+                }
+            }
+
+            $labels = $relatedModel->attributeLabels();
+            if (isset($labels[$neededAttribute])) {
+                return $labels[$neededAttribute];
+            }
+        }
+
+        return $this->generateAttributeLabel($attribute);
+    }
+
+    /**
+     * Returns the text hint for the specified attribute.
+     * If the attribute looks like `relatedModel.attribute`, then the attribute will be received from the related model.
+     * @param string $attribute the attribute name
+     * @return string the attribute hint
+     * @see attributeHints()
+     * @since 2.0.4
+     */
+    public function getAttributeHint($attribute)
+    {
+        $hints = $this->attributeHints();
+        if (isset($hints[$attribute])) {
+            return $hints[$attribute];
+        } elseif (strpos($attribute, '.')) {
+            $attributeParts = explode('.', $attribute);
+            $neededAttribute = array_pop($attributeParts);
+
+            $relatedModel = $this;
+            foreach ($attributeParts as $relationName) {
+                if ($relatedModel->isRelationPopulated($relationName) && $relatedModel->$relationName instanceof self) {
+                    $relatedModel = $relatedModel->$relationName;
+                } else {
+                    try {
+                        $relation = $relatedModel->getRelation($relationName);
+                    } catch (InvalidParamException $e) {
+                        return '';
+                    }
+                    /* @var $modelClass ActiveRecordInterface */
+                    $modelClass = $relation->modelClass;
+                    $relatedModel = $modelClass::instance();
+                }
+            }
+
+            $hints = $relatedModel->attributeHints();
+            if (isset($hints[$neededAttribute])) {
+                return $hints[$neededAttribute];
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * The default implementation returns the names of the columns whose values have been populated into this record.
+     */
+    public function fields()
+    {
+        $fields = array_keys($this->_attributes);
+
+        return array_combine($fields, $fields);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * The default implementation returns the names of the relations that have been populated into this record.
+     */
+    public function extraFields()
+    {
+        $fields = array_keys($this->getRelatedRecords());
+
+        return array_combine($fields, $fields);
+    }
+
+    /**
+     * Sets the element value at the specified offset to null.
+     * This method is required by the SPL interface [[\ArrayAccess]].
+     * It is implicitly called when you use something like `unset($model[$offset])`.
+     * @param mixed $offset the offset to unset element
+     */
+    public function offsetUnset($offset)
+    {
+        if (property_exists($this, $offset)) {
+            $this->$offset = null;
+        } else {
+            unset($this->$offset);
+        }
+    }
+
+    /**
+     * Resets dependent related models checking if their links contain specific attribute.
+     * @param string $attribute The changed attribute name.
+     */
+    private function resetDependentRelations($attribute)
+    {
+        foreach ($this->_relationsDependencies[$attribute] as $relation) {
+            unset($this->_related[$relation]);
+        }
+        unset($this->_relationsDependencies[$attribute]);
+    }
+
+    /**
+     * Sets relation dependencies for a property
+     * @param string $name property name
+     * @param ActiveQueryInterface $relation relation instance
+     * @param string|null $viaRelationName intermediate relation
+     */
+    private function setRelationDependencies($name, $relation, $viaRelationName = null)
+    {
+        if (empty($relation->via) && $relation->link) {
+            foreach ($relation->link as $attribute) {
+                $this->_relationsDependencies[$attribute][$name] = $name;
+                if ($viaRelationName !== null) {
+                    $this->_relationsDependencies[$attribute][] = $viaRelationName;
+                }
+            }
+        } elseif ($relation->via instanceof ActiveQueryInterface) {
+            $this->setRelationDependencies($name, $relation->via);
+        } elseif (is_array($relation->via)) {
+            list($viaRelationName, $viaQuery) = $relation->via;
+            $this->setRelationDependencies($name, $viaQuery, $viaRelationName);
+        }
+    }
+}
+

--- a/lib/WorseReflection/Tests/Benchmarks/fixtures/yii/BaseObject.php.test
+++ b/lib/WorseReflection/Tests/Benchmarks/fixtures/yii/BaseObject.php.test
@@ -1,0 +1,295 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace Phpactor\WorseReflection\Tests\Workspace;
+
+use Yii;
+
+/**
+ * BaseObject is the base class that implements the *property* feature.
+ *
+ * A property is defined by a getter method (e.g. `getLabel`), and/or a setter method (e.g. `setLabel`). For example,
+ * the following getter and setter methods define a property named `label`:
+ *
+ * ```php
+ * private $_label;
+ *
+ * public function getLabel()
+ * {
+ *     return $this->_label;
+ * }
+ *
+ * public function setLabel($value)
+ * {
+ *     $this->_label = $value;
+ * }
+ * ```
+ *
+ * Property names are *case-insensitive*.
+ *
+ * A property can be accessed like a member variable of an object. Reading or writing a property will cause the invocation
+ * of the corresponding getter or setter method. For example,
+ *
+ * ```php
+ * // equivalent to $label = $object->getLabel();
+ * $label = $object->label;
+ * // equivalent to $object->setLabel('abc');
+ * $object->label = 'abc';
+ * ```
+ *
+ * If a property has only a getter method and has no setter method, it is considered as *read-only*. In this case, trying
+ * to modify the property value will cause an exception.
+ *
+ * One can call [[hasProperty()]], [[canGetProperty()]] and/or [[canSetProperty()]] to check the existence of a property.
+ *
+ * Besides the property feature, BaseObject also introduces an important object initialization life cycle. In particular,
+ * creating an new instance of BaseObject or its derived class will involve the following life cycles sequentially:
+ *
+ * 1. the class constructor is invoked;
+ * 2. object properties are initialized according to the given configuration;
+ * 3. the `init()` method is invoked.
+ *
+ * In the above, both Step 2 and 3 occur at the end of the class constructor. It is recommended that
+ * you perform object initialization in the `init()` method because at that stage, the object configuration
+ * is already applied.
+ *
+ * In order to ensure the above life cycles, if a child class of BaseObject needs to override the constructor,
+ * it should be done like the following:
+ *
+ * ```php
+ * public function __construct($param1, $param2, ..., $config = [])
+ * {
+ *     ...
+ *     parent::__construct($config);
+ * }
+ * ```
+ *
+ * That is, a `$config` parameter (defaults to `[]`) should be declared as the last parameter
+ * of the constructor, and the parent implementation should be called at the end of the constructor.
+ *
+ * @author Qiang Xue <qiang.xue@gmail.com>
+ * @since 2.0.13
+ */
+class BaseObject implements Configurable
+{
+    /**
+     * Returns the fully qualified name of this class.
+     * @return string the fully qualified name of this class.
+     * @deprecated since 2.0.14. On PHP >=5.5, use `::class` instead.
+     */
+    public static function className()
+    {
+        return get_called_class();
+    }
+
+    /**
+     * Constructor.
+     *
+     * The default implementation does two things:
+     *
+     * - Initializes the object with the given configuration `$config`.
+     * - Call [[init()]].
+     *
+     * If this method is overridden in a child class, it is recommended that
+     *
+     * - the last parameter of the constructor is a configuration array, like `$config` here.
+     * - call the parent implementation at the end of the constructor.
+     *
+     * @param array $config name-value pairs that will be used to initialize the object properties
+     */
+    public function __construct($config = [])
+    {
+        if (!empty($config)) {
+            Yii::configure($this, $config);
+        }
+        $this->init();
+    }
+
+    /**
+     * Initializes the object.
+     * This method is invoked at the end of the constructor after the object is initialized with the
+     * given configuration.
+     */
+    public function init()
+    {
+    }
+
+    /**
+     * Returns the value of an object property.
+     *
+     * Do not call this method directly as it is a PHP magic method that
+     * will be implicitly called when executing `$value = $object->property;`.
+     * @param string $name the property name
+     * @return mixed the property value
+     * @throws UnknownPropertyException if the property is not defined
+     * @throws InvalidCallException if the property is write-only
+     * @see __set()
+     */
+    public function __get($name)
+    {
+        $getter = 'get' . $name;
+        if (method_exists($this, $getter)) {
+            return $this->$getter();
+        } elseif (method_exists($this, 'set' . $name)) {
+            throw new InvalidCallException('Getting write-only property: ' . get_class($this) . '::' . $name);
+        }
+
+        throw new UnknownPropertyException('Getting unknown property: ' . get_class($this) . '::' . $name);
+    }
+
+    /**
+     * Sets value of an object property.
+     *
+     * Do not call this method directly as it is a PHP magic method that
+     * will be implicitly called when executing `$object->property = $value;`.
+     * @param string $name the property name or the event name
+     * @param mixed $value the property value
+     * @throws UnknownPropertyException if the property is not defined
+     * @throws InvalidCallException if the property is read-only
+     * @see __get()
+     */
+    public function __set($name, $value)
+    {
+        $setter = 'set' . $name;
+        if (method_exists($this, $setter)) {
+            $this->$setter($value);
+        } elseif (method_exists($this, 'get' . $name)) {
+            throw new InvalidCallException('Setting read-only property: ' . get_class($this) . '::' . $name);
+        } else {
+            throw new UnknownPropertyException('Setting unknown property: ' . get_class($this) . '::' . $name);
+        }
+    }
+
+    /**
+     * Checks if a property is set, i.e. defined and not null.
+     *
+     * Do not call this method directly as it is a PHP magic method that
+     * will be implicitly called when executing `isset($object->property)`.
+     *
+     * Note that if the property is not defined, false will be returned.
+     * @param string $name the property name or the event name
+     * @return bool whether the named property is set (not null).
+     * @see https://secure.php.net/manual/en/function.isset.php
+     */
+    public function __isset($name)
+    {
+        $getter = 'get' . $name;
+        if (method_exists($this, $getter)) {
+            return $this->$getter() !== null;
+        }
+
+        return false;
+    }
+
+    /**
+     * Sets an object property to null.
+     *
+     * Do not call this method directly as it is a PHP magic method that
+     * will be implicitly called when executing `unset($object->property)`.
+     *
+     * Note that if the property is not defined, this method will do nothing.
+     * If the property is read-only, it will throw an exception.
+     * @param string $name the property name
+     * @throws InvalidCallException if the property is read only.
+     * @see https://secure.php.net/manual/en/function.unset.php
+     */
+    public function __unset($name)
+    {
+        $setter = 'set' . $name;
+        if (method_exists($this, $setter)) {
+            $this->$setter(null);
+        } elseif (method_exists($this, 'get' . $name)) {
+            throw new InvalidCallException('Unsetting read-only property: ' . get_class($this) . '::' . $name);
+        }
+    }
+
+    /**
+     * Calls the named method which is not a class method.
+     *
+     * Do not call this method directly as it is a PHP magic method that
+     * will be implicitly called when an unknown method is being invoked.
+     * @param string $name the method name
+     * @param array $params method parameters
+     * @throws UnknownMethodException when calling unknown method
+     * @return mixed the method return value
+     */
+    public function __call($name, $params)
+    {
+        throw new UnknownMethodException('Calling unknown method: ' . get_class($this) . "::$name()");
+    }
+
+    /**
+     * Returns a value indicating whether a property is defined.
+     *
+     * A property is defined if:
+     *
+     * - the class has a getter or setter method associated with the specified name
+     *   (in this case, property name is case-insensitive);
+     * - the class has a member variable with the specified name (when `$checkVars` is true);
+     *
+     * @param string $name the property name
+     * @param bool $checkVars whether to treat member variables as properties
+     * @return bool whether the property is defined
+     * @see canGetProperty()
+     * @see canSetProperty()
+     */
+    public function hasProperty($name, $checkVars = true)
+    {
+        return $this->canGetProperty($name, $checkVars) || $this->canSetProperty($name, false);
+    }
+
+    /**
+     * Returns a value indicating whether a property can be read.
+     *
+     * A property is readable if:
+     *
+     * - the class has a getter method associated with the specified name
+     *   (in this case, property name is case-insensitive);
+     * - the class has a member variable with the specified name (when `$checkVars` is true);
+     *
+     * @param string $name the property name
+     * @param bool $checkVars whether to treat member variables as properties
+     * @return bool whether the property can be read
+     * @see canSetProperty()
+     */
+    public function canGetProperty($name, $checkVars = true)
+    {
+        return method_exists($this, 'get' . $name) || $checkVars && property_exists($this, $name);
+    }
+
+    /**
+     * Returns a value indicating whether a property can be set.
+     *
+     * A property is writable if:
+     *
+     * - the class has a setter method associated with the specified name
+     *   (in this case, property name is case-insensitive);
+     * - the class has a member variable with the specified name (when `$checkVars` is true);
+     *
+     * @param string $name the property name
+     * @param bool $checkVars whether to treat member variables as properties
+     * @return bool whether the property can be written
+     * @see canGetProperty()
+     */
+    public function canSetProperty($name, $checkVars = true)
+    {
+        return method_exists($this, 'set' . $name) || $checkVars && property_exists($this, $name);
+    }
+
+    /**
+     * Returns a value indicating whether a method is defined.
+     *
+     * The default implementation is a call to php function `method_exists()`.
+     * You may override this method when you implemented the php magic method `__call()`.
+     * @param string $name the method name
+     * @return bool whether the method is defined
+     */
+    public function hasMethod($name)
+    {
+        return method_exists($this, $name);
+    }
+}

--- a/lib/WorseReflection/Tests/Benchmarks/fixtures/yii/Component.php.test
+++ b/lib/WorseReflection/Tests/Benchmarks/fixtures/yii/Component.php.test
@@ -1,0 +1,766 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace Phpactor\WorseReflection\Tests\Workspace;
+
+use Yii;
+use yii\helpers\StringHelper;
+
+/**
+ * Component is the base class that implements the *property*, *event* and *behavior* features.
+ *
+ * Component provides the *event* and *behavior* features, in addition to the *property* feature which is implemented in
+ * its parent class [[\yii\base\BaseObject|BaseObject]].
+ *
+ * Event is a way to "inject" custom code into existing code at certain places. For example, a comment object can trigger
+ * an "add" event when the user adds a comment. We can write custom code and attach it to this event so that when the event
+ * is triggered (i.e. comment will be added), our custom code will be executed.
+ *
+ * An event is identified by a name that should be unique within the class it is defined at. Event names are *case-sensitive*.
+ *
+ * One or multiple PHP callbacks, called *event handlers*, can be attached to an event. You can call [[trigger()]] to
+ * raise an event. When an event is raised, the event handlers will be invoked automatically in the order they were
+ * attached.
+ *
+ * To attach an event handler to an event, call [[on()]]:
+ *
+ * ```php
+ * $post->on('update', function ($event) {
+ *     // send email notification
+ * });
+ * ```
+ *
+ * In the above, an anonymous function is attached to the "update" event of the post. You may attach
+ * the following types of event handlers:
+ *
+ * - anonymous function: `function ($event) { ... }`
+ * - object method: `[$object, 'handleAdd']`
+ * - static class method: `['Page', 'handleAdd']`
+ * - global function: `'handleAdd'`
+ *
+ * The signature of an event handler should be like the following:
+ *
+ * ```php
+ * function foo($event)
+ * ```
+ *
+ * where `$event` is an [[Event]] object which includes parameters associated with the event.
+ *
+ * You can also attach a handler to an event when configuring a component with a configuration array.
+ * The syntax is like the following:
+ *
+ * ```php
+ * [
+ *     'on add' => function ($event) { ... }
+ * ]
+ * ```
+ *
+ * where `on add` stands for attaching an event to the `add` event.
+ *
+ * Sometimes, you may want to associate extra data with an event handler when you attach it to an event
+ * and then access it when the handler is invoked. You may do so by
+ *
+ * ```php
+ * $post->on('update', function ($event) {
+ *     // the data can be accessed via $event->data
+ * }, $data);
+ * ```
+ *
+ * A behavior is an instance of [[Behavior]] or its child class. A component can be attached with one or multiple
+ * behaviors. When a behavior is attached to a component, its public properties and methods can be accessed via the
+ * component directly, as if the component owns those properties and methods.
+ *
+ * To attach a behavior to a component, declare it in [[behaviors()]], or explicitly call [[attachBehavior]]. Behaviors
+ * declared in [[behaviors()]] are automatically attached to the corresponding component.
+ *
+ * One can also attach a behavior to a component when configuring it with a configuration array. The syntax is like the
+ * following:
+ *
+ * ```php
+ * [
+ *     'as tree' => [
+ *         'class' => 'Tree',
+ *     ],
+ * ]
+ * ```
+ *
+ * where `as tree` stands for attaching a behavior named `tree`, and the array will be passed to [[\Yii::createObject()]]
+ * to create the behavior object.
+ *
+ * For more details and usage information on Component, see the [guide article on components](guide:concept-components).
+ *
+ * @property Behavior[] $behaviors List of behaviors attached to this component. This property is read-only.
+ *
+ * @author Qiang Xue <qiang.xue@gmail.com>
+ * @since 2.0
+ */
+class Component extends BaseObject
+{
+    /**
+     * @var array the attached event handlers (event name => handlers)
+     */
+    private $_events = [];
+    /**
+     * @var array the event handlers attached for wildcard patterns (event name wildcard => handlers)
+     * @since 2.0.14
+     */
+    private $_eventWildcards = [];
+    /**
+     * @var Behavior[]|null the attached behaviors (behavior name => behavior). This is `null` when not initialized.
+     */
+    private $_behaviors;
+
+
+    /**
+     * Returns the value of a component property.
+     *
+     * This method will check in the following order and act accordingly:
+     *
+     *  - a property defined by a getter: return the getter result
+     *  - a property of a behavior: return the behavior property value
+     *
+     * Do not call this method directly as it is a PHP magic method that
+     * will be implicitly called when executing `$value = $component->property;`.
+     * @param string $name the property name
+     * @return mixed the property value or the value of a behavior's property
+     * @throws UnknownPropertyException if the property is not defined
+     * @throws InvalidCallException if the property is write-only.
+     * @see __set()
+     */
+    public function __get($name)
+    {
+        $getter = 'get' . $name;
+        if (method_exists($this, $getter)) {
+            // read property, e.g. getName()
+            return $this->$getter();
+        }
+
+        // behavior property
+        $this->ensureBehaviors();
+        foreach ($this->_behaviors as $behavior) {
+            if ($behavior->canGetProperty($name)) {
+                return $behavior->$name;
+            }
+        }
+
+        if (method_exists($this, 'set' . $name)) {
+            throw new InvalidCallException('Getting write-only property: ' . get_class($this) . '::' . $name);
+        }
+
+        throw new UnknownPropertyException('Getting unknown property: ' . get_class($this) . '::' . $name);
+    }
+
+    /**
+     * Sets the value of a component property.
+     *
+     * This method will check in the following order and act accordingly:
+     *
+     *  - a property defined by a setter: set the property value
+     *  - an event in the format of "on xyz": attach the handler to the event "xyz"
+     *  - a behavior in the format of "as xyz": attach the behavior named as "xyz"
+     *  - a property of a behavior: set the behavior property value
+     *
+     * Do not call this method directly as it is a PHP magic method that
+     * will be implicitly called when executing `$component->property = $value;`.
+     * @param string $name the property name or the event name
+     * @param mixed $value the property value
+     * @throws UnknownPropertyException if the property is not defined
+     * @throws InvalidCallException if the property is read-only.
+     * @see __get()
+     */
+    public function __set($name, $value)
+    {
+        $setter = 'set' . $name;
+        if (method_exists($this, $setter)) {
+            // set property
+            $this->$setter($value);
+
+            return;
+        } elseif (strncmp($name, 'on ', 3) === 0) {
+            // on event: attach event handler
+            $this->on(trim(substr($name, 3)), $value);
+
+            return;
+        } elseif (strncmp($name, 'as ', 3) === 0) {
+            // as behavior: attach behavior
+            $name = trim(substr($name, 3));
+            $this->attachBehavior($name, $value instanceof Behavior ? $value : Yii::createObject($value));
+
+            return;
+        }
+
+        // behavior property
+        $this->ensureBehaviors();
+        foreach ($this->_behaviors as $behavior) {
+            if ($behavior->canSetProperty($name)) {
+                $behavior->$name = $value;
+                return;
+            }
+        }
+
+        if (method_exists($this, 'get' . $name)) {
+            throw new InvalidCallException('Setting read-only property: ' . get_class($this) . '::' . $name);
+        }
+
+        throw new UnknownPropertyException('Setting unknown property: ' . get_class($this) . '::' . $name);
+    }
+
+    /**
+     * Checks if a property is set, i.e. defined and not null.
+     *
+     * This method will check in the following order and act accordingly:
+     *
+     *  - a property defined by a setter: return whether the property is set
+     *  - a property of a behavior: return whether the property is set
+     *  - return `false` for non existing properties
+     *
+     * Do not call this method directly as it is a PHP magic method that
+     * will be implicitly called when executing `isset($component->property)`.
+     * @param string $name the property name or the event name
+     * @return bool whether the named property is set
+     * @see https://secure.php.net/manual/en/function.isset.php
+     */
+    public function __isset($name)
+    {
+        $getter = 'get' . $name;
+        if (method_exists($this, $getter)) {
+            return $this->$getter() !== null;
+        }
+
+        // behavior property
+        $this->ensureBehaviors();
+        foreach ($this->_behaviors as $behavior) {
+            if ($behavior->canGetProperty($name)) {
+                return $behavior->$name !== null;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Sets a component property to be null.
+     *
+     * This method will check in the following order and act accordingly:
+     *
+     *  - a property defined by a setter: set the property value to be null
+     *  - a property of a behavior: set the property value to be null
+     *
+     * Do not call this method directly as it is a PHP magic method that
+     * will be implicitly called when executing `unset($component->property)`.
+     * @param string $name the property name
+     * @throws InvalidCallException if the property is read only.
+     * @see https://secure.php.net/manual/en/function.unset.php
+     */
+    public function __unset($name)
+    {
+        $setter = 'set' . $name;
+        if (method_exists($this, $setter)) {
+            $this->$setter(null);
+            return;
+        }
+
+        // behavior property
+        $this->ensureBehaviors();
+        foreach ($this->_behaviors as $behavior) {
+            if ($behavior->canSetProperty($name)) {
+                $behavior->$name = null;
+                return;
+            }
+        }
+
+        throw new InvalidCallException('Unsetting an unknown or read-only property: ' . get_class($this) . '::' . $name);
+    }
+
+    /**
+     * Calls the named method which is not a class method.
+     *
+     * This method will check if any attached behavior has
+     * the named method and will execute it if available.
+     *
+     * Do not call this method directly as it is a PHP magic method that
+     * will be implicitly called when an unknown method is being invoked.
+     * @param string $name the method name
+     * @param array $params method parameters
+     * @return mixed the method return value
+     * @throws UnknownMethodException when calling unknown method
+     */
+    public function __call($name, $params)
+    {
+        $this->ensureBehaviors();
+        foreach ($this->_behaviors as $object) {
+            if ($object->hasMethod($name)) {
+                return call_user_func_array([$object, $name], $params);
+            }
+        }
+        throw new UnknownMethodException('Calling unknown method: ' . get_class($this) . "::$name()");
+    }
+
+    /**
+     * This method is called after the object is created by cloning an existing one.
+     * It removes all behaviors because they are attached to the old object.
+     */
+    public function __clone()
+    {
+        $this->_events = [];
+        $this->_eventWildcards = [];
+        $this->_behaviors = null;
+    }
+
+    /**
+     * Returns a value indicating whether a property is defined for this component.
+     *
+     * A property is defined if:
+     *
+     * - the class has a getter or setter method associated with the specified name
+     *   (in this case, property name is case-insensitive);
+     * - the class has a member variable with the specified name (when `$checkVars` is true);
+     * - an attached behavior has a property of the given name (when `$checkBehaviors` is true).
+     *
+     * @param string $name the property name
+     * @param bool $checkVars whether to treat member variables as properties
+     * @param bool $checkBehaviors whether to treat behaviors' properties as properties of this component
+     * @return bool whether the property is defined
+     * @see canGetProperty()
+     * @see canSetProperty()
+     */
+    public function hasProperty($name, $checkVars = true, $checkBehaviors = true)
+    {
+        return $this->canGetProperty($name, $checkVars, $checkBehaviors) || $this->canSetProperty($name, false, $checkBehaviors);
+    }
+
+    /**
+     * Returns a value indicating whether a property can be read.
+     *
+     * A property can be read if:
+     *
+     * - the class has a getter method associated with the specified name
+     *   (in this case, property name is case-insensitive);
+     * - the class has a member variable with the specified name (when `$checkVars` is true);
+     * - an attached behavior has a readable property of the given name (when `$checkBehaviors` is true).
+     *
+     * @param string $name the property name
+     * @param bool $checkVars whether to treat member variables as properties
+     * @param bool $checkBehaviors whether to treat behaviors' properties as properties of this component
+     * @return bool whether the property can be read
+     * @see canSetProperty()
+     */
+    public function canGetProperty($name, $checkVars = true, $checkBehaviors = true)
+    {
+        if (method_exists($this, 'get' . $name) || $checkVars && property_exists($this, $name)) {
+            return true;
+        } elseif ($checkBehaviors) {
+            $this->ensureBehaviors();
+            foreach ($this->_behaviors as $behavior) {
+                if ($behavior->canGetProperty($name, $checkVars)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns a value indicating whether a property can be set.
+     *
+     * A property can be written if:
+     *
+     * - the class has a setter method associated with the specified name
+     *   (in this case, property name is case-insensitive);
+     * - the class has a member variable with the specified name (when `$checkVars` is true);
+     * - an attached behavior has a writable property of the given name (when `$checkBehaviors` is true).
+     *
+     * @param string $name the property name
+     * @param bool $checkVars whether to treat member variables as properties
+     * @param bool $checkBehaviors whether to treat behaviors' properties as properties of this component
+     * @return bool whether the property can be written
+     * @see canGetProperty()
+     */
+    public function canSetProperty($name, $checkVars = true, $checkBehaviors = true)
+    {
+        if (method_exists($this, 'set' . $name) || $checkVars && property_exists($this, $name)) {
+            return true;
+        } elseif ($checkBehaviors) {
+            $this->ensureBehaviors();
+            foreach ($this->_behaviors as $behavior) {
+                if ($behavior->canSetProperty($name, $checkVars)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns a value indicating whether a method is defined.
+     *
+     * A method is defined if:
+     *
+     * - the class has a method with the specified name
+     * - an attached behavior has a method with the given name (when `$checkBehaviors` is true).
+     *
+     * @param string $name the property name
+     * @param bool $checkBehaviors whether to treat behaviors' methods as methods of this component
+     * @return bool whether the method is defined
+     */
+    public function hasMethod($name, $checkBehaviors = true)
+    {
+        if (method_exists($this, $name)) {
+            return true;
+        } elseif ($checkBehaviors) {
+            $this->ensureBehaviors();
+            foreach ($this->_behaviors as $behavior) {
+                if ($behavior->hasMethod($name)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns a list of behaviors that this component should behave as.
+     *
+     * Child classes may override this method to specify the behaviors they want to behave as.
+     *
+     * The return value of this method should be an array of behavior objects or configurations
+     * indexed by behavior names. A behavior configuration can be either a string specifying
+     * the behavior class or an array of the following structure:
+     *
+     * ```php
+     * 'behaviorName' => [
+     *     'class' => 'BehaviorClass',
+     *     'property1' => 'value1',
+     *     'property2' => 'value2',
+     * ]
+     * ```
+     *
+     * Note that a behavior class must extend from [[Behavior]]. Behaviors can be attached using a name or anonymously.
+     * When a name is used as the array key, using this name, the behavior can later be retrieved using [[getBehavior()]]
+     * or be detached using [[detachBehavior()]]. Anonymous behaviors can not be retrieved or detached.
+     *
+     * Behaviors declared in this method will be attached to the component automatically (on demand).
+     *
+     * @return array the behavior configurations.
+     */
+    public function behaviors()
+    {
+        return [];
+    }
+
+    /**
+     * Returns a value indicating whether there is any handler attached to the named event.
+     * @param string $name the event name
+     * @return bool whether there is any handler attached to the event.
+     */
+    public function hasEventHandlers($name)
+    {
+        $this->ensureBehaviors();
+
+        foreach ($this->_eventWildcards as $wildcard => $handlers) {
+            if (!empty($handlers) && StringHelper::matchWildcard($wildcard, $name)) {
+                return true;
+            }
+        }
+
+        return !empty($this->_events[$name]) || Event::hasHandlers($this, $name);
+    }
+
+    /**
+     * Attaches an event handler to an event.
+     *
+     * The event handler must be a valid PHP callback. The following are
+     * some examples:
+     *
+     * ```
+     * function ($event) { ... }         // anonymous function
+     * [$object, 'handleClick']          // $object->handleClick()
+     * ['Page', 'handleClick']           // Page::handleClick()
+     * 'handleClick'                     // global function handleClick()
+     * ```
+     *
+     * The event handler must be defined with the following signature,
+     *
+     * ```
+     * function ($event)
+     * ```
+     *
+     * where `$event` is an [[Event]] object which includes parameters associated with the event.
+     *
+     * Since 2.0.14 you can specify event name as a wildcard pattern:
+     *
+     * ```php
+     * $component->on('event.group.*', function ($event) {
+     *     Yii::trace($event->name . ' is triggered.');
+     * });
+     * ```
+     *
+     * @param string $name the event name
+     * @param callable $handler the event handler
+     * @param mixed $data the data to be passed to the event handler when the event is triggered.
+     * When the event handler is invoked, this data can be accessed via [[Event::data]].
+     * @param bool $append whether to append new event handler to the end of the existing
+     * handler list. If false, the new handler will be inserted at the beginning of the existing
+     * handler list.
+     * @see off()
+     */
+    public function on($name, $handler, $data = null, $append = true)
+    {
+        $this->ensureBehaviors();
+
+        if (strpos($name, '*') !== false) {
+            if ($append || empty($this->_eventWildcards[$name])) {
+                $this->_eventWildcards[$name][] = [$handler, $data];
+            } else {
+                array_unshift($this->_eventWildcards[$name], [$handler, $data]);
+            }
+            return;
+        }
+
+        if ($append || empty($this->_events[$name])) {
+            $this->_events[$name][] = [$handler, $data];
+        } else {
+            array_unshift($this->_events[$name], [$handler, $data]);
+        }
+    }
+
+    /**
+     * Detaches an existing event handler from this component.
+     *
+     * This method is the opposite of [[on()]].
+     *
+     * Note: in case wildcard pattern is passed for event name, only the handlers registered with this
+     * wildcard will be removed, while handlers registered with plain names matching this wildcard will remain.
+     *
+     * @param string $name event name
+     * @param callable $handler the event handler to be removed.
+     * If it is null, all handlers attached to the named event will be removed.
+     * @return bool if a handler is found and detached
+     * @see on()
+     */
+    public function off($name, $handler = null)
+    {
+        $this->ensureBehaviors();
+        if (empty($this->_events[$name]) && empty($this->_eventWildcards[$name])) {
+            return false;
+        }
+        if ($handler === null) {
+            unset($this->_events[$name], $this->_eventWildcards[$name]);
+            return true;
+        }
+
+        $removed = false;
+        // plain event names
+        if (isset($this->_events[$name])) {
+            foreach ($this->_events[$name] as $i => $event) {
+                if ($event[0] === $handler) {
+                    unset($this->_events[$name][$i]);
+                    $removed = true;
+                }
+            }
+            if ($removed) {
+                $this->_events[$name] = array_values($this->_events[$name]);
+                return $removed;
+            }
+        }
+
+        // wildcard event names
+        if (isset($this->_eventWildcards[$name])) {
+            foreach ($this->_eventWildcards[$name] as $i => $event) {
+                if ($event[0] === $handler) {
+                    unset($this->_eventWildcards[$name][$i]);
+                    $removed = true;
+                }
+            }
+            if ($removed) {
+                $this->_eventWildcards[$name] = array_values($this->_eventWildcards[$name]);
+                // remove empty wildcards to save future redundant regex checks:
+                if (empty($this->_eventWildcards[$name])) {
+                    unset($this->_eventWildcards[$name]);
+                }
+            }
+        }
+
+        return $removed;
+    }
+
+    /**
+     * Triggers an event.
+     * This method represents the happening of an event. It invokes
+     * all attached handlers for the event including class-level handlers.
+     * @param string $name the event name
+     * @param Event $event the event parameter. If not set, a default [[Event]] object will be created.
+     */
+    public function trigger($name, Event $event = null)
+    {
+        $this->ensureBehaviors();
+
+        $eventHandlers = [];
+        foreach ($this->_eventWildcards as $wildcard => $handlers) {
+            if (StringHelper::matchWildcard($wildcard, $name)) {
+                $eventHandlers = array_merge($eventHandlers, $handlers);
+            }
+        }
+
+        if (!empty($this->_events[$name])) {
+            $eventHandlers = array_merge($eventHandlers, $this->_events[$name]);
+        }
+
+        if (!empty($eventHandlers)) {
+            if ($event === null) {
+                $event = new Event();
+            }
+            if ($event->sender === null) {
+                $event->sender = $this;
+            }
+            $event->handled = false;
+            $event->name = $name;
+            foreach ($eventHandlers as $handler) {
+                $event->data = $handler[1];
+                call_user_func($handler[0], $event);
+                // stop further handling if the event is handled
+                if ($event->handled) {
+                    return;
+                }
+            }
+        }
+
+        // invoke class-level attached handlers
+        Event::trigger($this, $name, $event);
+    }
+
+    /**
+     * Returns the named behavior object.
+     * @param string $name the behavior name
+     * @return null|Behavior the behavior object, or null if the behavior does not exist
+     */
+    public function getBehavior($name)
+    {
+        $this->ensureBehaviors();
+        return isset($this->_behaviors[$name]) ? $this->_behaviors[$name] : null;
+    }
+
+    /**
+     * Returns all behaviors attached to this component.
+     * @return Behavior[] list of behaviors attached to this component
+     */
+    public function getBehaviors()
+    {
+        $this->ensureBehaviors();
+        return $this->_behaviors;
+    }
+
+    /**
+     * Attaches a behavior to this component.
+     * This method will create the behavior object based on the given
+     * configuration. After that, the behavior object will be attached to
+     * this component by calling the [[Behavior::attach()]] method.
+     * @param string $name the name of the behavior.
+     * @param string|array|Behavior $behavior the behavior configuration. This can be one of the following:
+     *
+     *  - a [[Behavior]] object
+     *  - a string specifying the behavior class
+     *  - an object configuration array that will be passed to [[Yii::createObject()]] to create the behavior object.
+     *
+     * @return Behavior the behavior object
+     * @see detachBehavior()
+     */
+    public function attachBehavior($name, $behavior)
+    {
+        $this->ensureBehaviors();
+        return $this->attachBehaviorInternal($name, $behavior);
+    }
+
+    /**
+     * Attaches a list of behaviors to the component.
+     * Each behavior is indexed by its name and should be a [[Behavior]] object,
+     * a string specifying the behavior class, or an configuration array for creating the behavior.
+     * @param array $behaviors list of behaviors to be attached to the component
+     * @see attachBehavior()
+     */
+    public function attachBehaviors($behaviors)
+    {
+        $this->ensureBehaviors();
+        foreach ($behaviors as $name => $behavior) {
+            $this->attachBehaviorInternal($name, $behavior);
+        }
+    }
+
+    /**
+     * Detaches a behavior from the component.
+     * The behavior's [[Behavior::detach()]] method will be invoked.
+     * @param string $name the behavior's name.
+     * @return null|Behavior the detached behavior. Null if the behavior does not exist.
+     */
+    public function detachBehavior($name)
+    {
+        $this->ensureBehaviors();
+        if (isset($this->_behaviors[$name])) {
+            $behavior = $this->_behaviors[$name];
+            unset($this->_behaviors[$name]);
+            $behavior->detach();
+            return $behavior;
+        }
+
+        return null;
+    }
+
+    /**
+     * Detaches all behaviors from the component.
+     */
+    public function detachBehaviors()
+    {
+        $this->ensureBehaviors();
+        foreach ($this->_behaviors as $name => $behavior) {
+            $this->detachBehavior($name);
+        }
+    }
+
+    /**
+     * Makes sure that the behaviors declared in [[behaviors()]] are attached to this component.
+     */
+    public function ensureBehaviors()
+    {
+        if ($this->_behaviors === null) {
+            $this->_behaviors = [];
+            foreach ($this->behaviors() as $name => $behavior) {
+                $this->attachBehaviorInternal($name, $behavior);
+            }
+        }
+    }
+
+    /**
+     * Attaches a behavior to this component.
+     * @param string|int $name the name of the behavior. If this is an integer, it means the behavior
+     * is an anonymous one. Otherwise, the behavior is a named one and any existing behavior with the same name
+     * will be detached first.
+     * @param string|array|Behavior $behavior the behavior to be attached
+     * @return Behavior the attached behavior.
+     */
+    private function attachBehaviorInternal($name, $behavior)
+    {
+        if (!($behavior instanceof Behavior)) {
+            $behavior = Yii::createObject($behavior);
+        }
+        if (is_int($name)) {
+            $behavior->attach($this);
+            $this->_behaviors[] = $behavior;
+        } else {
+            if (isset($this->_behaviors[$name])) {
+                $this->_behaviors[$name]->detach();
+            }
+            $behavior->attach($this);
+            $this->_behaviors[$name] = $behavior;
+        }
+
+        return $behavior;
+    }
+}
+

--- a/lib/WorseReflection/Tests/Benchmarks/fixtures/yii/Model.php.test
+++ b/lib/WorseReflection/Tests/Benchmarks/fixtures/yii/Model.php.test
@@ -1,0 +1,1052 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace Phpactor\WorseReflection\Tests\Workspace;
+
+use ArrayAccess;
+use ArrayIterator;
+use ArrayObject;
+use IteratorAggregate;
+use ReflectionClass;
+use Yii;
+use yii\helpers\Inflector;
+use yii\validators\RequiredValidator;
+use yii\validators\Validator;
+
+/**
+ * Model is the base class for data models.
+ *
+ * Model implements the following commonly used features:
+ *
+ * - attribute declaration: by default, every public class member is considered as
+ *   a model attribute
+ * - attribute labels: each attribute may be associated with a label for display purpose
+ * - massive attribute assignment
+ * - scenario-based validation
+ *
+ * Model also raises the following events when performing data validation:
+ *
+ * - [[EVENT_BEFORE_VALIDATE]]: an event raised at the beginning of [[validate()]]
+ * - [[EVENT_AFTER_VALIDATE]]: an event raised at the end of [[validate()]]
+ *
+ * You may directly use Model to store model data, or extend it with customization.
+ *
+ * For more details and usage information on Model, see the [guide article on models](guide:structure-models).
+ *
+ * @property \yii\validators\Validator[] $activeValidators The validators applicable to the current
+ * [[scenario]]. This property is read-only.
+ * @property array $attributes Attribute values (name => value).
+ * @property array $errors An array of errors for all attributes. Empty array is returned if no error. The
+ * result is a two-dimensional array. See [[getErrors()]] for detailed description. This property is read-only.
+ * @property array $firstErrors The first errors. The array keys are the attribute names, and the array values
+ * are the corresponding error messages. An empty array will be returned if there is no error. This property is
+ * read-only.
+ * @property ArrayIterator $iterator An iterator for traversing the items in the list. This property is
+ * read-only.
+ * @property string $scenario The scenario that this model is in. Defaults to [[SCENARIO_DEFAULT]].
+ * @property ArrayObject|\yii\validators\Validator[] $validators All the validators declared in the model.
+ * This property is read-only.
+ *
+ * @author Qiang Xue <qiang.xue@gmail.com>
+ * @since 2.0
+ */
+class Model extends Component implements StaticInstanceInterface, IteratorAggregate, ArrayAccess, Arrayable
+{
+    use ArrayableTrait;
+    use StaticInstanceTrait;
+
+    /**
+     * The name of the default scenario.
+     */
+    const SCENARIO_DEFAULT = 'default';
+    /**
+     * @event ModelEvent an event raised at the beginning of [[validate()]]. You may set
+     * [[ModelEvent::isValid]] to be false to stop the validation.
+     */
+    const EVENT_BEFORE_VALIDATE = 'beforeValidate';
+    /**
+     * @event Event an event raised at the end of [[validate()]]
+     */
+    const EVENT_AFTER_VALIDATE = 'afterValidate';
+
+    /**
+     * @var array validation errors (attribute name => array of errors)
+     */
+    private $_errors;
+    /**
+     * @var ArrayObject list of validators
+     */
+    private $_validators;
+    /**
+     * @var string current scenario
+     */
+    private $_scenario = self::SCENARIO_DEFAULT;
+
+
+    /**
+     * Returns the validation rules for attributes.
+     *
+     * Validation rules are used by [[validate()]] to check if attribute values are valid.
+     * Child classes may override this method to declare different validation rules.
+     *
+     * Each rule is an array with the following structure:
+     *
+     * ```php
+     * [
+     *     ['attribute1', 'attribute2'],
+     *     'validator type',
+     *     'on' => ['scenario1', 'scenario2'],
+     *     //...other parameters...
+     * ]
+     * ```
+     *
+     * where
+     *
+     *  - attribute list: required, specifies the attributes array to be validated, for single attribute you can pass a string;
+     *  - validator type: required, specifies the validator to be used. It can be a built-in validator name,
+     *    a method name of the model class, an anonymous function, or a validator class name.
+     *  - on: optional, specifies the [[scenario|scenarios]] array in which the validation
+     *    rule can be applied. If this option is not set, the rule will apply to all scenarios.
+     *  - additional name-value pairs can be specified to initialize the corresponding validator properties.
+     *    Please refer to individual validator class API for possible properties.
+     *
+     * A validator can be either an object of a class extending [[Validator]], or a model class method
+     * (called *inline validator*) that has the following signature:
+     *
+     * ```php
+     * // $params refers to validation parameters given in the rule
+     * function validatorName($attribute, $params)
+     * ```
+     *
+     * In the above `$attribute` refers to the attribute currently being validated while `$params` contains an array of
+     * validator configuration options such as `max` in case of `string` validator. The value of the attribute currently being validated
+     * can be accessed as `$this->$attribute`. Note the `$` before `attribute`; this is taking the value of the variable
+     * `$attribute` and using it as the name of the property to access.
+     *
+     * Yii also provides a set of [[Validator::builtInValidators|built-in validators]].
+     * Each one has an alias name which can be used when specifying a validation rule.
+     *
+     * Below are some examples:
+     *
+     * ```php
+     * [
+     *     // built-in "required" validator
+     *     [['username', 'password'], 'required'],
+     *     // built-in "string" validator customized with "min" and "max" properties
+     *     ['username', 'string', 'min' => 3, 'max' => 12],
+     *     // built-in "compare" validator that is used in "register" scenario only
+     *     ['password', 'compare', 'compareAttribute' => 'password2', 'on' => 'register'],
+     *     // an inline validator defined via the "authenticate()" method in the model class
+     *     ['password', 'authenticate', 'on' => 'login'],
+     *     // a validator of class "DateRangeValidator"
+     *     ['dateRange', 'DateRangeValidator'],
+     * ];
+     * ```
+     *
+     * Note, in order to inherit rules defined in the parent class, a child class needs to
+     * merge the parent rules with child rules using functions such as `array_merge()`.
+     *
+     * @return array validation rules
+     * @see scenarios()
+     */
+    public function rules()
+    {
+        return [];
+    }
+
+    /**
+     * Returns a list of scenarios and the corresponding active attributes.
+     *
+     * An active attribute is one that is subject to validation in the current scenario.
+     * The returned array should be in the following format:
+     *
+     * ```php
+     * [
+     *     'scenario1' => ['attribute11', 'attribute12', ...],
+     *     'scenario2' => ['attribute21', 'attribute22', ...],
+     *     ...
+     * ]
+     * ```
+     *
+     * By default, an active attribute is considered safe and can be massively assigned.
+     * If an attribute should NOT be massively assigned (thus considered unsafe),
+     * please prefix the attribute with an exclamation character (e.g. `'!rank'`).
+     *
+     * The default implementation of this method will return all scenarios found in the [[rules()]]
+     * declaration. A special scenario named [[SCENARIO_DEFAULT]] will contain all attributes
+     * found in the [[rules()]]. Each scenario will be associated with the attributes that
+     * are being validated by the validation rules that apply to the scenario.
+     *
+     * @return array a list of scenarios and the corresponding active attributes.
+     */
+    public function scenarios()
+    {
+        $scenarios = [self::SCENARIO_DEFAULT => []];
+        foreach ($this->getValidators() as $validator) {
+            foreach ($validator->on as $scenario) {
+                $scenarios[$scenario] = [];
+            }
+            foreach ($validator->except as $scenario) {
+                $scenarios[$scenario] = [];
+            }
+        }
+        $names = array_keys($scenarios);
+
+        foreach ($this->getValidators() as $validator) {
+            if (empty($validator->on) && empty($validator->except)) {
+                foreach ($names as $name) {
+                    foreach ($validator->attributes as $attribute) {
+                        $scenarios[$name][$attribute] = true;
+                    }
+                }
+            } elseif (empty($validator->on)) {
+                foreach ($names as $name) {
+                    if (!in_array($name, $validator->except, true)) {
+                        foreach ($validator->attributes as $attribute) {
+                            $scenarios[$name][$attribute] = true;
+                        }
+                    }
+                }
+            } else {
+                foreach ($validator->on as $name) {
+                    foreach ($validator->attributes as $attribute) {
+                        $scenarios[$name][$attribute] = true;
+                    }
+                }
+            }
+        }
+
+        foreach ($scenarios as $scenario => $attributes) {
+            if (!empty($attributes)) {
+                $scenarios[$scenario] = array_keys($attributes);
+            }
+        }
+
+        return $scenarios;
+    }
+
+    /**
+     * Returns the form name that this model class should use.
+     *
+     * The form name is mainly used by [[\yii\widgets\ActiveForm]] to determine how to name
+     * the input fields for the attributes in a model. If the form name is "A" and an attribute
+     * name is "b", then the corresponding input name would be "A[b]". If the form name is
+     * an empty string, then the input name would be "b".
+     *
+     * The purpose of the above naming schema is that for forms which contain multiple different models,
+     * the attributes of each model are grouped in sub-arrays of the POST-data and it is easier to
+     * differentiate between them.
+     *
+     * By default, this method returns the model class name (without the namespace part)
+     * as the form name. You may override it when the model is used in different forms.
+     *
+     * @return string the form name of this model class.
+     * @see load()
+     * @throws InvalidConfigException when form is defined with anonymous class and `formName()` method is
+     * not overridden.
+     */
+    public function formName()
+    {
+        $reflector = new ReflectionClass($this);
+        if (PHP_VERSION_ID >= 70000 && $reflector->isAnonymous()) {
+            throw new InvalidConfigException('The "formName()" method should be explicitly defined for anonymous models');
+        }
+        return $reflector->getShortName();
+    }
+
+    /**
+     * Returns the list of attribute names.
+     * By default, this method returns all public non-static properties of the class.
+     * You may override this method to change the default behavior.
+     * @return array list of attribute names.
+     */
+    public function attributes()
+    {
+        $class = new ReflectionClass($this);
+        $names = [];
+        foreach ($class->getProperties(\ReflectionProperty::IS_PUBLIC) as $property) {
+            if (!$property->isStatic()) {
+                $names[] = $property->getName();
+            }
+        }
+
+        return $names;
+    }
+
+    /**
+     * Returns the attribute labels.
+     *
+     * Attribute labels are mainly used for display purpose. For example, given an attribute
+     * `firstName`, we can declare a label `First Name` which is more user-friendly and can
+     * be displayed to end users.
+     *
+     * By default an attribute label is generated using [[generateAttributeLabel()]].
+     * This method allows you to explicitly specify attribute labels.
+     *
+     * Note, in order to inherit labels defined in the parent class, a child class needs to
+     * merge the parent labels with child labels using functions such as `array_merge()`.
+     *
+     * @return array attribute labels (name => label)
+     * @see generateAttributeLabel()
+     */
+    public function attributeLabels()
+    {
+        return [];
+    }
+
+    /**
+     * Returns the attribute hints.
+     *
+     * Attribute hints are mainly used for display purpose. For example, given an attribute
+     * `isPublic`, we can declare a hint `Whether the post should be visible for not logged in users`,
+     * which provides user-friendly description of the attribute meaning and can be displayed to end users.
+     *
+     * Unlike label hint will not be generated, if its explicit declaration is omitted.
+     *
+     * Note, in order to inherit hints defined in the parent class, a child class needs to
+     * merge the parent hints with child hints using functions such as `array_merge()`.
+     *
+     * @return array attribute hints (name => hint)
+     * @since 2.0.4
+     */
+    public function attributeHints()
+    {
+        return [];
+    }
+
+    /**
+     * Performs the data validation.
+     *
+     * This method executes the validation rules applicable to the current [[scenario]].
+     * The following criteria are used to determine whether a rule is currently applicable:
+     *
+     * - the rule must be associated with the attributes relevant to the current scenario;
+     * - the rules must be effective for the current scenario.
+     *
+     * This method will call [[beforeValidate()]] and [[afterValidate()]] before and
+     * after the actual validation, respectively. If [[beforeValidate()]] returns false,
+     * the validation will be cancelled and [[afterValidate()]] will not be called.
+     *
+     * Errors found during the validation can be retrieved via [[getErrors()]],
+     * [[getFirstErrors()]] and [[getFirstError()]].
+     *
+     * @param string[]|string $attributeNames attribute name or list of attribute names that should be validated.
+     * If this parameter is empty, it means any attribute listed in the applicable
+     * validation rules should be validated.
+     * @param bool $clearErrors whether to call [[clearErrors()]] before performing validation
+     * @return bool whether the validation is successful without any error.
+     * @throws InvalidArgumentException if the current scenario is unknown.
+     */
+    public function validate($attributeNames = null, $clearErrors = true)
+    {
+        if ($clearErrors) {
+            $this->clearErrors();
+        }
+
+        if (!$this->beforeValidate()) {
+            return false;
+        }
+
+        $scenarios = $this->scenarios();
+        $scenario = $this->getScenario();
+        if (!isset($scenarios[$scenario])) {
+            throw new InvalidArgumentException("Unknown scenario: $scenario");
+        }
+
+        if ($attributeNames === null) {
+            $attributeNames = $this->activeAttributes();
+        }
+
+        $attributeNames = (array)$attributeNames;
+
+        foreach ($this->getActiveValidators() as $validator) {
+            $validator->validateAttributes($this, $attributeNames);
+        }
+        $this->afterValidate();
+
+        return !$this->hasErrors();
+    }
+
+    /**
+     * This method is invoked before validation starts.
+     * The default implementation raises a `beforeValidate` event.
+     * You may override this method to do preliminary checks before validation.
+     * Make sure the parent implementation is invoked so that the event can be raised.
+     * @return bool whether the validation should be executed. Defaults to true.
+     * If false is returned, the validation will stop and the model is considered invalid.
+     */
+    public function beforeValidate()
+    {
+        $event = new ModelEvent();
+        $this->trigger(self::EVENT_BEFORE_VALIDATE, $event);
+
+        return $event->isValid;
+    }
+
+    /**
+     * This method is invoked after validation ends.
+     * The default implementation raises an `afterValidate` event.
+     * You may override this method to do postprocessing after validation.
+     * Make sure the parent implementation is invoked so that the event can be raised.
+     */
+    public function afterValidate()
+    {
+        $this->trigger(self::EVENT_AFTER_VALIDATE);
+    }
+
+    /**
+     * Returns all the validators declared in [[rules()]].
+     *
+     * This method differs from [[getActiveValidators()]] in that the latter
+     * only returns the validators applicable to the current [[scenario]].
+     *
+     * Because this method returns an ArrayObject object, you may
+     * manipulate it by inserting or removing validators (useful in model behaviors).
+     * For example,
+     *
+     * ```php
+     * $model->validators[] = $newValidator;
+     * ```
+     *
+     * @return ArrayObject|\yii\validators\Validator[] all the validators declared in the model.
+     */
+    public function getValidators()
+    {
+        if ($this->_validators === null) {
+            $this->_validators = $this->createValidators();
+        }
+
+        return $this->_validators;
+    }
+
+    /**
+     * Returns the validators applicable to the current [[scenario]].
+     * @param string $attribute the name of the attribute whose applicable validators should be returned.
+     * If this is null, the validators for ALL attributes in the model will be returned.
+     * @return \yii\validators\Validator[] the validators applicable to the current [[scenario]].
+     */
+    public function getActiveValidators($attribute = null)
+    {
+        $activeAttributes = $this->activeAttributes();
+        if ($attribute !== null && !in_array($attribute, $activeAttributes, true)) {
+            return [];
+        }
+        $scenario = $this->getScenario();
+        $validators = [];
+        foreach ($this->getValidators() as $validator) {
+            if ($attribute === null) {
+                $validatorAttributes = $validator->getValidationAttributes($activeAttributes);
+                $attributeValid = !empty($validatorAttributes);
+            } else {
+                $attributeValid = in_array($attribute, $validator->getValidationAttributes($attribute), true);
+            }
+            if ($attributeValid && $validator->isActive($scenario)) {
+                $validators[] = $validator;
+            }
+        }
+
+        return $validators;
+    }
+
+    /**
+     * Creates validator objects based on the validation rules specified in [[rules()]].
+     * Unlike [[getValidators()]], each time this method is called, a new list of validators will be returned.
+     * @return ArrayObject validators
+     * @throws InvalidConfigException if any validation rule configuration is invalid
+     */
+    public function createValidators()
+    {
+        $validators = new ArrayObject();
+        foreach ($this->rules() as $rule) {
+            if ($rule instanceof Validator) {
+                $validators->append($rule);
+            } elseif (is_array($rule) && isset($rule[0], $rule[1])) { // attributes, validator type
+                $validator = Validator::createValidator($rule[1], $this, (array) $rule[0], array_slice($rule, 2));
+                $validators->append($validator);
+            } else {
+                throw new InvalidConfigException('Invalid validation rule: a rule must specify both attribute names and validator type.');
+            }
+        }
+
+        return $validators;
+    }
+
+    /**
+     * Returns a value indicating whether the attribute is required.
+     * This is determined by checking if the attribute is associated with a
+     * [[\yii\validators\RequiredValidator|required]] validation rule in the
+     * current [[scenario]].
+     *
+     * Note that when the validator has a conditional validation applied using
+     * [[\yii\validators\RequiredValidator::$when|$when]] this method will return
+     * `false` regardless of the `when` condition because it may be called be
+     * before the model is loaded with data.
+     *
+     * @param string $attribute attribute name
+     * @return bool whether the attribute is required
+     */
+    public function isAttributeRequired($attribute)
+    {
+        foreach ($this->getActiveValidators($attribute) as $validator) {
+            if ($validator instanceof RequiredValidator && $validator->when === null) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns a value indicating whether the attribute is safe for massive assignments.
+     * @param string $attribute attribute name
+     * @return bool whether the attribute is safe for massive assignments
+     * @see safeAttributes()
+     */
+    public function isAttributeSafe($attribute)
+    {
+        return in_array($attribute, $this->safeAttributes(), true);
+    }
+
+    /**
+     * Returns a value indicating whether the attribute is active in the current scenario.
+     * @param string $attribute attribute name
+     * @return bool whether the attribute is active in the current scenario
+     * @see activeAttributes()
+     */
+    public function isAttributeActive($attribute)
+    {
+        return in_array($attribute, $this->activeAttributes(), true);
+    }
+
+    /**
+     * Returns the text label for the specified attribute.
+     * @param string $attribute the attribute name
+     * @return string the attribute label
+     * @see generateAttributeLabel()
+     * @see attributeLabels()
+     */
+    public function getAttributeLabel($attribute)
+    {
+        $labels = $this->attributeLabels();
+        return isset($labels[$attribute]) ? $labels[$attribute] : $this->generateAttributeLabel($attribute);
+    }
+
+    /**
+     * Returns the text hint for the specified attribute.
+     * @param string $attribute the attribute name
+     * @return string the attribute hint
+     * @see attributeHints()
+     * @since 2.0.4
+     */
+    public function getAttributeHint($attribute)
+    {
+        $hints = $this->attributeHints();
+        return isset($hints[$attribute]) ? $hints[$attribute] : '';
+    }
+
+    /**
+     * Returns a value indicating whether there is any validation error.
+     * @param string|null $attribute attribute name. Use null to check all attributes.
+     * @return bool whether there is any error.
+     */
+    public function hasErrors($attribute = null)
+    {
+        return $attribute === null ? !empty($this->_errors) : isset($this->_errors[$attribute]);
+    }
+
+    /**
+     * Returns the errors for all attributes or a single attribute.
+     * @param string $attribute attribute name. Use null to retrieve errors for all attributes.
+     * @property array An array of errors for all attributes. Empty array is returned if no error.
+     * The result is a two-dimensional array. See [[getErrors()]] for detailed description.
+     * @return array errors for all attributes or the specified attribute. Empty array is returned if no error.
+     * Note that when returning errors for all attributes, the result is a two-dimensional array, like the following:
+     *
+     * ```php
+     * [
+     *     'username' => [
+     *         'Username is required.',
+     *         'Username must contain only word characters.',
+     *     ],
+     *     'email' => [
+     *         'Email address is invalid.',
+     *     ]
+     * ]
+     * ```
+     *
+     * @see getFirstErrors()
+     * @see getFirstError()
+     */
+    public function getErrors($attribute = null)
+    {
+        if ($attribute === null) {
+            return $this->_errors === null ? [] : $this->_errors;
+        }
+
+        return isset($this->_errors[$attribute]) ? $this->_errors[$attribute] : [];
+    }
+
+    /**
+     * Returns the first error of every attribute in the model.
+     * @return array the first errors. The array keys are the attribute names, and the array
+     * values are the corresponding error messages. An empty array will be returned if there is no error.
+     * @see getErrors()
+     * @see getFirstError()
+     */
+    public function getFirstErrors()
+    {
+        if (empty($this->_errors)) {
+            return [];
+        }
+
+        $errors = [];
+        foreach ($this->_errors as $name => $es) {
+            if (!empty($es)) {
+                $errors[$name] = reset($es);
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Returns the first error of the specified attribute.
+     * @param string $attribute attribute name.
+     * @return string the error message. Null is returned if no error.
+     * @see getErrors()
+     * @see getFirstErrors()
+     */
+    public function getFirstError($attribute)
+    {
+        return isset($this->_errors[$attribute]) ? reset($this->_errors[$attribute]) : null;
+    }
+
+    /**
+     * Returns the errors for all attributes as a one-dimensional array.
+     * @param bool $showAllErrors boolean, if set to true every error message for each attribute will be shown otherwise
+     * only the first error message for each attribute will be shown.
+     * @return array errors for all attributes as a one-dimensional array. Empty array is returned if no error.
+     * @see getErrors()
+     * @see getFirstErrors()
+     * @since 2.0.14
+     */
+    public function getErrorSummary($showAllErrors)
+    {
+        $lines = [];
+        $errors = $showAllErrors ? $this->getErrors() : $this->getFirstErrors();
+        foreach ($errors as $es) {
+            $lines = array_merge((array)$es, $lines);
+        }
+        return $lines;
+    }
+
+    /**
+     * Adds a new error to the specified attribute.
+     * @param string $attribute attribute name
+     * @param string $error new error message
+     */
+    public function addError($attribute, $error = '')
+    {
+        $this->_errors[$attribute][] = $error;
+    }
+
+    /**
+     * Adds a list of errors.
+     * @param array $items a list of errors. The array keys must be attribute names.
+     * The array values should be error messages. If an attribute has multiple errors,
+     * these errors must be given in terms of an array.
+     * You may use the result of [[getErrors()]] as the value for this parameter.
+     * @since 2.0.2
+     */
+    public function addErrors(array $items)
+    {
+        foreach ($items as $attribute => $errors) {
+            if (is_array($errors)) {
+                foreach ($errors as $error) {
+                    $this->addError($attribute, $error);
+                }
+            } else {
+                $this->addError($attribute, $errors);
+            }
+        }
+    }
+
+    /**
+     * Removes errors for all attributes or a single attribute.
+     * @param string $attribute attribute name. Use null to remove errors for all attributes.
+     */
+    public function clearErrors($attribute = null)
+    {
+        if ($attribute === null) {
+            $this->_errors = [];
+        } else {
+            unset($this->_errors[$attribute]);
+        }
+    }
+
+    /**
+     * Generates a user friendly attribute label based on the give attribute name.
+     * This is done by replacing underscores, dashes and dots with blanks and
+     * changing the first letter of each word to upper case.
+     * For example, 'department_name' or 'DepartmentName' will generate 'Department Name'.
+     * @param string $name the column name
+     * @return string the attribute label
+     */
+    public function generateAttributeLabel($name)
+    {
+        return Inflector::camel2words($name, true);
+    }
+
+    /**
+     * Returns attribute values.
+     * @param array $names list of attributes whose value needs to be returned.
+     * Defaults to null, meaning all attributes listed in [[attributes()]] will be returned.
+     * If it is an array, only the attributes in the array will be returned.
+     * @param array $except list of attributes whose value should NOT be returned.
+     * @return array attribute values (name => value).
+     */
+    public function getAttributes($names = null, $except = [])
+    {
+        $values = [];
+        if ($names === null) {
+            $names = $this->attributes();
+        }
+        foreach ($names as $name) {
+            $values[$name] = $this->$name;
+        }
+        foreach ($except as $name) {
+            unset($values[$name]);
+        }
+
+        return $values;
+    }
+
+    /**
+     * Sets the attribute values in a massive way.
+     * @param array $values attribute values (name => value) to be assigned to the model.
+     * @param bool $safeOnly whether the assignments should only be done to the safe attributes.
+     * A safe attribute is one that is associated with a validation rule in the current [[scenario]].
+     * @see safeAttributes()
+     * @see attributes()
+     */
+    public function setAttributes($values, $safeOnly = true)
+    {
+        if (is_array($values)) {
+            $attributes = array_flip($safeOnly ? $this->safeAttributes() : $this->attributes());
+            foreach ($values as $name => $value) {
+                if (isset($attributes[$name])) {
+                    $this->$name = $value;
+                } elseif ($safeOnly) {
+                    $this->onUnsafeAttribute($name, $value);
+                }
+            }
+        }
+    }
+
+    /**
+     * This method is invoked when an unsafe attribute is being massively assigned.
+     * The default implementation will log a warning message if YII_DEBUG is on.
+     * It does nothing otherwise.
+     * @param string $name the unsafe attribute name
+     * @param mixed $value the attribute value
+     */
+    public function onUnsafeAttribute($name, $value)
+    {
+        if (YII_DEBUG) {
+            Yii::debug("Failed to set unsafe attribute '$name' in '" . get_class($this) . "'.", __METHOD__);
+        }
+    }
+
+    /**
+     * Returns the scenario that this model is used in.
+     *
+     * Scenario affects how validation is performed and which attributes can
+     * be massively assigned.
+     *
+     * @return string the scenario that this model is in. Defaults to [[SCENARIO_DEFAULT]].
+     */
+    public function getScenario()
+    {
+        return $this->_scenario;
+    }
+
+    /**
+     * Sets the scenario for the model.
+     * Note that this method does not check if the scenario exists or not.
+     * The method [[validate()]] will perform this check.
+     * @param string $value the scenario that this model is in.
+     */
+    public function setScenario($value)
+    {
+        $this->_scenario = $value;
+    }
+
+    /**
+     * Returns the attribute names that are safe to be massively assigned in the current scenario.
+     * @return string[] safe attribute names
+     */
+    public function safeAttributes()
+    {
+        $scenario = $this->getScenario();
+        $scenarios = $this->scenarios();
+        if (!isset($scenarios[$scenario])) {
+            return [];
+        }
+        $attributes = [];
+        foreach ($scenarios[$scenario] as $attribute) {
+            if (strncmp($attribute, '!', 1) !== 0 && !in_array('!' . $attribute, $scenarios[$scenario])) {
+                $attributes[] = $attribute;
+            }
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * Returns the attribute names that are subject to validation in the current scenario.
+     * @return string[] safe attribute names
+     */
+    public function activeAttributes()
+    {
+        $scenario = $this->getScenario();
+        $scenarios = $this->scenarios();
+        if (!isset($scenarios[$scenario])) {
+            return [];
+        }
+        $attributes = array_keys(array_flip($scenarios[$scenario]));
+        foreach ($attributes as $i => $attribute) {
+            if (strncmp($attribute, '!', 1) === 0) {
+                $attributes[$i] = substr($attribute, 1);
+            }
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * Populates the model with input data.
+     *
+     * This method provides a convenient shortcut for:
+     *
+     * ```php
+     * if (isset($_POST['FormName'])) {
+     *     $model->attributes = $_POST['FormName'];
+     *     if ($model->save()) {
+     *         // handle success
+     *     }
+     * }
+     * ```
+     *
+     * which, with `load()` can be written as:
+     *
+     * ```php
+     * if ($model->load($_POST) && $model->save()) {
+     *     // handle success
+     * }
+     * ```
+     *
+     * `load()` gets the `'FormName'` from the model's [[formName()]] method (which you may override), unless the
+     * `$formName` parameter is given. If the form name is empty, `load()` populates the model with the whole of `$data`,
+     * instead of `$data['FormName']`.
+     *
+     * Note, that the data being populated is subject to the safety check by [[setAttributes()]].
+     *
+     * @param array $data the data array to load, typically `$_POST` or `$_GET`.
+     * @param string $formName the form name to use to load the data into the model.
+     * If not set, [[formName()]] is used.
+     * @return bool whether `load()` found the expected form in `$data`.
+     */
+    public function load($data, $formName = null)
+    {
+        $scope = $formName === null ? $this->formName() : $formName;
+        if ($scope === '' && !empty($data)) {
+            $this->setAttributes($data);
+
+            return true;
+        } elseif (isset($data[$scope])) {
+            $this->setAttributes($data[$scope]);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Populates a set of models with the data from end user.
+     * This method is mainly used to collect tabular data input.
+     * The data to be loaded for each model is `$data[formName][index]`, where `formName`
+     * refers to the value of [[formName()]], and `index` the index of the model in the `$models` array.
+     * If [[formName()]] is empty, `$data[index]` will be used to populate each model.
+     * The data being populated to each model is subject to the safety check by [[setAttributes()]].
+     * @param array $models the models to be populated. Note that all models should have the same class.
+     * @param array $data the data array. This is usually `$_POST` or `$_GET`, but can also be any valid array
+     * supplied by end user.
+     * @param string $formName the form name to be used for loading the data into the models.
+     * If not set, it will use the [[formName()]] value of the first model in `$models`.
+     * This parameter is available since version 2.0.1.
+     * @return bool whether at least one of the models is successfully populated.
+     */
+    public static function loadMultiple($models, $data, $formName = null)
+    {
+        if ($formName === null) {
+            /* @var $first Model|false */
+            $first = reset($models);
+            if ($first === false) {
+                return false;
+            }
+            $formName = $first->formName();
+        }
+
+        $success = false;
+        foreach ($models as $i => $model) {
+            /* @var $model Model */
+            if ($formName == '') {
+                if (!empty($data[$i]) && $model->load($data[$i], '')) {
+                    $success = true;
+                }
+            } elseif (!empty($data[$formName][$i]) && $model->load($data[$formName][$i], '')) {
+                $success = true;
+            }
+        }
+
+        return $success;
+    }
+
+    /**
+     * Validates multiple models.
+     * This method will validate every model. The models being validated may
+     * be of the same or different types.
+     * @param array $models the models to be validated
+     * @param array $attributeNames list of attribute names that should be validated.
+     * If this parameter is empty, it means any attribute listed in the applicable
+     * validation rules should be validated.
+     * @return bool whether all models are valid. False will be returned if one
+     * or multiple models have validation error.
+     */
+    public static function validateMultiple($models, $attributeNames = null)
+    {
+        $valid = true;
+        /* @var $model Model */
+        foreach ($models as $model) {
+            $valid = $model->validate($attributeNames) && $valid;
+        }
+
+        return $valid;
+    }
+
+    /**
+     * Returns the list of fields that should be returned by default by [[toArray()]] when no specific fields are specified.
+     *
+     * A field is a named element in the returned array by [[toArray()]].
+     *
+     * This method should return an array of field names or field definitions.
+     * If the former, the field name will be treated as an object property name whose value will be used
+     * as the field value. If the latter, the array key should be the field name while the array value should be
+     * the corresponding field definition which can be either an object property name or a PHP callable
+     * returning the corresponding field value. The signature of the callable should be:
+     *
+     * ```php
+     * function ($model, $field) {
+     *     // return field value
+     * }
+     * ```
+     *
+     * For example, the following code declares four fields:
+     *
+     * - `email`: the field name is the same as the property name `email`;
+     * - `firstName` and `lastName`: the field names are `firstName` and `lastName`, and their
+     *   values are obtained from the `first_name` and `last_name` properties;
+     * - `fullName`: the field name is `fullName`. Its value is obtained by concatenating `first_name`
+     *   and `last_name`.
+     *
+     * ```php
+     * return [
+     *     'email',
+     *     'firstName' => 'first_name',
+     *     'lastName' => 'last_name',
+     *     'fullName' => function ($model) {
+     *         return $model->first_name . ' ' . $model->last_name;
+     *     },
+     * ];
+     * ```
+     *
+     * In this method, you may also want to return different lists of fields based on some context
+     * information. For example, depending on [[scenario]] or the privilege of the current application user,
+     * you may return different sets of visible fields or filter out some fields.
+     *
+     * The default implementation of this method returns [[attributes()]] indexed by the same attribute names.
+     *
+     * @return array the list of field names or field definitions.
+     * @see toArray()
+     */
+    public function fields()
+    {
+        $fields = $this->attributes();
+
+        return array_combine($fields, $fields);
+    }
+
+    /**
+     * Returns an iterator for traversing the attributes in the model.
+     * This method is required by the interface [[\IteratorAggregate]].
+     * @return ArrayIterator an iterator for traversing the items in the list.
+     */
+    public function getIterator()
+    {
+        $attributes = $this->getAttributes();
+        return new ArrayIterator($attributes);
+    }
+
+    /**
+     * Returns whether there is an element at the specified offset.
+     * This method is required by the SPL interface [[\ArrayAccess]].
+     * It is implicitly called when you use something like `isset($model[$offset])`.
+     * @param mixed $offset the offset to check on.
+     * @return bool whether or not an offset exists.
+     */
+    public function offsetExists($offset)
+    {
+        return isset($this->$offset);
+    }
+
+    /**
+     * Returns the element at the specified offset.
+     * This method is required by the SPL interface [[\ArrayAccess]].
+     * It is implicitly called when you use something like `$value = $model[$offset];`.
+     * @param mixed $offset the offset to retrieve element.
+     * @return mixed the element at the offset, null if no element is found at the offset
+     */
+    public function offsetGet($offset)
+    {
+        return $this->$offset;
+    }
+
+    /**
+     * Sets the element at the specified offset.
+     * This method is required by the SPL interface [[\ArrayAccess]].
+     * It is implicitly called when you use something like `$model[$offset] = $item;`.
+     * @param int $offset the offset to set element
+     * @param mixed $item the element value
+     */
+    public function offsetSet($offset, $item)
+    {
+        $this->$offset = $item;
+    }
+
+    /**
+     * Sets the element value at the specified offset to null.
+     * This method is required by the SPL interface [[\ArrayAccess]].
+     * It is implicitly called when you use something like `unset($model[$offset])`.
+     * @param mixed $offset the offset to unset element
+     */
+    public function offsetUnset($offset)
+    {
+        $this->$offset = null;
+    }
+}
+

--- a/lib/WorseReflection/Tests/Benchmarks/fixtures/yii/Record.php.test
+++ b/lib/WorseReflection/Tests/Benchmarks/fixtures/yii/Record.php.test
@@ -1,0 +1,21 @@
+<?php
+
+namespace Phpactor\WorseReflection\Tests\Workspace;
+
+use stdClass;
+
+/**
+ * Trash
+ *
+ * @property integer $id
+ * @property string $id2
+ * @property stdclass $id3
+ * @property bool $id4
+ * @property array $id5
+ * @property integer $id6
+ */
+class Record extends ActiveRecord
+{
+    const CONST_1 = '1';
+    const CONST_2 = '2';
+}

--- a/lib/WorseReflection/Tests/Benchmarks/fixtures/yii/StaticInstanceInterface.php.test
+++ b/lib/WorseReflection/Tests/Benchmarks/fixtures/yii/StaticInstanceInterface.php.test
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace Phpactor\WorseReflection\Tests\Workspace;
+
+/**
+ * StaticInstanceInterface is the interface for providing static instances to classes,
+ * which can be used to obtain class meta information that can not be expressed in static methods.
+ * For example: adjustments made by DI or behaviors reveal only at object level, but might be needed
+ * at class (static) level as well.
+ *
+ * To implement the [[instance()]] method you may use [[StaticInstanceTrait]].
+ *
+ * @author Paul Klimov <klimov.paul@gmail.com>
+ * @since 2.0.13
+ * @see StaticInstanceTrait
+ */
+interface StaticInstanceInterface
+{
+    /**
+     * Returns static class instance, which can be used to obtain meta information.
+     * @param bool $refresh whether to re-create static instance even, if it is already cached.
+     * @return static class instance.
+     */
+    public static function instance($refresh = false);
+}
+

--- a/lib/WorseReflection/Tests/Benchmarks/fixtures/yii/StaticInstanceTrait.php.test
+++ b/lib/WorseReflection/Tests/Benchmarks/fixtures/yii/StaticInstanceTrait.php.test
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace Phpactor\WorseReflection\Tests\Workspace;
+
+use Yii;
+
+/**
+ * StaticInstanceTrait provides methods to satisfy [[StaticInstanceInterface]] interface.
+ *
+ * @see StaticInstanceInterface
+ *
+ * @author Paul Klimov <klimov.paul@gmail.com>
+ * @since 2.0.13
+ */
+trait StaticInstanceTrait
+{
+    /**
+     * @var static[] static instances in format: `[className => object]`
+     */
+    private static $_instances = [];
+
+
+    /**
+     * Returns static class instance, which can be used to obtain meta information.
+     * @param bool $refresh whether to re-create static instance even, if it is already cached.
+     * @return static class instance.
+     */
+    public static function instance($refresh = false)
+    {
+        $className = get_called_class();
+        if ($refresh || !isset(self::$_instances[$className])) {
+            self::$_instances[$className] = Yii::createObject($className);
+        }
+        return self::$_instances[$className];
+    }
+}


### PR DESCRIPTION
- Adds a benchmark using the Yii ActiveRecord stack
- Add a cached docblock parser factory. It uses the standard WR cache (default to 5 second TTL),

```

\Phpactor\WorseReflection\Tests\Benchmarks\PhpUnitReflectClassBench

    test_case...............................I4 - [Mo0.9389μs vs. Mo0.9000μs] +4.33% (±8.13%)
    test_case_methods_and_properties........I4 ✔ [Mo10.96ms vs. Mo14.21ms] -22.83% (±10.99%)
    test_case_method_frames.................I4 ✔ [Mo0.28ms vs. Mo0.26ms] +8.16% (±5.81%)

\Phpactor\WorseReflection\Tests\Benchmarks\YiiBench

    benchMembers............................I0 - [Mo103.677ms vs. Mo193.790ms] -46.50% (±0.00%)
```