### PR TITLE
Gh 1665 fix inconsistent caching issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 
 Bug fixes:
 
+  - [wr] Inconsistent type resolution - removed node level cache #1673
   - [in] Fix exception when indexed file has no path #1643
   - [wr] Do not complete constants on class instance #1614
   - [wr] Include virtual properties in class members #1623

--- a/lib/CodeTransform/Adapter/WorseReflection/Helper/WorseMissingMethodFinder.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Helper/WorseMissingMethodFinder.php
@@ -2,26 +2,17 @@
 
 namespace Phpactor\CodeTransform\Adapter\WorseReflection\Helper;
 
-use Microsoft\PhpParser\Node\Expression\CallExpression;
-use Microsoft\PhpParser\Node\Expression\MemberAccessExpression;
-use Microsoft\PhpParser\Node\Expression\ScopedPropertyAccessExpression;
-use Microsoft\PhpParser\Node\SourceFileNode;
-use Microsoft\PhpParser\Parser;
-use Microsoft\PhpParser\Token;
 use Phpactor\CodeTransform\Domain\Helper\MissingMethodFinder;
 use Phpactor\CodeTransform\Domain\Helper\MissingMethodFinder\MissingMethod;
-use Phpactor\TextDocument\ByteOffsetRange;
 use Phpactor\TextDocument\TextDocument;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\MissingMethodDiagnostic;
-use Phpactor\WorseReflection\Core\Exception\NotFound;
-use Phpactor\WorseReflection\Core\Type\ClassType;
 use Phpactor\WorseReflection\Reflector;
 
 class WorseMissingMethodFinder implements MissingMethodFinder
 {
     private Reflector $reflector;
 
-    public function __construct(Reflector $reflector, Parser $parser)
+    public function __construct(Reflector $reflector)
     {
         $this->reflector = $reflector;
     }

--- a/lib/CodeTransform/Adapter/WorseReflection/Helper/WorseMissingMethodFinder.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Helper/WorseMissingMethodFinder.php
@@ -12,6 +12,7 @@ use Phpactor\CodeTransform\Domain\Helper\MissingMethodFinder;
 use Phpactor\CodeTransform\Domain\Helper\MissingMethodFinder\MissingMethod;
 use Phpactor\TextDocument\ByteOffsetRange;
 use Phpactor\TextDocument\TextDocument;
+use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\MissingMethodDiagnostic;
 use Phpactor\WorseReflection\Core\Exception\NotFound;
 use Phpactor\WorseReflection\Core\Type\ClassType;
 use Phpactor\WorseReflection\Reflector;
@@ -20,83 +21,25 @@ class WorseMissingMethodFinder implements MissingMethodFinder
 {
     private Reflector $reflector;
 
-    private Parser $parser;
-
     public function __construct(Reflector $reflector, Parser $parser)
     {
         $this->reflector = $reflector;
-        $this->parser = $parser;
     }
 
     
     public function find(TextDocument $sourceCode): array
     {
-        $node = $this->parser->parseSourceFile($sourceCode->__toString());
-        $names = $this->methodNames($node);
+        $diagnostics = $this->reflector->diagnostics($sourceCode)->byClass(MissingMethodDiagnostic::class);
         $missing = [];
 
-        foreach ($names as $name) {
-            $offset = $this->reflector->reflectOffset($sourceCode, $name->start);
-            $containerType = $offset->symbolContext()->containerType();
-
-            if (!$containerType->isDefined()) {
-                continue;
-            }
-
-            if (!$containerType instanceof ClassType) {
-                continue;
-            }
-
-            try {
-                $class = $this->reflector->reflectClassLike($containerType->name());
-            } catch (NotFound $notFound) {
-                continue;
-            }
-
-            $methodName = $name->getText($sourceCode->__toString());
-            if (!is_string($methodName)) {
-                continue;
-            }
-            try {
-                $class->methods()->get($methodName);
-            } catch (NotFound $notFound) {
-                $missing[] = new MissingMethod(
-                    $methodName,
-                    ByteOffsetRange::fromInts($name->start, $name->start + $name->length)
-                );
-            }
+        /** @var MissingMethodDiagnostic $missingMethod */
+        foreach ($diagnostics as $missingMethod) {
+            $missing[] = new MissingMethod(
+                $missingMethod->methodName(),
+                $missingMethod->range(),
+            );
         }
 
         return $missing;
-    }
-
-    /**
-     * @return Token[]
-     */
-    private function methodNames(SourceFileNode $node): array
-    {
-        $names = [];
-        foreach ($node->getDescendantNodes() as $node) {
-            if ((!$node instanceof CallExpression)) {
-                continue;
-            }
-
-            assert($node instanceof CallExpression);
-
-            $memberName = null;
-            if ($node->callableExpression instanceof MemberAccessExpression) {
-                $memberName = $node->callableExpression->memberName;
-            } elseif ($node->callableExpression instanceof ScopedPropertyAccessExpression) {
-                $memberName = $node->callableExpression->memberName;
-            }
-
-            if (!($memberName instanceof Token)) {
-                continue;
-            }
-
-            $names[] = $memberName;
-        }
-
-        return $names;
     }
 }

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Helper/WorseMissingMethodFinderTest.php
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Helper/WorseMissingMethodFinderTest.php
@@ -3,7 +3,6 @@
 namespace Phpactor\CodeTransform\Tests\Adapter\WorseReflection\Helper;
 
 use Generator;
-use Microsoft\PhpParser\Parser;
 use Phpactor\CodeTransform\Adapter\WorseReflection\Helper\WorseMissingMethodFinder;
 use Phpactor\CodeTransform\Tests\Adapter\WorseReflection\WorseTestCase;
 use Phpactor\TestUtils\ExtractOffset;
@@ -20,7 +19,7 @@ class WorseMissingMethodFinderTest extends WorseTestCase
         $reflector = $this->reflectorForWorkspace($source);
         $document = TextDocumentBuilder::create($source)->build();
 
-        $methods = (new WorseMissingMethodFinder($reflector, new Parser()))->find($document, $offset);
+        $methods = (new WorseMissingMethodFinder($reflector))->find($document);
         self::assertCount($expectedCount, $methods);
     }
 

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Helper/WorseMissingMethodFinderTest.php
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Helper/WorseMissingMethodFinderTest.php
@@ -43,7 +43,7 @@ class WorseMissingMethodFinderTest extends WorseTestCase
                 EOT
             , 0
         ];
