### PR TITLE
Improved keyword completion

### DIFF
--- a/lib/Completion/Bridge/TolerantParser/CompletionContext.php
+++ b/lib/Completion/Bridge/TolerantParser/CompletionContext.php
@@ -23,7 +23,6 @@ use Microsoft\PhpParser\Node\StatementNode;
 use Microsoft\PhpParser\Node\Statement\ClassDeclaration;
 use Microsoft\PhpParser\Node\Statement\CompoundStatementNode;
 use Microsoft\PhpParser\Node\Statement\EnumDeclaration;
-use Microsoft\PhpParser\Node\Statement\InlineHtml;
 use Microsoft\PhpParser\Node\Statement\InterfaceDeclaration;
 use Microsoft\PhpParser\Node\Statement\TraitDeclaration;
 use Microsoft\PhpParser\Node\TraitUseClause;
@@ -233,30 +232,12 @@ class CompletionContext
         return true;
     }
 
-    public static function functionName(Node $node): bool
+    public static function methodName(Node $node): bool
     {
-        $node = NodeUtil::firstDescendantNodeBeforeOffset($node->getRoot(), $node->getStartPosition());
-
-        if (!$node instanceof MethodDeclaration) {
-            return false;
-        }
-
-        return true;
+        return $node->parent instanceof MethodDeclaration;
     }
 
-    private static function isClassClause(?Node $node): bool
-    {
-        if (null === $node) {
-            return false;
-        }
-        return
-            $node instanceof InterfaceBaseClause ||
-            $node instanceof ClassInterfaceClause ||
-            $node instanceof TraitUseClause ||
-            $node instanceof ClassBaseClause;
-    }
-
-    public static function declaration(Node $node, ByteOffset $offset)
+    public static function declaration(Node $node, ByteOffset $offset): bool
     {
         if (!$node->parent) {
             return false;
@@ -305,5 +286,17 @@ class CompletionContext
         }
 
         return true;
+    }
+
+    private static function isClassClause(?Node $node): bool
+    {
+        if (null === $node) {
+            return false;
+        }
+        return
+            $node instanceof InterfaceBaseClause ||
+            $node instanceof ClassInterfaceClause ||
+            $node instanceof TraitUseClause ||
+            $node instanceof ClassBaseClause;
     }
 }

--- a/lib/Completion/Bridge/TolerantParser/CompletionContext.php
+++ b/lib/Completion/Bridge/TolerantParser/CompletionContext.php
@@ -17,10 +17,13 @@ use Microsoft\PhpParser\Node\InterfaceBaseClause;
 use Microsoft\PhpParser\Node\MethodDeclaration;
 use Microsoft\PhpParser\Node\NamespaceUseClause;
 use Microsoft\PhpParser\Node\Parameter;
+use Microsoft\PhpParser\Node\QualifiedName as MicrosoftQualifiedName;
+use Microsoft\PhpParser\Node\SourceFileNode;
 use Microsoft\PhpParser\Node\StatementNode;
 use Microsoft\PhpParser\Node\Statement\ClassDeclaration;
 use Microsoft\PhpParser\Node\Statement\CompoundStatementNode;
 use Microsoft\PhpParser\Node\Statement\EnumDeclaration;
+use Microsoft\PhpParser\Node\Statement\InlineHtml;
 use Microsoft\PhpParser\Node\Statement\InterfaceDeclaration;
 use Microsoft\PhpParser\Node\Statement\TraitDeclaration;
 use Microsoft\PhpParser\Node\TraitUseClause;
@@ -251,5 +254,56 @@ class CompletionContext
             $node instanceof ClassInterfaceClause ||
             $node instanceof TraitUseClause ||
             $node instanceof ClassBaseClause;
+    }
+
+    public static function declaration(Node $node, ByteOffset $offset)
+    {
+        if (!$node->parent) {
+            return false;
+        }
+        if (!$node->parent->parent) {
+            return false;
+        }
+        if (!$node instanceof MicrosoftQualifiedName) {
+            return false;
+        }
+        if (!$node->parent->parent instanceof SourceFileNode) {
+            return false;
+        }
+
+        if ($node->parent->getText() !== $node->getText()) {
+            return false;
+        }
+
+        $previous = NodeUtil::previousSibling($node->parent);
+
+        // for some reason `class Foobar { func<>` will result in `func` being an sibling to `class Foobar` instead of
+        // within the members node.
+        // To fix this ensure that if the previous is a declaration then make sure that it doesn't have a missing closed token
+        if ($previous instanceof ClassDeclaration) {
+            if ($previous->classMembers->closeBrace instanceof MissingToken) {
+                return false;
+            }
+        }
+        if ($previous instanceof TraitDeclaration) {
+            if ($previous->traitMembers->closeBrace instanceof MissingToken) {
+                return false;
+            }
+        }
+        if ($previous instanceof InterfaceDeclaration) {
+            if ($previous->interfaceMembers->closeBrace instanceof MissingToken) {
+                return false;
+            }
+        }
+        if ($previous instanceof EnumDeclaration) {
+            if ($previous->enumMembers->closeBrace instanceof MissingToken) {
+                return false;
+            }
+        }
+        if ($node->getEndPosition() < $previous->getEndPosition()) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/lib/Completion/Bridge/TolerantParser/CompletionContext.php
+++ b/lib/Completion/Bridge/TolerantParser/CompletionContext.php
@@ -241,4 +241,15 @@ class CompletionContext
             $node instanceof TraitUseClause ||
             $node instanceof ClassBaseClause;
     }
