### PR TITLE
Allow parsing $this return type in docblock

### DIFF
--- a/lib/DocblockParser/Parser.php
+++ b/lib/DocblockParser/Parser.php
@@ -184,7 +184,7 @@ final class Parser
             }
         }
 
-        if ($this->ifType()) {
+        if ($this->ifType() || $this->tokens->if(Token::T_VARIABLE)) {
             $type = $this->parseTypes();
         }
 
@@ -266,6 +266,10 @@ final class Parser
         }
 
         if ($this->tokens->current->type === Token::T_VARIABLE) {
+            if ($this->tokens->current->value === '$this') {
+                $variable = $this->tokens->chomp(Token::T_VARIABLE);
+                return new ThisNode($variable);
+            }
             return $this->parseConditionalType();
         }
 

--- a/lib/DocblockParser/Tests/Unit/Printer/examples/this.test
+++ b/lib/DocblockParser/Tests/Unit/Printer/examples/this.test
@@ -1,0 +1,10 @@
+/**
+ * @var $this 
+ */
+---
+Docblock: = 
+ ElementList: = /**
+ * 
+  VarTag: = @var
+   VariableNode: = $this 
+ */

--- a/lib/WorseReflection/Tests/Inference/type/virtual_method_return_static.test
+++ b/lib/WorseReflection/Tests/Inference/type/virtual_method_return_static.test
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @method static sendMessage(string $text)
+ */
+class Mailer
+{
+}
+
+class CoolMailer
+{
+}
+
+$mailer = new Mailer();
+$coolMailer = new CoolMailer();
+
+// wrAssertType('Mailer', $mailer->sendMessage('foo'));
+// wrAssertType('CoolMailer', $coolMailer->sendMessage('foo'));

--- a/lib/WorseReflection/Tests/Inference/type/virtual_method_return_this.test
+++ b/lib/WorseReflection/Tests/Inference/type/virtual_method_return_this.test
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @method $this sendMessage(string $text)
+ */
+class Mailer
+{
+}
+
+class CoolMailer
+{
+}
+
+$mailer = new Mailer();
+//$coolMailer = new CoolMailer();
+
+wrAssertType('Mailer', $mailer->sendMessage('foo'));
+//wrAssertType('CoolMailer', $coolMailer->sendMessage('foo'));

--- a/lib/WorseReflection/Tests/Inference/type/virtual_static_method_return_static.test
+++ b/lib/WorseReflection/Tests/Inference/type/virtual_static_method_return_static.test
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @method static static sendMessage(string $text)
+ */
+class Mailer
+{
+}
+
+class CoolMailer
+{
+}
+
+$mailer = new Mailer();
+$coolMailer = new CoolMailer();
+
+wrAssertType('Mailer', $mailer::sendMessage('foo'));
+// wrAssertType('CoolMailer', $coolMailer::sendMessage('foo'));


### PR DESCRIPTION
This fixes part of #1802. With this little patch this is now recognized:
```php
<?php
/** @method $this bla() */
class a {}

$o = new a;
$r = $->bla(); // $r is of type a
```
I am not sure though, if it cannot have some implications for condititional types parsing. 