### PR TITLE
Fix docblock `static` caching issue

### DIFF
--- a/lib/WorseReflection/Bridge/Phpactor/DocblockParser/CachedParserFactory.php
+++ b/lib/WorseReflection/Bridge/Phpactor/DocblockParser/CachedParserFactory.php
@@ -25,7 +25,8 @@ class CachedParserFactory implements DocBlockFactory
         if (!trim($docblock)) {
             return new PlainDocblock('');
         }
-        return $this->cache->getOrSet($docblock, function () use ($resolver, $docblock) {
+
+        return $this->cache->getOrSet('docblock_' . $docblock, function () use ($resolver, $docblock) {
             return $this->innerFactory->create($resolver, $docblock);
         });
     }

--- a/lib/WorseReflection/Bridge/Phpactor/DocblockParser/CachedParserFactory.php
+++ b/lib/WorseReflection/Bridge/Phpactor/DocblockParser/CachedParserFactory.php
@@ -5,6 +5,7 @@ namespace Phpactor\WorseReflection\Bridge\Phpactor\DocblockParser;
 use Phpactor\WorseReflection\Core\Cache;
 use Phpactor\WorseReflection\Core\DocBlock\DocBlock;
 use Phpactor\WorseReflection\Core\DocBlock\DocBlockFactory;
+use Phpactor\WorseReflection\Core\DocBlock\PlainDocblock;
 use Phpactor\WorseReflection\Core\TypeResolver;
 
 class CachedParserFactory implements DocBlockFactory
@@ -21,6 +22,9 @@ class CachedParserFactory implements DocBlockFactory
 
     public function create(TypeResolver $resolver, string $docblock): DocBlock
     {
+        if (!trim($docblock)) {
+            return new PlainDocblock('');
+        }
         return $this->cache->getOrSet($docblock, function () use ($resolver, $docblock) {
             return $this->innerFactory->create($resolver, $docblock);
         });

--- a/lib/WorseReflection/Bridge/Phpactor/DocblockParser/CachedParserFactory.php
+++ b/lib/WorseReflection/Bridge/Phpactor/DocblockParser/CachedParserFactory.php
@@ -20,14 +20,14 @@ class CachedParserFactory implements DocBlockFactory
         $this->innerFactory = $innerFactory;
     }
 
-    public function create(TypeResolver $resolver, string $docblock): DocBlock
+    public function create(string $docblock): DocBlock
     {
         if (!trim($docblock)) {
             return new PlainDocblock('');
         }
 
-        return $this->cache->getOrSet('docblock_' . $docblock, function () use ($resolver, $docblock) {
-            return $this->innerFactory->create($resolver, $docblock);
+        return $this->cache->getOrSet('docblock_' . $docblock, function () use ($docblock) {
+            return $this->innerFactory->create($docblock);
         });
     }
 }

--- a/lib/WorseReflection/Bridge/Phpactor/DocblockParser/CachedParserFactory.php
+++ b/lib/WorseReflection/Bridge/Phpactor/DocblockParser/CachedParserFactory.php
@@ -6,7 +6,6 @@ use Phpactor\WorseReflection\Core\Cache;
 use Phpactor\WorseReflection\Core\DocBlock\DocBlock;
 use Phpactor\WorseReflection\Core\DocBlock\DocBlockFactory;
 use Phpactor\WorseReflection\Core\DocBlock\PlainDocblock;
-use Phpactor\WorseReflection\Core\TypeResolver;
 
 class CachedParserFactory implements DocBlockFactory
 {

--- a/lib/WorseReflection/Bridge/Phpactor/DocblockParser/DocblockParserFactory.php
+++ b/lib/WorseReflection/Bridge/Phpactor/DocblockParser/DocblockParserFactory.php
@@ -8,7 +8,6 @@ use Phpactor\WorseReflection\Core\DocBlock\DocBlockFactory;
 use Phpactor\WorseReflection\Core\DocBlock\PlainDocblock;
 use Phpactor\DocblockParser\Lexer;
 use Phpactor\DocblockParser\Parser;
-use Phpactor\WorseReflection\Core\TypeResolver;
 use Phpactor\WorseReflection\Reflector;
 
 class DocblockParserFactory implements DocBlockFactory

--- a/lib/WorseReflection/Bridge/Phpactor/DocblockParser/DocblockParserFactory.php
+++ b/lib/WorseReflection/Bridge/Phpactor/DocblockParser/DocblockParserFactory.php
@@ -40,7 +40,7 @@ class DocblockParserFactory implements DocBlockFactory
         $this->reflector = $reflector;
     }
 
-    public function create(TypeResolver $resolver, string $docblock): DocBlock
+    public function create(string $docblock): DocBlock
     {
         if (empty(trim($docblock))) {
             return new PlainDocblock();
@@ -59,7 +59,7 @@ class DocblockParserFactory implements DocBlockFactory
         assert($node instanceof ParserDocblock);
         return new ParsedDocblock(
             $node,
-            new TypeConverter($this->reflector, $resolver)
+            new TypeConverter($this->reflector)
         );
     }
 }

--- a/lib/WorseReflection/Bridge/Phpactor/DocblockParser/ParsedDocblock.php
+++ b/lib/WorseReflection/Bridge/Phpactor/DocblockParser/ParsedDocblock.php
@@ -32,6 +32,7 @@ use Phpactor\WorseReflection\Core\TemplateMap;
 use Phpactor\WorseReflection\Core\Type;
 use Phpactor\WorseReflection\Core\TypeFactory;
 use Phpactor\WorseReflection\Core\DocBlock\DocBlockVars;
+use Phpactor\WorseReflection\Core\TypeResolver;
 use Phpactor\WorseReflection\Core\Virtual\VirtualReflectionMethod;
 use Phpactor\WorseReflection\Core\Virtual\VirtualReflectionParameter;
 use Phpactor\WorseReflection\Core\Virtual\VirtualReflectionProperty;
@@ -43,6 +44,8 @@ class ParsedDocblock implements DocBlock
     private ParserDocblock $node;
 
     private TypeConverter $typeConverter;
+
+    private TypeResolver $typeResolver;
 
     public function __construct(ParserDocblock $node, TypeConverter $typeConverter)
     {
@@ -263,5 +266,11 @@ class ParsedDocblock implements DocBlock
                 $method->position()
             ));
         }
