### PR TITLE
Performatnce

### DIFF
--- a/lib/Extension/WorseReflectionAnalyse/Command/AnalyseCommand.php
+++ b/lib/Extension/WorseReflectionAnalyse/Command/AnalyseCommand.php
@@ -107,7 +107,7 @@ class AnalyseCommand extends Command
     {
         foreach ($results as $file => $diagnostics) {
             foreach ($diagnostics as $diagnostic) {
-                $output->writeln(json_encode([
+                $output->writeln((string)json_encode([
                     'file' => $file,
                     'range' => ['start' => $diagnostic->range()->start()->toInt(), 'end' => $diagnostic->range()->end()->toInt()],
                     'message' => $diagnostic->message(),

--- a/lib/Extension/WorseReflectionAnalyse/Command/AnalyseCommand.php
+++ b/lib/Extension/WorseReflectionAnalyse/Command/AnalyseCommand.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class AnalyseCommand extends Command
@@ -28,11 +29,12 @@ class AnalyseCommand extends Command
     {
         $this->setDescription('Experimental diagnostics for files in the given path');
         $this->addArgument(self::ARG_PATH, InputArgument::REQUIRED, 'Path to analyse');
+        $this->addOption('format', null, InputOption::VALUE_REQUIRED, 'json');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $start = microtime(true);
+        $start = (float)microtime(true);
 
         /**
          * @var array<string,Diagnostics> $results
@@ -45,17 +47,37 @@ class AnalyseCommand extends Command
         $output->writeln('');
         $progress = new ProgressBar($output, $count);
         $progress->start();
+        $hasErrors = false;
 
         foreach ($this->analyser->analyse($path) as $file => $diagnostics) {
             $progress->advance();
             $results[$file] = $diagnostics;
+            if (0 !== $diagnostics->count()) {
+                $hasErrors = true;
+            }
         }
         $progress->finish();
         $output->writeln('');
         $output->writeln('');
 
-        $errorCount = 0;
+        switch ($input->getOption('format')) {
+            case 'json':
+                $this->renderJson($output, $results);
+                break;
+            default:
+                $this->renderTable($output, $results, $start);
+        }
 
+
+        return $hasErrors ? 1 : 0;
+    }
+
+    /**
+     * @param array<string,Diagnostics> $results
+     */
+    private function renderTable(OutputInterface $output, array $results, float $start): void
+    {
+        $errorCount = 0;
         foreach ($results as $file => $diagnostics) {
             if (!count($diagnostics)) {
                 continue;
@@ -76,7 +98,22 @@ class AnalyseCommand extends Command
             $output->writeln('');
         }
         $output->writeln(sprintf('%s problems in %s seconds', $errorCount, number_format(microtime(true) - $start, 4)));
+    }
 
-        return $errorCount ? 1 : 0;
+    /**
+     * @param array<string,Diagnostics> $results
+     */
+    private function renderJson(OutputInterface $output, array $results): void
+    {
+        foreach ($results as $file => $diagnostics) {
+            foreach ($diagnostics as $diagnostic) {
+                $output->writeln(json_encode([
+                    'file' => $file,
+                    'range' => ['start' => $diagnostic->range()->start()->toInt(), 'end' => $diagnostic->range()->end()->toInt()],
+                    'message' => $diagnostic->message(),
+                    'severity' => $diagnostic->severity(),
+                ]));
+            }
+        }
     }
 }

--- a/lib/WorseReflection/Bridge/Phpactor/DocblockParser/ParsedDocblock.php
+++ b/lib/WorseReflection/Bridge/Phpactor/DocblockParser/ParsedDocblock.php
@@ -53,7 +53,7 @@ class ParsedDocblock implements DocBlock
 
     public function methodType(string $methodName): Type
     {
-        foreach ($this->node->descendantElements(MethodTag::class) as $methodTag) {
+        foreach ($this->node->tags(MethodTag::class) as $methodTag) {
             assert($methodTag instanceof MethodTag);
             if ($methodTag->methodName() !== $methodName) {
                 continue;
@@ -72,7 +72,7 @@ class ParsedDocblock implements DocBlock
     public function vars(): DocBlockVars
     {
         $vars = [];
-        foreach ($this->node->descendantElements(VarTag::class) as $varTag) {
+        foreach ($this->node->tags(VarTag::class) as $varTag) {
             assert($varTag instanceof VarTag);
             $vars[] = new DocBlockVar(
                 $varTag->variable ? ltrim($varTag->name() ?? '', '$') : '',
@@ -86,7 +86,7 @@ class ParsedDocblock implements DocBlock
     public function parameterType(string $paramName): Type
     {
         $types = [];
-        foreach ($this->node->descendantElements(ParamTag::class) as $paramTag) {
+        foreach ($this->node->tags(ParamTag::class) as $paramTag) {
             assert($paramTag instanceof ParamTag);
             if (ltrim($paramTag->paramName(), '$') !== $paramName) {
                 continue;
@@ -100,7 +100,7 @@ class ParsedDocblock implements DocBlock
     public function propertyType(string $propertyName): Type
     {
         $types = [];
-        foreach ($this->node->descendantElements(PropertyTag::class) as $propertyTag) {
+        foreach ($this->node->tags(PropertyTag::class) as $propertyTag) {
             assert($propertyTag instanceof PropertyTag);
             if (ltrim($propertyTag->propertyName(), '$') !== $propertyName) {
                 continue;
@@ -120,7 +120,7 @@ class ParsedDocblock implements DocBlock
 
     public function returnType(): Type
     {
-        foreach ($this->node->descendantElements(ReturnTag::class) as $tag) {
+        foreach ($this->node->tags(ReturnTag::class) as $tag) {
             assert($tag instanceof ReturnTag);
             return $this->convertType($tag->type());
         }
@@ -141,7 +141,7 @@ class ParsedDocblock implements DocBlock
     public function properties(ReflectionClassLike $declaringClass): CoreReflectionPropertyCollection
     {
         $properties = [];
-        foreach ($this->node->descendantElements(PropertyTag::class) as $propertyTag) {
+        foreach ($this->node->tags(PropertyTag::class) as $propertyTag) {
             assert($propertyTag instanceof PropertyTag);
             $type = $this->convertType($propertyTag->type);
             $property = new VirtualReflectionProperty(
@@ -166,7 +166,7 @@ class ParsedDocblock implements DocBlock
     public function methods(ReflectionClassLike $declaringClass): CoreReflectionMethodCollection
     {
         $methods = [];
-        foreach ($this->node->descendantElements(MethodTag::class) as $methodTag) {
+        foreach ($this->node->tags(MethodTag::class) as $methodTag) {
             assert($methodTag instanceof MethodTag);
             $params = ReflectionParameterCollection::empty();
             $method = new VirtualReflectionMethod(
@@ -195,7 +195,7 @@ class ParsedDocblock implements DocBlock
 
     public function deprecation(): Deprecation
     {
-        foreach ($this->node->descendantElements(DeprecatedTag::class) as $deprecatedTag) {
+        foreach ($this->node->tags(DeprecatedTag::class) as $deprecatedTag) {
             assert($deprecatedTag instanceof DeprecatedTag);
             return new Deprecation(true, $deprecatedTag->text());
         }
@@ -206,7 +206,7 @@ class ParsedDocblock implements DocBlock
     public function templateMap(): TemplateMap
     {
         $map = [];
-        foreach ($this->node->descendantElements(TemplateTag::class) as $templateTag) {
+        foreach ($this->node->tags(TemplateTag::class) as $templateTag) {
             assert($templateTag instanceof TemplateTag);
             $map[$templateTag->placeholder()] = $this->convertType($templateTag->type);
         }
@@ -216,7 +216,7 @@ class ParsedDocblock implements DocBlock
     public function extends(): array
     {
         $extends = [];
-        foreach ($this->node->descendantElements(ExtendsTag::class) as $extendsTag) {
+        foreach ($this->node->tags(ExtendsTag::class) as $extendsTag) {
             assert($extendsTag instanceof ExtendsTag);
             $extends[] = $this->convertType($extendsTag->type);
         }
@@ -226,7 +226,7 @@ class ParsedDocblock implements DocBlock
     public function implements(): array
     {
         $implements = [];
-        foreach ($this->node->descendantElements(ImplementsTag::class) as $implementsTag) {
+        foreach ($this->node->tags(ImplementsTag::class) as $implementsTag) {
             assert($implementsTag instanceof ImplementsTag);
             $implements = array_merge($implements, array_map(function (TypeNode $type) {
                 return $this->convertType($type);
@@ -238,7 +238,7 @@ class ParsedDocblock implements DocBlock
     public function mixins(): array
     {
         $mixins = [];
-        foreach ($this->node->descendantElements(MixinTag::class) as $mixinTag) {
+        foreach ($this->node->tags(MixinTag::class) as $mixinTag) {
             assert($mixinTag instanceof MixinTag);
             $mixins[] = $this->convertType($mixinTag->class);
         }

--- a/lib/WorseReflection/Tests/Benchmarks/DiagnosticsBench.php
+++ b/lib/WorseReflection/Tests/Benchmarks/DiagnosticsBench.php
@@ -7,7 +7,6 @@ use GlobIterator;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\MissingMethodProvider;
 use Phpactor\WorseReflection\Reflector;
 use Phpactor\WorseReflection\ReflectorBuilder;
-use Phpactor\WorseReflection\Tests\Inference\TestAssertWalker;
 use SplFileInfo;
 
 /**

--- a/lib/WorseReflection/Tests/Benchmarks/DiagnosticsBench.php
+++ b/lib/WorseReflection/Tests/Benchmarks/DiagnosticsBench.php
@@ -2,9 +2,13 @@
 
 namespace Phpactor\WorseReflection\Tests\Benchmarks;
 
+use Generator;
+use GlobIterator;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\MissingMethodProvider;
 use Phpactor\WorseReflection\Reflector;
 use Phpactor\WorseReflection\ReflectorBuilder;
+use Phpactor\WorseReflection\Tests\Inference\TestAssertWalker;
+use SplFileInfo;
 
 /**
  * @Iterations(5)
@@ -18,18 +22,31 @@ class DiagnosticsBench
     {
         $this->reflector = ReflectorBuilder::create()
             ->addDiagnosticProvider(new MissingMethodProvider())
-            ->enableContextualSourceLocation()
-            ->enableCache()
             ->build();
     }
 
     /**
      * @BeforeMethods({"init"})
+     * @ParamProviders({"providePaths"})
+     * @param array{path:string} $params
      */
-    public function benchDiagnostics(): void
+    public function benchDiagnostics(array $params): void
     {
         $diagnostics = $this->reflector->diagnostics(
-            file_get_contents(__DIR__ . '/fixtures/diagnostics/lots_of_missing_methods.test')
+            (string)file_get_contents($params['path'])
         );
+    }
+
+    /**
+     * @return Generator<array{path:string}>
+     */
+    public function providePaths(): Generator
+    {
+        foreach ((new GlobIterator(__DIR__ . '/fixtures/diagnostics/*.test')) as $info) {
+            assert($info instanceof SplFileInfo);
+            yield $info->getFilename() => [
+                'path' => $info->getRealPath()
+            ];
+        }
     }
 }

--- a/lib/WorseReflection/Tests/Benchmarks/fixtures/diagnostics/method_chain.test
+++ b/lib/WorseReflection/Tests/Benchmarks/fixtures/diagnostics/method_chain.test
@@ -1,0 +1,6 @@
+<?php
+
+class Fizz { public function bang(): Fizz {} }
+
+$fizz = new Fizz();
+$fizz->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang(->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang(->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang(->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang(->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang(->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang(->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang(->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang()->bang(->bang()->bang()->bang(->bang()->bang();


### PR DESCRIPTION
Improve docblock parsing performance a bit

- Do not descend into nodes when it is only necessary to get the immediate children of the docblock.