-        yield 'missing method' => [
+        yield '1 missing method' => [
             <<<'EOT'
                 <?php
                 class foobar { public function bar() { $this->foo(); } }

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/WorseTestCase.php
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/WorseTestCase.php
@@ -4,6 +4,7 @@ namespace Phpactor\CodeTransform\Tests\Adapter\WorseReflection;
 
 use Phpactor\CodeTransform\Tests\Adapter\AdapterTestCase;
 use Phpactor\WorseReflection\Bridge\Phpactor\MemberProvider\DocblockMemberProvider;
+use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\MissingMethods;
 use Phpactor\WorseReflection\Core\SourceCode;
 use Phpactor\WorseReflection\Core\SourceCodeLocator\TemporarySourceLocator;
 use Phpactor\WorseReflection\Reflector;
@@ -17,6 +18,7 @@ class WorseTestCase extends AdapterTestCase
     {
         $builder = ReflectorBuilder::create();
         $builder->addMemberProvider(new DocblockMemberProvider());
+        $builder->addDiagnosticProvider(new MissingMethods());
 
         foreach ((array)glob($this->workspace()->path('/*.php')) as $file) {
             $locator = new TemporarySourceLocator(ReflectorBuilder::create()->build(), true);

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/WorseTestCase.php
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/WorseTestCase.php
@@ -4,7 +4,7 @@ namespace Phpactor\CodeTransform\Tests\Adapter\WorseReflection;
 
 use Phpactor\CodeTransform\Tests\Adapter\AdapterTestCase;
 use Phpactor\WorseReflection\Bridge\Phpactor\MemberProvider\DocblockMemberProvider;
-use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\MissingMethods;
+use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\MissingMethodsProvider;
 use Phpactor\WorseReflection\Core\SourceCode;
 use Phpactor\WorseReflection\Core\SourceCodeLocator\TemporarySourceLocator;
 use Phpactor\WorseReflection\Reflector;
@@ -18,7 +18,7 @@ class WorseTestCase extends AdapterTestCase
     {
         $builder = ReflectorBuilder::create();
         $builder->addMemberProvider(new DocblockMemberProvider());
-        $builder->addDiagnosticProvider(new MissingMethods());
+        $builder->addDiagnosticProvider(new MissingMethodsProvider());
 
         foreach ((array)glob($this->workspace()->path('/*.php')) as $file) {
             $locator = new TemporarySourceLocator(ReflectorBuilder::create()->build(), true);

--- a/lib/Extension/CodeTransform/CodeTransformExtension.php
+++ b/lib/Extension/CodeTransform/CodeTransformExtension.php
@@ -291,8 +291,7 @@ class CodeTransformExtension implements Extension
         });
         $container->register(MissingMethodFinder::class, function (Container $container) {
             return new WorseMissingMethodFinder(
-                $container->get(WorseReflectionExtension::SERVICE_REFLECTOR),
-                $container->get(WorseReflectionExtension::SERVICE_PARSER)
+                $container->get(WorseReflectionExtension::SERVICE_REFLECTOR)
             );
         });
     }

--- a/lib/Extension/WorseReflection/WorseReflectionExtension.php
+++ b/lib/Extension/WorseReflection/WorseReflectionExtension.php
@@ -7,7 +7,7 @@ use Phpactor\Extension\ClassToFile\ClassToFileExtension;
 use Phpactor\Extension\FilePathResolver\FilePathResolverExtension;
 use Phpactor\WorseReflection\Bridge\Phpactor\MemberProvider\DocblockMemberProvider;
 use Phpactor\WorseReflection\Bridge\Phpactor\MemberProvider\MixinMemberProvider;
-use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\MissingMethods;
+use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\MissingMethodsProvider;
 use Phpactor\WorseReflection\Core\Cache;
 use Phpactor\WorseReflection\Core\Cache\TtlCache;
 use Phpactor\WorseReflection\Core\SourceCodeLocator\NativeReflectionFunctionSourceLocator;
@@ -147,7 +147,7 @@ class WorseReflectionExtension implements Extension
     private function registerDiagnosticProviders(ContainerBuilder $container): void
     {
         $container->register('worse_reflection.diagnostic.missing_method', function (Container $container) {
-            return new MissingMethods();
+            return new MissingMethodsProvider();
         }, [ self::TAG_DIAGNOSTIC_PROVIDER => []]);
     }
 }

--- a/lib/Extension/WorseReflectionAnalyse/Command/AnalyseCommand.php
+++ b/lib/Extension/WorseReflectionAnalyse/Command/AnalyseCommand.php
@@ -3,7 +3,6 @@
 namespace Phpactor\Extension\WorseReflectionAnalyse\Command;
 
 use Phpactor\Extension\WorseReflectionAnalyse\Model\Analyser;
-use Phpactor\WorseReflection\Core\Diagnostic;
 use Phpactor\WorseReflection\Core\Diagnostics;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
@@ -54,7 +53,7 @@ class AnalyseCommand extends Command
             foreach ($diagnostics as $diagnostic) {
                 $table->addRow([
                     sprintf('%s:%s', $diagnostic->range()->start()->toInt(), $diagnostic->range()->end()->toInt()),
-                    Diagnostic::severityAsString($diagnostic->severity()),
+                    $diagnostic->severity()->toString(),
                     $diagnostic->message(),
                 ]);
             }

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/MissingMethodDiagnostic.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/MissingMethodDiagnostic.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics;
+
+use Phpactor\TextDocument\ByteOffsetRange;
+use Phpactor\WorseReflection\Core\Diagnostic;
+
+class MissingMethodDiagnostic implements Diagnostic
+{
+    private string $message;
+
+    private int $severity;
+
+    private ByteOffsetRange $range;
+
+    private string $classType;
+
+    private string $methodName;
+
+    public function __construct(
+        ByteOffsetRange $range,
+        string $message,
+        int $severity,
+        string $classType,
+        string $methodName,
+    ) {
+        $this->message = $message;
+        $this->severity = $severity;
+        $this->range = $range;
+        $this->classType = $classType;
+        $this->methodName = $methodName;
+    }
+
+    public function range(): ByteOffsetRange
+    {
+        return $this->range;
+    }
+
+    public function severity(): int
+    {
+        return $this->severity;
+    }
+
+    public function message(): string
+    {
+        return $this->message;
+    }
+
+    public function classType(): string
+    {
+        return $this->classType;
+    }
+
+    public function methodName(): string
+    {
+        return $this->methodName;
+    }
+}

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/MissingMethodDiagnostic.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/MissingMethodDiagnostic.php
@@ -4,12 +4,13 @@ namespace Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics;
 
 use Phpactor\TextDocument\ByteOffsetRange;
 use Phpactor\WorseReflection\Core\Diagnostic;
+use Phpactor\WorseReflection\Core\DiagnosticSeverity;
 
 class MissingMethodDiagnostic implements Diagnostic
 {
     private string $message;
 
-    private int $severity;
+    private DiagnosticSeverity $severity;
 
     private ByteOffsetRange $range;
 
@@ -20,7 +21,7 @@ class MissingMethodDiagnostic implements Diagnostic
     public function __construct(
         ByteOffsetRange $range,
         string $message,
-        int $severity,
+        DiagnosticSeverity $severity,
         string $classType,
         string $methodName,
     ) {
@@ -36,7 +37,7 @@ class MissingMethodDiagnostic implements Diagnostic
         return $this->range;
     }
 
-    public function severity(): int
+    public function severity(): DiagnosticSeverity
     {
         return $this->severity;
     }

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/MissingMethodDiagnostic.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/MissingMethodDiagnostic.php
@@ -23,7 +23,7 @@ class MissingMethodDiagnostic implements Diagnostic
         string $message,
         DiagnosticSeverity $severity,
         string $classType,
-        string $methodName,
+        string $methodName
     ) {
         $this->message = $message;
         $this->severity = $severity;

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/MissingMethods.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/MissingMethods.php
@@ -9,7 +9,6 @@ use Microsoft\PhpParser\Node\Expression\MemberAccessExpression;
 use Microsoft\PhpParser\Node\Expression\ScopedPropertyAccessExpression;
 use Microsoft\PhpParser\Token;
 use Phpactor\TextDocument\ByteOffsetRange;
-use Phpactor\WorseReflection\Core\Diagnostic;
 use Phpactor\WorseReflection\Core\DiagnosticProvider;
 use Phpactor\WorseReflection\Core\DiagnosticSeverity;
 use Phpactor\WorseReflection\Core\Exception\NotFound;
@@ -68,7 +67,7 @@ class MissingMethods implements DiagnosticProvider
                     $methodName,
                     $containerType->__toString()
                 ),
-                DiagnosticSeverity::ERROR,
+                DiagnosticSeverity::ERROR(),
                 $class->name()->__toString(),
                 $methodName
             );

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/MissingMethods.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/MissingMethods.php
@@ -11,6 +11,7 @@ use Microsoft\PhpParser\Token;
 use Phpactor\TextDocument\ByteOffsetRange;
 use Phpactor\WorseReflection\Core\Diagnostic;
 use Phpactor\WorseReflection\Core\DiagnosticProvider;
+use Phpactor\WorseReflection\Core\DiagnosticSeverity;
 use Phpactor\WorseReflection\Core\Exception\NotFound;
 use Phpactor\WorseReflection\Core\Inference\Frame;
 use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
@@ -57,7 +58,7 @@ class MissingMethods implements DiagnosticProvider
         try {
             $name = $class->methods()->get($methodName);
         } catch (NotFound $notFound) {
-            yield new Diagnostic(
+            yield new MissingMethodDiagnostic(
                 ByteOffsetRange::fromInts(
                     $memberName->getStartPosition(),
                     $memberName->getEndPosition()
@@ -67,7 +68,9 @@ class MissingMethods implements DiagnosticProvider
                     $methodName,
                     $containerType->__toString()
                 ),
-                Diagnostic::ERROR
+                DiagnosticSeverity::ERROR,
+                $class->name()->__toString(),
+                $methodName
             );
         }
     }

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/MissingMethodsProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/MissingMethodsProvider.php
@@ -16,7 +16,7 @@ use Phpactor\WorseReflection\Core\Inference\Frame;
 use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
 use Phpactor\WorseReflection\Core\Type\ReflectedClassType;
 
-class MissingMethods implements DiagnosticProvider
+class MissingMethodsProvider implements DiagnosticProvider
 {
     public function provide(NodeContextResolver $resolver, Frame $frame, Node $node): Generator
     {

--- a/lib/WorseReflection/Core/Diagnostic.php
+++ b/lib/WorseReflection/Core/Diagnostic.php
@@ -2,58 +2,17 @@
 
 namespace Phpactor\WorseReflection\Core;
 
+use Phpactor\LanguageServerProtocol\DiagnosticSeverity;
 use Phpactor\TextDocument\ByteOffsetRange;
 
-class Diagnostic
+interface Diagnostic
 {
-    public const ERROR = 1;
-    public const WARNING = 2;
-    public const INFORMATION = 3;
-    public const HINT = 4;
+    public function range(): ByteOffsetRange;
 
-    private string $message;
+    /**
+     * @return DiagnosticSeverity::*
+     */
+    public function severity(): int;
 
-    private int $severity;
-
-    private ByteOffsetRange $range;
-
-    public function __construct(
-        ByteOffsetRange $range,
-        string $message,
-        int $severity
-    ) {
-        $this->message = $message;
-        $this->severity = $severity;
-        $this->range = $range;
-    }
-
-    public function range(): ByteOffsetRange
-    {
-        return $this->range;
-    }
-
-    public function severity(): int
-    {
-        return $this->severity;
-    }
-
-    public function message(): string
-    {
-        return $this->message;
-    }
-
-    public static function severityAsString(int $severity): string
-    {
-        switch ($severity) {
-            case self::HINT:
-                return 'HINT';
-            case self::ERROR:
-                return 'ERROR';
-            case self::WARNING:
-                return 'WARN';
-            case self::INFORMATION:
-                return 'INFO';
-        }
-        return 'unknown';
-    }
+    public function message(): string;
 }

--- a/lib/WorseReflection/Core/Diagnostic.php
+++ b/lib/WorseReflection/Core/Diagnostic.php
@@ -2,17 +2,13 @@
 
 namespace Phpactor\WorseReflection\Core;
 
-use Phpactor\LanguageServerProtocol\DiagnosticSeverity;
 use Phpactor\TextDocument\ByteOffsetRange;
 
 interface Diagnostic
 {
     public function range(): ByteOffsetRange;
 
-    /**
-     * @return DiagnosticSeverity::*
-     */
-    public function severity(): int;
+    public function severity(): DiagnosticSeverity;
 
     public function message(): string;
 }

--- a/lib/WorseReflection/Core/DiagnosticSeverity.php
+++ b/lib/WorseReflection/Core/DiagnosticSeverity.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Phpactor\WorseReflection\Core;
+
+final class DiagnosticSeverity
+{
+    public const ERROR = 1;
+    public const WARNING = 2;
+    public const INFORMATION = 3;
+    public const HINT = 4;
+
+    public static function severityAsString(int $severity): string
+    {
+        switch ($severity) {
+            case self::HINT:
+                return 'HINT';
+            case self::ERROR:
+                return 'ERROR';
+            case self::WARNING:
+                return 'WARN';
+            case self::INFORMATION:
+                return 'INFO';
+        }
+        return 'unknown';
+    }
+}

--- a/lib/WorseReflection/Core/DiagnosticSeverity.php
+++ b/lib/WorseReflection/Core/DiagnosticSeverity.php
@@ -9,9 +9,27 @@ final class DiagnosticSeverity
     public const INFORMATION = 3;
     public const HINT = 4;
 
-    public static function severityAsString(int $severity): string
+    /**
+     * @var self::*
+     */
+    private $level;
+
+    /**
+     * @param self::* $level
+     */
+    private function __construct(int $level)
     {
-        switch ($severity) {
+        $this->level = $level;
+    }
+
+    public static function ERROR(): self
+    {
+        return new self(self::ERROR);
+    }
+
+    public function toString(): string
+    {
+        switch ($this->level) {
             case self::HINT:
                 return 'HINT';
             case self::ERROR:

--- a/lib/WorseReflection/Core/Diagnostics.php
+++ b/lib/WorseReflection/Core/Diagnostics.php
@@ -8,17 +8,18 @@ use IteratorAggregate;
 use Traversable;
 
 /**
- * @implements IteratorAggregate<Diagnostic>
+ * @template T of Diagnostic
+ * @implements IteratorAggregate<T>
  */
-class Diagnostics implements IteratorAggregate, Countable
+final class Diagnostics implements IteratorAggregate, Countable
 {
     /**
-     * @var Diagnostic[]
+     * @var T[]
      */
     private array $diagnostics;
 
     /**
-     * @param Diagnostic[] $diagnostics
+     * @param T[] $diagnostics
      */
     public function __construct(array $diagnostics)
     {
@@ -33,5 +34,16 @@ class Diagnostics implements IteratorAggregate, Countable
     public function count(): int
     {
         return count($this->diagnostics);
+    }
+
+    /**
+     * @template C of Diagnostic
+     * @param class-string<C> $classFqn
+     * @return self<C>
+     */
+    public function byClass(string $classFqn): self
+    {
+         // @phpstan-ignore-next-line
+        return new self(array_filter($this->diagnostics, fn (Diagnostic $d) => $d instanceof $classFqn));
     }
 }

--- a/lib/WorseReflection/Core/Diagnostics.php
+++ b/lib/WorseReflection/Core/Diagnostics.php
@@ -8,18 +8,17 @@ use IteratorAggregate;
 use Traversable;
 
 /**
- * @template T of Diagnostic
- * @implements IteratorAggregate<T>
+ * @implements IteratorAggregate<Diagnostic>
  */
 final class Diagnostics implements IteratorAggregate, Countable
 {
     /**
-     * @var T[]
+     * @var Diagnostic[]
      */
     private array $diagnostics;
 
     /**
-     * @param T[] $diagnostics
+     * @param Diagnostic[] $diagnostics
      */
     public function __construct(array $diagnostics)
     {
@@ -37,13 +36,10 @@ final class Diagnostics implements IteratorAggregate, Countable
     }
 
     /**
-     * @template C of Diagnostic
-     * @param class-string<C> $classFqn
-     * @return self<C>
+     * @param class-string $classFqn
      */
     public function byClass(string $classFqn): self
     {
-         // @phpstan-ignore-next-line
         return new self(array_filter($this->diagnostics, fn (Diagnostic $d) => $d instanceof $classFqn));
     }
 }

--- a/lib/WorseReflection/Core/Inference/FrameResolver.php
+++ b/lib/WorseReflection/Core/Inference/FrameResolver.php
@@ -33,7 +33,7 @@ final class FrameResolver
     public function __construct(
         NodeContextResolver $nodeContextResolver,
         array $globalWalkers,
-        array $nodeWalkers,
+        array $nodeWalkers
     ) {
         $this->nodeContextResolver = $nodeContextResolver;
         $this->globalWalkers = $globalWalkers;

--- a/lib/WorseReflection/Core/Inference/FrameResolver.php
+++ b/lib/WorseReflection/Core/Inference/FrameResolver.php
@@ -9,7 +9,6 @@ use Microsoft\PhpParser\Node\Expression\AnonymousFunctionCreationExpression;
 use Microsoft\PhpParser\Node\Expression\ArrowFunctionCreationExpression;
 use Microsoft\PhpParser\Node\SourceFileNode;
 use Microsoft\PhpParser\Token;
-use Phpactor\WorseReflection\Core\Cache;
 use Phpactor\WorseReflection\Reflector;
 use RuntimeException;
 

--- a/lib/WorseReflection/Core/Inference/NodeContextResolver.php
+++ b/lib/WorseReflection/Core/Inference/NodeContextResolver.php
@@ -5,7 +5,6 @@ namespace Phpactor\WorseReflection\Core\Inference;
 use Microsoft\PhpParser\MissingToken;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Token;
-use Phpactor\WorseReflection\Core\Cache;
 use Phpactor\WorseReflection\Core\Exception\CouldNotResolveNode;
 use Phpactor\WorseReflection\Core\Name;
 use Phpactor\WorseReflection\Reflector;

--- a/lib/WorseReflection/Core/Inference/NodeContextResolver.php
+++ b/lib/WorseReflection/Core/Inference/NodeContextResolver.php
@@ -18,8 +18,6 @@ class NodeContextResolver
     
     private LoggerInterface $logger;
     
-    private Cache $cache;
-
     /**
      * @var array<class-name,Resolver>
      */
@@ -31,12 +29,10 @@ class NodeContextResolver
     public function __construct(
         Reflector $reflector,
         LoggerInterface $logger,
-        Cache $cache,
         array $resolverMap = []
     ) {
         $this->logger = $logger;
         $this->reflector = $reflector;
-        $this->cache = $cache;
         $this->resolverMap = $resolverMap;
     }
 
@@ -68,21 +64,17 @@ class NodeContextResolver
             return NodeContext::none();
         }
 
-        $key = 'sc:'.spl_object_hash($node);
+        if (false === $node instanceof Node) {
+            throw new CouldNotResolveNode(sprintf(
+                'Non-node class passed to resolveNode, got "%s"',
+                get_class($node)
+            ));
+        }
 
-        return $this->cache->getOrSet($key, function () use ($frame, $node) {
-            if (false === $node instanceof Node) {
-                throw new CouldNotResolveNode(sprintf(
-                    'Non-node class passed to resolveNode, got "%s"',
-                    get_class($node)
-                ));
-            }
+        $context = $this->doResolveNode($frame, $node);
+        $context = $context->withScope(new ReflectionScope($this->reflector, $node));
 
-            $context = $this->doResolveNode($frame, $node);
-            $context = $context->withScope(new ReflectionScope($this->reflector, $node));
-
-            return $context;
-        });
+        return $context;
     }
 
     private function doResolveNode(Frame $frame, Node $node): NodeContext

--- a/lib/WorseReflection/Core/Inference/Resolver/ReturnStatementResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/ReturnStatementResolver.php
@@ -24,16 +24,12 @@ class ReturnStatementResolver implements Resolver
         $type = $resolver->resolveNode($frame, $node->expression)->type();
         $context = $context->withType($type);
 
-        if ($frame->returnType()->isDefined()) {
-            if ($frame->returnType()->isVoid()) {
-                $frame->withReturnType($type);
-            } else {
-                $frame->withReturnType($frame->returnType()->addType($type));
-            }
+        if ($frame->returnType()->isVoid()) {
+            $frame->withReturnType($type);
             return $context;
         }
 
-        $frame->withReturnType($type);
+        $frame->withReturnType($frame->returnType()->addType($type));
 
         return $context;
     }

--- a/lib/WorseReflection/Core/ServiceLocator.php
+++ b/lib/WorseReflection/Core/ServiceLocator.php
@@ -101,7 +101,6 @@ class ServiceLocator
         $this->symbolContextResolver = new NodeContextResolver(
             $this->reflector,
             $this->logger,
-            $cache,
             (new DefaultResolverFactory(
                 $this->reflector,
                 $nameResolver
@@ -111,7 +110,6 @@ class ServiceLocator
 
         $this->frameBuilder = FrameResolver::create(
             $this->symbolContextResolver,
-            $cache,
             array_merge([
                 new FunctionLikeWalker(),
                 new PassThroughWalker(),

--- a/lib/WorseReflection/Tests/Benchmarks/DiagnosticsBench.php
+++ b/lib/WorseReflection/Tests/Benchmarks/DiagnosticsBench.php
@@ -2,7 +2,7 @@
 
 namespace Phpactor\WorseReflection\Tests\Benchmarks;
 
-use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\MissingMethods;
+use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\MissingMethodsProvider;
 use Phpactor\WorseReflection\Reflector;
 use Phpactor\WorseReflection\ReflectorBuilder;
 
@@ -17,7 +17,7 @@ class DiagnosticsBench
     public function init(): void
     {
         $this->reflector = ReflectorBuilder::create()
-            ->addDiagnosticProvider(new MissingMethods())
+            ->addDiagnosticProvider(new MissingMethodsProvider())
             ->enableContextualSourceLocation()
             ->enableCache()
             ->build();

--- a/lib/WorseReflection/Tests/Benchmarks/PhpUnitReflectClassBench.php
+++ b/lib/WorseReflection/Tests/Benchmarks/PhpUnitReflectClassBench.php
@@ -7,8 +7,7 @@ use Phpactor\WorseReflection\Core\ClassName;
 
 /**
  * @Iterations(5)
- * @Revs(10)
- * @Warmup(1)
+ * @Revs(1)
  */
 class PhpUnitReflectClassBench extends BaseBenchCase
 {

--- a/lib/WorseReflection/Tests/Benchmarks/ReflectMethodBench.php
+++ b/lib/WorseReflection/Tests/Benchmarks/ReflectMethodBench.php
@@ -8,7 +8,7 @@ use Phpactor\WorseReflection\Tests\Benchmarks\Examples\MethodClass;
 
 /**
  * @Iterations(10)
- * @Revs(30)
+ * @Revs(1)
  * @OutputTimeUnit("milliseconds", precision=2)
  */
 class ReflectMethodBench extends BaseBenchCase

--- a/lib/WorseReflection/Tests/Benchmarks/ReflectPropertyBench.php
+++ b/lib/WorseReflection/Tests/Benchmarks/ReflectPropertyBench.php
@@ -8,7 +8,7 @@ use Phpactor\WorseReflection\Tests\Benchmarks\Examples\PropertyClass;
 
 /**
  * @Iterations(10)
- * @Revs(30)
+ * @Revs(1)
  * @OutputTimeUnit("milliseconds", precision=2)
  * @Assert("mode(variant.time.avg) <= mode(baseline.time.avg) +/- 10%")
  */

--- a/lib/WorseReflection/Tests/Benchmarks/SelfReflectClassBench.php
+++ b/lib/WorseReflection/Tests/Benchmarks/SelfReflectClassBench.php
@@ -7,7 +7,6 @@ use Phpactor\WorseReflection\Core\ClassName;
 /**
  * @Iterations(5)
  * @Revs(10)
- * @Warmup(1)
  * @OutputTimeUnit("milliseconds", precision=2)
  * @Assert("mode(variant.time.avg) <= mode(baseline.time.avg) +/- 10%")
  * @Assert("mode(variant.mem.peak) <= mode(baseline.mem.peak) +/- 10%")

--- a/lib/WorseReflection/Tests/Benchmarks/YiiBench.php
+++ b/lib/WorseReflection/Tests/Benchmarks/YiiBench.php
@@ -5,7 +5,6 @@ namespace Phpactor\WorseReflection\Tests\Benchmarks;
 /**
  * @Iterations(5)
  * @Revs(1)
- * @Warmup(1)
  */
 class YiiBench extends BaseBenchCase
 {

--- a/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Diagonstics/MissingMethodsTest.php
+++ b/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Diagonstics/MissingMethodsTest.php
@@ -2,13 +2,13 @@
 
 namespace Phpactor\WorseReflection\Tests\Integration\Bridge\TolerantParser\Diagonstics;
 
-use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\MissingMethods;
+use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\MissingMethodsProvider;
 use Phpactor\WorseReflection\Core\DiagnosticProvider;
 
 class MissingMethodsTest extends DiagnosticsTestCase
 {
     protected function provider(): DiagnosticProvider
     {
-        return new MissingMethods();
+        return new MissingMethodsProvider();
     }
 }

--- a/lib/WorseReflection/Tests/Integration/Core/Inference/NodeContextResolverTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/Inference/NodeContextResolverTest.php
@@ -2,7 +2,6 @@
 
 namespace Phpactor\WorseReflection\Tests\Integration\Core\Inference;
 
-use Phpactor\WorseReflection\Core\Cache\NullCache;
 use Phpactor\WorseReflection\Core\DefaultResolverFactory;
 use Phpactor\WorseReflection\Core\Inference\NodeToTypeConverter;
 use Phpactor\WorseReflection\Core\Inference\PropertyAssignments;
@@ -1159,7 +1158,6 @@ class NodeContextResolverTest extends IntegrationTestCase
         $resolver = new NodeContextResolver(
             $reflector,
             $this->logger(),
-            new NullCache(),
             (new DefaultResolverFactory($reflector, $nameResolver))->createResolvers(),
         );
 


### PR DESCRIPTION
## Part 1

We have a cache for both the "frame" walker and the "node context resolver", the idea was to avoid repeating work within a single request but:

- I don't know why there would be repeated work in a single request

Probably these caches were added because of the benchmarks, which do indeed show a `6000%` perforamnce degredation, but the benchmarks are completely wrong, as they warm up the cache before hand, so of course when the benchmark runs it's faster.

Benchmarking properly there seems to be a 26% performance penalty by removing these caches, which is really a small price to pay for having consistency. 


```
PhpUnitReflectClassBench                                                                                                                                        
========================                                                                                                                                        
                                                                                                                                                                
Average iteration times by variant                                                                                                                              
                                                                                                                                                
911.6ms   │       █                                                                                                                             
797.6ms   │       █▃                                                                                                                            
683.7ms   │       ██                                                                                                                            
569.7ms   │       ██                                                                                                                            
455.8ms   │       ██                                                                                                                            
341.8ms   │       ██                                                                                                                            
227.9ms   │       ██                                                                                                                            
113.9ms   │ ▁▁ ▃▃ ██                                                                                                                            
          └──────────                                                                                                                           
            1  2  3                                                                                                                             
                                                                                                                                                
[█ <current>] [█ master]                                                                                                                        
                                                                                                                                                
1: test_case            2: test_case_methods_a᠁ 3: test_case_method_fr᠁                                                                         
                                                                                                                                                
Memory by variant                                                                                                                               
                                                                                                                                                
65.3mb    │       █▅                                                                                                                            
57.1mb    │       ██                                                                                                                            
48.9mb    │       ██                                                                                                                            
40.8mb    │       ██                                                                                                                            
32.6mb    │       ██                                                                                                                            
24.5mb    │    ▂▂ ██                                                                                                                            
16.3mb    │ ▆▆ ██ ██                                                                                                                            
8.2mb     │ ██ ██ ██                                                                                                                            
          └──────────                                                                                                                           
            1  2  3                                                                                                                             
                                                                                                                                                
[█ <current>] [█ master]                                                                                                                        
                                                                                                                                                
1: test_case            2: test_case_methods_a᠁ 3: test_case_method_fr᠁                                                                         
                                                                                                                                                
<current>                                                                                                                                       
+-------------------------------------+----------+-----------+--------+----------+                                                              
| subject                             | memory   | mode      | rstdev | stdev    |                                                              
+-------------------------------------+----------+-----------+--------+----------+                                                              
| test_case ()                        | 13.985mb | 11.183ms  | ±0.85% | 94.730μs |                                                              
| test_case_methods_and_properties () | 18.132mb | 36.368ms  | ±4.56% | 1.697ms  |                                                              
| test_case_method_frames ()          | 65.254mb | 911.597ms | ±5.13% | 48.050ms |                                                                              
+-------------------------------------+----------+-----------+--------+----------+                                                                                                                           

master                                             
+-------------------------------------+----------+-----------+--------+-----------+                                                                                                                          
| subject                             | memory   | mode      | rstdev | stdev     |                                                                                                                          
+-------------------------------------+----------+-----------+--------+-----------+                                                                                                                          
| test_case ()                        | 13.989mb | 11.279ms  | ±1.15% | 130.940μs |                                                                                                                          
| test_case_methods_and_properties () | 18.136mb | 35.851ms  | ±1.49% | 540.033μs |                                                                                                                          
| test_case_method_frames ()          | 62.068mb | 713.262ms | ±2.23% | 16.095ms  |                                                                                                                          
+-------------------------------------+----------+-----------+--------+-----------+ 
```

However, some things make extensive use of this cache, such as the MisssingMethodFinder (generate method diagnostic).

## Part 2

We previously introduced Diagnostics but as of yet they are not used.

This PR also refactors the "missing method finder" to make use of the MissingMethod diagnostics and allows diagnostic providers to issue any class that implements `Diagnostic` allowing us to provide things like `MissingMethodFinder` with the stuff it needs.

On a large test class (`ReflectionClassTest`) the performance is improved by 100% (still too slow, but twice as fast).