+    }
+
+    public function withTypeResolver(TypeResolver $typeResolver): DocBlock
+    {
+        $this->typeResolver = $typeResolver;
+        return $this;
     }
 }

--- a/lib/WorseReflection/Bridge/Phpactor/DocblockParser/ParsedDocblock.php
+++ b/lib/WorseReflection/Bridge/Phpactor/DocblockParser/ParsedDocblock.php
@@ -45,8 +45,6 @@ class ParsedDocblock implements DocBlock
 
     private TypeConverter $typeConverter;
 
-    private TypeResolver $typeResolver;
-
     public function __construct(ParserDocblock $node, TypeConverter $typeConverter)
     {
         $this->node = $node;
@@ -270,12 +268,11 @@ class ParsedDocblock implements DocBlock
 
     public function withTypeResolver(TypeResolver $typeResolver): DocBlock
     {
-        $this->typeResolver = $typeResolver;
-        return $this;
+        return new self($this->node, $this->typeConverter->withTypeResolver($typeResolver));
     }
 
     private function convertType(?TypeNode $type): Type
     {
-        return $this->typeConverter->withTypeResolver($this->typeResolver)->convert($type);
+        return $this->typeConverter->convert($type);
     }
 }

--- a/lib/WorseReflection/Bridge/Phpactor/DocblockParser/ParsedDocblock.php
+++ b/lib/WorseReflection/Bridge/Phpactor/DocblockParser/ParsedDocblock.php
@@ -245,6 +245,11 @@ class ParsedDocblock implements DocBlock
         return $mixins;
     }
 
+    public function withTypeResolver(TypeResolver $typeResolver): DocBlock
+    {
+        return new self($this->node, $this->typeConverter->withTypeResolver($typeResolver));
+    }
+
     private function addParameters(VirtualReflectionMethod $method, ReflectionParameterCollection $collection, ?ParameterList $parameterList): void
     {
         if (null === $parameterList) {
@@ -264,11 +269,6 @@ class ParsedDocblock implements DocBlock
                 $method->position()
             ));
         }
-    }
-
-    public function withTypeResolver(TypeResolver $typeResolver): DocBlock
-    {
-        return new self($this->node, $this->typeConverter->withTypeResolver($typeResolver));
     }
 
     private function convertType(?TypeNode $type): Type

--- a/lib/WorseReflection/Bridge/Phpactor/DocblockParser/TypeConverter.php
+++ b/lib/WorseReflection/Bridge/Phpactor/DocblockParser/TypeConverter.php
@@ -72,6 +72,11 @@ class TypeConverter
         $this->resolver = $resolver ?: new PassthroughTypeResolver();
     }
 
