### PR TITLE
Render types based on detected PHP version

### DIFF
--- a/lib/CodeBuilder/Adapter/TolerantParser/Updater/AbstractMethodUpdater.php
+++ b/lib/CodeBuilder/Adapter/TolerantParser/Updater/AbstractMethodUpdater.php
@@ -176,7 +176,7 @@ abstract class AbstractMethodUpdater
             return;
         }
 
-        $returnType = (string) $returnType;
+        $returnType = (string) $this->renderer->render($returnType->type());
 
         if (!$methodDeclaration->returnTypeList && trim($returnType)) {
             $edits->after($methodDeclaration->closeParen, ': ' . $returnType);

--- a/lib/CodeBuilder/Adapter/TolerantParser/Updater/AbstractMethodUpdater.php
+++ b/lib/CodeBuilder/Adapter/TolerantParser/Updater/AbstractMethodUpdater.php
@@ -222,17 +222,17 @@ abstract class AbstractMethodUpdater
 
                 $parameterPrototype = $methodPrototype->parameters()->get($name);
 
-                $type = $parameterPrototype->type();
+                $type = (string)$this->renderer->render($parameterPrototype->type());
 
                 // adding a parameter type
-                if (null === $parameter->typeDeclarationList && $type->notNone()) {
+                if (null === $parameter->typeDeclarationList && $type) {
                     return false;
                 }
 
                 // if parameter has a different type
                 if (null !== $parameter->typeDeclarationList) {
                     $typeName = $parameter->typeDeclarationList->getText($methodDeclaration->getFileContents());
-                    if ($type->notNone() && (string) $type !== $typeName) {
+                    if ($type && (string) $type !== $typeName) {
                         return false;
                     }
                 }

--- a/lib/CodeBuilder/Adapter/Twig/TwigRenderer.php
+++ b/lib/CodeBuilder/Adapter/Twig/TwigRenderer.php
@@ -2,7 +2,6 @@
 
 namespace Phpactor\CodeBuilder\Adapter\Twig;
 
-use Phpactor\CodeBuilder\Adapter\WorseReflection\TypeRenderer\WorseTypeRenderer74;
 use Phpactor\CodeBuilder\Adapter\WorseReflection\TypeRenderer\WorseTypeRenderer80;
 use Phpactor\CodeBuilder\Domain\Code;
 use Phpactor\CodeBuilder\Domain\Prototype\Prototype;

--- a/lib/CodeBuilder/Adapter/Twig/TwigRenderer.php
+++ b/lib/CodeBuilder/Adapter/Twig/TwigRenderer.php
@@ -3,6 +3,7 @@
 namespace Phpactor\CodeBuilder\Adapter\Twig;
 
 use Phpactor\CodeBuilder\Adapter\WorseReflection\TypeRenderer\WorseTypeRenderer74;
+use Phpactor\CodeBuilder\Adapter\WorseReflection\TypeRenderer\WorseTypeRenderer80;
 use Phpactor\CodeBuilder\Domain\Code;
 use Phpactor\CodeBuilder\Domain\Prototype\Prototype;
 use Phpactor\CodeBuilder\Domain\Renderer;
@@ -52,7 +53,7 @@ final class TwigRenderer implements Renderer
             'strict_variables' => true,
             'autoescape' => false,
         ]);
-        $twig->addExtension(new TwigExtension(new TextFormat(), new WorseTypeRenderer74()));
+        $twig->addExtension(new TwigExtension(new TextFormat(), new WorseTypeRenderer80()));
 
         return $twig;
     }

--- a/lib/CodeBuilder/Adapter/Twig/TwigRenderer.php
+++ b/lib/CodeBuilder/Adapter/Twig/TwigRenderer.php
@@ -2,18 +2,20 @@
 
 namespace Phpactor\CodeBuilder\Adapter\Twig;
 
+use Phpactor\CodeBuilder\Adapter\WorseReflection\TypeRenderer\WorseTypeRenderer74;
 use Phpactor\CodeBuilder\Domain\Code;
 use Phpactor\CodeBuilder\Domain\Prototype\Prototype;
 use Phpactor\CodeBuilder\Domain\Renderer;
