### PR TITLE
RPC command documentation generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ vimdoc: build/bin/vimdoc
 	vimdoc .
 
 configreference:
-	./bin/phpactor development:generate-documentation extension.documentor > doc/reference/configuration.rst
-	./bin/phpactor development:generate-documentation rpc.documentor > doc/reference/rpc_command.rst
+	./bin/phpactor development:generate-documentation extension > doc/reference/configuration.rst
+	./bin/phpactor development:generate-documentation rpc > doc/reference/rpc_command.rst
 
 # Put it first so that "make" without argument is like "make help".
 help:

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ build/vimdoc:
 
 build/vimdoc/build: build/vimdoc
 	cd build/vimdoc; python3 setup.py config
-	cd build/vimdoc; python3 setup.py build 
+	cd build/vimdoc; python3 setup.py build
 
 build/bin/vimdoc: build/vimdoc/build
 	cd build/vimdoc; python3 setup.py install --user
@@ -28,6 +28,7 @@ vimdoc: build/bin/vimdoc
 
 configreference:
 	./bin/phpactor development:configuration-reference > doc/reference/configuration.rst
+	./bin/phpactor development:command-reference > doc/reference/rpc_command.rst
 
 # Put it first so that "make" without argument is like "make help".
 help:

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ vimdoc: build/bin/vimdoc
 	vimdoc .
 
 configreference:
-	./bin/phpactor development:configuration-reference > doc/reference/configuration.rst
-	./bin/phpactor development:command-reference > doc/reference/rpc_command.rst
+	./bin/phpactor development:generate-documentation extension.documentor > doc/reference/configuration.rst
+	./bin/phpactor development:generate-documentation rpc.documentor > doc/reference/rpc_command.rst
 
 # Put it first so that "make" without argument is like "make help".
 help:

--- a/doc/reference/command.rst
+++ b/doc/reference/command.rst
@@ -1,0 +1,75 @@
+Commands
+=============
+
+
+.. This document is generated via the `development:command-reference` command
+
+
+.. contents::
+   :depth: 2
+   :backlinks: none
+   :local:
+
+
+.. _GotoDefinitionHandler:
+
+
+GotoDefinitionHandler
+---------------------
+
+
+.. _param_language:
+
+
+``language``
+""""""""""""
+
+
+Type: string
+
+
+**Default**: ``"php"``
+
+
+.. _param_target:
+
+
+``target``
+""""""""""
+
+
+Type: string
+
+
+**Default**: ``"focused_window"``
+
+
+.. _param_offset:
+
+
+``offset``
+""""""""""
+
+
+**Default**: ``null``
+
+
+.. _param_source:
+
+
+``source``
+""""""""""
+
+
+**Default**: ``null``
+
+
+.. _param_path:
+
+
+``path``
+""""""""
+
+
+**Default**: ``null``
+

--- a/doc/reference/completion.rst
+++ b/doc/reference/completion.rst
@@ -71,7 +71,7 @@ Provide completion for local variables in a scope. Triggered on ``$``.
 ~~~~~~~~~~~~~~~~~~~~~
 
 Provide function name completion based on functions defined at _runtime_ in the
-Phpactor process. 
+Phpactor process.
 
 Note that any functions which are not loaded when _Phpactor_
 loads will not be available. So this is mainly useful for built-in functions.
@@ -82,7 +82,7 @@ This completor is disabled by default when using the :ref:`language_server`.
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Provide constant name completion based on constants defined at _runtime_ in the
-Phpactor process. 
+Phpactor process.
 
 This is mainly useful for built-in constants (e.g. ``JSON_PRETTY_PRINT`` or
 ``PHP_INT_MAX``).

--- a/doc/reference/configuration.rst
+++ b/doc/reference/configuration.rst
@@ -2,7 +2,7 @@ Configuration
 =============
 
 
-.. This document is generated via the `development:configuration-reference` command
+.. This document is generated via the `development:generate-documentation` command
 
 
 .. contents::

--- a/doc/reference/configuration.rst
+++ b/doc/reference/configuration.rst
@@ -2,7 +2,7 @@ Configuration
 =============
 
 
-.. This document is generated via. the `documentation:configuration-reference` command
+.. This document is generated via the `development:configuration-reference` command
 
 
 .. contents::
@@ -25,8 +25,6 @@ CoreExtension
 """"""""""""""""""""""""""
 
 
-
-
 Name of the "dumper" (renderer) to use for some CLI commands
 
 
@@ -38,8 +36,6 @@ Name of the "dumper" (renderer) to use for some CLI commands
 
 ``xdebug_disable``
 """"""""""""""""""
-
-
 
 
 If XDebug should be automatically disabled
@@ -55,8 +51,6 @@ If XDebug should be automatically disabled
 """""""""""
 
 
-
-
 Internal use only - name of the command which was executed
 
 
@@ -68,8 +62,6 @@ Internal use only - name of the command which was executed
 
 ``core.warn_on_develop``
 """"""""""""""""""""""""
-
-
 
 
 Internal use only: if an warning will be issed when on develop, may be removed in the future
@@ -85,8 +77,6 @@ Internal use only: if an warning will be issed when on develop, may be removed i
 """""""""""""""""""""""""
 
 
-
-
 Ensure that PHP has a memory_limit of at least this amount in bytes
 
 
@@ -98,8 +88,6 @@ Ensure that PHP has a memory_limit of at least this amount in bytes
 
 ``$schema``
 """""""""""
-
-
 
 
 Path to JSON schema, which can be used for config autocompletion, use phpactor config:initialize to update
@@ -122,8 +110,6 @@ ClassToFileExtension
 """"""""""""""""""""""""""""""
 
 
-
-
 Root path of the project (e.g. where composer.json is)
 
 
@@ -135,8 +121,6 @@ Root path of the project (e.g. where composer.json is)
 
 ``class_to_file.brute_force_conversion``
 """"""""""""""""""""""""""""""""""""""""
-
-
 
 
 If composer not found, fallback to scanning all files (very time consuming depending on project size)
@@ -159,8 +143,6 @@ CodeTransformExtension
 """""""""""""""""""""""""""""""""""""
 
 
-
-
 Variants which should be suggested when class-create is invoked
 
 
@@ -172,8 +154,6 @@ Variants which should be suggested when class-create is invoked
 
 ``code_transform.template_paths``
 """""""""""""""""""""""""""""""""
-
-
 
 
 Paths in which to look for code templates
@@ -189,8 +169,6 @@ Paths in which to look for code templates
 """"""""""""""""""""""""""""""
 
 
-
-
 Indentation chars to use in code generation and transformation
 
 
@@ -202,8 +180,6 @@ Indentation chars to use in code generation and transformation
 
 ``code_transform.refactor.generate_accessor.prefix``
 """"""""""""""""""""""""""""""""""""""""""""""""""""
-
-
 
 
 Prefix to use for generated accessors
@@ -219,8 +195,6 @@ Prefix to use for generated accessors
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 
-
-
 If the first letter of a generated accessor should be made uppercase
 
 
@@ -232,8 +206,6 @@ If the first letter of a generated accessor should be made uppercase
 
 ``code_transform.import_globals``
 """""""""""""""""""""""""""""""""
-
-
 
 
 Import functions even if they are in the global namespace
@@ -249,8 +221,6 @@ Import functions even if they are in the global namespace
 """"""""""""""""""""""""""""""""""""""""""""
 
 
-
-
 Object fill refactoring: show hint as a comment
 
 
@@ -262,8 +232,6 @@ Object fill refactoring: show hint as a comment
 
 ``code_transform.refactor.object_fill.named_parameters``
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""
-
-
 
 
 Object fill refactoring: use named parameters
@@ -286,8 +254,6 @@ CompletionWorseExtension
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 
-
-
 Enable or disable the ``doctrine_annotation`` completor.
 
 Completion for annotations provided by the Doctrine annotation library.
@@ -301,8 +267,6 @@ Completion for annotations provided by the Doctrine annotation library.
 
 ``completion_worse.completor.imported_names.enabled``
 """""""""""""""""""""""""""""""""""""""""""""""""""""
-
-
 
 
 Enable or disable the ``imported_names`` completor.
@@ -320,8 +284,6 @@ Completion for names imported into the current namespace.
 """"""""""""""""""""""""""""""""""""""""""""""""""""""
 
 
-
-
 Enable or disable the ``worse_parameter`` completor.
 
 Completion for method or function parameters.
@@ -335,8 +297,6 @@ Completion for method or function parameters.
 
 ``completion_worse.completor.named_parameter.enabled``
 """"""""""""""""""""""""""""""""""""""""""""""""""""""
-
-
 
 
 Enable or disable the ``named_parameter`` completor.
@@ -354,8 +314,6 @@ Completion for named parameters.
 """"""""""""""""""""""""""""""""""""""""""""""""""
 
 
-
-
 Enable or disable the ``constructor`` completor.
 
 Completion for constructors.
@@ -369,8 +327,6 @@ Completion for constructors.
 
 ``completion_worse.completor.class_member.enabled``
 """""""""""""""""""""""""""""""""""""""""""""""""""
-
-
 
 
 Enable or disable the ``class_member`` completor.
@@ -388,8 +344,6 @@ Completion for class members.
 """"""""""""""""""""""""""""""""""""""""""""""""
 
 
-
-
 Enable or disable the ``scf_class`` completor.
 
 Brute force completion for class names (not recommended).
@@ -403,8 +357,6 @@ Brute force completion for class names (not recommended).
 
 ``completion_worse.completor.local_variable.enabled``
 """""""""""""""""""""""""""""""""""""""""""""""""""""
-
-
 
 
 Enable or disable the ``local_variable`` completor.
@@ -422,8 +374,6 @@ Completion for local variables.
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 
-
-
 Enable or disable the ``declared_function`` completor.
 
 Completion for functions defined in the Phpactor runtime.
@@ -437,8 +387,6 @@ Completion for functions defined in the Phpactor runtime.
 
 ``completion_worse.completor.declared_constant.enabled``
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""
-
-
 
 
 Enable or disable the ``declared_constant`` completor.
@@ -456,8 +404,6 @@ Completion for constants defined in the Phpactor runtime.
 """""""""""""""""""""""""""""""""""""""""""""""""""""
 
 
-
-
 Enable or disable the ``declared_class`` completor.
 
 Completion for classes defined in the Phpactor runtime.
@@ -471,8 +417,6 @@ Completion for classes defined in the Phpactor runtime.
 
 ``completion_worse.completor.expression_name_search.enabled``
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-
-
 
 
 Enable or disable the ``expression_name_search`` completor.
@@ -490,8 +434,6 @@ Completion for class names, constants and functions at expression positions that
 """"""""""""""""""""""""""""""""""""""""""
 
 
-
-
 Enable or disable the ``use`` completor.
 
 Completion for use imports.
@@ -505,8 +447,6 @@ Completion for use imports.
 
 ``completion_worse.completor.class_like.enabled``
 """""""""""""""""""""""""""""""""""""""""""""""""
-
-
 
 
 Enable or disable the ``class_like`` completor.
@@ -524,8 +464,6 @@ Completion for class like contexts.
 """""""""""""""""""""""""""""""""""""""""""
 
 
-
-
 Enable or disable the ``type`` completor.
 
 Completion for types.
@@ -539,8 +477,6 @@ Completion for types.
 
 ``completion_worse.completor.keyword.enabled``
 """"""""""""""""""""""""""""""""""""""""""""""
