### PR TITLE
Property read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Improvements:
 
 Features:
 
+  - [wr] Support `@property-read`
   - [wr] Support for mixins #990
   - [rf] Support for constants, properties and promoted properties
   - [compl] Docblock completion

--- a/lib/DocblockParser/Parser.php
+++ b/lib/DocblockParser/Parser.php
@@ -98,6 +98,7 @@ final class Parser
                 return $this->parseMethod();
 
             case '@property':
+            case '@property-read':
                 return $this->parseProperty();
 
             case '@mixin':

--- a/lib/DocblockParser/Tests/Unit/Printer/examples/propertyread1.test
+++ b/lib/DocblockParser/Tests/Unit/Printer/examples/propertyread1.test
@@ -1,0 +1,10 @@
+/**
+ * @property-read string $foo
+ */
+---
+Docblock: = 
+ ElementList: = /**
+ * 
+  PropertyTag: = @property-read
+   ScalarNode: = string$foo
+ */


### PR DESCRIPTION
Support `@property-read` (just interprets it as a normal prop)