### PR TITLE
Add support for @var dockblock with variable followed by type

### DIFF
--- a/lib/DocblockParser/Ast/Tag/InvertedVarTag.php
+++ b/lib/DocblockParser/Ast/Tag/InvertedVarTag.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Phpactor\DocblockParser\Ast\Tag;
+
+class InvertedVarTag extends VarTag
+{
+    protected const CHILD_NAMES = [
+        'tag',
+        'variable',
+        'type',
+    ];
+}

--- a/lib/DocblockParser/Tests/Unit/Printer/examples/var3.test
+++ b/lib/DocblockParser/Tests/Unit/Printer/examples/var3.test
@@ -1,7 +1,7 @@
-/** @var string $foobar */
+/** @var $foobar \DateTime */
 ---
 Docblock: = 
  ElementList: = /** 
-  VarTag: = @var
-   ScalarNode: = string
-   VariableNode: = $foobar */
+  InvertedVarTag: = @var
+   VariableNode: = $foobar
+   ClassNode: = \DateTime */

--- a/lib/Extension/WorseReflection/WorseReflectionExtension.php
+++ b/lib/Extension/WorseReflection/WorseReflectionExtension.php
@@ -9,6 +9,7 @@ use Phpactor\WorseReflection\Bridge\Phpactor\MemberProvider\DocblockMemberProvid
 use Phpactor\WorseReflection\Bridge\Phpactor\MemberProvider\MixinMemberProvider;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\MissingDocblockProvider;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\MissingMethodProvider;
+use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\WrongVarOrderProvider;
 use Phpactor\WorseReflection\Core\Cache;
 use Phpactor\WorseReflection\Core\Cache\TtlCache;
 use Phpactor\WorseReflection\Core\SourceCodeLocator\NativeReflectionFunctionSourceLocator;
@@ -153,5 +154,8 @@ class WorseReflectionExtension implements Extension
         $container->register(MissingDocblockProvider::class, function (Container $container) {
             return new MissingDocblockProvider();
         }, [ self::TAG_DIAGNOSTIC_PROVIDER => []]);
+        $container->register(WrongVarOrderProvider::class, function (Container $container) {
+            return new WrongVarOrderProvider();
+        }, [ self::TAG_DIAGNOSTIC_PROVIDER => [] ]);
     }
 }

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/WrongVarOrderDiagnostic.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/WrongVarOrderDiagnostic.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics;
+
+use Phpactor\TextDocument\ByteOffsetRange;
+use Phpactor\WorseReflection\Core\Diagnostic;
+use Phpactor\WorseReflection\Core\DiagnosticSeverity;
+
+class WrongVarOrderDiagnostic implements Diagnostic
+{
+    private string $message;
+
+    private DiagnosticSeverity $severity;
+
+    private ByteOffsetRange $range;
+
+    public function __construct(
+        ByteOffsetRange $range,
+        string $message,
+        ?DiagnosticSeverity $severity = null
+    ) {
+        $this->range = $range;
+        $this->message = $message;
+        $this->severity = $severity ?: DiagnosticSeverity::INFORMATION();
+    }
+
+    public function range(): ByteOffsetRange
+    {
+        return $this->range;
+    }
+
+    public function severity(): DiagnosticSeverity
+    {
+        return $this->severity;
+    }
+
+    public function message(): string
+    {
+        return $this->message;
+    }
+}

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/WrongVarOrderProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/WrongVarOrderProvider.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics;
+
+use Generator;
+use Microsoft\PhpParser\Node;
+use Phpactor\DocblockParser\Ast\Tag\InvertedVarTag;
+use Phpactor\DocblockParser\DocblockParser;
+use Phpactor\TextDocument\ByteOffsetRange;
+use Phpactor\WorseReflection\Core\DiagnosticProvider;
+use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
+
+class WrongVarOrderProvider implements DiagnosticProvider
+{
+    private DocblockParser $docblockParser;
+
+    public function __construct(DocblockParser $docblockParser = null)
+    {
+        $this->docblockParser = $docblockParser ?: DocblockParser::create();
+    }
+
+    public function provide(NodeContextResolver $resolver, Frame $frame, Node $node): Generator
+    {
+        $comment = $node->getDocCommentText();
+
+        if (!$comment) {
+            return;
+        }
+
+        $parsedComment = $this->docblockParser->parse($node->getLeadingCommentAndWhitespaceText());
+        $invertedVarTags = $parsedComment->descendantElements(InvertedVarTag::class);
+
+        $offset = $node->getFullStartPosition();
+
+        foreach ($invertedVarTags as $invertedVarTag) {
+            $start = $offset + $invertedVarTag->start();
+            $end = $offset + $invertedVarTag->end();
+
+            yield new WrongVarOrderDiagnostic(ByteOffsetRange::fromInts($start, $end), '@var type must come before element name');
+        }
+    }
+}

--- a/lib/WorseReflection/Core/DiagnosticSeverity.php
+++ b/lib/WorseReflection/Core/DiagnosticSeverity.php
@@ -22,6 +22,11 @@ final class DiagnosticSeverity
         $this->level = $level;
     }
 
+    public static function INFORMATION(): self
+    {
+        return new self(self::INFORMATION);
+    }
+
     public static function ERROR(): self
     {
         return new self(self::ERROR);

--- a/lib/WorseReflection/Tests/Inference/variable/type_from_var_docblock_invalid.test
+++ b/lib/WorseReflection/Tests/Inference/variable/type_from_var_docblock_invalid.test
@@ -1,0 +1,6 @@
+<?php
+
+/** @var $foo string */
+$foo;
+
+wrAssertType('string', $foo);


### PR DESCRIPTION
Some of the software I have to work with comes with `@var` definitions with variable name first and then type. For example:

```
/** @var $date \DateTime */
```

This pull request adds a support for that

The reason for changing `var3.test` file instead of creating a new one is that `var2.test` seems identical.