+
+    public static function functionName(Node $node): bool
+    {
+        $node = NodeUtil::firstDescendantNodeBeforeOffset($node->getRoot(), $node->getStartPosition());
+
+        if (!$node instanceof MethodDeclaration) {
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/lib/Completion/Bridge/TolerantParser/CompletionContext.php
+++ b/lib/Completion/Bridge/TolerantParser/CompletionContext.php
@@ -230,6 +230,17 @@ class CompletionContext
         return true;
     }
 
+    public static function functionName(Node $node): bool
+    {
+        $node = NodeUtil::firstDescendantNodeBeforeOffset($node->getRoot(), $node->getStartPosition());
+
+        if (!$node instanceof MethodDeclaration) {
+            return false;
+        }
+
+        return true;
+    }
+
     private static function isClassClause(?Node $node): bool
     {
         if (null === $node) {
@@ -240,16 +251,5 @@ class CompletionContext
             $node instanceof ClassInterfaceClause ||
             $node instanceof TraitUseClause ||
             $node instanceof ClassBaseClause;
-    }
-
-    public static function functionName(Node $node): bool
-    {
-        $node = NodeUtil::firstDescendantNodeBeforeOffset($node->getRoot(), $node->getStartPosition());
-
-        if (!$node instanceof MethodDeclaration) {
-            return false;
-        }
-
-        return true;
     }
 }

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/KeywordCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/KeywordCompletor.php
@@ -20,6 +20,17 @@ class KeywordCompletor implements TolerantCompletor
             yield from $this->keywords(['implements ', 'extends ']);
             return true;
         }
+        if (CompletionContext::declaration($node, $offset)) {
+            yield from $this->keywords(['class ', 'trait ', 'function ', 'interface ']);
+            return true;
+        }
+
+        if (CompletionContext::functionName($node)) {
+            yield from $this->keywords([
+                '__construct(',
+            ]);
+            return true;
+        }
 
         if (
             CompletionContext::classMembersBody($node->parent)
@@ -27,13 +38,6 @@ class KeywordCompletor implements TolerantCompletor
             yield from $this->keywords([
                 'function ',
                 'const ',
-            ]);
-            return true;
-        }
-
-        if (CompletionContext::functionName($node)) {
-            yield from $this->keywords([
-                '__construct(',
             ]);
             return true;
         }
@@ -55,7 +59,7 @@ class KeywordCompletor implements TolerantCompletor
         foreach ($keywords as $keyword) {
             yield Suggestion::createWithOptions($keyword, [
                 'type' => Suggestion::TYPE_KEYWORD,
-                'priority' => Suggestion::PRIORITY_HIGH,
+                'priority' => 1,
             ]);
         }
     }

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/KeywordCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/KeywordCompletor.php
@@ -17,7 +17,7 @@ class KeywordCompletor implements TolerantCompletor
     public function complete(Node $node, TextDocument $source, ByteOffset $offset): Generator
     {
         if (CompletionContext::classClause($node, $offset)) {
-            yield from $this->keywords(['implements', 'extends']);
+            yield from $this->keywords(['implements ', 'extends ']);
             return true;
         }
 
@@ -25,14 +25,21 @@ class KeywordCompletor implements TolerantCompletor
             CompletionContext::classMembersBody($node->parent)
         ) {
             yield from $this->keywords([
-                'function',
-                'const',
+                'function ',
+                'const ',
+            ]);
+            return true;
+        }
+
+        if (CompletionContext::functionName($node)) {
+            yield from $this->keywords([
+                '__construct(',
             ]);
             return true;
         }
 
         if (CompletionContext::classMembersBody($node)) {
-            yield from $this->keywords(['private', 'protected', 'public']);
+            yield from $this->keywords(['private ', 'protected ', 'public ']);
             return true;
         }
 

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/KeywordCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/KeywordCompletor.php
@@ -25,7 +25,7 @@ class KeywordCompletor implements TolerantCompletor
             return true;
         }
 
