### PR TITLE
GH-1719: Create non existing class

### DIFF
--- a/doc/lsp/code-actions.rst
+++ b/doc/lsp/code-actions.rst
@@ -7,30 +7,32 @@ See `Language Server Specification (Code Action Request)`_ for details.
 
 List of currently available code actions:
 
-+---------------------------------------------+---------------------------------------+
-| Code Action                                 | Kind                                  |
-+=============================================+=======================================+
-| :ref:`refactoring_import_missing_class`     | ``quickfix.import_class``             |
-+---------------------------------------------+---------------------------------------+
-| :ref:`refactoring_complete_constructor`     | ``quickfix.complete_constructor``     |
-+---------------------------------------------+---------------------------------------+
-| :ref:`refactoring_add_missing_assignements` | ``quickfix.add_missing_properties``   |
-+---------------------------------------------+---------------------------------------+
-| :ref:`implement_contracts`                  | ``quickfix.implement_contracts``      |
-+---------------------------------------------+---------------------------------------+
-| :ref:`refactoring_fix_namespace_and_class`  | ``quickfix.fix_namespace_class_name`` |
-+---------------------------------------------+---------------------------------------+
-| :ref:`generation_class_new`                 | ``quickfix.create_class``             |
-+---------------------------------------------+---------------------------------------+
-| :ref:`generation_method`                    | ``quickfix.generate_method``          |
-+---------------------------------------------+---------------------------------------+
-| :ref:`generation_extract_method`            | ``quickfix.extract_method``           |
-+---------------------------------------------+---------------------------------------+
-| :ref:`generation_extract_expression`        | ``quickfix.extract_expression``       |
-+---------------------------------------------+---------------------------------------+
-| :ref:`generation_extract_constant`          | ``quickfix.extract_constant``         |
-+---------------------------------------------+---------------------------------------+
-| :ref:`generation_generate_accessors`        | ``quickfix.generate_accessors``       |
-+---------------------------------------------+---------------------------------------+
++---------------------------------------------+----------------------------------------+
+| Code Action                                 | Kind                                   |
++=============================================+========================================+
+| :ref:`refactoring_import_missing_class`     | ``quickfix.import_class``              |
++---------------------------------------------+----------------------------------------+
+| :ref:`refactoring_complete_constructor`     | ``quickfix.complete_constructor``      |
++---------------------------------------------+----------------------------------------+
+| :ref:`refactoring_add_missing_assignements` | ``quickfix.add_missing_properties``    |
++---------------------------------------------+----------------------------------------+
+| :ref:`implement_contracts`                  | ``quickfix.implement_contracts``       |
++---------------------------------------------+----------------------------------------+
+| :ref:`refactoring_fix_namespace_and_class`  | ``quickfix.fix_namespace_class_name``  |
++---------------------------------------------+----------------------------------------+
+| :ref:`generation_class_new`                 | ``quickfix.create_class``              |
++---------------------------------------------+----------------------------------------+
+| :ref:`generation_class_new`                 | ``quickfix.create_unresolvable_class`` |
++---------------------------------------------+----------------------------------------+
+| :ref:`generation_method`                    | ``quickfix.generate_method``           |
++---------------------------------------------+----------------------------------------+
+| :ref:`generation_extract_method`            | ``quickfix.extract_method``            |
++---------------------------------------------+----------------------------------------+
+| :ref:`generation_extract_expression`        | ``quickfix.extract_expression``        |
++---------------------------------------------+----------------------------------------+
+| :ref:`generation_extract_constant`          | ``quickfix.extract_constant``          |
++---------------------------------------------+----------------------------------------+
+| :ref:`generation_generate_accessors`        | ``quickfix.generate_accessors``        |
++---------------------------------------------+----------------------------------------+
 
 .. _Language Server Specification (Code Action Request): https://microsoft.github.io/language-server-protocol/specification#textDocument_codeAction

--- a/doc/reference/refactorings.rst
+++ b/doc/reference/refactorings.rst
@@ -767,6 +767,10 @@ from a class name.
 
 .. tabs::
 
+   .. tab:: Language Server
+
+       Invoke the code action menu on a non-existing class name
+
    .. tab:: CLI
 
        .. code-block::

--- a/lib/Extension/LanguageServerBridge/Converter/RangeConverter.php
+++ b/lib/Extension/LanguageServerBridge/Converter/RangeConverter.php
@@ -14,4 +14,12 @@ class RangeConverter
             PositionConverter::byteOffsetToPosition($range->end(), $text),
         );
     }