-
-
 
 
 Enable or disable the ``keyword`` completor.
@@ -558,8 +494,6 @@ Completion for keywords (not very accurate).
 """""""""""""""""""""""""""""""""""""""""""""""
 
 
-
-
 Enable or disable the ``docblock`` completor.
 
 Docblock completion.
@@ -575,8 +509,6 @@ Docblock completion.
 """""""""""""""""""""""""""""""""""""""""""""""
 
 
-
-
 **Default**: ``false``
 
 
@@ -585,8 +517,6 @@ Docblock completion.
 
 ``completion_worse.completor.class.limit``
 """"""""""""""""""""""""""""""""""""""""""
-
-
 
 
 Suggestion limit for the filesystem based SCF class_completor
@@ -600,8 +530,6 @@ Suggestion limit for the filesystem based SCF class_completor
 
 ``completion_worse.name_completion_priority``
 """""""""""""""""""""""""""""""""""""""""""""
-
-
 
 
 Strategy to use when ordering completion results for classes and functions:
@@ -620,8 +548,6 @@ Strategy to use when ordering completion results for classes and functions:
 """""""""""""""""""""""""""""
 
 
-
-
 Enable or disable completion snippets
 
 
@@ -635,8 +561,6 @@ Enable or disable completion snippets
 """""""""""""""""""""""""""""""""
 
 
-
-
 Enable experimental functionality
 
 
@@ -648,8 +572,6 @@ Enable experimental functionality
 
 ``completion_worse.debug``
 """"""""""""""""""""""""""
-
-
 
 
 Include debug info in completion results
@@ -672,8 +594,6 @@ CompletionExtension
 """""""""""""""""""""
 
 
-
-
 If results should be de-duplicated
 
 
@@ -687,8 +607,6 @@ If results should be de-duplicated
 """""""""""""""""""""""""""""""""""""""""""""
 
 
-
-
 If ``completion.dedupe``, match on completion description intead of name
 
 
@@ -700,8 +618,6 @@ If ``completion.dedupe``, match on completion description intead of name
 
 ``completion.limit``
 """"""""""""""""""""
-
-
 
 
 Sets a limit on the number of completion suggestions for any request
@@ -724,8 +640,6 @@ NavigationExtension
 """"""""""""""""""""""""""
 
 
-
-
 **Default**: ``[]``
 
 
@@ -734,8 +648,6 @@ NavigationExtension
 
 ``navigator.autocreate``
 """"""""""""""""""""""""
-
-
 
 
 **Default**: ``[]``
@@ -755,8 +667,6 @@ RpcExtension
 """"""""""""""""""""
 
 
-
-
 Should replays be stored?
 
 
@@ -768,8 +678,6 @@ Should replays be stored?
 
 ``rpc.replay_path``
 """""""""""""""""""
-
-
 
 
 Path where the replays should be stored
@@ -792,8 +700,6 @@ SourceCodeFilesystemExtension
 """""""""""""""""""""""""""""""""""""""
 
 
-
-
 **Default**: ``"%project_root%"``
 
 
@@ -811,8 +717,6 @@ WorseReflectionExtension
 """""""""""""""""""""""""""""""""""""""""""""""""
 
 
-
-
 Show hints for non-imported global classes and functions
 
 
@@ -824,8 +728,6 @@ Show hints for non-imported global classes and functions
 
 ``worse_reflection.enable_cache``
 """""""""""""""""""""""""""""""""
-
-
 
 
 If reflection caching should be enabled
@@ -841,8 +743,6 @@ If reflection caching should be enabled
 """""""""""""""""""""""""""""""""""
 
 
-
-
 If caching is enabled, limit the amount of time a cache entry can stay alive
 
 
@@ -854,8 +754,6 @@ If caching is enabled, limit the amount of time a cache entry can stay alive
 
 ``worse_reflection.enable_context_location``
 """"""""""""""""""""""""""""""""""""""""""""
-
-
 
 
 If source code is passed to a ``Reflector`` then temporarily make it available as a
@@ -873,8 +771,6 @@ located in another (e.g. when running a Language Server)
 """""""""""""""""""""""""""
 
 
-
-
 Enable mixins (unstable see issue #1791)
 
 
@@ -888,8 +784,6 @@ Enable mixins (unstable see issue #1791)
 """"""""""""""""""""""""""""""
 
 
-
-
 Cache directory for stubs
 
 
@@ -901,8 +795,6 @@ Cache directory for stubs
 
 ``worse_reflection.stub_dir``
 """""""""""""""""""""""""""""
-
-
 
 
 Location of the core PHP stubs - these will be scanned and cached on the first request
@@ -925,9 +817,7 @@ FilePathResolverExtension
 """""""""""""""""""""""""""""""""""
 
 
-
-
-**Default**: ``"\/home\/daniel\/www\/phpactor\/phpactor"``
+**Default**: ``"\/home\/mamazu\/packages\/phpactor\/phpactor"``
 
 
 .. _param_file_path_resolver.app_name:
@@ -935,8 +825,6 @@ FilePathResolverExtension
 
 ``file_path_resolver.app_name``
 """""""""""""""""""""""""""""""
-
-
 
 
 **Default**: ``"phpactor"``
@@ -949,8 +837,6 @@ FilePathResolverExtension
 """""""""""""""""""""""""""""""""""""""
 
 
-
-
 **Default**: ``null``
 
 
@@ -961,8 +847,6 @@ FilePathResolverExtension
 """""""""""""""""""""""""""""""""""
 
 
-
-
 **Default**: ``true``
 
 
@@ -971,8 +855,6 @@ FilePathResolverExtension
 
 ``file_path_resolver.enable_logging``
 """""""""""""""""""""""""""""""""""""
-
-
 
 
 **Default**: ``true``
@@ -1060,8 +942,6 @@ Type: string
 """""""""""""""""""""
 
 
-
-
 **Default**: ``null``
 
 
@@ -1079,8 +959,6 @@ ComposerAutoloaderExtension
 """""""""""""""""""
 
 
-
-
 Include of the projects autoloader to facilitate class location. Note that when including an autoloader code _may_ be executed. This option may be disabled when using the indexer
 
 
@@ -1092,8 +970,6 @@ Include of the projects autoloader to facilitate class location. Note that when 
 
 ``composer.autoloader_path``
 """"""""""""""""""""""""""""
-
-
 
 
 Path to project's autoloader, can be an array
@@ -1109,8 +985,6 @@ Path to project's autoloader, can be an array
 """"""""""""""""""""""""""""""""
 
 
-
-
 Immediately de-register the autoloader once it has been included (prevent conflicts with Phpactor's autoloader). Some platforms may require this to be disabled
 
 
@@ -1122,8 +996,6 @@ Immediately de-register the autoloader once it has been included (prevent confli
 
 ``composer.class_maps_only``
 """"""""""""""""""""""""""""
-
-
 
 
 Register the composer class maps only, do not register the autoloader - RECOMMENDED
@@ -1146,8 +1018,6 @@ ConsoleExtension
 """""""""""""""""""""
 
 
-
-
 Verbosity level
 
 
@@ -1162,8 +1032,6 @@ Verbosity level
 
 ``console.decorated``
 """""""""""""""""""""
-
-
 
 
 Whether to decorate messages (null for auto-guessing)
@@ -1209,8 +1077,6 @@ PhpExtension
 """""""""""""""
 
 
-
-
 Consider this value to be the project\'s version of PHP (e.g. `7.4`). If omitted
 it will check `composer.json` (by the configured platform then the PHP requirement) before
 falling back to the PHP version of the current process.
@@ -1233,8 +1099,6 @@ LanguageServerExtension
 """"""""""""""""""""""""""""""""
 
 
-
-
 **Default**: ``true``
 
 
@@ -1243,8 +1107,6 @@ LanguageServerExtension
 
 ``language_server.enable_workspace``
 """"""""""""""""""""""""""""""""""""
-
-
 
 
 If workspace management / text synchronization should be enabled (this isn't required for some language server implementations, e.g. static analyzers)
@@ -1260,8 +1122,6 @@ If workspace management / text synchronization should be enabled (this isn't req
 """"""""""""""""""""""""""""""""""""""
 
 
-
-
 Phpactor parameters (config) that apply only to the language server session
 
 
@@ -1273,8 +1133,6 @@ Phpactor parameters (config) that apply only to the language server session
 
 ``language_server.method_alias_map``
 """"""""""""""""""""""""""""""""""""
-
-
 
 
 Allow method names to be re-mapped. Useful for maintaining backwards compatibility
@@ -1290,8 +1148,6 @@ Allow method names to be re-mapped. Useful for maintaining backwards compatibili
 """""""""""""""""""""""""""""""""""""""""
 
 
-
-
 Amount of time to wait before analyzing the code again for diagnostics
 
 
@@ -1303,8 +1159,6 @@ Amount of time to wait before analyzing the code again for diagnostics
 
 ``language_server.diagnostics_on_update``
 """""""""""""""""""""""""""""""""""""""""
-
-
 
 
 Perform diagnostics when the text document is updated
@@ -1320,8 +1174,6 @@ Perform diagnostics when the text document is updated
 """""""""""""""""""""""""""""""""""""""
 
 
-
-
 Perform diagnostics when the text document is saved
 
 
@@ -1333,8 +1185,6 @@ Perform diagnostics when the text document is saved
 
 ``language_server.diagnostics_on_open``
 """""""""""""""""""""""""""""""""""""""
-
-
 
 
 Perform diagnostics when opening a text document
@@ -1350,8 +1200,6 @@ Perform diagnostics when opening a text document
 """"""""""""""""""""""""""""""""""""""""
 
 
-
-
 Specify which diagnostic providers should be active (default to all)
 
 
@@ -1363,8 +1211,6 @@ Specify which diagnostic providers should be active (default to all)
 
 ``language_server,file_events``
 """""""""""""""""""""""""""""""
-
-
 
 
 Register to recieve file events
@@ -1380,8 +1226,6 @@ Register to recieve file events
 """"""""""""""""""""""""""""""""""""
 
 
-
-
 **Default**: ``["**\/*.php"]``
 
 
@@ -1390,8 +1234,6 @@ Register to recieve file events
 
 ``language_server.profile``
 """""""""""""""""""""""""""
-
-
 
 
 Logs timing information for incoming LSP requests
@@ -1407,8 +1249,6 @@ Logs timing information for incoming LSP requests
 """""""""""""""""""""""""
 
 
-
-
 Log incoming and outgoing messages (needs log formatter to be set to ``json``)
 
 
@@ -1422,8 +1262,6 @@ Log incoming and outgoing messages (needs log formatter to be set to ``json``)
 """""""""""""""""""""""""""""""""""""""""
 
 
-
-
 Amount of time to wait before responding to a shutdown notification
 
 
