### PR TITLE
Gh 1811: Report unimported functions as functions not classes and other fix

### DIFF
--- a/lib/Extension/LanguageServerCodeTransform/Model/NameImport/CandidateFinder.php
+++ b/lib/Extension/LanguageServerCodeTransform/Model/NameImport/CandidateFinder.php
@@ -31,8 +31,8 @@ class CandidateFinder
     {
         $diagnostics = $this->reflector->diagnostics($item->text)->byClass(UnresolvableNameDiagnostic::class);
 
-        return new NameWithByteOffsets(...array_map(function (UnresolvableNameDiagnostic $diagnostic) {
-            return new NameWithByteOffset($diagnostic->name(), $diagnostic->range()->start());
+        return new NameWithByteOffsets(...array_map(function (UnresolvableNameDiagnostic $diagnostic): NameWithByteOffset {
+            return new NameWithByteOffset($diagnostic->name(), $diagnostic->range()->start(), $diagnostic->type());
         }, iterator_to_array($diagnostics)));
     }
 

--- a/lib/Extension/LanguageServerCodeTransform/Tests/Unit/CodeAction/ImportNameProviderTest.php
+++ b/lib/Extension/LanguageServerCodeTransform/Tests/Unit/CodeAction/ImportNameProviderTest.php
@@ -8,7 +8,6 @@ use Phpactor\Extension\LanguageServerBridge\Converter\PositionConverter;
 use Phpactor\Extension\LanguageServerCodeTransform\LanguageServerCodeTransformExtension;
 use Phpactor\Extension\LanguageServerCodeTransform\Tests\IntegrationTestCase;
 use Phpactor\Extension\WorseReflection\WorseReflectionExtension;
-use Phpactor\LanguageServerProtocol\CodeAction;
 use Phpactor\LanguageServerProtocol\CodeActionContext;
 use Phpactor\LanguageServerProtocol\CodeActionParams;
 use Phpactor\LanguageServerProtocol\CodeActionRequest;
@@ -90,7 +89,7 @@ class ImportNameProviderTest extends IntegrationTestCase
                 // File: subject.php
                 <?php new MissingNameFoo();'
                 EOT
-            , function (array $codeActions, array $diagnostics) {
+            , function (array $codeActions, array $diagnostics): void {
                 self::assertCount(0, $codeActions);
                 self::assertCount(1, $diagnostics);
             }
@@ -102,7 +101,7 @@ class ImportNameProviderTest extends IntegrationTestCase
                 // File: subject.php
                 <?php namespace Bar; new MissingNameFoo();'
                 EOT
-            , function (array $codeActions, array $diagnostics) {
+            , function (array $codeActions, array $diagnostics): void {
                 self::assertCount(0, $codeActions);
                 self::assertCount(1, $diagnostics);
             }
@@ -115,7 +114,7 @@ class ImportNameProviderTest extends IntegrationTestCase
                 // File: Generator.php
                 <?php class Generator {}
                 EOT
-            , function (array $codeActions, array $diagnostics) {
+            , function (array $codeActions, array $diagnostics): void {
                 self::assertCount(1, $codeActions);
                 self::assertCount(1, $diagnostics);
             }, false
@@ -127,7 +126,7 @@ class ImportNameProviderTest extends IntegrationTestCase
                 <?php namespace Foobar;
                 sprintf('foo %s', 'bar');
                 EOT
-            , function (array $codeActions, array $diagnostics) {
+            , function (array $codeActions, array $diagnostics): void {
                 self::assertCount(0, $codeActions);
                 self::assertCount(0, $diagnostics);
             }, false
@@ -152,7 +151,7 @@ class ImportNameProviderTest extends IntegrationTestCase
                 {
                 }
                 EOT
-            , function (array $codeActions, array $diagnostics) {
+            , function (array $codeActions, array $diagnostics): void {
                 self::assertCount(0, $codeActions);
                 self::assertCount(0, $diagnostics);
             }
@@ -167,7 +166,7 @@ class ImportNameProviderTest extends IntegrationTestCase
 
                 sprintf('foo', 'bar');
                 EOT
-            , function (array $codeActions, array $diagnostics) {
+            , function (array $codeActions, array $diagnostics): void {
                 self::assertCount(0, $codeActions);
                 self::assertCount(0, $diagnostics);
             }
@@ -184,7 +183,7 @@ class ImportNameProviderTest extends IntegrationTestCase
                 $bar = [];
                 explode(array_keys($bar));
                 EOT
-            , function (array $codeActions, array $diagnostics) {
+            , function (array $codeActions, array $diagnostics): void {
                 self::assertCount(3, $codeActions);
                 self::assertEquals('Import function "explode"', $codeActions[0]->title);
                 self::assertEquals('Import function "array_keys"', $codeActions[1]->title);
@@ -203,7 +202,7 @@ class ImportNameProviderTest extends IntegrationTestCase
                 if (INF) {
                 }
                 EOT
-            , function (array $codeActions, array $diagnostics) {
+            , function (array $codeActions, array $diagnostics): void {
                 self::assertCount(0, $codeActions);
                 self::assertCount(0, $diagnostics);
             }, true

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UnresolvableNameProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UnresolvableNameProvider.php
@@ -15,7 +15,6 @@ use Microsoft\PhpParser\Node\Expression\CallExpression;
 use Microsoft\PhpParser\Node\QualifiedName;
 use Microsoft\PhpParser\ResolvedName;
 use Phpactor\Name\FullyQualifiedName as PhpactorFullyQualifiedName;
-use Phpactor\Name\Name;
 use Phpactor\TextDocument\ByteOffsetRange;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Patch\TolerantQualifiedNameResolver;
 use Phpactor\WorseReflection\Core\DiagnosticProvider;
@@ -92,7 +91,7 @@ class UnresolvableNameProvider implements DiagnosticProvider
             !$name->parent instanceof ScopedPropertyAccessExpression &&
             !$name->parent instanceof FunctionDeclaration &&
             !$name->parent instanceof MethodDeclaration &&
-            !$name->parent instanceof Parameter &&
+            //!$name->parent instanceof Parameter &&
             !$name->parent instanceof Attribute
         ) {
             return;

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UnresolvableNameProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UnresolvableNameProvider.php
@@ -91,7 +91,6 @@ class UnresolvableNameProvider implements DiagnosticProvider
             !$name->parent instanceof ScopedPropertyAccessExpression &&
             !$name->parent instanceof FunctionDeclaration &&
             !$name->parent instanceof MethodDeclaration &&
-            //!$name->parent instanceof Parameter &&
             !$name->parent instanceof Attribute
         ) {
             return;

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UnresolvableNameProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UnresolvableNameProvider.php
@@ -7,7 +7,6 @@ use Microsoft\PhpParser\Node\Attribute;
 use Microsoft\PhpParser\Node\ClassBaseClause;
 use Microsoft\PhpParser\Node\DelimitedList\QualifiedNameList;
 use Microsoft\PhpParser\Node\MethodDeclaration;
-use Microsoft\PhpParser\Node\Parameter;
 use Microsoft\PhpParser\Node\Expression\ScopedPropertyAccessExpression;
 use Microsoft\PhpParser\Node\Statement\FunctionDeclaration;
 use Microsoft\PhpParser\Node\Expression\ObjectCreationExpression;

--- a/lib/WorseReflection/Core/Inference/Resolver/ArrayCreationExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/ArrayCreationExpressionResolver.php
@@ -35,7 +35,11 @@ class ArrayCreationExpressionResolver implements Resolver
             $value = $resolver->resolveNode($frame, $element->elementValue)->type();
             if ($element->elementKey) {
                 $key = $resolver->resolveNode($frame, $element->elementKey)->type();
-                $array[TypeUtil::valueOrNull($key)] = $value;
+                $keyValue = TypeUtil::valueOrNull($key);
+                if (null === $keyValue) {
+                    continue;
+                }
+                $array[$keyValue] = $value;
                 continue;
             }
 

--- a/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Diagonstics/UnresolvableNameProvider/ConstantsParam.test
+++ b/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Diagonstics/UnresolvableNameProvider/ConstantsParam.test
@@ -1,0 +1,9 @@
+<?php
+
+class RpcCommand
+{
+    public function __construct(
+        $inputStream = STDIN
+    ) {
+    }
+}

--- a/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Diagonstics/UnresolvableNameProvider/Parameter.test
+++ b/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Diagonstics/UnresolvableNameProvider/Parameter.test
@@ -1,0 +1,9 @@
+<?php
+
+class RpcCommand
+{
+    public function __construct(
+        $inputStream = Foo::BAR
+    ) {
+    }
+}

--- a/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Diagonstics/UnresolvableNameProviderTest.php
+++ b/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Diagonstics/UnresolvableNameProviderTest.php
@@ -5,7 +5,6 @@ namespace Phpactor\WorseReflection\Tests\Integration\Bridge\TolerantParser\Diago
 use Closure;
 use Generator;
 use Phpactor\TextDocument\TextDocumentBuilder;
-use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\UnresolvableNameDiagnostic;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\UnresolvableNameProvider;
 use Phpactor\WorseReflection\Core\DiagnosticProvider;
 use Phpactor\WorseReflection\Core\Diagnostics;

--- a/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Diagonstics/UnresolvableNameProviderTest.php
+++ b/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Diagonstics/UnresolvableNameProviderTest.php
@@ -56,7 +56,7 @@ class UnresolvableNameProviderTest extends DiagnosticsTestCase
     public function checkParameter(Diagnostics $diagnostics): void
     {
         self::assertCount(1, $diagnostics);
-        self::assertEquals('class', $diagnostics->byClass(UnresolvableNameDiagnostic::class)->at(0)->type());
+        self::assertEquals('Class "Foo" not found', $diagnostics->at(0)->message());
     }
 
     /**

--- a/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Diagonstics/UnresolvableNameProviderTest.php
+++ b/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Diagonstics/UnresolvableNameProviderTest.php
@@ -5,6 +5,7 @@ namespace Phpactor\WorseReflection\Tests\Integration\Bridge\TolerantParser\Diago
 use Closure;
 use Generator;
 use Phpactor\TextDocument\TextDocumentBuilder;
+use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\UnresolvableNameDiagnostic;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\UnresolvableNameProvider;
 use Phpactor\WorseReflection\Core\DiagnosticProvider;
 use Phpactor\WorseReflection\Core\Diagnostics;
@@ -45,6 +46,17 @@ class UnresolvableNameProviderTest extends DiagnosticsTestCase
     public function checkClassNameConstant(Diagnostics $diagnostics): void
     {
         self::assertCount(1, $diagnostics);
+    }
+
+    public function checkConstantsParam(Diagnostics $diagnostics): void
+    {
+        self::assertCount(0, $diagnostics);
+    }
+
+    public function checkParameter(Diagnostics $diagnostics): void
+    {
+        self::assertCount(1, $diagnostics);
+        self::assertEquals('class', $diagnostics->byClass(UnresolvableNameDiagnostic::class)->at(0)->type());
     }
 
     /**


### PR DESCRIPTION
- Ensure that the "type" of the import is passed to the code action
- Do not report "standalone" names (i.e. constants) in parameter default values.

For the second I'm not 100% sure there wasn't a reason to report this in the first place, but it means `$in = STDIN` for example would have `STDIN` reported as an unimported class.