+
+    public static function toPhpactorRange(Range $range, string $text): ByteOffsetRange
+    {
+        return new ByteOffsetRange(
+            PositionConverter::positionToByteOffset($range->start, $text),
+            PositionConverter::positionToByteOffset($range->end, $text),
+        );
+    }
 }

--- a/lib/Extension/LanguageServerCodeTransform/CodeAction/CreateUnresolvableClassProvider.php
+++ b/lib/Extension/LanguageServerCodeTransform/CodeAction/CreateUnresolvableClassProvider.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerCodeTransform\CodeAction;
+
+use Amp\CancellationToken;
+use Amp\Promise;
+use Phpactor\ClassFileConverter\Domain\ClassName;
+use Phpactor\ClassFileConverter\Domain\ClassToFile;
+use Phpactor\Extension\LanguageServerBridge\Converter\RangeConverter;
+use Phpactor\Extension\LanguageServerCodeTransform\LspCommand\CreateClassCommand;
+use Phpactor\LanguageServerProtocol\CodeAction;
+use Phpactor\LanguageServerProtocol\Command;
+use Phpactor\LanguageServerProtocol\Range;
+use Phpactor\LanguageServerProtocol\TextDocumentItem;
+use Phpactor\LanguageServer\Core\CodeAction\CodeActionProvider;
+use Phpactor\LanguageServer\Test\ProtocolFactory;
+use Phpactor\TextDocument\TextDocumentUri;
+use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\UnresolvableNameDiagnostic;
+use Phpactor\WorseReflection\Core\Reflector\SourceCodeReflector;
+use function Amp\call;
+
+class CreateUnresolvableClassProvider implements CodeActionProvider
+{
+    public const KIND = 'quickfix.create_unresolable_class';
+
+    private SourceCodeReflector $reflector;
+
+    private ClassToFile $classToFile;
+
+    public function __construct(SourceCodeReflector $reflector, ClassToFile $classToFile)
+    {
+        $this->reflector = $reflector;
+        $this->classToFile = $classToFile;
+    }
+
+    public function provideActionsFor(TextDocumentItem $textDocument, Range $range, CancellationToken $cancel): Promise
+    {
+        return call(function () use ($textDocument) {
+            $diagnostics = $this->reflector->diagnostics($textDocument->text)->byClass(UnresolvableNameDiagnostic::class);
+            $actions = [];
+            foreach ($diagnostics as $diagnostic) {
+                assert($diagnostic instanceof UnresolvableNameDiagnostic);
+                if ($diagnostic->type() !== UnresolvableNameDiagnostic::TYPE_CLASS) {
+                    continue;
+                }
+
+                $title = sprintf('Create class "%s"', $diagnostic->name()->__toString());
+                foreach ($this->classToFile->classToFileCandidates(ClassName::fromString($diagnostic->name())) as $candidate) {
+                    $actions[] = CodeAction::fromArray([
+                        'title' =>  $title,
+                        'kind' => self::KIND,
+                        'diagnostics' => [
+                            ProtocolFactory::diagnostic(RangeConverter::toLspRange($diagnostic->range(), $textDocument->text), $diagnostic->message())
+                        ],
+                        'command' => new Command(
+                            $title,
+                            CreateClassCommand::NAME,
+                            [
+                                TextDocumentUri::fromString((string)$candidate)->__toString(),
+                                'default',
+                            ]
+                        )
+                    ]);
+                }
+            }
+
+            return $actions;
+        });
+    }
+
+    public function kinds(): array
+    {
+        return [
+            self::KIND
+        ];
+    }
+}

--- a/lib/Extension/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
+++ b/lib/Extension/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
@@ -15,6 +15,7 @@ use Phpactor\Container\Extension;
 use Phpactor\Extension\ClassToFile\ClassToFileExtension;
 use Phpactor\Extension\CodeTransform\CodeTransformExtension;
 use Phpactor\Extension\LanguageServerCodeTransform\CodeAction\CreateClassProvider;
+use Phpactor\Extension\LanguageServerCodeTransform\CodeAction\CreateUnresolvableClassProvider;
 use Phpactor\Extension\LanguageServerCodeTransform\CodeAction\ExtractConstantProvider;
 use Phpactor\Extension\LanguageServerCodeTransform\CodeAction\ExtractExpressionProvider;
 use Phpactor\Extension\LanguageServerCodeTransform\CodeAction\ExtractMethodProvider;