+    public function withTypeResolver(TypeResolver $typeResolver):self 
+    {
+        return new self($this->reflector, $typeResolver);
+    }
+
     public function convert(?TypeNode $type): Type
     {
         if ($type instanceof ScalarNode) {

--- a/lib/WorseReflection/Bridge/Phpactor/DocblockParser/TypeConverter.php
+++ b/lib/WorseReflection/Bridge/Phpactor/DocblockParser/TypeConverter.php
@@ -9,10 +9,12 @@ use Phpactor\DocblockParser\Ast\Type\LiteralFloatNode;
 use Phpactor\DocblockParser\Ast\Type\LiteralIntegerNode;
 use Phpactor\DocblockParser\Ast\Type\LiteralStringNode;
 use Phpactor\DocblockParser\Ast\Type\NullableNode;
+use Phpactor\WorseReflection\Core\Inference\Walker\PassThroughWalker;
 use Phpactor\WorseReflection\Core\TypeResolver;
 use Phpactor\DocblockParser\Ast\Type\ConstantNode;
 use Phpactor\DocblockParser\Ast\Type\ParenthesizedType;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionMember;
+use Phpactor\WorseReflection\Core\TypeResolver\PassthroughTypeResolver;
 use Phpactor\WorseReflection\Core\Type\ArrayKeyType;
 use Phpactor\DocblockParser\Ast\Node;
 use Phpactor\DocblockParser\Ast\TypeNode;
@@ -64,10 +66,10 @@ class TypeConverter
 
     private TypeResolver $resolver;
 
-    public function __construct(Reflector $reflector, TypeResolver $resolver)
+    public function __construct(Reflector $reflector, ?TypeResolver $resolver = null)
     {
         $this->reflector = $reflector;
-        $this->resolver = $resolver;
+        $this->resolver = $resolver ?: new PassthroughTypeResolver();
     }
 
     public function convert(?TypeNode $type): Type

--- a/lib/WorseReflection/Bridge/Phpactor/DocblockParser/TypeConverter.php
+++ b/lib/WorseReflection/Bridge/Phpactor/DocblockParser/TypeConverter.php
@@ -9,7 +9,6 @@ use Phpactor\DocblockParser\Ast\Type\LiteralFloatNode;
 use Phpactor\DocblockParser\Ast\Type\LiteralIntegerNode;
 use Phpactor\DocblockParser\Ast\Type\LiteralStringNode;
 use Phpactor\DocblockParser\Ast\Type\NullableNode;
-use Phpactor\WorseReflection\Core\Inference\Walker\PassThroughWalker;
 use Phpactor\WorseReflection\Core\TypeResolver;
 use Phpactor\DocblockParser\Ast\Type\ConstantNode;
 use Phpactor\DocblockParser\Ast\Type\ParenthesizedType;
@@ -72,7 +71,7 @@ class TypeConverter
         $this->resolver = $resolver ?: new PassthroughTypeResolver();
     }
 
-    public function withTypeResolver(TypeResolver $typeResolver):self 
+    public function withTypeResolver(TypeResolver $typeResolver):self
     {
         return new self($this->reflector, $typeResolver);
     }

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/AbstractReflectionClassMember.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/AbstractReflectionClassMember.php
@@ -54,9 +54,8 @@ abstract class AbstractReflectionClassMember extends AbstractReflectedNode imple
     public function docblock(): DocBlock
     {
         return $this->serviceLocator()->docblockFactory()->create(
-            new PhpactorMemberTypeResolver($this),
             $this->node()->getLeadingCommentAndWhitespaceText()
-        );
+        )->withTypeResolver(new PhpactorMemberTypeResolver($this));
     }
 
     public function visibility(): Visibility

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionClass.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionClass.php
@@ -312,9 +312,8 @@ class ReflectionClass extends AbstractReflectionClass implements CoreReflectionC
     public function docblock(): DocBlock
     {
         return $this->serviceLocator->docblockFactory()->create(
-            new ClassLikeTypeResolver($this),
             $this->node()->getLeadingCommentAndWhitespaceText()
-        );
+        )->withTypeResolver(new ClassLikeTypeResolver($this));
     }
 
     public function ancestors(): ReflectionClassCollection

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionEnum.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionEnum.php
@@ -95,9 +95,8 @@ class ReflectionEnum extends AbstractReflectionClass implements CoreReflectionEn
     public function docblock(): DocBlock
     {
         return $this->serviceLocator->docblockFactory()->create(
-            new ClassLikeTypeResolver($this),
             $this->node()->getLeadingCommentAndWhitespaceText()
-        );
+        )->withTypeResolver(new ClassLikeTypeResolver($this));
     }
 
     /**

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionFunction.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionFunction.php
@@ -46,7 +46,7 @@ class ReflectionFunction extends AbstractReflectedNode implements CoreReflection
 
     public function docblock(): DocBlock
     {
-        return $this->serviceLocator->docblockFactory()->create(new DefaultTypeResolver($this->scope()), $this->node()->getLeadingCommentAndWhitespaceText());
+        return $this->serviceLocator->docblockFactory()->create($this->node()->getLeadingCommentAndWhitespaceText())->withTypeResolver(new DefaultTypeResolver($this->scope()));
     }
 
     public function inferredType(): Type

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionInterface.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionInterface.php
@@ -146,9 +146,8 @@ class ReflectionInterface extends AbstractReflectionClass implements CoreReflect
     public function docblock(): DocBlock
     {
         return $this->serviceLocator->docblockFactory()->create(
-            new ClassLikeTypeResolver($this),
             $this->node()->getLeadingCommentAndWhitespaceText()
-        );
+        )->withTypeResolver(new ClassLikeTypeResolver($this));
     }
 
     /**

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionTrait.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionTrait.php
@@ -90,9 +90,8 @@ class ReflectionTrait extends AbstractReflectionClass implements CoreReflectionT
     public function docblock(): DocBlock
     {
         return $this->serviceLocator->docblockFactory()->create(
-            new ClassLikeTypeResolver($this),
             $this->node()->getLeadingCommentAndWhitespaceText()
-        );
+        )->withTypeResolver(new ClassLikeTypeResolver($this));
     }
 
     public function traits(): ReflectionTraitCollection

--- a/lib/WorseReflection/Core/DocBlock/DocBlock.php
+++ b/lib/WorseReflection/Core/DocBlock/DocBlock.php
@@ -9,7 +9,6 @@ use Phpactor\WorseReflection\Core\Reflection\ReflectionClassLike;
 use Phpactor\WorseReflection\Core\TemplateMap;
 use Phpactor\WorseReflection\Core\Type;
 use Phpactor\WorseReflection\Core\TypeResolver;
-use Phpactor\WorseReflection\Core\TypeResolver\ClassLikeTypeResolver;
 
 interface DocBlock
 {

--- a/lib/WorseReflection/Core/DocBlock/DocBlock.php
+++ b/lib/WorseReflection/Core/DocBlock/DocBlock.php
@@ -8,6 +8,8 @@ use Phpactor\WorseReflection\Core\Reflection\Collection\ReflectionPropertyCollec
 use Phpactor\WorseReflection\Core\Reflection\ReflectionClassLike;
 use Phpactor\WorseReflection\Core\TemplateMap;
 use Phpactor\WorseReflection\Core\Type;
+use Phpactor\WorseReflection\Core\TypeResolver;
+use Phpactor\WorseReflection\Core\TypeResolver\ClassLikeTypeResolver;
 
 interface DocBlock
 {
@@ -51,4 +53,6 @@ interface DocBlock
      * @return Type[]
      */
     public function mixins(): array;