+use Phpactor\CodeBuilder\Util\TextFormat;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 use Twig\Error\LoaderError;
 
 final class TwigRenderer implements Renderer
 {
-    private $twig;
+    private Environment $twig;
 
-    private $templateNameResolver;
+    private TemplateNameResolver $templateNameResolver;
 
     public function __construct(
         Environment $twig = null,
@@ -44,18 +46,18 @@ final class TwigRenderer implements Renderer
         return Code::fromString(rtrim($code));
     }
 
-    private function createTwig()
+    private function createTwig(): Environment
     {
         $twig = new Environment(new FilesystemLoader(__DIR__ . '/../../../../templates/code'), [
             'strict_variables' => true,
             'autoescape' => false,
         ]);
-        $twig->addExtension(new TwigExtension($this));
+        $twig->addExtension(new TwigExtension(new TextFormat(), new WorseTypeRenderer74()));
 
         return $twig;
     }
 
-    private function twigRender(Prototype $prototype, string $templateName, string $variant = null)
+    private function twigRender(Prototype $prototype, string $templateName, string $variant = null): string
     {
         return $this->twig->render($templateName, [
             'prototype' => $prototype,

--- a/lib/CodeBuilder/Adapter/WorseReflection/TypeRenderer/WorseTypeRenderer.php
+++ b/lib/CodeBuilder/Adapter/WorseReflection/TypeRenderer/WorseTypeRenderer.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Phpactor\CodeBuilder\Adapter\WorseReflection\TypeRenderer;
+
+use Phpactor\WorseReflection\Core\Type;
+
+interface WorseTypeRenderer
+{
+    public function render(Type $type): ?string;
+}

--- a/lib/CodeBuilder/Adapter/WorseReflection/TypeRenderer/WorseTypeRenderer74.php
+++ b/lib/CodeBuilder/Adapter/WorseReflection/TypeRenderer/WorseTypeRenderer74.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Phpactor\CodeBuilder\Adapter\WorseReflection\TypeRenderer;
+
+use Phpactor\WorseReflection\Core\Type;
+use Phpactor\WorseReflection\Core\Type\AggregateType;
+use Phpactor\WorseReflection\Core\Type\ArrayType;
+use Phpactor\WorseReflection\Core\Type\BooleanType;
+use Phpactor\WorseReflection\Core\Type\ClassType;
+use Phpactor\WorseReflection\Core\Type\ScalarType;
+use Phpactor\WorseReflection\Core\Type\SelfType;
+use Phpactor\WorseReflection\Core\Type\VoidType;
+
+class WorseTypeRenderer74 implements WorseTypeRenderer
+{
+    public function render(Type $type): ?string
+    {
+        if ($type instanceof AggregateType) {
+            return null;
+        }
+
+        if ($type instanceof ArrayType) {
+            return $type->toPhpString();
+        }
+
+        if ($type instanceof BooleanType) {
+            return 'bool';
+        }
+
+        if ($type instanceof ScalarType) {
+            return $type->toPhpString();
+        }
+
+        if ($type instanceof ClassType) {
+            return $type->toPhpString();
+        }
+
+        if ($type instanceof SelfType) {
+            return $type->__toString();
+        }
+
+        if ($type instanceof VoidType) {
+            return $type->__toString();
+        }
+
+        return null;
+    }
+}

--- a/lib/CodeBuilder/Adapter/WorseReflection/TypeRenderer/WorseTypeRenderer74.php
+++ b/lib/CodeBuilder/Adapter/WorseReflection/TypeRenderer/WorseTypeRenderer74.php
@@ -7,6 +7,7 @@ use Phpactor\WorseReflection\Core\Type\AggregateType;
 use Phpactor\WorseReflection\Core\Type\ArrayType;
 use Phpactor\WorseReflection\Core\Type\BooleanType;
 use Phpactor\WorseReflection\Core\Type\ClassType;
+use Phpactor\WorseReflection\Core\Type\NullableType;
 use Phpactor\WorseReflection\Core\Type\ScalarType;
 use Phpactor\WorseReflection\Core\Type\SelfType;
 use Phpactor\WorseReflection\Core\Type\VoidType;
@@ -15,6 +16,9 @@ class WorseTypeRenderer74 implements WorseTypeRenderer
 {
     public function render(Type $type): ?string
     {
+        if ($type instanceof NullableType) {
+            return '?' . $this->render($type->type);
+        }
         if ($type instanceof AggregateType) {
             return null;
         }
@@ -32,7 +36,7 @@ class WorseTypeRenderer74 implements WorseTypeRenderer
         }
 
         if ($type instanceof ClassType) {
-            return $type->toPhpString();
+            return $type->short();
         }
 
         if ($type instanceof SelfType) {

--- a/lib/CodeBuilder/Adapter/WorseReflection/TypeRenderer/WorseTypeRenderer74.php
+++ b/lib/CodeBuilder/Adapter/WorseReflection/TypeRenderer/WorseTypeRenderer74.php
@@ -19,6 +19,7 @@ class WorseTypeRenderer74 implements WorseTypeRenderer
         if ($type instanceof NullableType) {
             return '?' . $this->render($type->type);
         }
+
         if ($type instanceof AggregateType) {
             return null;
         }

--- a/lib/CodeBuilder/Adapter/WorseReflection/TypeRenderer/WorseTypeRenderer80.php
+++ b/lib/CodeBuilder/Adapter/WorseReflection/TypeRenderer/WorseTypeRenderer80.php
@@ -11,7 +11,7 @@ class WorseTypeRenderer80 extends WorseTypeRenderer74
     public function render(Type $type): ?string
     {
         if ($type instanceof UnionType) {
-            return $type->toPhpString();
+            return $type->short();
         }
         if ($type instanceof MixedType) {
             return $type->toPhpString();

--- a/lib/CodeBuilder/Adapter/WorseReflection/TypeRenderer/WorseTypeRenderer80.php
+++ b/lib/CodeBuilder/Adapter/WorseReflection/TypeRenderer/WorseTypeRenderer80.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Phpactor\CodeBuilder\Adapter\WorseReflection\TypeRenderer;
+
+use Phpactor\WorseReflection\Core\Type;
+use Phpactor\WorseReflection\Core\Type\MixedType;
+use Phpactor\WorseReflection\Core\Type\UnionType;
+
+class WorseTypeRenderer80 extends WorseTypeRenderer74
+{
+    public function render(Type $type): ?string
+    {
+        if ($type instanceof UnionType) {
+            return $type->toPhpString();
+        }
+        if ($type instanceof MixedType) {
+            return $type->toPhpString();
+        }
+
+        return parent::render($type);
+    }
+}

--- a/lib/CodeBuilder/Adapter/WorseReflection/TypeRenderer/WorseTypeRenderer81.php
+++ b/lib/CodeBuilder/Adapter/WorseReflection/TypeRenderer/WorseTypeRenderer81.php
@@ -5,7 +5,6 @@ namespace Phpactor\CodeBuilder\Adapter\WorseReflection\TypeRenderer;
 use Phpactor\WorseReflection\Core\Type;
 use Phpactor\WorseReflection\Core\Type\IntersectionType;
 use Phpactor\WorseReflection\Core\Type\StaticType;
-use Phpactor\WorseReflection\Core\Type\UnionType;
 
 class WorseTypeRenderer81 extends WorseTypeRenderer80
 {

--- a/lib/CodeBuilder/Adapter/WorseReflection/TypeRenderer/WorseTypeRenderer81.php
+++ b/lib/CodeBuilder/Adapter/WorseReflection/TypeRenderer/WorseTypeRenderer81.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Phpactor\CodeBuilder\Adapter\WorseReflection\TypeRenderer;
+
+use Phpactor\WorseReflection\Core\Type;
+use Phpactor\WorseReflection\Core\Type\IntersectionType;
+use Phpactor\WorseReflection\Core\Type\StaticType;
+use Phpactor\WorseReflection\Core\Type\UnionType;
+
+class WorseTypeRenderer81 extends WorseTypeRenderer80
+{
+    public function render(Type $type): ?string
+    {
+        if ($type instanceof UnionType) {
+            return $type->toPhpString();
+        }
+
+        if ($type instanceof IntersectionType) {
+            return $type->toPhpString();
+        }
+
+        if ($type instanceof StaticType) {
+            return $type->toPhpString();
+        }
+
+        return parent::render($type);
+    }
+}

--- a/lib/CodeBuilder/Adapter/WorseReflection/TypeRenderer/WorseTypeRenderer81.php
+++ b/lib/CodeBuilder/Adapter/WorseReflection/TypeRenderer/WorseTypeRenderer81.php
@@ -11,12 +11,8 @@ class WorseTypeRenderer81 extends WorseTypeRenderer80
 {
     public function render(Type $type): ?string
     {
-        if ($type instanceof UnionType) {
-            return $type->toPhpString();
-        }
-
         if ($type instanceof IntersectionType) {
-            return $type->toPhpString();
+            return $type->short();
         }
 
         if ($type instanceof StaticType) {

--- a/lib/CodeBuilder/Adapter/WorseReflection/TypeRenderer/WorseTypeRenderer82.php
+++ b/lib/CodeBuilder/Adapter/WorseReflection/TypeRenderer/WorseTypeRenderer82.php
@@ -3,7 +3,6 @@
 namespace Phpactor\CodeBuilder\Adapter\WorseReflection\TypeRenderer;
 
 use Phpactor\WorseReflection\Core\Type;
-use Phpactor\WorseReflection\Core\Type\BooleanLiteralType;
 use Phpactor\WorseReflection\Core\Type\NullType;
 
 class WorseTypeRenderer82 extends WorseTypeRenderer80

--- a/lib/CodeBuilder/Adapter/WorseReflection/TypeRenderer/WorseTypeRenderer82.php
+++ b/lib/CodeBuilder/Adapter/WorseReflection/TypeRenderer/WorseTypeRenderer82.php
@@ -14,14 +14,6 @@ class WorseTypeRenderer82 extends WorseTypeRenderer80
             return $type->toPhpString();
         }
 
-        if ($type instanceof BooleanLiteralType) {
-            if (false === $type->isTrue()) {
-                return 'false';
-            }
-
-            return 'true';
-        }
-
         return parent::render($type);
     }
 }

--- a/lib/CodeBuilder/Adapter/WorseReflection/TypeRenderer/WorseTypeRenderer82.php
+++ b/lib/CodeBuilder/Adapter/WorseReflection/TypeRenderer/WorseTypeRenderer82.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Phpactor\CodeBuilder\Adapter\WorseReflection\TypeRenderer;
+
+use Phpactor\WorseReflection\Core\Type;
+use Phpactor\WorseReflection\Core\Type\BooleanLiteralType;
+use Phpactor\WorseReflection\Core\Type\NullType;
+
+class WorseTypeRenderer82 extends WorseTypeRenderer80
+{
+    public function render(Type $type): ?string
+    {
+        if ($type instanceof NullType) {
+            return $type->toPhpString();
+        }
+
+        if ($type instanceof BooleanLiteralType) {
+            if (false === $type->isTrue()) {
+                return 'false';
+            }
+
+            return 'true';
+        }
+
+        return parent::render($type);
+    }
+}

--- a/lib/CodeBuilder/Adapter/WorseReflection/TypeRenderer/WorseTypeRendererFactory.php
+++ b/lib/CodeBuilder/Adapter/WorseReflection/TypeRenderer/WorseTypeRendererFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Phpactor\CodeBuilder\Adapter\WorseReflection\TypeRenderer;
+
+final class WorseTypeRendererFactory
+{
+    /**
+     * @var array<string,WorseTypeRenderer>
+     */
+    private array $versionToRendererMap;
+
+    /**
+     * @param array<string,WorseTypeRenderer> $versionToRendererMap
+     */
+    public function __construct(array $versionToRendererMap)
+    {
+        $this->versionToRendererMap = $versionToRendererMap;
+    }
+
+    public function rendererFor(string $phpVersion): WorseTypeRenderer
+    {
+        if (!isset($this->versionToRendererMap[$phpVersion])) {
+            return new WorseTypeRenderer74();
+        }
+
+        return $this->versionToRendererMap[$phpVersion];
+    }
+}

--- a/lib/CodeBuilder/Adapter/WorseReflection/TypeRenderer/WorseTypeRendererFactory.php
+++ b/lib/CodeBuilder/Adapter/WorseReflection/TypeRenderer/WorseTypeRendererFactory.php
@@ -19,10 +19,12 @@ final class WorseTypeRendererFactory
 
     public function rendererFor(string $phpVersion): WorseTypeRenderer
     {
-        if (!isset($this->versionToRendererMap[$phpVersion])) {
-            return new WorseTypeRenderer74();
+        foreach ($this->versionToRendererMap as $version => $renderer) {
+            if (0 === strpos($phpVersion, $version)) {
+                return $renderer;
+            }
         }
 
-        return $this->versionToRendererMap[$phpVersion];
+        return new WorseTypeRenderer74();
     }
 }

--- a/lib/CodeBuilder/Adapter/WorseReflection/WorseBuilderFactory.php
+++ b/lib/CodeBuilder/Adapter/WorseReflection/WorseBuilderFactory.php
@@ -139,8 +139,8 @@ class WorseBuilderFactory implements BuilderFactory
                     $type = $type->valueType;
                 }
             }
-            $typeName = $this->resolveTypeNameFromNameImports($type, $imports);
-            $parameterBuilder->type($typeName);
+            $type = $method->scope()->resolveLocalType($type);
+            $parameterBuilder->type($type->short(), $type);
         }
 
         if ($parameter->isVariadic()) {
@@ -165,21 +165,5 @@ class WorseBuilderFactory implements BuilderFactory
 
             $classBuilder->end()->use($type->name()->full());
         }
-    }
-
-    private function resolveTypeNameFromNameImports(Type $type, NameImports $imports): string
-    {
-        if ($type instanceof MissingType) {
-            return '';
-        }
-        $typeName = $type->short();
-
-        foreach ($imports as $alias => $import) {
-            if ($typeName == $import->head()) {
-                $typeName = $alias;
-            }
-        }
-
-        return $typeName;
     }
 }

--- a/lib/CodeBuilder/Adapter/WorseReflection/WorseBuilderFactory.php
+++ b/lib/CodeBuilder/Adapter/WorseReflection/WorseBuilderFactory.php
@@ -10,7 +10,6 @@ use Phpactor\TextDocument\TextDocumentBuilder;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionClass;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionTrait;
 use Phpactor\WorseReflection\Core\Type\ArrayType;
-use Phpactor\WorseReflection\Core\Type\MissingType;
 use Phpactor\WorseReflection\Reflector;
 use Phpactor\CodeBuilder\Domain\Builder\SourceCodeBuilder;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionProperty;
@@ -21,7 +20,6 @@ use Phpactor\WorseReflection\Core\ClassName;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionParameter;
 use Phpactor\CodeBuilder\Domain\Builder\MethodBuilder;
 use Phpactor\CodeBuilder\Domain\Builder\ClassLikeBuilder;
-use Phpactor\WorseReflection\Core\NameImports;
 
 class WorseBuilderFactory implements BuilderFactory
 {
@@ -98,7 +96,7 @@ class WorseBuilderFactory implements BuilderFactory
         $type = $property->inferredType();
         if (($type->isDefined())) {
             $this->importClassesForMemberType($classBuilder, $property->class()->name(), $type);
-            $propertyBuilder->type(($type->short()));
+            $propertyBuilder->type($type->short(), $type);
             $propertyBuilder->docType((string)$type);
         }
     }
@@ -112,7 +110,7 @@ class WorseBuilderFactory implements BuilderFactory
             $type = $method->returnType();
             $this->importClassesForMemberType($classBuilder, $method->class()->name(), $type);
             $typeName = $type->short();
-            $methodBuilder->returnType($typeName);
+            $methodBuilder->returnType($typeName, $type);
         }
 
         if ($method->isStatic()) {

--- a/lib/CodeBuilder/Domain/Builder/MethodBuilder.php
+++ b/lib/CodeBuilder/Domain/Builder/MethodBuilder.php
@@ -2,6 +2,7 @@
 
 namespace Phpactor\CodeBuilder\Domain\Builder;
 
+use Phpactor\CodeBuilder\Domain\Prototype\Type;
 use Phpactor\CodeBuilder\Domain\Prototype\UpdatePolicy;
 use Phpactor\CodeBuilder\Domain\Prototype\Visibility;
 use Phpactor\CodeBuilder\Domain\Prototype\Parameters;
@@ -63,9 +64,12 @@ class MethodBuilder extends AbstractBuilder implements NamedBuilder
         return $this;
     }
 
-    public function returnType(string $returnType): MethodBuilder
+    /**
+     * @param mixed $originalType
+     */
+    public function returnType(string $returnType, $originalType = null): MethodBuilder
     {
-        $this->returnType = ReturnType::fromString($returnType);
+        $this->returnType = new ReturnType(new Type($returnType, $originalType));
 
         return $this;
     }

--- a/lib/CodeBuilder/Domain/Builder/ParameterBuilder.php
+++ b/lib/CodeBuilder/Domain/Builder/ParameterBuilder.php
@@ -35,9 +35,12 @@ class ParameterBuilder extends AbstractBuilder
         return [];
     }
 
-    public function type(string $type): ParameterBuilder
+    /**
+     * @param mixed $originalType
+     */
+    public function type(string $type, $originalType = null): ParameterBuilder
     {
-        $this->type = Type::fromString($type);
+        $this->type = new Type($type, $originalType);
 
         return $this;
     }

--- a/lib/CodeBuilder/Domain/Builder/PropertyBuilder.php
+++ b/lib/CodeBuilder/Domain/Builder/PropertyBuilder.php
@@ -40,9 +40,12 @@ class PropertyBuilder extends AbstractBuilder implements NamedBuilder
         return $this;
     }
 
-    public function type(string $type): PropertyBuilder
+    /**
+     * @param mixed $originalType
+     */
+    public function type(string $type, $originalType = null): PropertyBuilder
     {
-        $this->type = Type::fromString($type);
+        $this->type = new Type($type, $originalType);
 
         return $this;
     }

--- a/lib/CodeBuilder/Domain/Builder/PropertyBuilder.php
+++ b/lib/CodeBuilder/Domain/Builder/PropertyBuilder.php
@@ -7,6 +7,7 @@ use Phpactor\CodeBuilder\Domain\Prototype\UpdatePolicy;
 use Phpactor\CodeBuilder\Domain\Prototype\Visibility;
 use Phpactor\CodeBuilder\Domain\Prototype\DefaultValue;
 use Phpactor\CodeBuilder\Domain\Prototype\Property;
+use Exception;
 
 class PropertyBuilder extends AbstractBuilder implements NamedBuilder
 {

--- a/lib/CodeBuilder/Domain/Builder/PropertyBuilder.php
+++ b/lib/CodeBuilder/Domain/Builder/PropertyBuilder.php
@@ -7,7 +7,6 @@ use Phpactor\CodeBuilder\Domain\Prototype\UpdatePolicy;
 use Phpactor\CodeBuilder\Domain\Prototype\Visibility;
 use Phpactor\CodeBuilder\Domain\Prototype\DefaultValue;
 use Phpactor\CodeBuilder\Domain\Prototype\Property;
-use Exception;
 
 class PropertyBuilder extends AbstractBuilder implements NamedBuilder
 {

--- a/lib/CodeBuilder/Domain/Prototype/ReturnType.php
+++ b/lib/CodeBuilder/Domain/Prototype/ReturnType.php
@@ -4,7 +4,7 @@ namespace Phpactor\CodeBuilder\Domain\Prototype;
 
 final class ReturnType extends Prototype
 {
-    private $type;
+    private Type $type;
 
     public function __construct(Type $type)
     {
@@ -30,5 +30,10 @@ final class ReturnType extends Prototype
     public function notNone(): bool
     {
         return $this->type->notNone();
+    }
+
+    public function type(): Type
+    {
+        return $this->type;
     }
 }

--- a/lib/CodeBuilder/Domain/Prototype/Type.php
+++ b/lib/CodeBuilder/Domain/Prototype/Type.php
@@ -23,9 +23,7 @@ final class Type extends Prototype
         $this->originalType = $originalType;
     }
 
-    /**
-     * @return string
-     */
+    
     public function __toString(): string
     {
         return $this->type ?? '';

--- a/lib/CodeBuilder/Domain/Prototype/Type.php
+++ b/lib/CodeBuilder/Domain/Prototype/Type.php
@@ -8,15 +8,35 @@ final class Type extends Prototype
 
     private bool $none = false;
 
-    public function __construct(string $type = null)
+    /**
+     * @var mixed
+     */
+    private $originalType;
+
+    /**
+     * @param mixed $originalType
+     */
+    public function __construct(string $type = null, $originalType = null)
     {
         parent::__construct();
         $this->type = $type;
+        $this->originalType = $originalType;
     }
 
-    public function __toString()
+    /**
+     * @return string
+     */
+    public function __toString(): string
     {
         return $this->type ?? '';
+    }
+
+    /**
+     * @return mixed
+     */
+    public function originalType()
+    {
+        return $this->originalType;
     }
 
     public static function fromString(string $type): Type

--- a/lib/CodeTransform/Adapter/WorseReflection/GenerateFromExisting/InterfaceFromExistingGenerator.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/GenerateFromExisting/InterfaceFromExistingGenerator.php
@@ -50,7 +50,7 @@ final class InterfaceFromExistingGenerator implements GenerateFromExisting
             }
 
             if ($method->returnType()->isDefined()) {
-                $methodBuilder->returnType($method->returnType()->short());
+                $methodBuilder->returnType($method->returnType()->short(), $method->returnType());
 
                 foreach ($method->returnType()->classNamedTypes() as $classType) {
                     $sourceBuilder->use($classType->toPhpString());

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseExtractMethod.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseExtractMethod.php
@@ -345,7 +345,7 @@ class WorseExtractMethod implements ExtractMethod
             $methodBuilder->body()->line('return $' . $variable->name() . ';');
             $type = $variable->type();
             if ($type->isDefined()) {
-                $methodBuilder->returnType($type->short());
+                $methodBuilder->returnType($type->short(), $type);
                 foreach ($type->classNamedTypes() as $classType) {
                     $methodBuilder->end()->end()->use($classType->name()->full());
                 }
@@ -424,7 +424,7 @@ class WorseExtractMethod implements ExtractMethod
         $expressionType = $offset->symbolContext()->type();
 
         if ($expressionType->isDefined()) {
-            $methodBuilder->returnType($expressionType->short());
+            $methodBuilder->returnType($expressionType->short(), $expressionType);
         }
 
         foreach ($expressionType->classNamedTypes() as $classType) {

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseExtractMethod.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseExtractMethod.php
@@ -343,7 +343,7 @@ class WorseExtractMethod implements ExtractMethod
             /** @var Variable $variable */
             $variable = reset($returnVariables);
             $methodBuilder->body()->line('return $' . $variable->name() . ';');
-            $type = $variable->type();
+            $type = $variable->type()->generalize()->reduce();
             if ($type->isDefined()) {
                 $methodBuilder->returnType($type->short(), $type);
                 foreach ($type->classNamedTypes() as $classType) {

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseGenerateAccessor.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseGenerateAccessor.php
@@ -84,7 +84,7 @@ class WorseGenerateAccessor implements GenerateAccessor
 
             $type = $reflectionProperty->inferredType();
             if ($type->isDefined()) {
-                $method->returnType($type->short());
+                $method->returnType($type->short(), $type);
             }
         }
 

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseGenerateMethod.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseGenerateMethod.php
@@ -124,7 +124,7 @@ class WorseGenerateMethod implements GenerateMethod
 
         $inferredType = $methodCall->inferredReturnType();
         if ($inferredType->isDefined()) {
-            $methodBuilder->returnType($inferredType->toPhpString());
+            $methodBuilder->returnType($inferredType->toPhpString(), $inferredType);
             // this will not render localized types see https://github.com/phpactor/phpactor/issues/1453
             // if ($inferredType->__toString() !== $inferredType->toPhpString()) {
             //     $methodBuilder->docblock('@return ' . $inferredType->__toString());

--- a/lib/CodeTransform/Adapter/WorseReflection/Transformer/AddMissingProperties.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Transformer/AddMissingProperties.php
@@ -91,7 +91,7 @@ class AddMissingProperties implements Transformer
                         $sourceBuilder->use($importClass->name()->__toString());
                     }
                     $type = $type->toLocalType($class->scope());
-                    $propertyBuilder->type($type->toPhpString());
+                    $propertyBuilder->type($type->toPhpString(), $type);
                     $propertyBuilder->docType((string)$type->generalize());
 
                     // if this was an array assignment initialize the array

--- a/lib/CodeTransform/Adapter/WorseReflection/Transformer/CompleteConstructor.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Transformer/CompleteConstructor.php
@@ -68,7 +68,7 @@ class CompleteConstructor implements Transformer
                 $parameterType = $parameter->inferredType();
                 if ($parameterType->isDefined()) {
                     $parameterType = $parameterType->toLocalType($class->scope());
-                    $propertyBuilder->type($parameterType->toPhpString());
+                    $propertyBuilder->type($parameterType->toPhpString(), $parameterType);
                     $propertyBuilder->docType((string)$parameterType);
                 }
             }

--- a/lib/CodeTransform/Adapter/WorseReflection/Transformer/UpdateReturnTypeTransformer.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Transformer/UpdateReturnTypeTransformer.php
@@ -46,7 +46,7 @@ class UpdateReturnTypeTransformer implements Transformer
                 $builder->use($classType->name());
             }
 
-            $methodBuilder->returnType($localReplacement->reduce()->toPhpString());
+            $methodBuilder->returnType($localReplacement->reduce()->toPhpString(), $localReplacement->reduce());
         }
 
         return $this->updater->textEditsFor($builder->build(), Code::fromString($code));

--- a/lib/Extension/CodeTransform/CodeTransformExtension.php
+++ b/lib/Extension/CodeTransform/CodeTransformExtension.php
@@ -2,6 +2,12 @@
 
 namespace Phpactor\Extension\CodeTransform;
 
+use Phpactor\CodeBuilder\Adapter\WorseReflection\TypeRenderer\WorseTypeRenderer;
+use Phpactor\CodeBuilder\Adapter\WorseReflection\TypeRenderer\WorseTypeRenderer74;
+use Phpactor\CodeBuilder\Adapter\WorseReflection\TypeRenderer\WorseTypeRenderer80;
+use Phpactor\CodeBuilder\Adapter\WorseReflection\TypeRenderer\WorseTypeRenderer81;
+use Phpactor\CodeBuilder\Adapter\WorseReflection\TypeRenderer\WorseTypeRenderer82;
+use Phpactor\CodeBuilder\Adapter\WorseReflection\TypeRenderer\WorseTypeRendererFactory;
 use Phpactor\CodeBuilder\Domain\BuilderFactory;
 use Phpactor\CodeBuilder\Domain\Updater;
 use Phpactor\CodeBuilder\Util\TextFormat;
@@ -319,9 +325,23 @@ class CodeTransformExtension implements Extension
                 'autoescape' => false,
             ]);
             $renderer = new TwigRenderer($twig);
-            $twig->addExtension(new TwigExtension($renderer, $container->get(TextFormat::class)));
+            $twig->addExtension(new TwigExtension(
+                $container->get(TextFormat::class),
+                $container->get(WorseTypeRenderer::class)
+            ));
 
             return $renderer;
+        });
+
+        $container->register(WorseTypeRenderer::class, function (Container $container) {
+            $version = $container->get(PhpVersionResolver::class);
+            assert($version instanceof PhpVersionResolver);
+            return (new WorseTypeRendererFactory([
+                '7.4' => new WorseTypeRenderer74(),
+                '8.0' => new WorseTypeRenderer80(),
+                '8.1' => new WorseTypeRenderer81(),
+                '8.2' => new WorseTypeRenderer82(),
+            ]))->rendererFor($version->resolve());
         });
 
         $container->register(TextFormat::class, function (Container $container) {

--- a/lib/Extension/CodeTransform/CodeTransformExtension.php
+++ b/lib/Extension/CodeTransform/CodeTransformExtension.php
@@ -336,12 +336,13 @@ class CodeTransformExtension implements Extension
         $container->register(WorseTypeRenderer::class, function (Container $container) {
             $version = $container->get(PhpVersionResolver::class);
             assert($version instanceof PhpVersionResolver);
+            $version = $version->resolve();
             return (new WorseTypeRendererFactory([
                 '7.4' => new WorseTypeRenderer74(),
                 '8.0' => new WorseTypeRenderer80(),
                 '8.1' => new WorseTypeRenderer81(),
                 '8.2' => new WorseTypeRenderer82(),
-            ]))->rendererFor($version->resolve());
+            ]))->rendererFor($version);
         });
 
         $container->register(TextFormat::class, function (Container $container) {

--- a/templates/code/7.4/Property.php.twig
+++ b/templates/code/7.4/Property.php.twig
@@ -1,5 +1,5 @@
 {% set renderedType = render_type(prototype.type) %}
-{% if prototype.docTypeAddsAdditionalInfo %}
+{% if prototype.docType != renderedType %}
 /**
  * @var {{ prototype.docType }}
  */

--- a/templates/code/7.4/Property.php.twig
+++ b/templates/code/7.4/Property.php.twig
@@ -1,10 +1,11 @@
+{% set renderedType = render_type(prototype.type) %}
 {% if prototype.docTypeAddsAdditionalInfo %}
 /**
  * @var {{ prototype.docType }}
  */
 {% endif %}
 {{ prototype.visibility }}
-{%- if prototype.type.notNone %}
- {{ prototype.type }} 
+{%- if renderedType %}
+ {{ renderedType }} 
 {%- endif %}
  ${{ prototype.name}}{% if prototype.defaultValue.notNone %} = {{ prototype.defaultValue.export }}{% endif %};

--- a/templates/code/Method.php.twig
+++ b/templates/code/Method.php.twig
@@ -1,3 +1,4 @@
+{% set renderedType = render_type(prototype.returnType.type) %}
 {% if prototype.docblock.notNone %}
 /**
 {% for line in prototype.docblock.asLines %}
@@ -6,4 +7,4 @@
  */
 {% endif %}
 {% if prototype.isAbstract %}abstract {%endif %}{{ prototype.visibility }} {% if prototype.isStatic %}static {%endif %}function {{ prototype.name}}({% spaceless %}
-{% for parameter in prototype.parameters %}{{ generator.render(parameter, variant)|raw }}{% if not loop.last %}, {% endif %}{% endfor %}{% endspaceless %}){% if prototype.returnType.notNone %}: {{ prototype.returnType }}{% endif %}
+{% for parameter in prototype.parameters %}{{ generator.render(parameter, variant)|raw }}{% if not loop.last %}, {% endif %}{% endfor %}{% endspaceless %}){% if renderedType %}: {{ renderedType }}{% endif %}

--- a/templates/code/Parameter.php.twig
+++ b/templates/code/Parameter.php.twig
@@ -1,3 +1,4 @@
-{% if prototype.type.notNone %}{{ prototype.type }} {% endif %}
+{% set renderedType = render_type(prototype.type) %}
+{% if renderedType %}{{ renderedType }} {% endif %}
 {% if prototype.byReference %}&{% endif %}{% if prototype.isVariadic %}...{% endif %}{% if true %}${{ prototype.name }}{% endif %}
 {% if prototype.defaultValue.notNone %} = {{ prototype.defaultValue.export|raw }}{% endif %}

--- a/templates/code/Type.php.twig
+++ b/templates/code/Type.php.twig
@@ -1,0 +1,1 @@
+{{ render_type(prototype) }}


### PR DESCRIPTION
This PR attempts to support passing the raw Type through to the code renderer - allowing us to granularly filter what types are rendered based on the detected PHP version.

Tried a few different ways -- didn't want to "infect" the code builder with the static reflection types, and didn't want to break all the existing code. This solution passes the "original type" as an extra, optional, parameter and introduces a Twig function to render the type.