@@ -221,6 +222,15 @@ class LanguageServerCodeTransformExtension implements Extension
             );
         }, [
             LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => [],
+            LanguageServerExtension::TAG_CODE_ACTION_PROVIDER => []
+        ]);
+
+        $container->register(CreateUnresolvableClassProvider::class, function (Container $container) {
+            return new CreateUnresolvableClassProvider(
+                $container->get(WorseReflectionExtension::SERVICE_REFLECTOR),
+                $container->get(ClassToFileExtension::SERVICE_CONVERTER)
+            );
+        }, [
             LanguageServerExtension::TAG_CODE_ACTION_PROVIDER => []
         ]);
 

--- a/lib/Extension/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
+++ b/lib/Extension/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
@@ -228,6 +228,7 @@ class LanguageServerCodeTransformExtension implements Extension
         $container->register(CreateUnresolvableClassProvider::class, function (Container $container) {
             return new CreateUnresolvableClassProvider(
                 $container->get(WorseReflectionExtension::SERVICE_REFLECTOR),
+                $container->get(CodeTransformExtension::SERVICE_CLASS_GENERATORS),
                 $container->get(ClassToFileExtension::SERVICE_CONVERTER)
             );
         }, [

--- a/lib/Extension/LanguageServerCodeTransform/Tests/Unit/CodeAction/CreateUnresolvableClassProviderTest.php
+++ b/lib/Extension/LanguageServerCodeTransform/Tests/Unit/CodeAction/CreateUnresolvableClassProviderTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerCodeTransform\Tests\Unit\CodeAction;
+
+use Amp\CancellationTokenSource;
+use Closure;
+use Generator;
+use Phpactor\ClassFileConverter\Domain\ClassName;
+use Phpactor\ClassFileConverter\Domain\ClassToFile;
+use Phpactor\ClassFileConverter\Domain\FilePath;
+use Phpactor\ClassFileConverter\Domain\FilePathCandidates;
+use Phpactor\Extension\LanguageServerBridge\Converter\RangeConverter;
+use Phpactor\LanguageServerProtocol\CodeAction;
+use Phpactor\TestUtils\ExtractOffset;
+use Phpactor\TextDocument\ByteOffsetRange;
+use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\UnresolvableNameProvider;
+use Prophecy\PhpUnit\ProphecyTrait;
+use function Amp\Promise\wait;
+use Phpactor\Extension\LanguageServerCodeTransform\CodeAction\CreateUnresolvableClassProvider;
+use Phpactor\Extension\LanguageServerCodeTransform\Tests\IntegrationTestCase;
+use Phpactor\LanguageServer\Test\ProtocolFactory;
+use Phpactor\WorseReflection\ReflectorBuilder;
+
+class CreateUnresolvableClassProviderTest extends IntegrationTestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @dataProvider provideCodeAction
+     */
+    public function testReturnsCodeActions(string $source, Closure $assertion): void
+    {
+        [$source, $start, $end] = ExtractOffset::fromSource($source);
+
+        $classToFile = $this->prophesize(ClassToFile::class);
+        $classToFile->classToFileCandidates(ClassName::fromString('Foo'))->willReturn(FilePathCandidates::fromFilePaths([FilePath::fromString('/foo')]));
+        $reflector = ReflectorBuilder::create()->addDiagnosticProvider(new UnresolvableNameProvider(false))->build();
+        $provider = new CreateUnresolvableClassProvider($reflector, $classToFile->reveal());
+        $actions = wait($provider->provideActionsFor(
+            ProtocolFactory::textDocumentItem('file://foo', $source),
+            RangeConverter::toLspRange(ByteOffsetRange::fromInts($start, $end), $source),
+            (new CancellationTokenSource)->getToken(),
+        ));
+        $assertion(...$actions);
+    }
+
+    /**
+     * @return Generator<array{string,Closure(CodeAction[]): void}>
+     */
+    public function provideCodeAction(): Generator
+    {
+        yield 'empty file' => [
+            '<<>?php <>',
+            function (CodeAction ...$actions): void {
+                self::assertCount(0, $actions);
+            }
+        ];
+        yield [
+            '<?php new Fo<>o<>();',
+            function (CodeAction ...$actions): void {
+                self::assertCount(1, $actions);
+            }
+        ];
+    }
+}

--- a/lib/Extension/LanguageServerCodeTransform/Tests/Unit/LspCommand/CreateClassCommandTest.php
+++ b/lib/Extension/LanguageServerCodeTransform/Tests/Unit/LspCommand/CreateClassCommandTest.php
@@ -14,7 +14,6 @@ use Phpactor\CodeTransform\Domain\SourceCode;
 use Phpactor\Extension\LanguageServerCodeTransform\LspCommand\CreateClassCommand;
 use Phpactor\LanguageServerProtocol\ApplyWorkspaceEditResponse;
 use Phpactor\LanguageServer\Core\Rpc\ResponseMessage;
-use Phpactor\LanguageServer\Core\Server\ResponseWatcher;
 use Phpactor\LanguageServer\Core\Server\ResponseWatcher\TestResponseWatcher;
 use Phpactor\LanguageServer\LanguageServerTesterBuilder;
 use Phpactor\LanguageServer\Test\LanguageServerTester;

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UnresolvableNameDiagnostic.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UnresolvableNameDiagnostic.php
@@ -9,8 +9,8 @@ use Phpactor\WorseReflection\Core\DiagnosticSeverity;
 
 class UnresolvableNameDiagnostic implements Diagnostic
 {
-    private const TYPE_CLASS = 'class';
-    private const TYPE_FUNCTION = 'function';
+    public const TYPE_CLASS = 'class';
+    public const TYPE_FUNCTION = 'function';
 
     private ByteOffsetRange $range;
 
@@ -59,6 +59,9 @@ class UnresolvableNameDiagnostic implements Diagnostic
         return sprintf('%s "%s" not found', ucfirst($this->type), $this->name->head()->__toString());
     }
 
+    /**
+     * @return self::TYPE_*
+     */
     public function type(): string
     {
         return $this->type;

--- a/lib/WorseReflection/Core/Diagnostics.php
+++ b/lib/WorseReflection/Core/Diagnostics.php
@@ -5,6 +5,7 @@ namespace Phpactor\WorseReflection\Core;
 use ArrayIterator;
 use Countable;
 use IteratorAggregate;
+use Phpactor\TextDocument\ByteOffsetRange;
 use RuntimeException;
 use Traversable;
 
@@ -54,5 +55,25 @@ final class Diagnostics implements IteratorAggregate, Countable
         }
 
         return $this->diagnostics[$index];
+    }
+
+    public function withinRange(ByteOffsetRange $byteOffsetRange): self
+    {
+        return new self(array_filter(
+            $this->diagnostics,
+            fn (Diagnostic $d) => 
+            $d->range()->start()->toInt() >= $byteOffsetRange->start()->toInt() && 
+            $d->range()->end()->toInt() <= $byteOffsetRange->end()->toInt()
+        ));
+    }
+
+    public function containingRange(ByteOffsetRange $byteOffsetRange): self
+    {
+        return new self(array_filter(
+            $this->diagnostics,
+            fn (Diagnostic $d) => 
+            $d->range()->start()->toInt() <= $byteOffsetRange->start()->toInt() && 
+            $d->range()->end()->toInt() >= $byteOffsetRange->end()->toInt()
+        ));
     }
 }