+
+    public function withTypeResolver(TypeResolver $classLikeTypeResolver): self;
 }

--- a/lib/WorseReflection/Core/DocBlock/DocBlockFactory.php
+++ b/lib/WorseReflection/Core/DocBlock/DocBlockFactory.php
@@ -2,8 +2,6 @@
 
 namespace Phpactor\WorseReflection\Core\DocBlock;
 
-use Phpactor\WorseReflection\Core\TypeResolver;
-
 interface DocBlockFactory
 {
     public function create(string $docblock): DocBlock;

--- a/lib/WorseReflection/Core/DocBlock/DocBlockFactory.php
+++ b/lib/WorseReflection/Core/DocBlock/DocBlockFactory.php
@@ -6,5 +6,5 @@ use Phpactor\WorseReflection\Core\TypeResolver;
 
 interface DocBlockFactory
 {
-    public function create(TypeResolver $resolver, string $docblock): DocBlock;
+    public function create(string $docblock): DocBlock;
 }

--- a/lib/WorseReflection/Core/DocBlock/PlainDocblock.php
+++ b/lib/WorseReflection/Core/DocBlock/PlainDocblock.php
@@ -11,6 +11,7 @@ use Phpactor\WorseReflection\Core\TemplateMap;
 use Phpactor\WorseReflection\Core\Type;
 use Phpactor\WorseReflection\Core\TypeFactory;
 use Phpactor\WorseReflection\Core\Deprecation;
+use Phpactor\WorseReflection\Core\TypeResolver;
 use function preg_replace;
 
 class PlainDocblock implements DocBlock
@@ -114,5 +115,10 @@ class PlainDocblock implements DocBlock
     public function mixins(): array
     {
         return [];
+    }
+
+    public function withTypeResolver(TypeResolver $classLikeTypeResolver): DocBlock
+    {
+        return $this;
     }
 }