-        if (CompletionContext::functionName($node)) {
+        if (CompletionContext::methodName($node)) {
             yield from $this->keywords([
                 '__construct(',
             ]);

--- a/lib/Completion/Tests/Integration/Bridge/TolerantParser/WorseReflection/KeywordCompletorTest.php
+++ b/lib/Completion/Tests/Integration/Bridge/TolerantParser/WorseReflection/KeywordCompletorTest.php
@@ -25,7 +25,7 @@ class KeywordCompletorTest extends TolerantCompletorTestCase
     public function provideComplete(): Generator
     {
         yield 'member keywords' => [
-            '<?php class Foobar { <>',
+            '<?php class Foobar { p<>',
             $this->expect(['private ', 'protected ', 'public ']),
         ];
 
@@ -33,14 +33,20 @@ class KeywordCompletorTest extends TolerantCompletorTestCase
             '<?php class Foobar { private <>',
             $this->expect(['const ', 'function ']),
         ];
-        yield '__construct' => [
-            '<?php class Foobar { public function __<>',
-            $this->expect(['__construct(']),
-        ];
         yield 'member keyword postfix 2' => [
             '<?php class Foobar { private func<>',
             $this->expect(['const ', 'function ']),
         ];
+
+        yield '__construct' => [
+            '<?php class Foobar { public function __<>',
+            $this->expect(['__construct(']),
+        ];
+        yield '__construct 2' => [
+            '<?php class Foo extends Bar implements One {    public function __<> }',
+            $this->expect(['__construct(']),
+        ];
+
 
         yield 'class implements 1' => [
             '<?php class Foobar <>',
@@ -50,14 +56,18 @@ class KeywordCompletorTest extends TolerantCompletorTestCase
             '<?php class Foobar impl<>',
             $this->expect(['extends ', 'implements ']),
         ];
-        yield 'class implements 2' => [
-            '<?php class Foobar impl<>',
-            $this->expect(['extends ', 'implements ']),
-        ];
 
         yield 'class keyword' => [
             '<?php cl<>',
-            $this->expect(['class ', 'trait ', 'function ', 'interface ']),
+            $this->expect(['class ', 'function ', 'interface ', 'trait ']),
+        ];
+        yield 'class keyword 2' => [
+            '<?php class F {} cl<>',
+            $this->expect(['class ', 'function ', 'interface ', 'trait ']),
+        ];
+        yield 'class keyword 3' => [
+            '<?php class F {function fo() {}} cl<>',
+            $this->expect(['class ', 'function ', 'interface ', 'trait ']),
         ];
     }
 

--- a/lib/Completion/Tests/Integration/Bridge/TolerantParser/WorseReflection/KeywordCompletorTest.php
+++ b/lib/Completion/Tests/Integration/Bridge/TolerantParser/WorseReflection/KeywordCompletorTest.php
@@ -26,25 +26,29 @@ class KeywordCompletorTest extends TolerantCompletorTestCase
     {
         yield 'member keywords' => [
             '<?php class Foobar { <>',
-            $this->expect(['private', 'protected', 'public']),
+            $this->expect(['private ', 'protected ', 'public ']),
         ];
 
         yield 'member keyword postfix' => [
             '<?php class Foobar { private <>',
-            $this->expect(['const', 'function']),
+            $this->expect(['const ', 'function ']),
+        ];
+        yield '__construct' => [
+            '<?php class Foobar { public function __<>',
+            $this->expect(['__construct(']),
         ];
         yield 'member keyword postfix 2' => [
             '<?php class Foobar { private func<>',
-            $this->expect(['const', 'function']),
+            $this->expect(['const ', 'function ']),
         ];
 
         yield 'class implements 1' => [
             '<?php class Foobar <>',
-            $this->expect(['extends', 'implements']),
+            $this->expect(['extends ', 'implements ']),
         ];
         yield 'class implements 2' => [
             '<?php class Foobar impl<>',
-            $this->expect(['extends', 'implements']),
+            $this->expect(['extends ', 'implements ']),
         ];
     }
 

--- a/lib/Completion/Tests/Integration/Bridge/TolerantParser/WorseReflection/KeywordCompletorTest.php
+++ b/lib/Completion/Tests/Integration/Bridge/TolerantParser/WorseReflection/KeywordCompletorTest.php
@@ -50,6 +50,15 @@ class KeywordCompletorTest extends TolerantCompletorTestCase
             '<?php class Foobar impl<>',
             $this->expect(['extends ', 'implements ']),
         ];