@@ -1435,8 +1273,6 @@ Amount of time to wait before responding to a shutdown notification
 
 ``language_server.self_destruct_timeout``
 """""""""""""""""""""""""""""""""""""""""
-
-
 
 
 Wait this amount of time after a shutdown request before self-destructing
@@ -1459,8 +1295,6 @@ LanguageServerCompletionExtension
 """"""""""""""""""""""""""""""""""""""""""""""""""
 
 
-
-
 If the leading dollar should be trimmed for variable completion suggestions
 
 
@@ -1479,8 +1313,6 @@ LanguageServerReferenceFinderExtension
 
 ``language_server_reference_reference_finder.reference_timeout``
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-
-
 
 
 Stop searching for references after this time (in seconds) has expired
@@ -1503,8 +1335,6 @@ LanguageServerWorseReflectionExtension
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 
-
-
 Minimum interval to update the workspace index as documents are updated (in milliseconds)
 
 
@@ -1525,8 +1355,6 @@ LanguageServerIndexerExtension
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 
-
-
 **Default**: ``250``
 
 
@@ -1542,8 +1370,6 @@ LanguageServerCodeTransformExtension
 
 ``language_server_code_transform.import_name.report_non_existing_names``
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-
-
 
 
 Show an error if a diagnostic name cannot be resolved - can produce false positives
@@ -1566,8 +1392,6 @@ LanguageServerPhpstanExtension
 """""""""""""""""""""""""""""""""""
 
 
-
-
 Enable PHPStan diagnostics
 
 
@@ -1581,8 +1405,6 @@ Enable PHPStan diagnostics
 """""""""""""""""""""""""""""""
 
 
-
-
 Path to the PHPStan executable
 
 
@@ -1594,8 +1416,6 @@ Path to the PHPStan executable
 
 ``language_server_phpstan.level``
 """""""""""""""""""""""""""""""""
-
-
 
 
 Override the PHPStan level
@@ -1618,8 +1438,6 @@ LanguageServerPsalmExtension
 """""""""""""""""""""""""""""
 
 
-
-
 Path to pslam if different from vendor/bin/psalm
 
 
@@ -1631,8 +1449,6 @@ Path to pslam if different from vendor/bin/psalm
 
 ``language_server_psalm.enabled``
 """""""""""""""""""""""""""""""""
-
-
 
 
 **Default**: ``false``
@@ -1652,8 +1468,6 @@ BehatExtension
 """""""""""""""""
 
 
-
-
 **Default**: ``false``
 
 
@@ -1662,8 +1476,6 @@ BehatExtension
 
 ``behat.config_path``
 """""""""""""""""""""
-
-
 
 
 Path to the main behat.yml (including the filename behat.yml)
@@ -1677,8 +1489,6 @@ Path to the main behat.yml (including the filename behat.yml)
 
 ``behat.symfony.di_xml_path``
 """""""""""""""""""""""""""""
-
-
 
 
 If using Symfony, set this path to the XML container dump to find contexts which are defined as services
@@ -1701,8 +1511,6 @@ IndexerExtension
 """"""""""""""""""""""""""""
 
 
-
-
 List of allowed watchers. The first watcher that supports the current system will be used
 
 
@@ -1714,8 +1522,6 @@ List of allowed watchers. The first watcher that supports the current system wil
 
 ``indexer.index_path``
 """"""""""""""""""""""
-
-
 
 
 Path where the index should be saved
@@ -1731,8 +1537,6 @@ Path where the index should be saved
 """"""""""""""""""""""""""""
 
 
-
-
 Glob patterns to include while indexing
 
 
@@ -1744,8 +1548,6 @@ Glob patterns to include while indexing
 
 ``indexer.exclude_patterns``
 """"""""""""""""""""""""""""
-
-
 
 
 Glob patterns to exclude while indexing
@@ -1761,8 +1563,6 @@ Glob patterns to exclude while indexing
 """"""""""""""""""""""
 
 
-
-
 Paths to external folders to index. They will be indexed only once, if you want to take any changes into account you will have to reindex your project manually.
 
 
@@ -1774,8 +1574,6 @@ Paths to external folders to index. They will be indexed only once, if you want 
 
 ``indexer.poll_time``
 """""""""""""""""""""
-
-
 
 
 For polling indexers only: the time, in milliseconds, between polls (e.g. filesystem scans)