--- a/lib/WorseReflection/Core/Inference/Walker/VariableWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/VariableWalker.php
@@ -91,7 +91,7 @@ class VariableWalker implements Walker
     private function injectVariablesFromComment(PhpactorReflectionScope $scope, Frame $frame, Node $node): Type
     {
         $comment = $node->getLeadingCommentAndWhitespaceText();
-        $docblock = $this->docblockFactory->create(new DefaultTypeResolver($scope), $comment);
+        $docblock = $this->docblockFactory->create($comment)->withTypeResolver(new DefaultTypeResolver($scope));
 
         if (false === $docblock->isDefined()) {
             return TypeFactory::undefined();

--- a/lib/WorseReflection/Tests/Inference/SelfTest.php
+++ b/lib/WorseReflection/Tests/Inference/SelfTest.php
@@ -13,7 +13,7 @@ class SelfTest extends IntegrationTestCase
     public function testSelf(string $path): void
     {
         $source = (string)file_get_contents($path);
-        $reflector = $this->createReflector($source);
+        $reflector = $this->createBuilder($source)->enableCache()->build();
         $reflector->reflectOffset($source, mb_strlen($source));
 
         // the wrAssertType function in the source code will cause

--- a/lib/WorseReflection/Tests/Inference/return-statement/class_method.test
+++ b/lib/WorseReflection/Tests/Inference/return-statement/class_method.test
@@ -1,0 +1,8 @@
+<?php
+
+class Foo {
+    public function bar() {
+        return 'string';
+        wrReturnType('"string"');
+    }
+}

--- a/lib/WorseReflection/Tests/Unit/Bridge/Phpactor/DocblockParser/DocblockParserFactoryTest.php
+++ b/lib/WorseReflection/Tests/Unit/Bridge/Phpactor/DocblockParser/DocblockParserFactoryTest.php
@@ -9,7 +9,6 @@ use Phpactor\WorseReflection\Core\Reflection\ReflectionClassLike;
 use Phpactor\WorseReflection\Core\Type;
 use Phpactor\WorseReflection\Core\TypeFactory;
 use Phpactor\WorseReflection\Core\TypeResolver\ClassLikeTypeResolver;
-use Phpactor\WorseReflection\Core\TypeResolver\PassthroughTypeResolver;
 use Phpactor\WorseReflection\Core\Type\ArrayType;
 use Phpactor\WorseReflection\Core\Type\BooleanType;
 use Phpactor\WorseReflection\Core\Type\CallableType;

--- a/lib/WorseReflection/Tests/Unit/Bridge/Phpactor/DocblockParser/DocblockParserFactoryTest.php
+++ b/lib/WorseReflection/Tests/Unit/Bridge/Phpactor/DocblockParser/DocblockParserFactoryTest.php
@@ -332,11 +332,11 @@ class DocblockParserFactoryTest extends IntegrationTestCase
 
     private function parseDocblockWithReflector(Reflector $reflector, string $docblock): DocBlock
     {
-        return (new DocblockParserFactory($reflector))->create(new PassthroughTypeResolver(), $docblock);
+        return (new DocblockParserFactory($reflector))->create($docblock);
     }
 
     private function parseDocblockWithClass(Reflector $reflector, ReflectionClassLike $classLike, string $docblock): DocBlock
     {
-        return (new DocblockParserFactory($reflector))->create(new ClassLikeTypeResolver($classLike), $docblock);
+        return (new DocblockParserFactory($reflector))->create($docblock)->withTypeResolver(new ClassLikeTypeResolver($classLike));
     }
 }


### PR DESCRIPTION
The dynamic "type resolver" (which would resolve `static` on doclock types) was cached, so `static` would not return the correct context class. This PR injects the "type resolver" after the caching and enables caching for the inference tests.