### PR TITLE
Better Completion Documentation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Bug fixes:
 
 Improvements:
 
+  - [wr] Markdown formatted member completion documentation
   - [ls] publish diagnostics on open and update
   - [ct] Add missing properties for array assignments #1640
   - [cmp] Provide variables from parent frame for anonymous use #1602
@@ -78,6 +79,8 @@ Improvements:
 
 Features:
 
+  - [ct] Generate constructor refactoring
+  - [ct] Fill object refactoring
   - [ct] Remove unused imports diagnositcs and code transformation #1758
   - [wr] Added native WR single-pass diagnostics #1700
   - [cmd] Index clean command #1691 @mamazu

--- a/doc/reference/configuration.rst
+++ b/doc/reference/configuration.rst
@@ -1530,28 +1530,6 @@ LanguageServerIndexerExtension
 **Default**: ``250``
 
 
-.. _LanguageServerHoverExtension:
-
-
-LanguageServerHoverExtension
-----------------------------
-
-
-.. _param_language_server_hover.template_paths:
-
-
-``language_server_hover.template_paths``
-""""""""""""""""""""""""""""""""""""""""
-
-
-
-
-Paths in which to look for templates for hover information.
-
-
-**Default**: ``["%project_config%\/templates\/markdown","%config%\/templates\/markdown"]``
-
-
 .. _LanguageServerCodeTransformExtension:
 
 
@@ -1864,4 +1842,26 @@ Recurse over class implementations to resolve all class implementations (not jus
 
 
 **Default**: ``true``
+
+
+.. _ObjectRendererExtension:
+
+
+ObjectRendererExtension
+-----------------------
+
+
+.. _param_object_renderer.template_paths.markdown:
+
+
+``object_renderer.template_paths.markdown``
+"""""""""""""""""""""""""""""""""""""""""""
+
+
+
+
+Paths in which to look for templates for hover information.
+
+
+**Default**: ``["%project_config%\/templates\/markdown","%config%\/templates\/markdown"]``
 

--- a/lib/Completion/Bridge/WorseReflection/Formatter/TypeFormatter.php
+++ b/lib/Completion/Bridge/WorseReflection/Formatter/TypeFormatter.php
@@ -5,6 +5,7 @@ namespace Phpactor\Completion\Bridge\WorseReflection\Formatter;
 use Phpactor\WorseReflection\Core\Type;
 use Phpactor\Completion\Core\Formatter\Formatter;
 use Phpactor\Completion\Core\Formatter\ObjectFormatter;
+use Phpactor\WorseReflection\TypeUtil;
 
 class TypeFormatter implements Formatter
 {
@@ -16,7 +17,6 @@ class TypeFormatter implements Formatter
     public function format(ObjectFormatter $formatter, object $type): string
     {
         assert($type instanceof Type);
-
-        return $type->short();
+        return TypeUtil::shortenClassTypes($type);
     }
 }

--- a/lib/Completion/Bridge/WorseReflection/Formatter/TypeFormatter.php
+++ b/lib/Completion/Bridge/WorseReflection/Formatter/TypeFormatter.php
@@ -17,6 +17,6 @@ class TypeFormatter implements Formatter
     {
         assert($type instanceof Type);
 
-        return $type->__toString();
+        return $type->short();
     }
 }

--- a/lib/Completion/Tests/Benchmark/Bridge/TolerantParser/WorseReflection/ClassMemberCompletorBench.php
+++ b/lib/Completion/Tests/Benchmark/Bridge/TolerantParser/WorseReflection/ClassMemberCompletorBench.php
@@ -5,6 +5,7 @@ namespace Phpactor\Completion\Tests\Benchmark\Bridge\TolerantParser\WorseReflect
 use Phpactor\Completion\Bridge\TolerantParser\TolerantCompletor;
 use Phpactor\Completion\Core\Formatter\ObjectFormatter;
 use Phpactor\Completion\Tests\Benchmark\Bridge\TolerantParser\TolerantCompletorBenchCase;
+use Phpactor\ObjectRenderer\ObjectRendererBuilder;
 use Phpactor\WorseReflection\ReflectorBuilder;
 use Phpactor\Completion\Bridge\TolerantParser\WorseReflection\WorseClassMemberCompletor;
 
@@ -13,6 +14,11 @@ class ClassMemberCompletorBench extends TolerantCompletorBenchCase
     protected function createTolerant(string $source): TolerantCompletor
     {
         $reflector = ReflectorBuilder::create()->addSource($source)->build();
-        return new WorseClassMemberCompletor($reflector, new ObjectFormatter(), new ObjectFormatter());
+        return new WorseClassMemberCompletor(
+            $reflector,
+            new ObjectFormatter(),
+            new ObjectFormatter(),
+            ObjectRendererBuilder::create()->build()
+        );
     }
 }

--- a/lib/Completion/Tests/Integration/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletorTest.php
+++ b/lib/Completion/Tests/Integration/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletorTest.php
@@ -5,6 +5,7 @@ namespace Phpactor\Completion\Tests\Integration\Bridge\TolerantParser\WorseRefle
 use Phpactor\Completion\Bridge\TolerantParser\TolerantCompletor;
 use Phpactor\Completion\Core\Suggestion;
 use Phpactor\Completion\Tests\Integration\Bridge\TolerantParser\TolerantCompletorTestCase;
+use Phpactor\ObjectRenderer\ObjectRendererBuilder;
 use Phpactor\TextDocument\TextDocument;
 use Phpactor\WorseReflection\Bridge\Phpactor\MemberProvider\DocblockMemberProvider;
 use Phpactor\WorseReflection\ReflectorBuilder;
@@ -189,7 +190,7 @@ class WorseClassMemberCompletorTest extends TolerantCompletorTestCase
                     'type' => Suggestion::TYPE_METHOD,
                     'name' => 'foo',
                     'short_description' => 'pub foo(): Foobar|Barbar',
-                    'documentation' => 'Returns a foobar',
+                    'documentation' => '',
                     'snippet' => 'foo()',
                 ]
             ]
@@ -946,7 +947,8 @@ class WorseClassMemberCompletorTest extends TolerantCompletorTestCase
         return new WorseClassMemberCompletor(
             $reflector,
             $this->formatter(),
-            $this->snippetFormatter($reflector)
+            $this->snippetFormatter($reflector),
+            ObjectRendererBuilder::create()->renderEmptyOnNotFound()->build()
         );
     }
 }

--- a/lib/Extension/CompletionWorse/CompletionWorseExtension.php
+++ b/lib/Extension/CompletionWorse/CompletionWorseExtension.php
@@ -49,7 +49,7 @@ use Phpactor\Completion\Core\Formatter\ObjectFormatter;
 use Phpactor\Container\Extension;
 use Phpactor\Container\ContainerBuilder;
 use Phpactor\Extension\Completion\CompletionExtension;
-use Phpactor\Extension\LanguageServerHover\LanguageServerHoverExtension;
+use Phpactor\Extension\ObjectRenderer\ObjectRendererExtension;
 use Phpactor\Extension\SourceCodeFilesystem\SourceCodeFilesystemExtension;
 use Phpactor\Extension\WorseReflection\WorseReflectionExtension;
 use Phpactor\MapResolver\Resolver;
@@ -314,7 +314,7 @@ class CompletionWorseExtension implements Extension
                         $container->get(WorseReflectionExtension::SERVICE_REFLECTOR),
                         $container->get(CompletionExtension::SERVICE_SHORT_DESC_FORMATTER),
                         $container->get(CompletionExtension::SERVICE_SNIPPET_FORMATTER),
-                        $container->get(LanguageServerHoverExtension::SERVICE_MARKDOWN_RENDERER)
+                        $container->get(ObjectRendererExtension::SERVICE_MARKDOWN_RENDERER)
                     );
                 },
             ],

--- a/lib/Extension/CompletionWorse/CompletionWorseExtension.php
+++ b/lib/Extension/CompletionWorse/CompletionWorseExtension.php
@@ -49,6 +49,7 @@ use Phpactor\Completion\Core\Formatter\ObjectFormatter;
 use Phpactor\Container\Extension;
 use Phpactor\Container\ContainerBuilder;
 use Phpactor\Extension\Completion\CompletionExtension;
+use Phpactor\Extension\LanguageServerHover\LanguageServerHoverExtension;
 use Phpactor\Extension\SourceCodeFilesystem\SourceCodeFilesystemExtension;
 use Phpactor\Extension\WorseReflection\WorseReflectionExtension;
 use Phpactor\MapResolver\Resolver;
@@ -312,7 +313,8 @@ class CompletionWorseExtension implements Extension
                     return new WorseClassMemberCompletor(
                         $container->get(WorseReflectionExtension::SERVICE_REFLECTOR),
                         $container->get(CompletionExtension::SERVICE_SHORT_DESC_FORMATTER),
-                        $container->get(CompletionExtension::SERVICE_SNIPPET_FORMATTER)
+                        $container->get(CompletionExtension::SERVICE_SNIPPET_FORMATTER),
+                        $container->get(LanguageServerHoverExtension::SERVICE_MARKDOWN_RENDERER)
                     );
                 },
             ],

--- a/lib/Extension/CompletionWorse/Tests/Unit/CompletionWorseExtensionTest.php
+++ b/lib/Extension/CompletionWorse/Tests/Unit/CompletionWorseExtensionTest.php
@@ -12,6 +12,8 @@ use Phpactor\Extension\ClassToFile\ClassToFileExtension;
 use Phpactor\Extension\CompletionWorse\CompletionWorseExtension;
 use Phpactor\Extension\Completion\CompletionExtension;
 use Phpactor\Extension\ComposerAutoloader\ComposerAutoloaderExtension;
+use Phpactor\Extension\ObjectRenderer\ObjectRendererExtension;
+use Phpactor\Extension\Php\PhpExtension;
 use Phpactor\Extension\ReferenceFinder\ReferenceFinderExtension;
 use Phpactor\Extension\SourceCodeFilesystem\SourceCodeFilesystemExtension;
 use Phpactor\Extension\WorseReflection\WorseReflectionExtension;
@@ -72,9 +74,12 @@ class CompletionWorseExtensionTest extends TestCase
             CompletionWorseExtension::class,
             SourceCodeFilesystemExtension::class,
             ReferenceFinderExtension::class,
+            ObjectRendererExtension::class,
+            PhpExtension::class,
         ],
             array_merge([
                 FilePathResolverExtension::PARAM_APPLICATION_ROOT => __DIR__,
+                ObjectRendererExtension::PARAM_TEMPLATE_PATHS => [],
             ], $config)
         );
     }

--- a/lib/Extension/LanguageServerCompletion/Handler/CompletionHandler.php
+++ b/lib/Extension/LanguageServerCompletion/Handler/CompletionHandler.php
@@ -14,6 +14,7 @@ use Phpactor\LanguageServerProtocol\CompletionList;
 use Phpactor\LanguageServerProtocol\CompletionOptions;
 use Phpactor\LanguageServerProtocol\CompletionParams;
 use Phpactor\LanguageServerProtocol\InsertTextFormat;
+use Phpactor\LanguageServerProtocol\MarkupContent;
 use Phpactor\LanguageServerProtocol\Range;
 use Phpactor\LanguageServerProtocol\ServerCapabilities;
 use Phpactor\LanguageServerProtocol\SignatureHelpOptions;
@@ -99,7 +100,7 @@ class CompletionHandler implements Handler, CanRegisterCapabilities
                          'label' => $name,
                          'kind' => PhpactorToLspCompletionType::fromPhpactorType($suggestion->type()),
                          'detail' => $this->formatShortDescription($suggestion),
-                         'documentation' => $suggestion->documentation(),
+                         'documentation' => new MarkupContent('markdown', $suggestion->documentation()),
                          'insertText' => $insertText,
                          'sortText' => $this->sortText($suggestion),
                          'textEdit' => $this->textEdit($suggestion, $insertText, $textDocument),

--- a/lib/Extension/LanguageServerCompletion/Handler/CompletionHandler.php
+++ b/lib/Extension/LanguageServerCompletion/Handler/CompletionHandler.php
@@ -100,7 +100,7 @@ class CompletionHandler implements Handler, CanRegisterCapabilities
                          'label' => $name,
                          'kind' => PhpactorToLspCompletionType::fromPhpactorType($suggestion->type()),
                          'detail' => $this->formatShortDescription($suggestion),
-                         'documentation' => new MarkupContent('markdown', $suggestion->documentation()),
+                         'documentation' => new MarkupContent('markdown', $suggestion->documentation() ?? ''),
                          'insertText' => $insertText,
                          'sortText' => $this->sortText($suggestion),
                          'textEdit' => $this->textEdit($suggestion, $insertText, $textDocument),

--- a/lib/Extension/LanguageServerCompletion/Tests/IntegrationTestCase.php
+++ b/lib/Extension/LanguageServerCompletion/Tests/IntegrationTestCase.php
@@ -17,6 +17,7 @@ use Phpactor\Extension\LanguageServerHover\LanguageServerHoverExtension;
 use Phpactor\Extension\LanguageServerWorseReflection\LanguageServerWorseReflectionExtension;
 use Phpactor\Extension\LanguageServer\LanguageServerExtension;
 use Phpactor\Extension\Logger\LoggingExtension;
+use Phpactor\Extension\ObjectRenderer\ObjectRendererExtension;
 use Phpactor\Extension\Php\PhpExtension;
 use Phpactor\Extension\ReferenceFinder\ReferenceFinderExtension;
 use Phpactor\Extension\SourceCodeFilesystem\SourceCodeFilesystemExtension;
@@ -59,9 +60,10 @@ class IntegrationTestCase extends TestCase
             ReferenceFinderExtension::class,
 
             LanguageServerBridgeExtension::class,
+            ObjectRendererExtension::class,
         ], [
             FilePathResolverExtension::PARAM_APPLICATION_ROOT => __DIR__ .'/../../../../',
-            LanguageServerHoverExtension::PARAM_TEMPLATE_PATHS => [],
+            ObjectRendererExtension::PARAM_TEMPLATE_PATHS => [],
             IndexerExtension::PARAM_ENABLED_WATCHERS => [],
         ]);
 

--- a/lib/Extension/LanguageServerCompletion/Tests/Unit/Handler/CompletionHandlerTest.php
+++ b/lib/Extension/LanguageServerCompletion/Tests/Unit/Handler/CompletionHandlerTest.php
@@ -10,6 +10,8 @@ use Phpactor\Extension\LanguageServerCodeTransform\Model\NameImport\NameImporter
 use Phpactor\Extension\LanguageServerCodeTransform\Model\NameImport\NameImporterResult;
 use Phpactor\LanguageServerProtocol\CompletionItem;
 use Phpactor\LanguageServerProtocol\CompletionList;
+use Phpactor\LanguageServerProtocol\MarkupContent;
+use Phpactor\LanguageServerProtocol\MarkupKind;
 use Phpactor\LanguageServerProtocol\Position;
 use Phpactor\LanguageServerProtocol\Range;
 use Phpactor\LanguageServerProtocol\TextEdit;
@@ -366,7 +368,7 @@ class CompletionHandlerTest extends TestCase
             'label' => $label,
             'kind' => $type,
             'detail' => '',
-            'documentation' => '',
+            'documentation' => new MarkupContent(MarkupKind::MARKDOWN, ''),
             'insertText' => $label,
             'insertTextFormat' => 1,
         ], $data));

--- a/lib/Extension/LanguageServerHover/LanguageServerHoverExtension.php
+++ b/lib/Extension/LanguageServerHover/LanguageServerHoverExtension.php
@@ -20,7 +20,7 @@ use Twig\Environment;
 class LanguageServerHoverExtension implements Extension
 {
     public const PARAM_TEMPLATE_PATHS = 'language_server_hover.template_paths';
-    private const SERVICE_MARKDOWN_RENDERER = 'language_server_completion.object_renderer.markdown';
+    public const SERVICE_MARKDOWN_RENDERER = 'language_server_completion.object_renderer.markdown';
 
     
     public function configure(Resolver $schema): void

--- a/lib/Extension/LanguageServerHover/LanguageServerHoverExtension.php
+++ b/lib/Extension/LanguageServerHover/LanguageServerHoverExtension.php
@@ -2,79 +2,29 @@
 
 namespace Phpactor\Extension\LanguageServerHover;
 
-use Phpactor\CodeBuilder\Domain\TemplatePathResolver\PhpVersionPathResolver;
 use Phpactor\Container\Container;
 use Phpactor\Container\ContainerBuilder;
-use Phpactor\Extension\LanguageServerHover\Twig\TwigFunctions;
-use Phpactor\Extension\Logger\LoggingExtension;
-use Phpactor\Extension\ObjectRenderer\ObjectRendererBuilder;
-use Phpactor\Extension\Php\Model\PhpVersionResolver;
+use Phpactor\Extension\ObjectRenderer\ObjectRendererExtension;
 use Phpactor\Extension\WorseReflection\WorseReflectionExtension;
-use Phpactor\Extension\FilePathResolver\FilePathResolverExtension;
 use Phpactor\Extension\LanguageServer\LanguageServerExtension;
 use Phpactor\Extension\LanguageServerHover\Handler\HoverHandler;
 use Phpactor\Container\Extension;
 use Phpactor\MapResolver\Resolver;
-use Twig\Environment;
 
 class LanguageServerHoverExtension implements Extension
 {
-    public const PARAM_TEMPLATE_PATHS = 'language_server_hover.template_paths';
-    public const SERVICE_MARKDOWN_RENDERER = 'language_server_completion.object_renderer.markdown';
-
-    
-    public function configure(Resolver $schema): void
-    {
-        $schema->setDefaults([
-            self::PARAM_TEMPLATE_PATHS => [
-                '%project_config%/templates/markdown',
-                '%config%/templates/markdown',
-            ]
-        ]);
-
-        $schema->setDescriptions([
-            self::PARAM_TEMPLATE_PATHS => 'Paths in which to look for templates for hover information.'
-        ]);
-    }
-
-    
     public function load(ContainerBuilder $container): void
     {
         $container->register('language_server_completion.handler.hover', function (Container $container) {
             return new HoverHandler(
                 $container->get(LanguageServerExtension::SERVICE_SESSION_WORKSPACE),
                 $container->get(WorseReflectionExtension::SERVICE_REFLECTOR),
-                $container->get(self::SERVICE_MARKDOWN_RENDERER)
+                $container->get(ObjectRendererExtension::SERVICE_MARKDOWN_RENDERER)
             );
         }, [ LanguageServerExtension::TAG_METHOD_HANDLER => []]);
+    }
 
-        $container->register(self::SERVICE_MARKDOWN_RENDERER, function (Container $container) {
-            $resolver = $container->get(FilePathResolverExtension::SERVICE_FILE_PATH_RESOLVER);
-            $templatePaths = $container->getParameter(self::PARAM_TEMPLATE_PATHS);
-            $templatePaths[] = __DIR__ . '/../../../templates/help/markdown';
-
-            $resolvedTemplatePaths = array_map(function (string $path) use ($resolver) {
-                return $resolver->resolve($path);
-            }, $templatePaths);
-
-            $phpVersion = $container->get(PhpVersionResolver::class)->resolve();
-            $paths = (new PhpVersionPathResolver($phpVersion))->resolve($resolvedTemplatePaths);
-
-            $builder = ObjectRendererBuilder::create()
-                ->setLogger(LoggingExtension::channelLogger($container, 'LSP-HOVER'))
-                ->enableInterfaceCandidates()
-                ->enableAncestoralCandidates()
-                ->configureTwig(function (Environment $env) {
-                    $env = TwigFunctions::add($env);
-                    return $env;
-                })
-                ->renderEmptyOnNotFound();
-
-            foreach ($paths as $path) {
-                $builder = $builder->addTemplatePath($path);
-            }
-            
-            return $builder->build();
-        });
+    public function configure(Resolver $schema): void
+    {
     }
 }

--- a/lib/Extension/LanguageServerHover/Twig/Functions/TypeShortName.php
+++ b/lib/Extension/LanguageServerHover/Twig/Functions/TypeShortName.php
@@ -3,11 +3,12 @@
 namespace Phpactor\Extension\LanguageServerHover\Twig\Functions;
 
 use Phpactor\WorseReflection\Core\Type;
+use Phpactor\WorseReflection\TypeUtil;
 
 class TypeShortName
 {
     public function __invoke(Type $type): string
     {
-        return $type->__toString();
+        return TypeUtil::shortenClassTypes($type);
     }
 }

--- a/lib/Extension/ObjectRenderer/ObjectRendererExtension.php
+++ b/lib/Extension/ObjectRenderer/ObjectRendererExtension.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Phpactor\Extension\ObjectRenderer;
+
+use Phpactor\CodeBuilder\Domain\TemplatePathResolver\PhpVersionPathResolver;
+use Phpactor\Container\Container;
+use Phpactor\Container\ContainerBuilder;
+use Phpactor\Extension\LanguageServerHover\Twig\TwigFunctions;
+use Phpactor\Container\Extension;
+use Phpactor\Extension\Logger\LoggingExtension;
+use Phpactor\Extension\Php\Model\PhpVersionResolver;
+use Phpactor\Extension\FilePathResolver\FilePathResolverExtension;
+use Phpactor\MapResolver\Resolver;
+use Twig\Environment;
+
+class ObjectRendererExtension implements Extension
+{
+    public const PARAM_TEMPLATE_PATHS = 'object_renderer.template_paths.markdown';
+    public const SERVICE_MARKDOWN_RENDERER = 'object_renderer.renderer.markdown';
+    
+    public function configure(Resolver $schema): void
+    {
+        $schema->setDefaults([
+            self::PARAM_TEMPLATE_PATHS => [
+                '%project_config%/templates/markdown',
+                '%config%/templates/markdown',
+            ]
+        ]);
+
+        $schema->setDescriptions([
+            self::PARAM_TEMPLATE_PATHS => 'Paths in which to look for templates for hover information.'
+        ]);
+    }
+
+
+    public function load(ContainerBuilder $container): void
+    {
+        $container->register(self::SERVICE_MARKDOWN_RENDERER, function (Container $container) {
+            $resolver = $container->get(FilePathResolverExtension::SERVICE_FILE_PATH_RESOLVER);
+            $templatePaths = $container->getParameter(self::PARAM_TEMPLATE_PATHS);
+            $templatePaths[] = __DIR__ . '/../../../templates/help/markdown';
+
+            $resolvedTemplatePaths = array_map(function (string $path) use ($resolver) {
+                return $resolver->resolve($path);
+            }, $templatePaths);
+
+            $phpVersion = $container->get(PhpVersionResolver::class)->resolve();
+            $paths = (new PhpVersionPathResolver($phpVersion))->resolve($resolvedTemplatePaths);
+
+            $builder = ObjectRendererBuilder::create()
+                ->setLogger(LoggingExtension::channelLogger($container, 'LSP-HOVER'))
+                ->enableInterfaceCandidates()
+                ->enableAncestoralCandidates()
+                ->configureTwig(function (Environment $env) {
+                    $env = TwigFunctions::add($env);
+                    return $env;
+                })
+                    ->renderEmptyOnNotFound();
+
+            foreach ($paths as $path) {
+                $builder = $builder->addTemplatePath($path);
+            }
+
+            return $builder->build();
+        });
+    }
+}

--- a/lib/Phpactor.php
+++ b/lib/Phpactor.php
@@ -22,12 +22,12 @@ use Phpactor\Extension\LanguageServerSelectionRange\LanguageServerSelectionRange
 use Phpactor\Extension\LanguageServerWorseReflection\LanguageServerWorseReflectionExtension;
 use Phpactor\Extension\LanguageServer\LanguageServerExtension;
 use Phpactor\Extension\LanguageServer\LanguageServerExtraExtension;
+use Phpactor\Extension\ObjectRenderer\ObjectRendererExtension;
 use Phpactor\Extension\WorseReflectionAnalyse\WorseReflectionAnalyseExtension;
 use Phpactor\Indexer\Extension\IndexerExtension;
 use RuntimeException;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Webmozart\PathUtil\Path;
 use Phpactor\Container\PhpactorContainer;
 use Phpactor\Extension\Core\CoreExtension;
 use Phpactor\Extension\CodeTransformExtra\CodeTransformExtraExtension;
@@ -154,6 +154,7 @@ class Phpactor
             LanguageServerPsalmExtension::class,
             BehatExtension::class,
             IndexerExtension::class,
+            ObjectRendererExtension::class
         ];
 
         if (class_exists(DebugExtension::class)) {

--- a/lib/WorseReflection/Tests/Unit/TypeUtilTest.php
+++ b/lib/WorseReflection/Tests/Unit/TypeUtilTest.php
@@ -9,6 +9,7 @@ use Phpactor\WorseReflection\Core\Type;
 use Phpactor\WorseReflection\Core\TypeFactory;
 use Phpactor\WorseReflection\Core\Type\GenericClassType;
 use Phpactor\WorseReflection\ReflectorBuilder;
+use Phpactor\WorseReflection\TypeUtil;
 
 class TypeUtilTest extends TestCase
 {
@@ -74,6 +75,47 @@ class TypeUtilTest extends TestCase
     }
 
     public function provideShort(): Generator
+    {
+        yield 'scalar' => [
+            TypeFactory::string(),
+            'string',
+        ];
+
+        yield 'Root class' => [
+            TypeFactory::class('Foo'),
+            'Foo',
+        ];
+        yield 'Namespaced class' => [
+            TypeFactory::class('\Foo\Bar'),
+            'Bar',
+        ];
+        yield 'Union' => [
+            TypeFactory::union(
+                TypeFactory::class('\Foo\Bar'),
+            ),
+            'Bar',
+        ];
+        yield 'Union with two elements' => [
+            TypeFactory::union(
+                TypeFactory::class('\Foo\Bar'),
+                TypeFactory::class('\Foo\Baz'),
+            ),
+            'Bar|Baz',
+        ];
+    }
+
+    /**
+     * @dataProvider provideShortenClassTypes
+     */
+    public function testShortenClassTypes(Type $type, string $expected): void
+    {
+        self::assertEquals(
+            $expected,
+            TypeUtil::shortenClassTypes($type)->__toString()
+        );
+    }
+
+    public function provideShortenClassTypes(): Generator
     {
         yield 'scalar' => [
             TypeFactory::string(),

--- a/lib/WorseReflection/TypeUtil.php
+++ b/lib/WorseReflection/TypeUtil.php
@@ -7,6 +7,7 @@ use Phpactor\WorseReflection\Core\Type;
 use Phpactor\WorseReflection\Core\TypeFactory;
 use Phpactor\WorseReflection\Core\Type\BooleanLiteralType;
 use Phpactor\WorseReflection\Core\Type\BooleanType;
+use Phpactor\WorseReflection\Core\Type\ClassType;
 use Phpactor\WorseReflection\Core\Type\IntType;
 use Phpactor\WorseReflection\Core\Type\Literal;
 use Phpactor\WorseReflection\Core\Type\MissingType;
@@ -77,6 +78,17 @@ class TypeUtil
         }
 
         return new BooleanType();
+    }
+
+    public static function shortenClassTypes(Type $type): Type
+    {
+        return $type->map(function (Type $type) {
+            if ($type instanceof ClassType) {
+                return TypeFactory::class($type->name()->short());
+            }
+
+            return $type;
+        });
     }
 
     /**

--- a/templates/help/markdown/Phpactor/WorseReflection/Core/Type.twig
+++ b/templates/help/markdown/Phpactor/WorseReflection/Core/Type.twig
@@ -1,1 +1,1 @@
-{% if typeType(object) %}{{- typeType(object) }} {% endif %}{{- object -}}
+{% if typeType(object) %}{{- typeType(object) }} {% endif %}{{- typeShortName(object) -}}


### PR DESCRIPTION
Use the "hover" renderer to render the completion documentation:

![image](https://user-images.githubusercontent.com/530801/179915505-f37192cd-b85f-4704-b8cc-36b7cc57d6ed.png)

Also renders short class names (i.e. the "name" only) in rendered documentation