@@ -1791,8 +1589,6 @@ For polling indexers only: the time, in milliseconds, between polls (e.g. filesy
 """""""""""""""""""""""
 
 
-
-
 For real-time indexers only: the time, in milliseconds, to buffer the results
 
 
@@ -1804,8 +1600,6 @@ For real-time indexers only: the time, in milliseconds, to buffer the results
 
 ``indexer.project_root``
 """"""""""""""""""""""""
-
-
 
 
 The root path to use for scanning the index
@@ -1821,8 +1615,6 @@ The root path to use for scanning the index
 """""""""""""""""""""""""""""""""
 
 
-
-
 Recurse over class implementations to resolve all references
 
 
@@ -1834,8 +1626,6 @@ Recurse over class implementations to resolve all references
 
 ``indexer.implementation_finder.deep``
 """"""""""""""""""""""""""""""""""""""
-
-
 
 
 Recurse over class implementations to resolve all class implementations (not just the classes directly implementing the subject)
@@ -1856,8 +1646,6 @@ ObjectRendererExtension
 
 ``object_renderer.template_paths.markdown``
 """""""""""""""""""""""""""""""""""""""""""
-
-
 
 
 Paths in which to look for templates for hover information.

--- a/doc/reference/rpc_command.rst
+++ b/doc/reference/rpc_command.rst
@@ -2,7 +2,7 @@ Commands
 ========
 
 
-.. This document is generated via the `development:command-reference` command
+.. This document is generated via the `development:generate-documentation` command
 
 
 .. contents::

--- a/doc/reference/rpc_command.rst
+++ b/doc/reference/rpc_command.rst
@@ -1,5 +1,5 @@
 Commands
-=============
+========
 
 
 .. This document is generated via the `development:command-reference` command
@@ -18,7 +18,7 @@ GotoDefinitionHandler
 ---------------------
 
 
-.. _param_language:
+.. _RpcCommand_GlobalDefinitionHandler_language:
 
 
 ``language``
@@ -31,7 +31,7 @@ Type: string
 **Default**: ``"php"``
 
 
-.. _param_target:
+.. _RpcCommand_GlobalDefinitionHandler_target:
 
 
 ``target``
@@ -44,7 +44,7 @@ Type: string
 **Default**: ``"focused_window"``
 
 
-.. _param_offset:
+.. _RpcCommand_GlobalDefinitionHandler_offset:
 
 
 ``offset``
@@ -54,7 +54,7 @@ Type: string
 **Default**: ``null``
 
 
-.. _param_source:
+.. _RpcCommand_GlobalDefinitionHandler_source:
 
 
 ``source``
@@ -64,7 +64,7 @@ Type: string
 **Default**: ``null``
 
 
-.. _param_path:
+.. _RpcCommand_GlobalDefinitionHandler_path:
 
 
 ``path``

--- a/doc/reference/rpc_command.rst
+++ b/doc/reference/rpc_command.rst
@@ -1,5 +1,5 @@
-Commands
-========
+Legacy RPC Commands
+===================
 
 
 .. This document is generated via the `development:generate-documentation` command
@@ -18,7 +18,7 @@ StatusHandler
 -------------
 
 
-.. _RpcCommand_GlobalDefinitionHandler_type:
+.. _RpcCommand_status_type:
 
 
 ``type``
@@ -35,7 +35,7 @@ FileInfoHandler
 ---------------
 
 
-.. _RpcCommand_GlobalDefinitionHandler_path:
+.. _RpcCommand_file_info_path:
 
 
 ``path``
@@ -52,7 +52,7 @@ ReferencesHandler
 -----------------
 
 
-.. _RpcCommand_GlobalDefinitionHandler_mode:
+.. _RpcCommand_references_mode:
 
 
 ``mode``
@@ -62,7 +62,7 @@ ReferencesHandler
 **Default**: ``"find"``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_filesystem:
+.. _RpcCommand_references_filesystem:
 
 
 ``filesystem``
@@ -72,7 +72,7 @@ ReferencesHandler
 **Default**: ``"git"``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_replacement:
+.. _RpcCommand_references_replacement:
 
 
 ``replacement``
@@ -82,7 +82,7 @@ ReferencesHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_path:
+.. _RpcCommand_references_path:
 
 
 ``path``
@@ -92,7 +92,7 @@ ReferencesHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_offset:
+.. _RpcCommand_references_offset:
 
 
 ``offset``
@@ -102,7 +102,7 @@ ReferencesHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_source:
+.. _RpcCommand_references_source:
 
 
 ``source``
@@ -119,7 +119,7 @@ ClassCopyHandler
 ----------------
 
 
-.. _RpcCommand_GlobalDefinitionHandler_dest_path:
+.. _RpcCommand_copy_class_dest_path:
 
 
 ``dest_path``
@@ -129,7 +129,7 @@ ClassCopyHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_source_path:
+.. _RpcCommand_copy_class_source_path:
 
 
 ``source_path``
@@ -146,7 +146,7 @@ ClassMoveHandler
 ----------------
 
 
-.. _RpcCommand_GlobalDefinitionHandler_dest_path:
+.. _RpcCommand_move_class_dest_path:
 
 
 ``dest_path``
@@ -156,7 +156,7 @@ ClassMoveHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_confirmed:
+.. _RpcCommand_move_class_confirmed:
 
 
 ``confirmed``
@@ -166,7 +166,7 @@ ClassMoveHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_move_related:
+.. _RpcCommand_move_class_move_related:
 
 
 ``move_related``
@@ -176,7 +176,7 @@ ClassMoveHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_source_path:
+.. _RpcCommand_move_class_source_path:
 
 
 ``source_path``
@@ -193,7 +193,7 @@ ClassInflectHandler
 -------------------
 
 
-.. _RpcCommand_GlobalDefinitionHandler_new_path:
+.. _RpcCommand_class_inflect_new_path:
 
 
 ``new_path``
@@ -203,7 +203,7 @@ ClassInflectHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_variant:
+.. _RpcCommand_class_inflect_variant:
 
 
 ``variant``
@@ -213,7 +213,7 @@ ClassInflectHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_overwrite_existing:
+.. _RpcCommand_class_inflect_overwrite_existing:
 
 
 ``overwrite_existing``
@@ -223,7 +223,7 @@ ClassInflectHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_current_path:
+.. _RpcCommand_class_inflect_current_path:
 
 
 ``current_path``
@@ -240,7 +240,7 @@ ClassNewHandler
 ---------------
 
 
-.. _RpcCommand_GlobalDefinitionHandler_new_path:
+.. _RpcCommand_class_new_new_path:
 
 
 ``new_path``
@@ -250,7 +250,7 @@ ClassNewHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_variant:
+.. _RpcCommand_class_new_variant:
 
 
 ``variant``
@@ -260,7 +260,7 @@ ClassNewHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_overwrite_existing:
+.. _RpcCommand_class_new_overwrite_existing:
 
 
 ``overwrite_existing``
@@ -270,7 +270,7 @@ ClassNewHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_current_path:
+.. _RpcCommand_class_new_current_path:
 
 
 ``current_path``
@@ -287,7 +287,7 @@ TransformHandler
 ----------------
 
 
-.. _RpcCommand_GlobalDefinitionHandler_transform:
+.. _RpcCommand_transform_transform:
 
 
 ``transform``
@@ -297,7 +297,7 @@ TransformHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_path:
+.. _RpcCommand_transform_path:
 
 
 ``path``
@@ -307,7 +307,7 @@ TransformHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_source:
+.. _RpcCommand_transform_source:
 
 
 ``source``
@@ -324,7 +324,7 @@ ExtractConstantHandler
 ----------------------
 
 
-.. _RpcCommand_GlobalDefinitionHandler_constant_name:
+.. _RpcCommand_extract_constant_constant_name:
 
 
 ``constant_name``
@@ -334,7 +334,7 @@ ExtractConstantHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_constant_name_suggestion:
+.. _RpcCommand_extract_constant_constant_name_suggestion:
 
 
 ``constant_name_suggestion``
@@ -344,7 +344,7 @@ ExtractConstantHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_path:
+.. _RpcCommand_extract_constant_path:
 
 
 ``path``
@@ -354,7 +354,7 @@ ExtractConstantHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_offset:
+.. _RpcCommand_extract_constant_offset:
 
 
 ``offset``
@@ -364,7 +364,7 @@ ExtractConstantHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_source:
+.. _RpcCommand_extract_constant_source:
 
 
 ``source``
@@ -381,7 +381,7 @@ ExtractMethodHandler
 --------------------
 
 
-.. _RpcCommand_GlobalDefinitionHandler_method_name:
+.. _RpcCommand_extract_method_method_name:
 
 
 ``method_name``
@@ -391,7 +391,7 @@ ExtractMethodHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_offset_start:
+.. _RpcCommand_extract_method_offset_start:
 
 
 ``offset_start``
@@ -401,7 +401,7 @@ ExtractMethodHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_offset_end:
+.. _RpcCommand_extract_method_offset_end:
 
 
 ``offset_end``
@@ -411,7 +411,7 @@ ExtractMethodHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_source:
+.. _RpcCommand_extract_method_source:
 
 
 ``source``
@@ -421,7 +421,7 @@ ExtractMethodHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_path:
+.. _RpcCommand_extract_method_path:
 
 
 ``path``
@@ -438,7 +438,7 @@ GenerateAccessorHandler
 -----------------------
 
 
-.. _RpcCommand_GlobalDefinitionHandler_names:
+.. _RpcCommand_generate_accessor_names:
 
 
 ``names``
@@ -448,7 +448,7 @@ GenerateAccessorHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_path:
+.. _RpcCommand_generate_accessor_path:
 
 
 ``path``
@@ -458,7 +458,7 @@ GenerateAccessorHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_source:
+.. _RpcCommand_generate_accessor_source:
 
 
 ``source``
@@ -468,7 +468,7 @@ GenerateAccessorHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_offset:
+.. _RpcCommand_generate_accessor_offset:
 
 
 ``offset``
@@ -485,7 +485,7 @@ GenerateMethodHandler
 ---------------------
 
 
-.. _RpcCommand_GlobalDefinitionHandler_path:
+.. _RpcCommand_generate_method_path:
 
 
 ``path``
@@ -495,7 +495,7 @@ GenerateMethodHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_source:
+.. _RpcCommand_generate_method_source:
 
 
 ``source``
@@ -505,7 +505,7 @@ GenerateMethodHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_offset:
+.. _RpcCommand_generate_method_offset:
 
 
 ``offset``
@@ -522,7 +522,7 @@ ImportClassHandler
 ------------------
 
 
-.. _RpcCommand_GlobalDefinitionHandler_qualified_name:
+.. _RpcCommand_import_class_qualified_name:
 
 
 ``qualified_name``
@@ -532,7 +532,7 @@ ImportClassHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_alias:
+.. _RpcCommand_import_class_alias:
 
 
 ``alias``
@@ -542,7 +542,7 @@ ImportClassHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_offset:
+.. _RpcCommand_import_class_offset:
 
 
 ``offset``
@@ -552,7 +552,7 @@ ImportClassHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_source:
+.. _RpcCommand_import_class_source:
 
 
 ``source``
@@ -562,7 +562,7 @@ ImportClassHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_path:
+.. _RpcCommand_import_class_path:
 
 
 ``path``
@@ -579,7 +579,7 @@ RenameVariableHandler
 ---------------------
 
 
-.. _RpcCommand_GlobalDefinitionHandler_name:
+.. _RpcCommand_rename_variable_name:
 
 
 ``name``
@@ -589,7 +589,7 @@ RenameVariableHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_name_suggestion:
+.. _RpcCommand_rename_variable_name_suggestion:
 
 
 ``name_suggestion``
@@ -599,7 +599,7 @@ RenameVariableHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_scope:
+.. _RpcCommand_rename_variable_scope:
 
 
 ``scope``
@@ -609,7 +609,7 @@ RenameVariableHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_path:
+.. _RpcCommand_rename_variable_path:
 
 
 ``path``
@@ -619,7 +619,7 @@ RenameVariableHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_source:
+.. _RpcCommand_rename_variable_source:
 
 
 ``source``
@@ -629,7 +629,7 @@ RenameVariableHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_offset:
+.. _RpcCommand_rename_variable_offset:
 
 
 ``offset``
@@ -646,7 +646,7 @@ ChangeVisiblityHandler
 ----------------------
 
 
-.. _RpcCommand_GlobalDefinitionHandler_path:
+.. _RpcCommand_change_visibility_path:
 
 
 ``path``
@@ -656,7 +656,7 @@ ChangeVisiblityHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_source:
+.. _RpcCommand_change_visibility_source:
 
 
 ``source``
@@ -666,7 +666,7 @@ ChangeVisiblityHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_offset:
+.. _RpcCommand_change_visibility_offset:
 
 
 ``offset``
@@ -686,7 +686,7 @@ OverrideMethodHandler
 ---------------------
 
 
-.. _RpcCommand_GlobalDefinitionHandler_method_name:
+.. _RpcCommand_override_method_method_name:
 
 
 ``method_name``
@@ -696,7 +696,7 @@ OverrideMethodHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_class_name:
+.. _RpcCommand_override_method_class_name:
 
 
 ``class_name``
@@ -706,7 +706,7 @@ OverrideMethodHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_path:
+.. _RpcCommand_override_method_path:
 
 
 ``path``
@@ -716,7 +716,7 @@ OverrideMethodHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_source:
+.. _RpcCommand_override_method_source:
 
 
 ``source``
@@ -733,7 +733,7 @@ ExtractExpressionHandler
 ------------------------
 
 
-.. _RpcCommand_GlobalDefinitionHandler_variable_name:
+.. _RpcCommand_extract_expression_variable_name:
 
 
 ``variable_name``
@@ -743,7 +743,7 @@ ExtractExpressionHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_offset_start:
+.. _RpcCommand_extract_expression_offset_start:
 
 
 ``offset_start``
@@ -753,7 +753,7 @@ ExtractExpressionHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_path:
+.. _RpcCommand_extract_expression_path:
 
 
 ``path``
@@ -763,7 +763,7 @@ ExtractExpressionHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_source:
+.. _RpcCommand_extract_expression_source:
 
 
 ``source``
@@ -773,7 +773,7 @@ ExtractExpressionHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_offset_end:
+.. _RpcCommand_extract_expression_offset_end:
 
 
 ``offset_end``
@@ -790,7 +790,7 @@ ImportMissingClassesHandler
 ---------------------------
 
 
-.. _RpcCommand_GlobalDefinitionHandler_path:
+.. _RpcCommand_import_missing_classes_path:
 
 
 ``path``
@@ -800,7 +800,7 @@ ImportMissingClassesHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_source:
+.. _RpcCommand_import_missing_classes_source:
 
 
 ``source``
@@ -817,7 +817,7 @@ HoverHandler
 ------------
 
 
-.. _RpcCommand_GlobalDefinitionHandler_source:
+.. _RpcCommand_hover_source:
 
 
 ``source``
@@ -827,7 +827,7 @@ HoverHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_offset:
+.. _RpcCommand_hover_offset:
 
 
 ``offset``
@@ -844,7 +844,7 @@ CompleteHandler
 ---------------
 
 
-.. _RpcCommand_GlobalDefinitionHandler_type:
+.. _RpcCommand_complete_type:
 
 
 ``type``
@@ -854,7 +854,7 @@ CompleteHandler
 **Default**: ``"php"``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_source:
+.. _RpcCommand_complete_source:
 
 
 ``source``
@@ -864,7 +864,7 @@ CompleteHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_offset:
+.. _RpcCommand_complete_offset:
 
 
 ``offset``
@@ -881,7 +881,7 @@ NavigateHandler
 ---------------
 
 
-.. _RpcCommand_GlobalDefinitionHandler_source_path:
+.. _RpcCommand_navigate_source_path:
 
 
 ``source_path``
@@ -891,7 +891,7 @@ NavigateHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_destination:
+.. _RpcCommand_navigate_destination:
 
 
 ``destination``
@@ -901,7 +901,7 @@ NavigateHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_confirm_create:
+.. _RpcCommand_navigate_confirm_create:
 
 
 ``confirm_create``
@@ -918,7 +918,7 @@ ContextMenuHandler
 ------------------
 
 
-.. _RpcCommand_GlobalDefinitionHandler_action:
+.. _RpcCommand_context_menu_action:
 
 
 ``action``
@@ -928,7 +928,7 @@ ContextMenuHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_current_path:
+.. _RpcCommand_context_menu_current_path:
 
 
 ``current_path``
@@ -938,7 +938,7 @@ ContextMenuHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_source:
+.. _RpcCommand_context_menu_source:
 
 
 ``source``
@@ -948,7 +948,7 @@ ContextMenuHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_offset:
+.. _RpcCommand_context_menu_offset:
 
 
 ``offset``
@@ -965,7 +965,7 @@ EchoHandler
 -----------
 
 
-.. _RpcCommand_GlobalDefinitionHandler_message:
+.. _RpcCommand_echo_message:
 
 
 ``message``
@@ -982,7 +982,7 @@ ClassSearchHandler
 ------------------
 
 
-.. _RpcCommand_GlobalDefinitionHandler_short_name:
+.. _RpcCommand_class_search_short_name:
 
 
 ``short_name``
@@ -999,7 +999,7 @@ OffsetInfoHandler
 -----------------
 
 
-.. _RpcCommand_GlobalDefinitionHandler_offset:
+.. _RpcCommand_offset_info_offset:
 
 
 ``offset``
@@ -1009,7 +1009,7 @@ OffsetInfoHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_source:
+.. _RpcCommand_offset_info_source:
 
 
 ``source``
@@ -1026,7 +1026,7 @@ GotoDefinitionHandler
 ---------------------
 
 
-.. _RpcCommand_GlobalDefinitionHandler_language:
+.. _RpcCommand_goto_definition_language:
 
 
 ``language``
@@ -1039,7 +1039,7 @@ Type: string
 **Default**: ``"php"``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_target:
+.. _RpcCommand_goto_definition_target:
 
 
 ``target``
@@ -1052,7 +1052,7 @@ Type: string
 **Default**: ``"focused_window"``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_offset:
+.. _RpcCommand_goto_definition_offset:
 
 
 ``offset``
@@ -1062,7 +1062,7 @@ Type: string
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_source:
+.. _RpcCommand_goto_definition_source:
 
 
 ``source``
@@ -1072,7 +1072,7 @@ Type: string
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_path:
+.. _RpcCommand_goto_definition_path:
 
 
 ``path``
@@ -1089,7 +1089,7 @@ GotoTypeHandler
 ---------------
 
 
-.. _RpcCommand_GlobalDefinitionHandler_language:
+.. _RpcCommand_goto_type_language:
 
 
 ``language``
@@ -1099,7 +1099,7 @@ GotoTypeHandler
 **Default**: ``"php"``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_target:
+.. _RpcCommand_goto_type_target:
 
 
 ``target``
@@ -1109,7 +1109,7 @@ GotoTypeHandler
 **Default**: ``"focused_window"``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_offset:
+.. _RpcCommand_goto_type_offset:
 
 
 ``offset``
@@ -1119,7 +1119,7 @@ GotoTypeHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_source:
+.. _RpcCommand_goto_type_source:
 
 
 ``source``
@@ -1129,7 +1129,7 @@ GotoTypeHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_path:
+.. _RpcCommand_goto_type_path:
 
 
 ``path``
@@ -1146,7 +1146,7 @@ GotoImplementationHandler
 -------------------------
 
 
-.. _RpcCommand_GlobalDefinitionHandler_language:
+.. _RpcCommand_goto_implementation_language:
 
 
 ``language``
@@ -1156,7 +1156,7 @@ GotoImplementationHandler
 **Default**: ``"php"``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_target:
+.. _RpcCommand_goto_implementation_target:
 
 
 ``target``
@@ -1166,7 +1166,7 @@ GotoImplementationHandler
 **Default**: ``"focused_window"``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_offset:
+.. _RpcCommand_goto_implementation_offset:
 
 
 ``offset``
@@ -1176,7 +1176,7 @@ GotoImplementationHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_source:
+.. _RpcCommand_goto_implementation_source:
 
 
 ``source``
@@ -1186,7 +1186,7 @@ GotoImplementationHandler
 **Default**: ``null``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_path:
+.. _RpcCommand_goto_implementation_path:
 
 
 ``path``
@@ -1203,7 +1203,7 @@ IndexHandler
 ------------
 
 
-.. _RpcCommand_GlobalDefinitionHandler_watch:
+.. _RpcCommand_index_watch:
 
 
 ``watch``
@@ -1213,7 +1213,7 @@ IndexHandler
 **Default**: ``false``
 
 
-.. _RpcCommand_GlobalDefinitionHandler_interval:
+.. _RpcCommand_index_interval:
 
 
 ``interval``

--- a/doc/reference/rpc_command.rst
+++ b/doc/reference/rpc_command.rst
@@ -11,11 +11,11 @@ Legacy RPC Commands
    :local:
 
 
-.. _StatusHandler:
+.. _RpcHandler_StatusHandler:
 
 
-StatusHandler
--------------
+_RpcHandler_StatusHandler
+-------------------------
 
 
 .. _RpcCommand_status_type:
@@ -28,11 +28,11 @@ StatusHandler
 **Default**: ``"formatted"``
 
 
-.. _FileInfoHandler:
+.. _RpcHandler_FileInfoHandler:
 
 
-FileInfoHandler
----------------
+_RpcHandler_FileInfoHandler
+---------------------------
 
 
 .. _RpcCommand_file_info_path:
@@ -45,11 +45,11 @@ FileInfoHandler
 **Default**: ``null``
 
 
-.. _ReferencesHandler:
+.. _RpcHandler_ReferencesHandler:
 
 
-ReferencesHandler
------------------
+_RpcHandler_ReferencesHandler
+-----------------------------
 
 
 .. _RpcCommand_references_mode:
@@ -112,11 +112,11 @@ ReferencesHandler
 **Default**: ``null``
 
 
-.. _ClassCopyHandler:
+.. _RpcHandler_ClassCopyHandler:
 
 
-ClassCopyHandler
-----------------
+_RpcHandler_ClassCopyHandler
+----------------------------
 
 
 .. _RpcCommand_copy_class_dest_path:
@@ -139,11 +139,11 @@ ClassCopyHandler
 **Default**: ``null``
 
 
-.. _ClassMoveHandler:
+.. _RpcHandler_ClassMoveHandler:
 
 
-ClassMoveHandler
-----------------
+_RpcHandler_ClassMoveHandler
+----------------------------
 
 
 .. _RpcCommand_move_class_dest_path:
@@ -186,11 +186,11 @@ ClassMoveHandler
 **Default**: ``null``
 
 
-.. _ClassInflectHandler:
+.. _RpcHandler_ClassInflectHandler:
 
 
-ClassInflectHandler
--------------------
+_RpcHandler_ClassInflectHandler
+-------------------------------
 
 
 .. _RpcCommand_class_inflect_new_path:
@@ -233,11 +233,11 @@ ClassInflectHandler
 **Default**: ``null``
 
 
-.. _ClassNewHandler:
+.. _RpcHandler_ClassNewHandler:
 
 
-ClassNewHandler
----------------
+_RpcHandler_ClassNewHandler
+---------------------------
 
 
 .. _RpcCommand_class_new_new_path:
@@ -280,11 +280,11 @@ ClassNewHandler
 **Default**: ``null``
 
 
-.. _TransformHandler:
+.. _RpcHandler_TransformHandler:
 
 
-TransformHandler
-----------------
+_RpcHandler_TransformHandler
+----------------------------
 
 
 .. _RpcCommand_transform_transform:
@@ -317,11 +317,11 @@ TransformHandler
 **Default**: ``null``
 
 
-.. _ExtractConstantHandler:
+.. _RpcHandler_ExtractConstantHandler:
 
 
-ExtractConstantHandler
-----------------------
+_RpcHandler_ExtractConstantHandler
+----------------------------------
 
 
 .. _RpcCommand_extract_constant_constant_name:
@@ -374,11 +374,11 @@ ExtractConstantHandler
 **Default**: ``null``
 
 
-.. _ExtractMethodHandler:
+.. _RpcHandler_ExtractMethodHandler:
 
 
-ExtractMethodHandler
---------------------
+_RpcHandler_ExtractMethodHandler
+--------------------------------
 
 
 .. _RpcCommand_extract_method_method_name:
@@ -431,11 +431,11 @@ ExtractMethodHandler
 **Default**: ``null``
 
 
-.. _GenerateAccessorHandler:
+.. _RpcHandler_GenerateAccessorHandler:
 
 
-GenerateAccessorHandler
------------------------
+_RpcHandler_GenerateAccessorHandler
+-----------------------------------
 
 
 .. _RpcCommand_generate_accessor_names:
@@ -478,11 +478,11 @@ GenerateAccessorHandler
 **Default**: ``null``
 
 
-.. _GenerateMethodHandler:
+.. _RpcHandler_GenerateMethodHandler:
 
 
-GenerateMethodHandler
----------------------
+_RpcHandler_GenerateMethodHandler
+---------------------------------
 
 
 .. _RpcCommand_generate_method_path:
@@ -515,11 +515,11 @@ GenerateMethodHandler
 **Default**: ``null``
 
 
-.. _ImportClassHandler:
+.. _RpcHandler_ImportClassHandler:
 
 
-ImportClassHandler
-------------------
+_RpcHandler_ImportClassHandler
+------------------------------
 
 
 .. _RpcCommand_import_class_qualified_name:
@@ -572,11 +572,11 @@ ImportClassHandler
 **Default**: ``null``
 
 
-.. _RenameVariableHandler:
+.. _RpcHandler_RenameVariableHandler:
 
 
-RenameVariableHandler
----------------------
+_RpcHandler_RenameVariableHandler
+---------------------------------
 
 
 .. _RpcCommand_rename_variable_name:
@@ -639,11 +639,11 @@ RenameVariableHandler
 **Default**: ``null``
 
 
-.. _ChangeVisiblityHandler:
+.. _RpcHandler_ChangeVisiblityHandler:
 
 
-ChangeVisiblityHandler
-----------------------
+_RpcHandler_ChangeVisiblityHandler
+----------------------------------
 
 
 .. _RpcCommand_change_visibility_path:
@@ -679,11 +679,11 @@ Type: integer
 **Default**: ``null``
 
 
-.. _OverrideMethodHandler:
+.. _RpcHandler_OverrideMethodHandler:
 
 
-OverrideMethodHandler
----------------------
+_RpcHandler_OverrideMethodHandler
+---------------------------------
 
 
 .. _RpcCommand_override_method_method_name:
@@ -726,11 +726,11 @@ OverrideMethodHandler
 **Default**: ``null``
 
 
-.. _ExtractExpressionHandler:
+.. _RpcHandler_ExtractExpressionHandler:
 
 
-ExtractExpressionHandler
-------------------------
+_RpcHandler_ExtractExpressionHandler
+------------------------------------
 
 
 .. _RpcCommand_extract_expression_variable_name:
@@ -783,11 +783,11 @@ ExtractExpressionHandler
 **Default**: ``null``
 
 
-.. _ImportMissingClassesHandler:
+.. _RpcHandler_ImportMissingClassesHandler:
 
 
-ImportMissingClassesHandler
----------------------------
+_RpcHandler_ImportMissingClassesHandler
+---------------------------------------
 
 
 .. _RpcCommand_import_missing_classes_path:
@@ -810,11 +810,11 @@ ImportMissingClassesHandler
 **Default**: ``null``
 
 
-.. _HoverHandler:
+.. _RpcHandler_HoverHandler:
 
 
-HoverHandler
-------------
+_RpcHandler_HoverHandler
+------------------------
 
 
 .. _RpcCommand_hover_source:
@@ -837,11 +837,11 @@ HoverHandler
 **Default**: ``null``
 
 
-.. _CompleteHandler:
+.. _RpcHandler_CompleteHandler:
 
 
-CompleteHandler
----------------
+_RpcHandler_CompleteHandler
+---------------------------
 
 
 .. _RpcCommand_complete_type:
@@ -874,11 +874,11 @@ CompleteHandler
 **Default**: ``null``
 
 
-.. _NavigateHandler:
+.. _RpcHandler_NavigateHandler:
 
 
-NavigateHandler
----------------
+_RpcHandler_NavigateHandler
+---------------------------
 
 
 .. _RpcCommand_navigate_source_path:
@@ -911,11 +911,11 @@ NavigateHandler
 **Default**: ``null``
 
 
-.. _ContextMenuHandler:
+.. _RpcHandler_ContextMenuHandler:
 
 
-ContextMenuHandler
-------------------
+_RpcHandler_ContextMenuHandler
+------------------------------
 
 
 .. _RpcCommand_context_menu_action:
@@ -958,11 +958,11 @@ ContextMenuHandler
 **Default**: ``null``
 
 
-.. _EchoHandler:
+.. _RpcHandler_EchoHandler:
 
 
-EchoHandler
------------
+_RpcHandler_EchoHandler
+-----------------------
 
 
 .. _RpcCommand_echo_message:
@@ -975,11 +975,11 @@ EchoHandler
 **Default**: ``null``
 
 
-.. _ClassSearchHandler:
+.. _RpcHandler_ClassSearchHandler:
 
 
-ClassSearchHandler
-------------------
+_RpcHandler_ClassSearchHandler
+------------------------------
 
 
 .. _RpcCommand_class_search_short_name:
@@ -992,11 +992,11 @@ ClassSearchHandler
 **Default**: ``null``
 
 
-.. _OffsetInfoHandler:
+.. _RpcHandler_OffsetInfoHandler:
 
 
-OffsetInfoHandler
------------------
+_RpcHandler_OffsetInfoHandler
+-----------------------------
 
 
 .. _RpcCommand_offset_info_offset:
@@ -1019,11 +1019,11 @@ OffsetInfoHandler
 **Default**: ``null``
 
 
-.. _GotoDefinitionHandler:
+.. _RpcHandler_GotoDefinitionHandler:
 
 
-GotoDefinitionHandler
----------------------
+_RpcHandler_GotoDefinitionHandler
+---------------------------------
 
 
 .. _RpcCommand_goto_definition_language:
@@ -1082,11 +1082,11 @@ Type: string
 **Default**: ``null``
 
 
-.. _GotoTypeHandler:
+.. _RpcHandler_GotoTypeHandler:
 
 
-GotoTypeHandler
----------------
+_RpcHandler_GotoTypeHandler
+---------------------------
 
 
 .. _RpcCommand_goto_type_language:
@@ -1139,11 +1139,11 @@ GotoTypeHandler
 **Default**: ``null``
 
 
-.. _GotoImplementationHandler:
+.. _RpcHandler_GotoImplementationHandler:
 
 
-GotoImplementationHandler
--------------------------
+_RpcHandler_GotoImplementationHandler
+-------------------------------------
 
 
 .. _RpcCommand_goto_implementation_language:
@@ -1196,11 +1196,11 @@ GotoImplementationHandler
 **Default**: ``null``
 
 
-.. _IndexHandler:
+.. _RpcHandler_IndexHandler:
 
 
-IndexHandler
-------------
+_RpcHandler_IndexHandler
+------------------------
 
 
 .. _RpcCommand_index_watch:

--- a/doc/reference/rpc_command.rst
+++ b/doc/reference/rpc_command.rst
@@ -11,6 +11,1014 @@ Commands
    :local:
 
 
+.. _StatusHandler:
+
+
+StatusHandler
+-------------
+
+
+.. _RpcCommand_GlobalDefinitionHandler_type:
+
+
+``type``
+""""""""
+
+
+**Default**: ``"formatted"``
+
+
+.. _FileInfoHandler:
+
+
+FileInfoHandler
+---------------
+
+
+.. _RpcCommand_GlobalDefinitionHandler_path:
+
+
+``path``
+""""""""
+
+
+**Default**: ``null``
+
+
+.. _ReferencesHandler:
+
+
+ReferencesHandler
+-----------------
+
+
+.. _RpcCommand_GlobalDefinitionHandler_mode:
+
+
+``mode``
+""""""""
+
+
+**Default**: ``"find"``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_filesystem:
+
+
+``filesystem``
+""""""""""""""
+
+
+**Default**: ``"git"``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_replacement:
+
+
+``replacement``
+"""""""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_path:
+
+
+``path``
+""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_offset:
+
+
+``offset``
+""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_source:
+
+
+``source``
+""""""""""
+
+
+**Default**: ``null``
+
+
+.. _ClassCopyHandler:
+
+
+ClassCopyHandler
+----------------
+
+
+.. _RpcCommand_GlobalDefinitionHandler_dest_path:
+
+
+``dest_path``
+"""""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_source_path:
+
+
+``source_path``
+"""""""""""""""
+
+
+**Default**: ``null``
+
+
+.. _ClassMoveHandler:
+
+
+ClassMoveHandler
+----------------
+
+
+.. _RpcCommand_GlobalDefinitionHandler_dest_path:
+
+
+``dest_path``
+"""""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_confirmed:
+
+
+``confirmed``
+"""""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_move_related:
+
+
+``move_related``
+""""""""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_source_path:
+
+
+``source_path``
+"""""""""""""""
+
+
+**Default**: ``null``
+
+
+.. _ClassInflectHandler:
+
+
+ClassInflectHandler
+-------------------
+
+
+.. _RpcCommand_GlobalDefinitionHandler_new_path:
+
+
+``new_path``
+""""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_variant:
+
+
+``variant``
+"""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_overwrite_existing:
+
+
+``overwrite_existing``
+""""""""""""""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_current_path:
+
+
+``current_path``
+""""""""""""""""
+
+
+**Default**: ``null``
+
+
+.. _ClassNewHandler:
+
+
+ClassNewHandler
+---------------
+
+
+.. _RpcCommand_GlobalDefinitionHandler_new_path:
+
+
+``new_path``
+""""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_variant:
+
+
+``variant``
+"""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_overwrite_existing:
+
+
+``overwrite_existing``
+""""""""""""""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_current_path:
+
+
+``current_path``
+""""""""""""""""
+
+
+**Default**: ``null``
+
+
+.. _TransformHandler:
+
+
+TransformHandler
+----------------
+
+
+.. _RpcCommand_GlobalDefinitionHandler_transform:
+
+
+``transform``
+"""""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_path:
+
+
+``path``
+""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_source:
+
+
+``source``
+""""""""""
+
+
+**Default**: ``null``
+
+
+.. _ExtractConstantHandler:
+
+
+ExtractConstantHandler
+----------------------
+
+
+.. _RpcCommand_GlobalDefinitionHandler_constant_name:
+
+
+``constant_name``
+"""""""""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_constant_name_suggestion:
+
+
+``constant_name_suggestion``
+""""""""""""""""""""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_path:
+
+
+``path``
+""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_offset:
+
+
+``offset``
+""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_source:
+
+
+``source``
+""""""""""
+
+
+**Default**: ``null``
+
+
+.. _ExtractMethodHandler:
+
+
+ExtractMethodHandler
+--------------------
+
+
+.. _RpcCommand_GlobalDefinitionHandler_method_name:
+
+
+``method_name``
+"""""""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_offset_start:
+
+
+``offset_start``
+""""""""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_offset_end:
+
+
+``offset_end``
+""""""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_source:
+
+
+``source``
+""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_path:
+
+
+``path``
+""""""""
+
+
+**Default**: ``null``
+
+
+.. _GenerateAccessorHandler:
+
+
+GenerateAccessorHandler
+-----------------------
+
+
+.. _RpcCommand_GlobalDefinitionHandler_names:
+
+
+``names``
+"""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_path:
+
+
+``path``
+""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_source:
+
+
+``source``
+""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_offset:
+
+
+``offset``
+""""""""""
+
+
+**Default**: ``null``
+
+
+.. _GenerateMethodHandler:
+
+
+GenerateMethodHandler
+---------------------
+
+
+.. _RpcCommand_GlobalDefinitionHandler_path:
+
+
+``path``
+""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_source:
+
+
+``source``
+""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_offset:
+
+
+``offset``
+""""""""""
+
+
+**Default**: ``null``
+
+
+.. _ImportClassHandler:
+
+
+ImportClassHandler
+------------------
+
+
+.. _RpcCommand_GlobalDefinitionHandler_qualified_name:
+
+
+``qualified_name``
+""""""""""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_alias:
+
+
+``alias``
+"""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_offset:
+
+
+``offset``
+""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_source:
+
+
+``source``
+""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_path:
+
+
+``path``
+""""""""
+
+
+**Default**: ``null``
+
+
+.. _RenameVariableHandler:
+
+
+RenameVariableHandler
+---------------------
+
+
+.. _RpcCommand_GlobalDefinitionHandler_name:
+
+
+``name``
+""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_name_suggestion:
+
+
+``name_suggestion``
+"""""""""""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_scope:
+
+
+``scope``
+"""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_path:
+
+
+``path``
+""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_source:
+
+
+``source``
+""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_offset:
+
+
+``offset``
+""""""""""
+
+
+**Default**: ``null``
+
+
+.. _ChangeVisiblityHandler:
+
+
+ChangeVisiblityHandler
+----------------------
+
+
+.. _RpcCommand_GlobalDefinitionHandler_path:
+
+
+``path``
+""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_source:
+
+
+``source``
+""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_offset:
+
+
+``offset``
+""""""""""
+
+
+Type: integer
+
+
+**Default**: ``null``
+
+
+.. _OverrideMethodHandler:
+
+
+OverrideMethodHandler
+---------------------
+
+
+.. _RpcCommand_GlobalDefinitionHandler_method_name:
+
+
+``method_name``
+"""""""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_class_name:
+
+
+``class_name``
+""""""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_path:
+
+
+``path``
+""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_source:
+
+
+``source``
+""""""""""
+
+
+**Default**: ``null``
+
+
+.. _ExtractExpressionHandler:
+
+
+ExtractExpressionHandler
+------------------------
+
+
+.. _RpcCommand_GlobalDefinitionHandler_variable_name:
+
+
+``variable_name``
+"""""""""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_offset_start:
+
+
+``offset_start``
+""""""""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_path:
+
+
+``path``
+""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_source:
+
+
+``source``
+""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_offset_end:
+
+
+``offset_end``
+""""""""""""""
+
+
+**Default**: ``null``
+
+
+.. _ImportMissingClassesHandler:
+
+
+ImportMissingClassesHandler
+---------------------------
+
+
+.. _RpcCommand_GlobalDefinitionHandler_path:
+
+
+``path``
+""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_source:
+
+
+``source``
+""""""""""
+
+
+**Default**: ``null``
+
+
+.. _HoverHandler:
+
+
+HoverHandler
+------------
+
+
+.. _RpcCommand_GlobalDefinitionHandler_source:
+
+
+``source``
+""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_offset:
+
+
+``offset``
+""""""""""
+
+
+**Default**: ``null``
+
+
+.. _CompleteHandler:
+
+
+CompleteHandler
+---------------
+
+
+.. _RpcCommand_GlobalDefinitionHandler_type:
+
+
+``type``
+""""""""
+
+
+**Default**: ``"php"``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_source:
+
+
+``source``
+""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_offset:
+
+
+``offset``
+""""""""""
+
+
+**Default**: ``null``
+
+
+.. _NavigateHandler:
+
+
+NavigateHandler
+---------------
+
+
+.. _RpcCommand_GlobalDefinitionHandler_source_path:
+
+
+``source_path``
+"""""""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_destination:
+
+
+``destination``
+"""""""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_confirm_create:
+
+
+``confirm_create``
+""""""""""""""""""
+
+
+**Default**: ``null``
+
+
+.. _ContextMenuHandler:
+
+
+ContextMenuHandler
+------------------
+
+
+.. _RpcCommand_GlobalDefinitionHandler_action:
+
+
+``action``
+""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_current_path:
+
+
+``current_path``
+""""""""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_source:
+
+
+``source``
+""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_offset:
+
+
+``offset``
+""""""""""
+
+
+**Default**: ``null``
+
+
+.. _EchoHandler:
+
+
+EchoHandler
+-----------
+
+
+.. _RpcCommand_GlobalDefinitionHandler_message:
+
+
+``message``
+"""""""""""
+
+
+**Default**: ``null``
+
+
+.. _ClassSearchHandler:
+
+
+ClassSearchHandler
+------------------
+
+
+.. _RpcCommand_GlobalDefinitionHandler_short_name:
+
+
+``short_name``
+""""""""""""""
+
+
+**Default**: ``null``
+
+
+.. _OffsetInfoHandler:
+
+
+OffsetInfoHandler
+-----------------
+
+
+.. _RpcCommand_GlobalDefinitionHandler_offset:
+
+
+``offset``
+""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_source:
+
+
+``source``
+""""""""""
+
+
+**Default**: ``null``
+
+
 .. _GotoDefinitionHandler:
 
 
@@ -72,4 +1080,148 @@ Type: string
 
 
 **Default**: ``null``
+
+
+.. _GotoTypeHandler:
+
+
+GotoTypeHandler
+---------------
+
+
+.. _RpcCommand_GlobalDefinitionHandler_language:
+
+
+``language``
+""""""""""""
+
+
+**Default**: ``"php"``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_target:
+
+
+``target``
+""""""""""
+
+
+**Default**: ``"focused_window"``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_offset:
+
+
+``offset``
+""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_source:
+
+
+``source``
+""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_path:
+
+
+``path``
+""""""""
+
+
+**Default**: ``null``
+
+
+.. _GotoImplementationHandler:
+
+
+GotoImplementationHandler
+-------------------------
+
+
+.. _RpcCommand_GlobalDefinitionHandler_language:
+
+
+``language``
+""""""""""""
+
+
+**Default**: ``"php"``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_target:
+
+
+``target``
+""""""""""
+
+
+**Default**: ``"focused_window"``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_offset:
+
+
+``offset``
+""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_source:
+
+
+``source``
+""""""""""
+
+
+**Default**: ``null``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_path:
+
+
+``path``
+""""""""
+
+
+**Default**: ``null``
+
+
+.. _IndexHandler:
+
+
+IndexHandler
+------------
+
+
+.. _RpcCommand_GlobalDefinitionHandler_watch:
+
+
+``watch``
+"""""""""
+
+
+**Default**: ``false``
+
+
+.. _RpcCommand_GlobalDefinitionHandler_interval:
+
+
+``interval``
+""""""""""""
+
+
+Type: integer
+
+
+**Default**: ``5000``
 

--- a/lib/Extension/Debug/Command/GenerateDocumentationCommand.php
+++ b/lib/Extension/Debug/Command/GenerateDocumentationCommand.php
@@ -2,19 +2,22 @@
 
 namespace Phpactor\Extension\Debug\Command;
 
-use Phpactor\Extension\Debug\Model\Documentor;
+use Phpactor\Extension\Debug\Model\DocumentorRegistry;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class GenerateDocumentationCommand extends Command
 {
-    private Documentor $documentor;
+    private DocumentorRegistry $documentorRegistry;
 
-    public function __construct(Documentor $documentor)
+    private string $documentorName;
+
+    public function __construct(DocumentorRegistry $documentorRegistry, string $documentorName)
     {
         parent::__construct();
-        $this->documentor = $documentor;
+        $this->documentorRegistry = $documentorRegistry;
+        $this->documentorName = $documentorName;
     }
 
     protected function configure(): void
@@ -24,7 +27,9 @@ class GenerateDocumentationCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        fwrite(STDOUT, $this->documentor->document($this->getName()));
+        $documentor = $this->documentorRegistry->get($this->documentorName);
+        fwrite(STDOUT, $documentor->document($this->getName()));
+
         return 0;
     }
 }

--- a/lib/Extension/Debug/Command/GenerateDocumentationCommand.php
+++ b/lib/Extension/Debug/Command/GenerateDocumentationCommand.php
@@ -2,16 +2,16 @@
 
 namespace Phpactor\Extension\Debug\Command;
 
-use Phpactor\Extension\Debug\Model\ExtensionDocumentor;
+use Phpactor\Extension\Debug\Model\Documentor;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class DocumentExtensionsCommand extends Command
+class GenerateDocumentationCommand extends Command
 {
-    private ExtensionDocumentor $documentor;
+    private Documentor $documentor;
 
-    public function __construct(ExtensionDocumentor $documentor)
+    public function __construct(Documentor $documentor)
     {
         parent::__construct();
         $this->documentor = $documentor;
@@ -24,7 +24,7 @@ class DocumentExtensionsCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        fwrite(STDOUT, $this->documentor->document());
+        fwrite(STDOUT, $this->documentor->document($this->getName()));
         return 0;
     }
 }

--- a/lib/Extension/Debug/Command/GenerateDocumentationCommand.php
+++ b/lib/Extension/Debug/Command/GenerateDocumentationCommand.php
@@ -5,29 +5,28 @@ namespace Phpactor\Extension\Debug\Command;
 use Phpactor\Extension\Debug\Model\DocumentorRegistry;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class GenerateDocumentationCommand extends Command
 {
     private DocumentorRegistry $documentorRegistry;
 
-    private string $documentorName;
-
-    public function __construct(DocumentorRegistry $documentorRegistry, string $documentorName)
+    public function __construct(DocumentorRegistry $documentorRegistry)
     {
         parent::__construct();
         $this->documentorRegistry = $documentorRegistry;
-        $this->documentorName = $documentorName;
     }
 
     protected function configure(): void
     {
         $this->setDescription('Generate configuration reference as an RST document');
+        $this->addArgument('documentor', InputArgument::REQUIRED);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $documentor = $this->documentorRegistry->get($this->documentorName);
+        $documentor = $this->documentorRegistry->get($input->getArgument('documentor'));
         fwrite(STDOUT, $documentor->document($this->getName()));
 
         return 0;

--- a/lib/Extension/Debug/DebugExtension.php
+++ b/lib/Extension/Debug/DebugExtension.php
@@ -18,7 +18,7 @@ use RuntimeException;
 class DebugExtension implements Extension
 {
     public const TAG_DOCUMENTOR = 'debug.documentor';
-    public const EXTENSION_DOCUMENTOR_NAME = 'extension.documentor';
+    public const EXTENSION_DOCUMENTOR_NAME = 'extension';
 
     public function load(ContainerBuilder $container): void
     {

--- a/lib/Extension/Debug/DebugExtension.php
+++ b/lib/Extension/Debug/DebugExtension.php
@@ -12,7 +12,6 @@ use Phpactor\Extension\Debug\Model\ExtensionDocumentor;
 use Phpactor\Extension\Debug\Model\DocumentorRegistry;
 use Phpactor\Extension\Debug\Model\DefinitionDocumentor;
 use Phpactor\Extension\Core\Model\JsonSchemaBuilder;
-use Phpactor\Extension\Rpc\RpcExtension;
 use Phpactor\MapResolver\Resolver;
 use RuntimeException;
 
@@ -52,25 +51,11 @@ class DebugExtension implements Extension
             self::TAG_DOCUMENTOR => ['name' => self::EXTENSION_DOCUMENTOR_NAME]
         ]);
 
-        $container->register('generate_documentation_command.extensions', function (Container $container) {
-            return new GenerateDocumentationCommand(
-                $container->get(DocumentorRegistry::class),
-                self::EXTENSION_DOCUMENTOR_NAME
-            );
+        $container->register(GenerateDocumentationCommand::class, function (Container $container) {
+            return new GenerateDocumentationCommand($container->get(DocumentorRegistry::class));
         }, [
             ConsoleExtension::TAG_COMMAND => [
-                'name' => 'development:configuration-reference'
-            ]
-        ]);
-
-        $container->register('generate_documentation_command.command', function (Container $container) {
-            return new GenerateDocumentationCommand(
-                $container->get(DocumentorRegistry::class),
-                RpcExtension::RPC_DOCUMENTOR_NAME
-            );
-        }, [
-            ConsoleExtension::TAG_COMMAND => [
-                'name' => 'development:command-reference'
+                'name' => 'development:generate-documentation'
             ]
         ]);
 

--- a/lib/Extension/Debug/DebugExtension.php
+++ b/lib/Extension/Debug/DebugExtension.php
@@ -54,7 +54,8 @@ class DebugExtension implements Extension
 
         $container->register('generate_documentation_command.extensions', function (Container $container) {
             return new GenerateDocumentationCommand(
-                $container->get(DocumentorRegistry::class)->get(self::EXTENSION_DOCUMENTOR_NAME)
+                $container->get(DocumentorRegistry::class),
+                self::EXTENSION_DOCUMENTOR_NAME
             );
         }, [
             ConsoleExtension::TAG_COMMAND => [
@@ -64,7 +65,8 @@ class DebugExtension implements Extension
 
         $container->register('generate_documentation_command.command', function (Container $container) {
             return new GenerateDocumentationCommand(
-                $container->get(DocumentorRegistry::class)->get(RpcExtension::RPC_DOCUMENTOR_NAME)
+                $container->get(DocumentorRegistry::class),
+                RpcExtension::RPC_DOCUMENTOR_NAME
             );
         }, [
             ConsoleExtension::TAG_COMMAND => [

--- a/lib/Extension/Debug/DebugExtension.php
+++ b/lib/Extension/Debug/DebugExtension.php
@@ -12,7 +12,6 @@ use Phpactor\Extension\Debug\Model\ExtensionDocumentor;
 use Phpactor\Extension\Debug\Model\RpcCommandDocumentor;
 use Phpactor\Extension\Debug\Model\DefinitionDocumentor;
 use Phpactor\Extension\Core\Model\JsonSchemaBuilder;
-use Phpactor\Extension\ReferenceFinderRpc\Handler\GotoDefinitionHandler;
 use Phpactor\MapResolver\Resolver;
 
 class DebugExtension implements Extension
@@ -32,9 +31,7 @@ class DebugExtension implements Extension
 
         $container->register(RpcCommandDocumentor::class, function (Container $container) {
             return new RpcCommandDocumentor(
-                [
-                    GotoDefinitionHandler::class
-                ],
+                $container->get('rpc.handler_registry'),
                 $container->get(DefinitionDocumentor::class)
             );
         });

--- a/lib/Extension/Debug/Model/DefinitionDocumentor.php
+++ b/lib/Extension/Debug/Model/DefinitionDocumentor.php
@@ -12,6 +12,7 @@ class DefinitionDocumentor
         $help[] = "\n";
         $help[] = '``' . $definition->name() . '``';
         $help[] = str_repeat('"', mb_strlen($definition->name()) + 4);
+
         if ($definition->types()) {
             $help[] = "\n";
             $help[] = sprintf('Type: %s', implode('|', $definition->types()));
@@ -21,6 +22,7 @@ class DefinitionDocumentor
             $help[] = "\n";
             $help[] = $definition->description();
         }
+
         $help[] = "\n";
         $help[] = sprintf(
             '**Default**: ``%s``',

--- a/lib/Extension/Debug/Model/DefinitionDocumentor.php
+++ b/lib/Extension/Debug/Model/DefinitionDocumentor.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Phpactor\Extension\Debug\Model;
+
+use Phpactor\MapResolver\Definition;
+
+class DefinitionDocumentor
+{
+    public function document(string $prefix, Definition $definition): string
+    {
+        $help[] = sprintf('.. _%s_%s:', $prefix, $definition->name());
+        $help[] = "\n";
+        $help[] = '``' . $definition->name() . '``';
+        $help[] = str_repeat('"', mb_strlen($definition->name()) + 4);
+        if ($definition->types()) {
+            $help[] = "\n";
+            $help[] = sprintf('Type: %s', implode('|', $definition->types()));
+        }
+
+        if ($definition->description()) {
+            $help[] = "\n";
+            $help[] = $definition->description();
+        }
+        $help[] = "\n";
+        $help[] = sprintf(
+            '**Default**: ``%s``',
+            json_encode($definition->defaultValue())
+        );
+        $help[] = "\n";
+
+        $enum = $definition->enum();
+        if ($enum) {
+            $help[] = sprintf(
+                '**Allowed values**: %s',
+                implode(', ', array_map(fn ($v) => json_encode($v), $enum))
+            );
+            $help[] = "\n";
+        }
+
+        return implode("\n", $help);
+    }
+}

--- a/lib/Extension/Debug/Model/Documentor.php
+++ b/lib/Extension/Debug/Model/Documentor.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Phpactor\Extension\Debug\Model;
+
+interface Documentor
+{
+    public function document(string $commandName = ''): string;
+}

--- a/lib/Extension/Debug/Model/DocumentorRegistry.php
+++ b/lib/Extension/Debug/Model/DocumentorRegistry.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Phpactor\Extension\Debug\Model;
+
+use InvalidArgumentException;
+use Phpactor\Container\Container;
+
+class DocumentorRegistry
+{
+    /** @var array<string> */
+    private array $documentors;
+
+    private Container $container;
+
+    /**
+     * @param array<string> $documentors
+     */
+    public function __construct(Container $container, array $documentors)
+    {
+        $this->documentors = $documentors;
+        $this->container = $container;
+    }
+
+    public function get(string $string): Documentor
+    {
+        if (!array_key_exists($string, $this->documentors)) {
+            throw new InvalidArgumentException(
+                'Could not find documentor. Available documentors: ' . implode(', ', array_keys($this->documentors))
+            );
+        }
+
+        return $this->container->get($this->documentors[$string]);
+    }
+}

--- a/lib/Extension/ReferenceFinderRpc/Handler/GotoDefinitionHandler.php
+++ b/lib/Extension/ReferenceFinderRpc/Handler/GotoDefinitionHandler.php
@@ -42,6 +42,10 @@ class GotoDefinitionHandler implements Handler
             self::PARAM_SOURCE,
             self::PARAM_PATH,
         ]);
+        $resolver->setTypes([
+            self::PARAM_LANGUAGE => 'string',
+            self::PARAM_TARGET => 'string',
+        ]);
     }
 
     public function handle(array $arguments)

--- a/lib/Extension/ReferenceFinderRpc/Handler/GotoTypeHandler.php
+++ b/lib/Extension/ReferenceFinderRpc/Handler/GotoTypeHandler.php
@@ -11,7 +11,7 @@ use Phpactor\TextDocument\TextDocumentBuilder;
 
 class GotoTypeHandler implements Handler
 {
-    const NAME = 'goto_definition';
+    const NAME = 'goto_type';
     const PARAM_OFFSET = 'offset';
     const PARAM_SOURCE = 'source';
     const PARAM_PATH = 'path';

--- a/lib/Extension/ReferenceFinderRpc/Tests/Unit/Handler/GotoTypeHandlerTest.php
+++ b/lib/Extension/ReferenceFinderRpc/Tests/Unit/Handler/GotoTypeHandlerTest.php
@@ -21,7 +21,7 @@ class GotoTypeHandlerTest extends TestCase
 
     public function testGotoType(): void
     {
-        $location = $this->create()->handle('goto_definition', [
+        $location = $this->create()->handle('goto_type', [
             'source' => self::EXAMPLE_SOURCE,
             'offset' => self::EXAMPLE_OFFSET,
             'path' => self::EXAMPLE_PATH,

--- a/lib/Extension/Rpc/HandlerRegistry.php
+++ b/lib/Extension/Rpc/HandlerRegistry.php
@@ -5,4 +5,7 @@ namespace Phpactor\Extension\Rpc;
 interface HandlerRegistry
 {
     public function get($handlerName): Handler;
+
+    /** @return array<Handler> */
+    public function all(): array;
 }

--- a/lib/Extension/Rpc/Registry/ActiveHandlerRegistry.php
+++ b/lib/Extension/Rpc/Registry/ActiveHandlerRegistry.php
@@ -30,6 +30,11 @@ class ActiveHandlerRegistry implements HandlerRegistry
         return $this->handlers[$handlerName];
     }
 
+    public function all(): array
+    {
+        return $this->handlers;
+    }
+
     private function register(Handler $handler): void
     {
         $this->handlers[$handler->name()] = $handler;

--- a/lib/Extension/Rpc/Registry/LazyContainerHandlerRegistry.php
+++ b/lib/Extension/Rpc/Registry/LazyContainerHandlerRegistry.php
@@ -33,4 +33,14 @@ class LazyContainerHandlerRegistry implements HandlerRegistry
 
         return $this->container->get($this->serviceMap[$handlerName]);
     }
+
+    public function all(): array
+    {
+        return array_map(
+            function (string $serviceId) {
+                return $this->container->get($serviceId);
+            },
+            $this->serviceMap
+        );
+    }
 }

--- a/lib/Extension/Rpc/RpcCommandDocumentor.php
+++ b/lib/Extension/Rpc/RpcCommandDocumentor.php
@@ -49,7 +49,7 @@ class RpcCommandDocumentor implements Documentor
     {
         $handlerClass = get_class($handler);
         $parts = explode('\\', $handlerClass);
-        $documentedName = end($parts);
+        $documentedName = '_RpcHandler_'.end($parts);
 
         /** @phpstan-ignore-next-line */
         if (false === $documentedName) {
@@ -60,7 +60,7 @@ class RpcCommandDocumentor implements Documentor
         }
 
         $help = [
-            '.. _' . $documentedName . ':',
+            '.. ' . $documentedName . ':',
             "\n",
             $documentedName,
             str_repeat('-', mb_strlen($documentedName)),

--- a/lib/Extension/Rpc/RpcCommandDocumentor.php
+++ b/lib/Extension/Rpc/RpcCommandDocumentor.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Phpactor\Extension\Debug\Model;
+namespace Phpactor\Extension\Rpc;
 
-use Phpactor\Extension\Rpc\HandlerRegistry;
+use Phpactor\Extension\Debug\Model\DefinitionDocumentor;
+use Phpactor\Extension\Debug\Model\Documentor;
 use Phpactor\MapResolver\Resolver;
 use RuntimeException;
-use Phpactor\Extension\Rpc\Handler;
 
 class RpcCommandDocumentor implements Documentor
 {
@@ -20,7 +20,6 @@ class RpcCommandDocumentor implements Documentor
         $this->handlerRegistry = $handlerRegistry;
         $this->definitionDocumentor = $definitionDocumentor;
     }
-
 
     public function document(string $commandName=''): string
     {

--- a/lib/Extension/Rpc/RpcCommandDocumentor.php
+++ b/lib/Extension/Rpc/RpcCommandDocumentor.php
@@ -24,8 +24,8 @@ class RpcCommandDocumentor implements Documentor
     public function document(string $commandName=''): string
     {
         $docs = [
-            'Commands',
-            '========',
+            'Legacy RPC Commands',
+            '===================',
             "\n",
             ".. This document is generated via the `$commandName` command",
             "\n",
@@ -72,7 +72,7 @@ class RpcCommandDocumentor implements Documentor
 
         $hasDocumentation = false;
         foreach ($resolver->definitions() as $definition) {
-            $help[] = $this->definitionDocumentor->document('RpcCommand_GlobalDefinitionHandler', $definition);
+            $help[] = $this->definitionDocumentor->document('RpcCommand_'.$handler->name(), $definition);
             $hasDocumentation = true;
         }
 

--- a/lib/Extension/Rpc/RpcExtension.php
+++ b/lib/Extension/Rpc/RpcExtension.php
@@ -63,16 +63,14 @@ class RpcExtension implements Extension
             return new LazyContainerHandlerRegistry($container, $handlers);
         });
 
-        if (class_exists(DebugExtension::class)) {
-            $container->register(RpcCommandDocumentor::class, function ($container) {
-                return new RpcCommandDocumentor(
-                    $container->get('rpc.handler_registry'),
-                    $container->get(DefinitionDocumentor::class)
-                );
-            }, [ DebugExtension::TAG_DOCUMENTOR => [
-                'name' => self::RPC_DOCUMENTOR_NAME
-            ] ]);
-        }
+        $container->register(RpcCommandDocumentor::class, function ($container) {
+            return new RpcCommandDocumentor(
+                $container->get('rpc.handler_registry'),
+                $container->get(DefinitionDocumentor::class)
+            );
+        }, [ DebugExtension::TAG_DOCUMENTOR => [
+            'name' => self::RPC_DOCUMENTOR_NAME
+        ] ]);
 
         $this->registerHandlers($container);
     }

--- a/lib/Extension/Rpc/RpcExtension.php
+++ b/lib/Extension/Rpc/RpcExtension.php
@@ -23,7 +23,7 @@ class RpcExtension implements Extension
 {
     public const TAG_RPC_HANDLER = 'rpc.handler';
     public const SERVICE_REQUEST_HANDLER = 'rpc.request_handler';
-    public const RPC_DOCUMENTOR_NAME= 'rpc.documentor';
+    public const RPC_DOCUMENTOR_NAME= 'rpc';
     private const STORE_REPLAY = 'rpc.store_replay';
     private const REPLAY_PATH = 'rpc.replay_path';
 

--- a/lib/Extension/Rpc/RpcExtension.php
+++ b/lib/Extension/Rpc/RpcExtension.php
@@ -5,6 +5,8 @@ namespace Phpactor\Extension\Rpc;
 use Phpactor\Container\Container;
 use Phpactor\Container\ContainerBuilder;
 use Phpactor\Container\Extension;
+use Phpactor\Extension\Debug\DebugExtension;
+use Phpactor\Extension\Debug\Model\DefinitionDocumentor;
 use Phpactor\Extension\Logger\LoggingExtension;
 use Phpactor\Extension\Console\ConsoleExtension;
 use Phpactor\Extension\Rpc\Command\RpcCommand;
@@ -19,11 +21,11 @@ use RuntimeException;
 
 class RpcExtension implements Extension
 {
-    const TAG_RPC_HANDLER = 'rpc.handler';
+    public const TAG_RPC_HANDLER = 'rpc.handler';
     public const SERVICE_REQUEST_HANDLER = 'rpc.request_handler';
+    public const RPC_DOCUMENTOR_NAME= 'rpc.documentor';
     private const STORE_REPLAY = 'rpc.store_replay';
     private const REPLAY_PATH = 'rpc.replay_path';
-
 
     public function load(ContainerBuilder $container): void
     {
@@ -60,6 +62,17 @@ class RpcExtension implements Extension
 
             return new LazyContainerHandlerRegistry($container, $handlers);
         });
+
+        if (class_exists(DebugExtension::class)) {
+            $container->register(RpcCommandDocumentor::class, function ($container) {
+                return new RpcCommandDocumentor(
+                    $container->get('rpc.handler_registry'),
+                    $container->get(DefinitionDocumentor::class)
+                );
+            }, [ DebugExtension::TAG_DOCUMENTOR => [
+                'name' => self::RPC_DOCUMENTOR_NAME
+            ] ]);
+        }
 
         $this->registerHandlers($container);
     }


### PR DESCRIPTION
## What I did
* Generalized the `DocumentExtensionsCommand` to also be able to generate documentation for the commands
* Centralized / extracted the generation of the `Definition` printing logic to another class
* Added a command for generating configuration information from a `Handler`.

## What needs to be done
First of all this is only a prove of concept if the idea that I had is alright. If it is valid, then we need to add more `Handler`s to the list to document. And fill out the documentation info on all of the handlers

Relates to #1030 