+        yield 'class implements 2' => [
+            '<?php class Foobar impl<>',
+            $this->expect(['extends ', 'implements ']),
+        ];
+
+        yield 'class keyword' => [
+            '<?php cl<>',
+            $this->expect(['class ', 'trait ', 'function ', 'interface ']),
+        ];
     }
 
     protected function createTolerantCompletor(TextDocument $source): TolerantCompletor

--- a/lib/WorseReflection/Core/Inference/Resolver/CallExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/CallExpressionResolver.php
@@ -3,7 +3,6 @@
 namespace Phpactor\WorseReflection\Core\Inference\Resolver;
 
 use Microsoft\PhpParser\Node;
-use Microsoft\PhpParser\Node\Expression;
 use Microsoft\PhpParser\Node\Expression\CallExpression;
 use Microsoft\PhpParser\Node\Expression\ParenthesizedExpression;
 use Microsoft\PhpParser\Node\Expression\Variable;
@@ -16,7 +15,6 @@ use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
 use Phpactor\WorseReflection\Core\Inference\Symbol;
 use Phpactor\WorseReflection\Core\Type;
 use Phpactor\WorseReflection\Core\Type\CallableType;
-use Phpactor\WorseReflection\Core\Type\ClassStringType;
 use Phpactor\WorseReflection\Core\Type\ConditionalType;
 use Phpactor\WorseReflection\Core\Type\ReflectedClassType;
 use Phpactor\WorseReflection\Core\Util\NodeUtil;
@@ -70,14 +68,13 @@ class CallExpressionResolver implements Resolver
     }
 
     private function processConditionalType(
-        Type $type,
+        ConditionalType $type,
         Type $containerType,
         NodeContext $context,
         NodeContextResolver $resolver,
         Frame $frame,
         CallExpression $node
-    ): NodeContext
-    {
+    ): NodeContext {
         if ($containerType instanceof ReflectedClassType) {
             $reflection = $containerType->reflectionOrNull();
             if (!$reflection) {

--- a/lib/WorseReflection/Core/Util/NodeUtil.php
+++ b/lib/WorseReflection/Core/Util/NodeUtil.php
@@ -251,4 +251,22 @@ class NodeUtil
 
         return $node;
     }
+
+    public static function previousSibling(Node $node): ?Node
+    {
+        $parent = $node->parent;
+        $previous = null;
+        foreach ($parent->getChildNodes() as $childNode) {
+            if (null === $previous) {
+                $previous = $childNode;
+                continue;
+            }
+            if ($childNode === $node) {
+                return $previous;
+            }
+            $previous = $childNode;
+        }
+
+        return null;
+    }
 }

--- a/lib/WorseReflection/Tests/Inference/generics/class-string-generic.test
+++ b/lib/WorseReflection/Tests/Inference/generics/class-string-generic.test
@@ -1,2 +1,21 @@
 <?php
 
+
+class Foo {
+    /**
+     * @tempalte T
+     * @param class-string<T> $class
+     * @return T
+     */
+    public function foobar($class): object
+    {
+    }
+}
+
+$f = new Foo();
+$f = $f->foobar(Foo::class);
+
+// not supported yet
+wrAssertType('T', $f);
+
+

--- a/lib/WorseReflection/Tests/Inference/generics/class-string-generic.test
+++ b/lib/WorseReflection/Tests/Inference/generics/class-string-generic.test
@@ -1,20 +1,2 @@
 <?php
 
-class Foo {
-    /**
-     * @tempalte T
-     * @param class-string<T> $class
-     * @return T
-     */
-    public function foobar($class): object
-    {
-    }
-}
-
-$f = new Foo();
-$f = $f->foobar(Foo::class);
-
-// not supported yet
-wrAssertType('T', $f);
-
-

--- a/lib/WorseReflection/Tests/Inference/generics/class-string-generic.test
+++ b/lib/WorseReflection/Tests/Inference/generics/class-string-generic.test
@@ -13,6 +13,8 @@ class Foo {
 
 $f = new Foo();
 $f = $f->foobar(Foo::class);
-wrAssertType('Foo', $f);
+
+// not supported yet
+wrAssertType('T', $f);
 
 

--- a/lib/WorseReflection/Tests/Inference/generics/class-string-generic.test
+++ b/lib/WorseReflection/Tests/Inference/generics/class-string-generic.test
@@ -1,0 +1,18 @@
+<?php
+
+class Foo {
+    /**
+     * @tempalte T
+     * @param class-string<T> $class
+     * @return T
+     */
+    public function foobar($class): object
+    {
+    }
+}
+
+$f = new Foo();
+$f = $f->foobar(Foo::class);
+wrAssertType('Foo', $f);
+
+


### PR DESCRIPTION
- Support `function`, `class`, `interface`, `trait` and `enum` keywords
- Add `__construct` (not a keyword but useful, can be moved to something more suitable)