--- a/lib/WorseReflection/Core/Diagnostics.php
+++ b/lib/WorseReflection/Core/Diagnostics.php
@@ -61,8 +61,8 @@ final class Diagnostics implements IteratorAggregate, Countable
     {
         return new self(array_filter(
             $this->diagnostics,
-            fn (Diagnostic $d) => 
-            $d->range()->start()->toInt() >= $byteOffsetRange->start()->toInt() && 
+            fn (Diagnostic $d) =>
+            $d->range()->start()->toInt() >= $byteOffsetRange->start()->toInt() &&
             $d->range()->end()->toInt() <= $byteOffsetRange->end()->toInt()
         ));
     }
@@ -71,8 +71,8 @@ final class Diagnostics implements IteratorAggregate, Countable
     {
         return new self(array_filter(
             $this->diagnostics,
-            fn (Diagnostic $d) => 
-            $d->range()->start()->toInt() <= $byteOffsetRange->start()->toInt() && 
+            fn (Diagnostic $d) =>
+            $d->range()->start()->toInt() <= $byteOffsetRange->start()->toInt() &&
             $d->range()->end()->toInt() >= $byteOffsetRange->end()->toInt()
         ));
     }


### PR DESCRIPTION
This PR adds support for creating non-existing classes. 
![recorded](https://user-images.githubusercontent.com/530801/179358232-45455c10-af05-4645-936a-9d7d0190a480.gif)

The code action only applies when the cursor is on a non-existing class.