### PR TITLE
Trim trailing spaces

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -40,6 +40,8 @@ return (new Config())
         'single_quote' => true,
         'heredoc_indentation' => true,
         'global_namespace_import' => true,
+        'no_trailing_whitespace' => true,
+        'no_whitespace_in_blank_line' => true,
     ])
     ->setFinder($finder)
 ;

--- a/lib/ClassMover/Adapter/TolerantParser/TolerantClassReplacer.php
+++ b/lib/ClassMover/Adapter/TolerantParser/TolerantClassReplacer.php
@@ -93,11 +93,11 @@ class TolerantClassReplacer implements ClassReplacer
         if (ImportedNameReference::none() != $classRef->importedNameRef()) {
             return false;
         }
-        
+
         if ($classRef->isClassDeclaration()) {
             return false;
         }
-        
+
         return $classRef->fullName()->equals($originalName);
     }
 

--- a/lib/ClassMover/Domain/Reference/MemberReferences.php
+++ b/lib/ClassMover/Domain/Reference/MemberReferences.php
@@ -42,7 +42,7 @@ final class MemberReferences implements IteratorAggregate, Countable
         }));
     }
 
-    
+
     public function count(): int
     {
         return count($this->methodReferences);

--- a/lib/ClassMover/Extension/ClassMoverExtension.php
+++ b/lib/ClassMover/Extension/ClassMoverExtension.php
@@ -17,7 +17,7 @@ class ClassMoverExtension implements Extension
     {
     }
 
-    
+
     public function load(ContainerBuilder $container): void
     {
         $this->registerClassMover($container);

--- a/lib/CodeBuilder/Adapter/TolerantParser/Updater/AbstractMethodUpdater.php
+++ b/lib/CodeBuilder/Adapter/TolerantParser/Updater/AbstractMethodUpdater.php
@@ -188,7 +188,7 @@ abstract class AbstractMethodUpdater
         if (null === $firstReturnType) {
             return;
         }
-        
+
         $existingReturnType = $returnType ? NodeHelper::resolvedShortName($methodDeclaration, $firstReturnType) : null;
 
         if (null === $existingReturnType) {

--- a/lib/CodeBuilder/Adapter/TolerantParser/Util/ImportedNames.php
+++ b/lib/CodeBuilder/Adapter/TolerantParser/Util/ImportedNames.php
@@ -16,7 +16,7 @@ class ImportedNames implements IteratorAggregate
         $this->buildTable($node);
     }
 
-    
+
     public function getIterator(): Traversable
     {
         return new ArrayIterator($this->classNamesFromNode());

--- a/lib/CodeBuilder/Adapter/Twig/TwigExtension.php
+++ b/lib/CodeBuilder/Adapter/Twig/TwigExtension.php
@@ -48,7 +48,7 @@ class TwigExtension extends AbstractExtension
         ];
     }
 
-    
+
     public function indent(string $string, int $level = 0): string
     {
         return $this->textFormat->indent($string, $level);

--- a/lib/CodeBuilder/Domain/Prototype/Collection.php
+++ b/lib/CodeBuilder/Domain/Prototype/Collection.php
@@ -35,7 +35,7 @@ abstract class Collection implements IteratorAggregate, Countable
         /** @phpstan-ignore-next-line */
         return new static([]);
     }
-    
+
     public function getIterator(): Traversable
     {
         return new ArrayIterator($this->items);
@@ -63,7 +63,7 @@ abstract class Collection implements IteratorAggregate, Countable
         return $first;
     }
 
-    
+
     public function count(): int
     {
         return count($this->items);

--- a/lib/CodeBuilder/Domain/Prototype/Type.php
+++ b/lib/CodeBuilder/Domain/Prototype/Type.php
@@ -23,7 +23,7 @@ final class Type extends Prototype
         $this->originalType = $originalType;
     }
 
-    
+
     public function __toString(): string
     {
         return $this->type ?? '';

--- a/lib/CodeBuilder/Domain/TemplatePathResolver/FilterPhpVersionDirectoryIterator.php
+++ b/lib/CodeBuilder/Domain/TemplatePathResolver/FilterPhpVersionDirectoryIterator.php
@@ -22,7 +22,7 @@ class FilterPhpVersionDirectoryIterator extends FilterIterator
         $this->phpVersion = $phpVersion;
     }
 
-    
+
     public function accept(): bool
     {
         $file = $this->current();

--- a/lib/CodeBuilder/Tests/Unit/SourceBuilderTest.php
+++ b/lib/CodeBuilder/Tests/Unit/SourceBuilderTest.php
@@ -14,7 +14,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 class SourceBuilderTest extends TestCase
 {
     use \Prophecy\PhpUnit\ProphecyTrait;
-    
+
     /**
      * @var ObjectProphecy<Updater>
      */

--- a/lib/CodeTransform/Adapter/Native/GenerateNew/ClassGenerator.php
+++ b/lib/CodeTransform/Adapter/Native/GenerateNew/ClassGenerator.php
@@ -20,7 +20,7 @@ class ClassGenerator implements GenerateNew
         $this->renderer = $renderer;
     }
 
-    
+
     public function generateNew(ClassName $targetName): SourceCode
     {
         $builder = SourceCodeBuilder::create();

--- a/lib/CodeTransform/Adapter/TolerantParser/ClassToFile/Transformer/ClassNameFixerTransformer.php
+++ b/lib/CodeTransform/Adapter/TolerantParser/ClassToFile/Transformer/ClassNameFixerTransformer.php
@@ -55,7 +55,7 @@ class ClassNameFixerTransformer implements Transformer
         return TextEdits::fromTextEdits($edits);
     }
 
-    
+
     public function diagnostics(SourceCode $code): Diagnostics
     {
         $rootNode = $this->parser->parseSourceFile((string) $code);
@@ -96,17 +96,17 @@ class ClassNameFixerTransformer implements Transformer
         return new Diagnostics($diagnostics);
     }
 
-    
+
     private function fixClassName(SourceFileNode $rootNode, string $correctClassName): ?TextEdit
     {
         $classLike = $rootNode->getFirstDescendantNode(ClassLike::class);
-        
+
         if (null === $classLike) {
             return null;
         }
-        
+
         assert($classLike instanceof EnumDeclaration || $classLike instanceof ClassDeclaration || $classLike instanceof InterfaceDeclaration || $classLike instanceof TraitDeclaration);
-        
+
         $name = $classLike->name->getText($rootNode->getFileContents());
 
         if (!is_string($name) || $name === $correctClassName) {
@@ -158,11 +158,11 @@ class ClassNameFixerTransformer implements Transformer
         if (!$code->path()) {
             throw new RuntimeException('Source code has no path associated with it');
         }
-        
+
         $candidates = $this->fileToClass->fileToClassCandidates(
             FilePath::fromString((string) $code->path())
         );
-        
+
         $classFqn = $candidates->best();
 
         return $classFqn;

--- a/lib/CodeTransform/Adapter/TolerantParser/Refactor/TolerantExtractExpression.php
+++ b/lib/CodeTransform/Adapter/TolerantParser/Refactor/TolerantExtractExpression.php
@@ -63,7 +63,7 @@ class TolerantExtractExpression implements ExtractExpression
         if ($offsetEnd) {
             $endNode = $rootNode->getDescendantNodeAtPosition($offsetEnd);
             $expression = $this->getCommonExpression($startNode, $endNode);
-            
+
             if ($expression === null && $endNode instanceof ExpressionStatement) {
                 // <expression-statement> := <expression>;
                 // check if $endNode does not contain the semi-colon
@@ -77,11 +77,11 @@ class TolerantExtractExpression implements ExtractExpression
                             $item->getEndPosition() == $endNode->expression->getEndPosition();
                     }
                 );
-                
+
                 if (empty($expressions)) {
                     return null;
                 }
-                
+
                 $expression = $this->getCommonExpression($startNode, end($expressions));
             }
         } else {
@@ -94,7 +94,7 @@ class TolerantExtractExpression implements ExtractExpression
 
         return $expression;
     }
-    
+
     private function getCommonExpression(Node $node1, Node $node2): ?Expression
     {
         if ($node1 === $node2 && $node1 instanceof Expression) {
@@ -154,7 +154,7 @@ class TolerantExtractExpression implements ExtractExpression
         if (preg_match('/(\t| )*$/', $statement->getLeadingCommentAndWhitespaceText(), $matches) > 0) {
             $indentation = $matches[0];
         }
-        
+
         return [
             TextEdit::create($statement->getStartPosition(), 0, $assignment . $indentation),
             TextEdit::create($expression->getStartPosition(), strlen($extractedString), '$' . $variableName),

--- a/lib/CodeTransform/Adapter/TolerantParser/Refactor/TolerantRenameVariable.php
+++ b/lib/CodeTransform/Adapter/TolerantParser/Refactor/TolerantRenameVariable.php
@@ -107,7 +107,7 @@ class TolerantRenameVariable implements RenameVariable
             $name = $variable->variableName->getText($variable->getFileContents());
             return (string)$name;
         }
-            
+
         return $variable->getText();
     }
 

--- a/lib/CodeTransform/Adapter/WorseReflection/GenerateFromExisting/InterfaceFromExistingGenerator.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/GenerateFromExisting/InterfaceFromExistingGenerator.php
@@ -25,7 +25,7 @@ final class InterfaceFromExistingGenerator implements GenerateFromExisting
         $this->renderer = $renderer;
     }
 
-    
+
     public function generateFromExisting(ClassName $existingClass, ClassName $targetName): SourceCode
     {
         $existingClass = $this->reflector->reflectClass(ReflectionClassName::fromString((string) $existingClass));

--- a/lib/CodeTransform/Adapter/WorseReflection/Helper/WorseMissingMethodFinder.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Helper/WorseMissingMethodFinder.php
@@ -17,7 +17,7 @@ class WorseMissingMethodFinder implements MissingMethodFinder
         $this->reflector = $reflector;
     }
 
-    
+
     public function find(TextDocument $sourceCode): array
     {
         $diagnostics = $this->reflector->diagnostics($sourceCode)->byClass(MissingMethodDiagnostic::class);

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseExtractMethod.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseExtractMethod.php
@@ -76,7 +76,7 @@ class WorseExtractMethod implements ExtractMethod
                 }
                 $stmt = $prev;
             }
-            
+
             $endNode = $stmt ?? $endNode;
         }
 
@@ -97,7 +97,7 @@ class WorseExtractMethod implements ExtractMethod
             while ($stmt && $stmt->getStartPosition() < $offsetStart) {
                 $stmt = next($startNode->statements);
             }
-            
+
             $startNode = $stmt ?? $startNode;
             if (!$startNode instanceof Node) {
                 return false;
@@ -140,13 +140,13 @@ class WorseExtractMethod implements ExtractMethod
         $args = $this->addParametersAndGetArgs($parameterVariables, $methodBuilder, $builder);
 
         $returnVariables = $this->returnVariables($locals, $reflectionMethod, $source, $offsetStart, $offsetEnd);
-        
+
         $returnAssignment = $this->addReturnAndGetAssignment(
             $returnVariables,
             $methodBuilder,
             $args
         );
-        
+
         $prototype = $builder->build();
 
         $replacement = $this->replacement($name, $args, $selection, $returnAssignment);
@@ -408,19 +408,19 @@ class WorseExtractMethod implements ExtractMethod
     {
         $node = $this->parser->parseSourceFile($source->__toString());
         $endNode = $node->getDescendantNodeAtPosition($offsetEnd);
-        
+
         // end node is in the statement body, get last child node
         if ($endNode instanceof CompoundStatementNode) {
             $childNodes = iterator_to_array($endNode->getChildNodes());
             $endNode = end($childNodes);
             assert($endNode instanceof Node);
         }
-        
+
         // get the positional parent of the node
         while ($endNode->parent && $endNode->getEndPosition() === $endNode->parent->getEndPosition()) {
             $endNode = $endNode->parent;
         }
-        
+
         return !$endNode->parent instanceof CompoundStatementNode;
     }
 

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseGenerateMethod.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseGenerateMethod.php
@@ -43,7 +43,7 @@ class WorseGenerateMethod implements GenerateMethod
         $contextType = $this->contextType($sourceCode, $offset);
         $worseSourceCode = WorseSourceCode::fromPathAndString((string) $sourceCode->path(), (string) $sourceCode);
         $methodCall = $this->reflector->reflectMethodCall($worseSourceCode, $offset);
-        
+
         $this->validate($methodCall);
         $visibility = $this->determineVisibility($contextType, $methodCall->class());
 
@@ -51,7 +51,7 @@ class WorseGenerateMethod implements GenerateMethod
         $sourceCode = $this->resolveSourceCode($sourceCode, $methodCall, $visibility);
 
         $textEdits = $this->updater->textEditsFor($prototype, Code::fromString((string) $sourceCode));
-        
+
         return new TextDocumentEdits(TextDocumentUri::fromString($sourceCode->path()), $textEdits);
     }
 

--- a/lib/CodeTransform/Adapter/WorseReflection/Transformer/CompleteConstructor.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Transformer/CompleteConstructor.php
@@ -77,7 +77,7 @@ class CompleteConstructor implements Transformer
         return $this->updater->textEditsFor($sourceCodeBuilder->build(), Code::fromString((string) $source));
     }
 
-    
+
     public function diagnostics(SourceCode $source): Diagnostics
     {
         $diagnostics = [];
@@ -122,7 +122,7 @@ class CompleteConstructor implements Transformer
             if ($class instanceof ReflectionInterface) {
                 continue;
             }
-        
+
             if (!$class->methods()->belongingTo($class->name())->has('__construct')) {
                 continue;
             }

--- a/lib/CodeTransform/Tests/Adapter/TolerantParser/Refactor/TolerantExtractExpressionTest.php
+++ b/lib/CodeTransform/Tests/Adapter/TolerantParser/Refactor/TolerantExtractExpressionTest.php
@@ -23,7 +23,7 @@ class TolerantExtractExpressionTest extends TolerantTestCase
         }
 
         $extractMethod = new TolerantExtractExpression();
-        
+
         $textEdits = $extractMethod->extractExpression(SourceCode::fromString($source), $offsetStart, $offsetEnd, $name);
         $transformed = $textEdits->apply($source);
         $this->assertEquals(trim($expected), trim($transformed));
@@ -80,7 +80,7 @@ class TolerantExtractExpressionTest extends TolerantTestCase
             'extractExpression8A.test',
             'foobar',
         ];
- 
+
         yield 'preserve statement indentation: tabs and comments' => [
             'extractExpression8B.test',
             'foobar',
@@ -140,7 +140,7 @@ class TolerantExtractExpressionTest extends TolerantTestCase
     public function testWillNotExtractExpressionIfNoRange(): void
     {
         $extractMethod = new TolerantExtractExpression();
-        
+
         self::assertFalse($extractMethod->canExtractExpression(
             SourceCode::fromString('<?php new Foobar();'),
             8,

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/WorseGenerateMethodTest.php
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/WorseGenerateMethodTest.php
@@ -115,11 +115,11 @@ class WorseGenerateMethodTest extends WorseTestCase
     {
         $worseSourceCode = WorseSourceCode::fromPathAndString('file:///source', $source);
         $reflector = $this->reflectorForWorkspace($worseSourceCode);
-        
+
         $generateMethod = new WorseGenerateMethod($reflector, new WorseBuilderFactory($reflector), $this->updater());
         $sourceCode = SourceCode::fromStringAndPath($source, 'file:///source');
         $textDocumentEdits = $generateMethod->generateMethod($sourceCode, $start, $name);
-        
+
         $transformed = SourceCode::fromStringAndPath(
             (string) $textDocumentEdits->textEdits()->apply($sourceCode),
             $textDocumentEdits->uri()->path()

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/WorseGenerateMethodTest.php
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/WorseGenerateMethodTest.php
@@ -88,7 +88,7 @@ class WorseGenerateMethodTest extends WorseTestCase
         $this->expectException(TransformException::class);
         $this->expectExceptionMessage('Can only generate methods on classes');
         $source = <<<'EOT'
-            <?php 
+            <?php
             trait Hello
             {
             }

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Transformer/UpdateDocblockTransformerTest.php
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Transformer/UpdateDocblockTransformerTest.php
@@ -106,7 +106,7 @@ class UpdateDocblockTransformerTest extends WorseTestCase
                 }
                 EOT
         ];
- 
+
         yield 'add union of array literals' => [
             <<<'EOT'
                 <?php

--- a/lib/Completion/Bridge/TolerantParser/ChainTolerantCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/ChainTolerantCompletor.php
@@ -67,10 +67,10 @@ class ChainTolerantCompletor implements Completor
         // ` will evaluate the Variable node as an expression node with a
         // double variable `$\n    $bar = `
         $truncatedSource = substr($source, 0, $byteOffset);
-        
+
         // determine the last non-whitespace _character_ offset
         $characterOffset = OffsetHelper::lastNonWhitespaceCharacterOffset($truncatedSource);
-        
+
         // truncate the source at the character offset
         $truncatedSource = mb_substr($source, 0, $characterOffset);
 

--- a/lib/Completion/Bridge/TolerantParser/LimitingCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/LimitingCompletor.php
@@ -23,7 +23,7 @@ class LimitingCompletor implements TolerantCompletor, TolerantQualifiable
         $this->limit = $limit;
     }
 
-    
+
     public function complete(Node $node, TextDocument $source, ByteOffset $offset): Generator
     {
         /** @var TolerantCompletor $completor */

--- a/lib/Completion/Bridge/TolerantParser/ReferenceFinder/ClassLikeCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/ReferenceFinder/ClassLikeCompletor.php
@@ -31,7 +31,7 @@ class ClassLikeCompletor implements TolerantCompletor
         $this->prioritizer = $prioritizer;
     }
 
-    
+
     public function complete(Node $node, TextDocument $source, ByteOffset $offset): Generator
     {
         if (!CompletionContext::classLike($node)) {

--- a/lib/Completion/Bridge/TolerantParser/ReferenceFinder/ExpressionNameCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/ReferenceFinder/ExpressionNameCompletor.php
@@ -30,7 +30,7 @@ class ExpressionNameCompletor extends CoreNameSearcherCompletor implements Toler
         $this->snippetFormatter = $snippetFormatter;
     }
 
-    
+
     public function complete(Node $node, TextDocument $source, ByteOffset $offset): Generator
     {
         $parent = $node->parent;

--- a/lib/Completion/Bridge/TolerantParser/ReferenceFinder/UseNameCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/ReferenceFinder/UseNameCompletor.php
@@ -26,7 +26,7 @@ class UseNameCompletor implements TolerantCompletor
         $this->prioritizer = $prioritizer;
     }
 
-    
+
     public function complete(Node $node, TextDocument $source, ByteOffset $offset): Generator
     {
         $parent = $node->parent;

--- a/lib/Completion/Bridge/TolerantParser/TypeSuggestionProvider.php
+++ b/lib/Completion/Bridge/TolerantParser/TypeSuggestionProvider.php
@@ -67,7 +67,7 @@ class TypeSuggestionProvider
     private function nameImports(Node $node): Generator
     {
         $namespaceImports = $node->getImportTablesForCurrentScope()[0];
-        
+
         foreach ($namespaceImports as $alias => $resolvedName) {
             yield Suggestion::createWithOptions(
                 $alias,

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/AbstractParameterCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/AbstractParameterCompletor.php
@@ -162,7 +162,7 @@ abstract class AbstractParameterCompletor
             assert($callExpression instanceof CallExpression);
             return $callExpression->argumentExpressionList;
         }
-        
+
         assert($node instanceof MemberAccessExpression || $node instanceof ScopedPropertyAccessExpression);
         assert(null !== $node->parent);
 

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/Helper/VariableCompletionHelper.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/Helper/VariableCompletionHelper.php
@@ -85,7 +85,7 @@ class VariableCompletionHelper
     private function offsetToReflect(Node $node, int $offset): int
     {
         $parentNode = $node->parent;
-        
+
         // If the parent is an assignment expression, then only parse
         // until the start of the expression, not the start of the variable
         // under completion:

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletor.php
@@ -59,7 +59,7 @@ class WorseClassMemberCompletor implements TolerantCompletor, TolerantQualifiabl
     {
         $memberStartOffset = $offset;
         $isInstance = true;
-        
+
         if ($node instanceof MemberAccessExpression) {
             $memberStartOffset = $node->arrowToken->getFullStartPosition();
         }
@@ -80,9 +80,9 @@ class WorseClassMemberCompletor implements TolerantCompletor, TolerantQualifiabl
         if (!$memberName instanceof Token) {
             return true;
         }
-        
+
         $shouldCompleteOnlyName = strlen($source) > $offset->toInt() && substr($source, $offset->toInt(), 1) == '(';
-        
+
         $partialMatch = (string) $memberName->getText($node->getFileContents());
 
         $reflectionOffset = $this->reflector->reflectOffset($source, $memberStartOffset);

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseDeclaredClassCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseDeclaredClassCompletor.php
@@ -28,7 +28,7 @@ class WorseDeclaredClassCompletor implements TolerantCompletor, TolerantQualifia
         $this->formatter = $formatter;
     }
 
-    
+
     public function complete(Node $node, TextDocument $source, ByteOffset $offset): Generator
     {
         $classes = get_declared_classes();

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseNamedParameterCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseNamedParameterCompletor.php
@@ -35,7 +35,7 @@ class WorseNamedParameterCompletor implements TolerantCompletor
         $this->formatter = $formatter;
     }
 
-    
+
     public function complete(Node $node, TextDocument $source, ByteOffset $offset): Generator
     {
         if (null === $creation = NodeQuery::firstAncestorOrSelfInVia(

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseSignatureHelper.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseSignatureHelper.php
@@ -60,7 +60,7 @@ class WorseSignatureHelper implements SignatureHelper
         $nodeAtPosition = $rootNode->getDescendantNodeAtPosition($offset->toInt());
 
         [$argsNode, $callNode] = $this->resolveArgsAndCallNode($nodeAtPosition, $offset);
-        
+
         // if current position not inside a call expression
         if (!$callNode && self::isACallExpression($nodeAtPosition)) {
             $callNode = $nodeAtPosition;
@@ -107,37 +107,37 @@ class WorseSignatureHelper implements SignatureHelper
         if ($callable instanceof QualifiedName) {
             return $this->signatureHelpForFunction($callable, $position);
         }
-        
+
         if ($callable instanceof ScopedPropertyAccessExpression) {
             return $this->signatureHelpForScopedPropertyAccess($callable, $callNode, $position);
         }
-        
+
         if ($callable instanceof MemberAccessExpression) {
             $reflectionOffset = $this->reflector->reflectOffset($textDocument, $callable->getEndPosition());
             $symbolContext = $reflectionOffset->symbolContext();
-        
+
             if ($symbolContext->symbol()->symbolType() !== Symbol::METHOD) {
                 throw new CouldNotHelpWithSignature(sprintf(
                     'Could not provide signature member type "%s"',
                     $symbolContext->symbol()->symbolType()
                 ));
             }
-        
+
             $containerType = $symbolContext->containerType()->classNamedTypes()->firstOrNull();
-        
+
             if (!$containerType instanceof ClassType) {
                 throw new CouldNotHelpWithSignature(sprintf(
                     'Container type is not a class: "%s"',
                     $symbolContext->symbol()->name()
                 ));
             }
-        
+
             $reflectionClass = $this->reflector->reflectClassLike($containerType->name());
             $reflectionMethod = $reflectionClass->methods()->get($symbolContext->symbol()->name());
-        
+
             return $this->createSignatureHelp($reflectionMethod, $position);
         }
-        
+
         throw new CouldNotHelpWithSignature(sprintf('Could not provide signature for AST node of type "%s"', get_class($callable)));
     }
 
@@ -245,13 +245,13 @@ class WorseSignatureHelper implements SignatureHelper
         ) {
             return [null, $nodeAtPosition];
         }
-        
+
         if ($nodeAtPosition instanceof ArgumentExpressionList) {
             $argsNode = $nodeAtPosition;
             $callNode = $argsNode->parent ?? null;
             return [$argsNode, $callNode];
         }
-        
+
         if ($argsNode = $nodeAtPosition->getFirstChildNode(ArgumentExpressionList::class)) {
             return [$argsNode, $nodeAtPosition];
         }

--- a/lib/Completion/Bridge/WorseReflection/SnippetFormatter/NameSearchResultFunctionSnippetFormatter.php
+++ b/lib/Completion/Bridge/WorseReflection/SnippetFormatter/NameSearchResultFunctionSnippetFormatter.php
@@ -22,7 +22,7 @@ class NameSearchResultFunctionSnippetFormatter implements Formatter
             && $object->type()->isFunction();
     }
 
-    
+
     public function format(ObjectFormatter $formatter, object $nameSearchResult): string
     {
         assert($nameSearchResult instanceof NameSearchResult);

--- a/lib/Completion/Core/Completor/ArrayCompletor.php
+++ b/lib/Completion/Core/Completor/ArrayCompletor.php
@@ -20,7 +20,7 @@ class ArrayCompletor implements Completor
         $this->suggestions = $suggestions;
     }
 
-    
+
     public function complete(TextDocument $source, ByteOffset $byteOffset): Generator
     {
         yield from $this->suggestions;

--- a/lib/Completion/Core/Completor/DedupeCompletor.php
+++ b/lib/Completion/Core/Completor/DedupeCompletor.php
@@ -19,7 +19,7 @@ class DedupeCompletor implements Completor
         $this->matchShortDescription = $matchShortDescription;
     }
 
-    
+
     public function complete(TextDocument $source, ByteOffset $byteOffset): Generator
     {
         $seen = [];

--- a/lib/Completion/Core/Completor/LimitingCompletor.php
+++ b/lib/Completion/Core/Completor/LimitingCompletor.php
@@ -27,7 +27,7 @@ class LimitingCompletor implements Completor
         }
     }
 
-    
+
     public function complete(TextDocument $source, ByteOffset $byteOffset): Generator
     {
         $count = 0;

--- a/lib/Completion/Core/DocumentPrioritizer/ProximityPrioritizer.php
+++ b/lib/Completion/Core/DocumentPrioritizer/ProximityPrioritizer.php
@@ -34,7 +34,7 @@ class ProximityPrioritizer implements DocumentPrioritizer
     {
         $e1 = explode('/', $one->path());
         $e2 = explode('/', $two->path());
-        
+
         foreach ($e1 as $index => $segment) {
             if (isset($e2[$index]) && $e2[$index] === $segment) {
                 unset($e1[$index], $e2[$index]);
@@ -49,7 +49,7 @@ class ProximityPrioritizer implements DocumentPrioritizer
         if ($distance === 0) {
             return 1;
         }
-        
+
         $max = max($count1, $count2);
         $weight = $max / $distance;
         return 1 - $weight;

--- a/lib/Completion/Tests/Integration/Bridge/TolerantParser/WorseReflection/ImportedNameCompletorTest.php
+++ b/lib/Completion/Tests/Integration/Bridge/TolerantParser/WorseReflection/ImportedNameCompletorTest.php
@@ -96,7 +96,7 @@ class ImportedNameCompletorTest extends TolerantCompletorTestCase
 
         yield 'import multi-part non-aliased class' => [
             <<<'EOT'
-                <?php 
+                <?php
 
                     use Foo\Bar\Barfoo;
                     use Foo\Bar\Barbar;

--- a/lib/Completion/Tests/Integration/Bridge/TolerantParser/WorseReflection/WorseConstructorCompletorTest.php
+++ b/lib/Completion/Tests/Integration/Bridge/TolerantParser/WorseReflection/WorseConstructorCompletorTest.php
@@ -24,7 +24,7 @@ class WorseConstructorCompletorTest extends TolerantCompletorTestCase
     {
         yield 'no parameters' => [
             <<<'EOT'
-                <?php 
+                <?php
                 class Foobar { function __construct() {} }
 
                 $foobar = new Foobar($<>);
@@ -34,7 +34,7 @@ class WorseConstructorCompletorTest extends TolerantCompletorTestCase
 
         yield 'parameter 1' => [
             <<<'EOT'
-                <?php 
+                <?php
                 class Foobar { public function __construct(string $foo) {} }
 
                 $param = 'string';
@@ -51,7 +51,7 @@ class WorseConstructorCompletorTest extends TolerantCompletorTestCase
 
         yield 'parameter, 2nd pos' => [
             <<<'EOT'
-                <?php 
+                <?php
                 class Foobar { public function __construct(string $foo, Foobar $bar) {} }
 
                 $param = 'string';
@@ -69,7 +69,7 @@ class WorseConstructorCompletorTest extends TolerantCompletorTestCase
 
         yield 'parameter, 3rd pos' => [
             <<<'EOT'
-                <?php 
+                <?php
                 class Foobar { public function __construct(string $foo, Foobar $bar, $mixed) {} }
 
                 $param = 'string';
@@ -86,7 +86,7 @@ class WorseConstructorCompletorTest extends TolerantCompletorTestCase
 
         yield 'no suggestions when exceeding parameter arity' => [
             <<<'EOT'
-                <?php 
+                <?php
                 class Foobar { public function __construct(string $foo) {} }
 
                 $param = 'string';
@@ -97,7 +97,7 @@ class WorseConstructorCompletorTest extends TolerantCompletorTestCase
 
         yield 'namespaced class' => [
             <<<'EOT'
-                <?php 
+                <?php
 
                 namespace Hello;
 
@@ -117,10 +117,10 @@ class WorseConstructorCompletorTest extends TolerantCompletorTestCase
 
         yield 'complete on open braclet' => [
             <<<'EOT'
-                <?php 
+                <?php
                 class Hello
                 {
-                    public function __construct(string $foobar) 
+                    public function __construct(string $foobar)
                     {
                     }
                 }
@@ -142,7 +142,7 @@ class WorseConstructorCompletorTest extends TolerantCompletorTestCase
     {
         yield 'complete static method parameter' => [
             <<<'EOT'
-                <?php 
+                <?php
                 class Foobar { public static function barbar(string $foo, Foobar $bar, $mixed) {} }
 
                 $param = 'string';

--- a/lib/Completion/Tests/Integration/Bridge/TolerantParser/WorseReflection/WorseParameterCompletorTest.php
+++ b/lib/Completion/Tests/Integration/Bridge/TolerantParser/WorseReflection/WorseParameterCompletorTest.php
@@ -24,7 +24,7 @@ class WorseParameterCompletorTest extends TolerantCompletorTestCase
     {
         yield 'no parameters' => [
             <<<'EOT'
-                <?php 
+                <?php
                 class Foobar { public function barbar() {} }
 
                 $foobar = new Foobar();
@@ -36,7 +36,7 @@ class WorseParameterCompletorTest extends TolerantCompletorTestCase
 
         yield 'parameter' => [
             <<<'EOT'
-                <?php 
+                <?php
                 class Foobar { public function barbar(string $foo) {} }
 
                 $param = 'string';
@@ -54,7 +54,7 @@ class WorseParameterCompletorTest extends TolerantCompletorTestCase
 
         yield 'parameter, 2nd pos' => [
             <<<'EOT'
-                <?php 
+                <?php
                 class Foobar { public function barbar(string $foo, Foobar $bar) {} }
 
                 $param = 'string';
@@ -72,7 +72,7 @@ class WorseParameterCompletorTest extends TolerantCompletorTestCase
 
         yield 'parameter, 3rd pos' => [
             <<<'EOT'
-                <?php 
+                <?php
                 class Foobar { public function barbar(string $foo, Foobar $bar, $mixed) {} }
 
                 $param = 'string';
@@ -95,7 +95,7 @@ class WorseParameterCompletorTest extends TolerantCompletorTestCase
 
         yield 'no suggestions when exceeding parameter arity' => [
             <<<'EOT'
-                <?php 
+                <?php
                 class Foobar { public function barbar(string $foo) {} }
 
                 $param = 'string';
@@ -107,7 +107,7 @@ class WorseParameterCompletorTest extends TolerantCompletorTestCase
 
         yield 'function parameter completion' => [
             <<<'EOT'
-                <?php 
+                <?php
                 function foobar($bar, string $barbar) {}
 
                 $hello = 'string';
@@ -124,7 +124,7 @@ class WorseParameterCompletorTest extends TolerantCompletorTestCase
 
         yield 'function parameter completion, single parameters' => [
             <<<'EOT'
-                <?php 
+                <?php
                 function foobar($bar, string $barbar) {}
 
                 $hello = 'string';
@@ -142,7 +142,7 @@ class WorseParameterCompletorTest extends TolerantCompletorTestCase
 
         yield 'does not use variables declared after offset a' => [
             <<<'EOT'
-                <?php 
+                <?php
                 function foobar($bar, string $barbar) {}
 
                 class Hello
@@ -166,7 +166,7 @@ class WorseParameterCompletorTest extends TolerantCompletorTestCase
 
         yield 'does not use variables declared after offset with bracket' => [
             <<<'EOT'
-                <?php 
+                <?php
                 function foobar($bar, string $barbar) {}
 
                 class Hello
@@ -195,7 +195,7 @@ class WorseParameterCompletorTest extends TolerantCompletorTestCase
 
         yield 'can complete methods declared after the offset' => [
             <<<'EOT'
-                <?php 
+                <?php
                 class Hello
                 {
                     public function goodbye()
@@ -219,7 +219,7 @@ class WorseParameterCompletorTest extends TolerantCompletorTestCase
 
         yield 'complete on open braclet' => [
             <<<'EOT'
-                <?php 
+                <?php
                 class Hello
                 {
                     public function goodbye()
@@ -254,7 +254,7 @@ class WorseParameterCompletorTest extends TolerantCompletorTestCase
     {
         yield 'complete after comma' => [
             <<<'EOT'
-                <?php 
+                <?php
                 function foobar($bar, string $barbar) {}
 
                 $hello = 'string';
@@ -271,7 +271,7 @@ class WorseParameterCompletorTest extends TolerantCompletorTestCase
 
         yield 'complete on open braclet' => [
             <<<'EOT'
-                <?php 
+                <?php
                 function foobar($bar, string $barbar) {}
 
                 $hello = 'string';
@@ -299,7 +299,7 @@ class WorseParameterCompletorTest extends TolerantCompletorTestCase
     {
         yield 'complete static method parameter' => [
             <<<'EOT'
-                <?php 
+                <?php
                 class Foobar { public static function barbar(string $foo, Foobar $bar, $mixed) {} }
 
                 $param = 'string';

--- a/lib/Completion/Tests/Integration/Bridge/TolerantParser/WorseReflection/WorseSignatureHelperTest.php
+++ b/lib/Completion/Tests/Integration/Bridge/TolerantParser/WorseReflection/WorseSignatureHelperTest.php
@@ -440,7 +440,7 @@ class WorseSignatureHelperTest extends IntegrationTestCase
 
         yield 'non-existing static member' => [
             <<<'EOT'
-                <?php 
+                <?php
                 class Foo {}
 
                 Foo::bar(<>);

--- a/lib/Completion/Tests/Unit/Bridge/TolerantParser/ChainTolerantCompletorTest.php
+++ b/lib/Completion/Tests/Unit/Bridge/TolerantParser/ChainTolerantCompletorTest.php
@@ -22,22 +22,22 @@ class ChainTolerantCompletorTest extends TestCase
      * @var ObjectProphecy<TolerantCompletor>
      */
     private ObjectProphecy $completor1;
-    
+
     /**
      * @var ObjectProphecy<TolerantCompletor&TolerantQualifiable>
      */
     private ObjectProphecy $qualifiableCompletor1;
-    
+
     /**
      * @var ObjectProphecy<TolerantQualifier>
      */
     private ObjectProphecy $qualifier1;
-    
+
     /**
      * @var ObjectProphecy<TolerantCompletor&TolerantQualifiable>
      */
     private ObjectProphecy $qualifiableCompletor2;
-    
+
     /**
      * @var ObjectProphecy<TolerantQualifier>
      */

--- a/lib/Completion/Tests/Unit/Core/DocumentPrioritizer/SimilarityResultPrioritizerTest.php
+++ b/lib/Completion/Tests/Unit/Core/DocumentPrioritizer/SimilarityResultPrioritizerTest.php
@@ -20,7 +20,7 @@ class SimilarityResultPrioritizerTest extends TestCase
 
         self::assertEquals($priority, (new SimilarityResultPrioritizer())->priority($one, $two));
     }
-        
+
     /**
      * @return Generator<mixed>
      */

--- a/lib/ConfigLoader/Core/PathCandidates.php
+++ b/lib/ConfigLoader/Core/PathCandidates.php
@@ -19,7 +19,7 @@ class PathCandidates implements IteratorAggregate
         }
     }
 
-    
+
     public function getIterator(): Traversable
     {
         foreach ($this->candidates as $candidate) {

--- a/lib/ConfigLoader/Tests/Unit/Adapter/Deserializer/YamlDeserializerTest.php
+++ b/lib/ConfigLoader/Tests/Unit/Adapter/Deserializer/YamlDeserializerTest.php
@@ -13,8 +13,8 @@ class YamlDeserializerTest extends TestCase
         $this->expectException(CouldNotDeserialize::class);
         (new YamlDeserializer())->deserialize(
             <<<'EOT'
-                asd 
-                 \t 
+                asd
+                 \t
                 a
                  1235
                      123

--- a/lib/ConfigLoader/Tests/Unit/Core/ConfigLoaderTest.php
+++ b/lib/ConfigLoader/Tests/Unit/Core/ConfigLoaderTest.php
@@ -14,7 +14,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 class ConfigLoaderTest extends TestCase
 {
     use ProphecyTrait;
-    
+
     /**
      * @var ObjectProphecy<Deserializer>
      */
@@ -123,7 +123,7 @@ class ConfigLoaderTest extends TestCase
         $configFile2 = $this->workspace->path('barfoo.test');
         file_put_contents($configFile1, 'test1');
         file_put_contents($configFile2, 'test2');
-        
+
         $loader = new ConfigLoader(
             new Deserializers([
                 'test' => $this->deserializer->reveal()

--- a/lib/ConfigLoader/Tests/Unit/Core/DeserializersTest.php
+++ b/lib/ConfigLoader/Tests/Unit/Core/DeserializersTest.php
@@ -12,7 +12,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 class DeserializersTest extends TestCase
 {
     use ProphecyTrait;
-    
+
     /**
      * @var ObjectProphecy<Deserializer>
      */

--- a/lib/DocblockParser/Ast/ArrayKeyValueList.php
+++ b/lib/DocblockParser/Ast/ArrayKeyValueList.php
@@ -35,12 +35,12 @@ class ArrayKeyValueList extends Node implements IteratorAggregate, Countable
     {
         return new ArrayIterator($this->list);
     }
-    
+
     public function count(): int
     {
         return count($this->list);
     }
-    
+
     /**
      * @return ArrayKeyValueNode[]
      */

--- a/lib/DocblockParser/Ast/ParameterList.php
+++ b/lib/DocblockParser/Ast/ParameterList.php
@@ -49,7 +49,7 @@ class ParameterList extends Node implements IteratorAggregate, Countable
     {
         return new ArrayIterator($this->list);
     }
-    
+
     public function count(): int
     {
         return count($this->list);

--- a/lib/DocblockParser/Ast/Tag/DeprecatedTag.php
+++ b/lib/DocblockParser/Ast/Tag/DeprecatedTag.php
@@ -12,9 +12,9 @@ class DeprecatedTag extends TagNode
         'token',
         'text',
     ];
-    
+
     public ?TextNode $text;
-    
+
     public Token $token;
 
     public function __construct(Token $token, ?TextNode $text)

--- a/lib/DocblockParser/Ast/Tag/ExtendsTag.php
+++ b/lib/DocblockParser/Ast/Tag/ExtendsTag.php
@@ -12,9 +12,9 @@ class ExtendsTag extends TagNode
         'tag',
         'type',
     ];
-    
+
     public Token $tag;
-    
+
     public ?TypeNode $type;
 
     public function __construct(Token $tag, ?TypeNode $type = null)

--- a/lib/DocblockParser/Ast/Tag/ImplementsTag.php
+++ b/lib/DocblockParser/Ast/Tag/ImplementsTag.php
@@ -12,9 +12,9 @@ class ImplementsTag extends TagNode
         'tag',
         'tokensAndTypes',
     ];
-    
+
     public Token $tag;
-    
+
     /**
      * @var array<array-key, Token|TypeNode>
      */

--- a/lib/DocblockParser/Ast/Tag/MethodTag.php
+++ b/lib/DocblockParser/Ast/Tag/MethodTag.php
@@ -20,21 +20,21 @@ class MethodTag extends TagNode
         'parenClose',
         'text'
     ];
-    
+
     public ?TypeNode $type;
-    
+
     public ?Token $name;
-    
+
     public ?Token $static;
-    
+
     public ?ParameterList $parameters;
-    
+
     public ?TextNode $text;
-    
+
     public ?Token $parenOpen;
-    
+
     public ?Token $parenClose;
-    
+
     public ?Token $tag;
 
     public function __construct(

--- a/lib/DocblockParser/Ast/Tag/MixinTag.php
+++ b/lib/DocblockParser/Ast/Tag/MixinTag.php
@@ -12,9 +12,9 @@ class MixinTag extends TagNode
         'tag',
         'class'
     ];
-    
+
     public ?ClassNode $class;
-    
+
     public Token $tag;
 
     public function __construct(Token $tag, ?ClassNode $class)

--- a/lib/DocblockParser/Ast/Tag/ParamTag.php
+++ b/lib/DocblockParser/Ast/Tag/ParamTag.php
@@ -26,9 +26,9 @@ class ParamTag extends TagNode
      * @var ?VariableNode
      */
     public $variable;
-    
+
     public ?TextNode $text;
-    
+
     public Token $tag;
 
     public function __construct(Token $tag, ?TypeNode $type, ?VariableNode $variable, ?TextNode $text = null)

--- a/lib/DocblockParser/Ast/Tag/ParameterTag.php
+++ b/lib/DocblockParser/Ast/Tag/ParameterTag.php
@@ -14,11 +14,11 @@ class ParameterTag extends TagNode
         'name',
         'default',
     ];
-    
+
     public ?TypeNode $type;
-    
+
     public ?VariableNode $name;
-    
+
     public ?ValueNode $default;
 
     public function __construct(?TypeNode $type, ?VariableNode $name, ?ValueNode $default)

--- a/lib/DocblockParser/Ast/Tag/PropertyTag.php
+++ b/lib/DocblockParser/Ast/Tag/PropertyTag.php
@@ -13,11 +13,11 @@ class PropertyTag extends TagNode
         'type',
         'name',
     ];
-    
+
     public ?TypeNode $type;
-    
+
     public ?Token $name;
-    
+
     public Token $tag;
 
     public function __construct(Token $tag, ?TypeNode $type, ?Token $name)

--- a/lib/DocblockParser/Ast/Tag/ReturnTag.php
+++ b/lib/DocblockParser/Ast/Tag/ReturnTag.php
@@ -14,11 +14,11 @@ class ReturnTag extends TagNode
         'type',
         'text',
     ];
-    
+
     public ?TypeNode $type;
-    
+
     public ?TextNode $text;
-    
+
     public Token $tag;
 
     public function __construct(Token $tag, ?TypeNode $type, ?TextNode $text = null)

--- a/lib/DocblockParser/Ast/Tag/TemplateTag.php
+++ b/lib/DocblockParser/Ast/Tag/TemplateTag.php
@@ -14,13 +14,13 @@ class TemplateTag extends TagNode
         'constraint',
         'type'
     ];
-    
+
     public Token $tag;
-    
+
     public ?Token $placeholder;
-    
+
     public ?Token $constraint;
-    
+
     public ?TypeNode $type;
 
     public function __construct(Token $tag, ?Token $placeholder = null, ?Token $constraint = null, ?TypeNode $type = null)

--- a/lib/DocblockParser/Ast/Tag/VarTag.php
+++ b/lib/DocblockParser/Ast/Tag/VarTag.php
@@ -24,7 +24,7 @@ class VarTag extends TagNode
      * @var ?VariableNode
      */
     public $variable;
-    
+
     public Token $tag;
 
     public function __construct(Token $tag, ?TypeNode $type, ?VariableNode $variable)

--- a/lib/DocblockParser/Ast/Token.php
+++ b/lib/DocblockParser/Ast/Token.php
@@ -33,11 +33,11 @@ final class Token implements Element
     public const T_PAREN_CLOSE = 'PAREN_CLOSE';
     public const T_INVALID = 'INVALID';
     public const T_IS = 'IS';
-    
+
     public int $byteOffset;
-    
+
     public string $type;
-    
+
     public string $value;
 
     public function __construct(int $byteOffset, string $type, string $value)
@@ -51,12 +51,12 @@ final class Token implements Element
     {
         return $this->value;
     }
-    
+
     public function start(): int
     {
         return $this->byteOffset;
     }
-    
+
     public function end(): int
     {
         return $this->byteOffset + strlen($this->value);

--- a/lib/DocblockParser/Ast/Tokens.php
+++ b/lib/DocblockParser/Ast/Tokens.php
@@ -20,7 +20,7 @@ final class Tokens implements IteratorAggregate
      * @var Token[]
      */
     private array $tokens;
-    
+
     private int $position = 0;
 
     /**

--- a/lib/DocblockParser/Ast/Type/ClassNode.php
+++ b/lib/DocblockParser/Ast/Type/ClassNode.php
@@ -10,7 +10,7 @@ class ClassNode extends TypeNode
     protected const CHILD_NAMES = [
         'name'
     ];
-    
+
     public Token $name;
 
     public function __construct(Token $name)

--- a/lib/DocblockParser/Ast/Type/GenericNode.php
+++ b/lib/DocblockParser/Ast/Type/GenericNode.php
@@ -15,16 +15,16 @@ class GenericNode extends TypeNode
         'parameters',
         'close'
     ];
-    
+
     public Token $open;
-    
+
     public Token $close;
 
     /**
      * @var TypeList<Element>
      */
     public TypeList $parameters;
-    
+
     public TypeNode $type;
 
     /**

--- a/lib/DocblockParser/Ast/Type/IntersectionNode.php
+++ b/lib/DocblockParser/Ast/Type/IntersectionNode.php
@@ -10,7 +10,7 @@ class IntersectionNode extends TypeNode
     protected const CHILD_NAMES = [
         'types',
     ];
-    
+
     public TypeList $types;
 
     public function __construct(TypeList $types)

--- a/lib/DocblockParser/Ast/Type/ListBracketsNode.php
+++ b/lib/DocblockParser/Ast/Type/ListBracketsNode.php
@@ -11,9 +11,9 @@ class ListBracketsNode extends TypeNode
         'type',
         'listChars',
     ];
-    
+
     public TypeNode $type;
-    
+
     public Token $listChars;
 
     public function __construct(TypeNode $type, Token $listChars)

--- a/lib/DocblockParser/Ast/Type/NullNode.php
+++ b/lib/DocblockParser/Ast/Type/NullNode.php
@@ -10,7 +10,7 @@ class NullNode extends TypeNode
     protected const CHILD_NAMES = [
         'null',
     ];
-    
+
     public Token $null;
 
     public function __construct(Token $null)

--- a/lib/DocblockParser/Ast/Type/NullableNode.php
+++ b/lib/DocblockParser/Ast/Type/NullableNode.php
@@ -11,9 +11,9 @@ class NullableNode extends TypeNode
         'nullable',
         'type',
     ];
-    
+
     public Token $nullable;
-    
+
     public TypeNode $type;
 
     public function __construct(Token $nullable, TypeNode $type)

--- a/lib/DocblockParser/Ast/Type/ParenthesizedType.php
+++ b/lib/DocblockParser/Ast/Type/ParenthesizedType.php
@@ -12,7 +12,7 @@ class ParenthesizedType extends TypeNode
         'node',
         'closed',
     ];
-    
+
     public Token $open;
 
     public ?TypeNode $node;

--- a/lib/DocblockParser/Ast/Type/ScalarNode.php
+++ b/lib/DocblockParser/Ast/Type/ScalarNode.php
@@ -10,7 +10,7 @@ class ScalarNode extends TypeNode
     protected const CHILD_NAMES = [
         'name',
     ];
-    
+
     public Token $name;
 
     public function __construct(Token $name)

--- a/lib/DocblockParser/Ast/Type/ThisNode.php
+++ b/lib/DocblockParser/Ast/Type/ThisNode.php
@@ -10,7 +10,7 @@ class ThisNode extends TypeNode
     protected const CHILD_NAMES = [
         'name'
     ];
-    
+
     public Token $name;
 
     public function __construct(Token $name)

--- a/lib/DocblockParser/Ast/Type/UnionNode.php
+++ b/lib/DocblockParser/Ast/Type/UnionNode.php
@@ -10,7 +10,7 @@ class UnionNode extends TypeNode
     protected const CHILD_NAMES = [
         'types',
     ];
-    
+
     public TypeList $types;
 
     public function __construct(TypeList $types)

--- a/lib/DocblockParser/Ast/TypeList.php
+++ b/lib/DocblockParser/Ast/TypeList.php
@@ -35,12 +35,12 @@ class TypeList extends Node implements IteratorAggregate, Countable
     {
         return new ArrayIterator($this->list);
     }
-    
+
     public function count(): int
     {
         return count($this->list);
     }
-    
+
     public function types(): TypeNodes
     {
         return new TypeNodes(...array_filter($this->list, function (Element $element) {

--- a/lib/DocblockParser/Ast/Value/NullValue.php
+++ b/lib/DocblockParser/Ast/Value/NullValue.php
@@ -18,7 +18,7 @@ class NullValue extends ValueNode
     {
         return $this->null;
     }
-    
+
     public function value()
     {
         return null;

--- a/lib/DocblockParser/Ast/VariableNode.php
+++ b/lib/DocblockParser/Ast/VariableNode.php
@@ -7,7 +7,7 @@ class VariableNode extends Node
     protected const CHILD_NAMES = [
         'name'
     ];
-    
+
     public Token $name;
 
     public function __construct(Token $name)

--- a/lib/DocblockParser/Lexer.php
+++ b/lib/DocblockParser/Lexer.php
@@ -59,7 +59,7 @@ final class Lexer
     private const IGNORE_PATTERNS = [
         '\s+',
     ];
-    
+
     private string $pattern;
 
     public function __construct()

--- a/lib/DocblockParser/Parser.php
+++ b/lib/DocblockParser/Parser.php
@@ -57,7 +57,7 @@ final class Parser
     private const SCALAR_TYPES = [
         'int', 'float', 'bool', 'class-string', 'string', 'mixed', 'callable', 'false'
     ];
-    
+
     private Tokens $tokens;
 
     public function parse(Tokens $tokens): Node

--- a/lib/DocblockParser/Tests/Benchmark/PhpactorParserBench.php
+++ b/lib/DocblockParser/Tests/Benchmark/PhpactorParserBench.php
@@ -8,7 +8,7 @@ use Phpactor\DocblockParser\Parser;
 class PhpactorParserBench extends AbstractParserBenchCase
 {
     private Parser $parser;
-    
+
     private Lexer $lexer;
 
     public function setUp(): void

--- a/lib/DocblockParser/Tests/Unit/Ast/NodeTest.php
+++ b/lib/DocblockParser/Tests/Unit/Ast/NodeTest.php
@@ -130,8 +130,8 @@ class NodeTest extends NodeTestCase
             <<<'EOT'
                 /**
                  * This is a docblock
-                 * With some text - 
-                 * and maybe some 
+                 * With some text -
+                 * and maybe some
                  * ```
                  * Markdown
                  * ```
@@ -141,8 +141,8 @@ class NodeTest extends NodeTestCase
             , function (Docblock $docblock): void {
                 self::assertEquals(<<<'EOT'
                     This is a docblock
-                    With some text - 
-                    and maybe some 
+                    With some text -
+                    and maybe some
                     ```
                     Markdown
                     ```

--- a/lib/Extension/Behat/Adapter/Worse/WorseStepFactory.php
+++ b/lib/Extension/Behat/Adapter/Worse/WorseStepFactory.php
@@ -14,7 +14,7 @@ use Phpactor\WorseReflection\Core\Reflector\ClassReflector;
 class WorseStepFactory implements StepFactory
 {
     private ClassReflector $reflector;
-    
+
     private ContextClassResolver $contextClassResolver;
 
     public function __construct(ClassReflector $reflector, ContextClassResolver $contextClassResolver)

--- a/lib/Extension/Behat/Behat/Context.php
+++ b/lib/Extension/Behat/Behat/Context.php
@@ -5,7 +5,7 @@ namespace Phpactor\Extension\Behat\Behat;
 class Context
 {
     private string $suite;
-    
+
     private string $class;
 
     public function __construct(string $suite, string $class)

--- a/lib/Extension/Behat/Behat/Step.php
+++ b/lib/Extension/Behat/Behat/Step.php
@@ -9,13 +9,13 @@ use Phpactor\Extension\Behat\Behat\Pattern\TurnipPatternPolicy;
 class Step
 {
     private Context $context;
-    
+
     private string $method;
-    
+
     private string $pattern;
-    
+
     private string $path;
-    
+
     private int $startByteOffset;
 
     public function __construct(

--- a/lib/Extension/Behat/Behat/StepGenerator.php
+++ b/lib/Extension/Behat/Behat/StepGenerator.php
@@ -11,9 +11,9 @@ use IteratorAggregate;
 class StepGenerator implements IteratorAggregate
 {
     private BehatConfig $config;
-    
+
     private StepParser $parser;
-    
+
     private StepFactory $factory;
 
     public function __construct(BehatConfig $config, StepFactory $factory, StepParser $parser)

--- a/lib/Extension/Behat/BehatExtension.php
+++ b/lib/Extension/Behat/BehatExtension.php
@@ -26,7 +26,7 @@ class BehatExtension implements Extension
     const PARAM_CONFIG_PATH = 'behat.config_path';
     const PARAM_SYMFONY_XML_PATH = 'behat.symfony.di_xml_path';
     const PARAM_ENABLED = 'behat.enabled';
-    
+
     public function load(ContainerBuilder $container): void
     {
         $container->register('behat.step_factory', function (Container $container) {
@@ -86,7 +86,7 @@ class BehatExtension implements Extension
         });
     }
 
-    
+
     public function configure(Resolver $schema): void
     {
         $schema->setDefaults([

--- a/lib/Extension/Behat/Completor/FeatureStepCompletor.php
+++ b/lib/Extension/Behat/Completor/FeatureStepCompletor.php
@@ -16,9 +16,9 @@ use Phpactor\TextDocument\TextDocument;
 class FeatureStepCompletor implements Completor
 {
     private StepGenerator $generator;
-    
+
     private StepParser $parser;
-    
+
     private StepScorer $stepSorter;
 
     public function __construct(StepGenerator $generator, StepParser $parser, StepScorer $stepSorter = null)
@@ -28,7 +28,7 @@ class FeatureStepCompletor implements Completor
         $this->stepSorter = $stepSorter ?: new StepScorer();
     }
 
-    
+
     public function complete(TextDocument $source, ByteOffset $byteOffset): Generator
     {
         $currentLine = $this->lineForOffset($source->__toString(), $byteOffset->toInt());

--- a/lib/Extension/Behat/ReferenceFinder/StepDefinitionLocator.php
+++ b/lib/Extension/Behat/ReferenceFinder/StepDefinitionLocator.php
@@ -20,7 +20,7 @@ use Phpactor\WorseReflection\Core\TypeFactory;
 class StepDefinitionLocator implements DefinitionLocator
 {
     private StepGenerator $generator;
-    
+
     private StepParser $parser;
 
     public function __construct(StepGenerator $generator, StepParser $parser)
@@ -29,7 +29,7 @@ class StepDefinitionLocator implements DefinitionLocator
         $this->parser = $parser;
     }
 
-    
+
     public function locateDefinition(TextDocument $document, ByteOffset $byteOffset): TypeLocations
     {
         if (!$document->language()->in(['cucumber', 'behat', 'gherkin'])) {

--- a/lib/Extension/Behat/Tests/Integration/Completor/FeatureStepCompletorTest.php
+++ b/lib/Extension/Behat/Tests/Integration/Completor/FeatureStepCompletorTest.php
@@ -101,8 +101,8 @@ class FeatureStepCompletorTest extends TestCase
             BehatExtension::PARAM_CONFIG_PATH => __DIR__ .'/behat.yml',
             BehatExtension::PARAM_ENABLED => true,
         ]);
-        
-        
+
+
         return $container->get(CompletionExtension::SERVICE_REGISTRY)->completorForType('cucumber');
     }
 }

--- a/lib/Extension/Behat/Tests/Unit/Behat/StepScorerTest.php
+++ b/lib/Extension/Behat/Tests/Unit/Behat/StepScorerTest.php
@@ -74,7 +74,7 @@ class StepScorerTest extends TestCase
         ];
     }
 
-    
+
     private function createStep(string $string): Step
     {
         $context = new Context('foo', 'bar');

--- a/lib/Extension/Behat/Tests/Unit/ReferenceFinder/StepDefinitionLocatorTest.php
+++ b/lib/Extension/Behat/Tests/Unit/ReferenceFinder/StepDefinitionLocatorTest.php
@@ -54,7 +54,7 @@ class StepDefinitionLocatorTest extends TestCase
 
         $text = <<<'EOT'
             Feature: Hello
-                
+
                 Scenario: Something
                     Given I have a scenario step
                     And my <>name is "Daniel"

--- a/lib/Extension/ClassMover/Application/ClassMover.php
+++ b/lib/Extension/ClassMover/Application/ClassMover.php
@@ -166,16 +166,16 @@ class ClassMover
         $paths = [
             $src => $dest
         ];
-        
+
         if ($moveRelatedFiles) {
             $oldPaths = $this->getRelatedFiles($src);
             $newPaths = $this->pathFinder->destinationsFor($dest);
-        
+
             foreach ($oldPaths as $oldType => $oldPath) {
                 if (!isset($newPaths[$oldType])) {
                     continue;
                 }
-        
+
                 $newPath = $newPaths[$oldType];
                 $paths[$oldPath] = $newPath;
             }

--- a/lib/Extension/ClassMover/Application/Finder/FileFinder.php
+++ b/lib/Extension/ClassMover/Application/Finder/FileFinder.php
@@ -72,14 +72,14 @@ class FileFinder
 
         $filePaths = [ $path ];
         $filePaths = $this->traitFilePaths($reflection, $filePaths);
-        
+
         if ($private) {
             return FileList::fromFilePaths($filePaths);
         }
-        
+
         $filePaths = $this->parentFilePaths($reflection, $filePaths);
         $filePaths = $this->interfaceFilePaths($reflection, $filePaths);
-        
+
         return FileList::fromFilePaths($filePaths);
     }
 

--- a/lib/Extension/ClassMover/ClassMoverExtension.php
+++ b/lib/Extension/ClassMover/ClassMoverExtension.php
@@ -34,7 +34,7 @@ class ClassMoverExtension implements Extension
     {
     }
 
-    
+
     public function load(ContainerBuilder $container): void
     {
         $this->registerClassMover($container);
@@ -132,21 +132,21 @@ class ClassMoverExtension implements Extension
                 $container->get('console.prompter')
             );
         }, [ ConsoleExtension::TAG_COMMAND => [ 'name' => 'class:move' ]]);
-        
+
         $container->register('command.class_copy', function (Container $container) {
             return new ClassCopyCommand(
                 $container->get('application.class_copy'),
                 $container->get('console.prompter')
             );
         }, [ ConsoleExtension::TAG_COMMAND => [ 'name' => 'class:copy' ]]);
-        
+
         $container->register('command.class_references', function (Container $container) {
             return new ReferencesClassCommand(
                 $container->get('application.class_references'),
                 $container->get('console.dumper_registry')
             );
         }, [ ConsoleExtension::TAG_COMMAND => [ 'name' => 'references:class' ]]);
-        
+
         $container->register('command.member_references', function (Container $container) {
             return new ReferencesMemberCommand(
                 $container->get('application.method_references'),

--- a/lib/Extension/ClassToFile/ClassToFileExtension.php
+++ b/lib/Extension/ClassToFile/ClassToFileExtension.php
@@ -23,7 +23,7 @@ class ClassToFileExtension implements Extension
     const PARAM_PROJECT_ROOT = 'class_to_file.project_root';
     const PARAM_BRUTE_FORCE_CONVERSION = 'class_to_file.brute_force_conversion';
 
-    
+
     public function configure(Resolver $schema): void
     {
         $schema->setDefaults([
@@ -36,7 +36,7 @@ class ClassToFileExtension implements Extension
         ]);
     }
 
-    
+
     public function load(ContainerBuilder $container): void
     {
         $container->register(self::SERVICE_CONVERTER, function (Container $container) {

--- a/lib/Extension/ClassToFileExtra/ClassToFileExtraExtension.php
+++ b/lib/Extension/ClassToFileExtra/ClassToFileExtraExtension.php
@@ -35,7 +35,7 @@ class ClassToFileExtraExtension implements Extension
         }, [ RpcExtension::TAG_RPC_HANDLER => ['name' => FileInfoHandler::NAME] ]);
     }
 
-    
+
     public function configure(Resolver $schema): void
     {
     }

--- a/lib/Extension/CodeTransform/CodeTransformExtension.php
+++ b/lib/Extension/CodeTransform/CodeTransformExtension.php
@@ -88,7 +88,7 @@ class CodeTransformExtension implements Extension
     public const PARAM_OBJECT_FILL_HINT = 'code_transform.refactor.object_fill.hint';
     private const APP_TEMPLATE_PATH = '%application_root%/templates/code';
 
-    
+
     public function configure(Resolver $schema): void
     {
         $schema->setDefaults([

--- a/lib/Extension/CodeTransform/Rpc/AbstractClassGenerateHandler.php
+++ b/lib/Extension/CodeTransform/Rpc/AbstractClassGenerateHandler.php
@@ -109,7 +109,7 @@ abstract class AbstractClassGenerateHandler extends AbstractHandler
     {
         $newPath = $arguments[self::PARAM_NEW_PATH];
         $dirName = dirname($newPath);
-        
+
         if (!file_exists($dirName)) {
             if (!@mkdir($dirName, 0777, true)) {
                 throw new RuntimeException(sprintf(
@@ -118,7 +118,7 @@ abstract class AbstractClassGenerateHandler extends AbstractHandler
                 ));
             }
         }
-        
+
         if (!file_put_contents($newPath, (string) $code)) {
             throw new RuntimeException(sprintf(
                 'Could not save file contents to "%s"',

--- a/lib/Extension/CodeTransform/Tests/Unit/Rpc/ClassInflectHandlerTest.php
+++ b/lib/Extension/CodeTransform/Tests/Unit/Rpc/ClassInflectHandlerTest.php
@@ -55,7 +55,7 @@ class ClassInflectHandlerTest extends AbstractClassGenerateHandlerTest
             ClassName::fromString(self::EXAMPLE_CLASS_1),
             ClassName::fromString(self::EXAMPLE_CLASS_2)
         )->willReturn(SourceCode::fromStringAndPath('<?php', $this->exampleNewPath()));
-            
+
         $response = $this->createTester()->handle(ClassInflectHandler::NAME, [
             ClassInflectHandler::PARAM_CURRENT_PATH => self::EXAMPLE_PATH,
             ClassInflectHandler::PARAM_NEW_PATH => $this->exampleNewPath(),

--- a/lib/Extension/CodeTransformExtra/Command/ClassNewCommand.php
+++ b/lib/Extension/CodeTransformExtra/Command/ClassNewCommand.php
@@ -88,11 +88,11 @@ class ClassNewCommand extends Command
         } catch (FileAlreadyExists $exception) {
             $questionHelper = new QuestionHelper();
             $question = new ConfirmationQuestion('<question>File already exists, overwrite? [y/n]</>', false);
-        
+
             if (false === $questionHelper->ask($input, $output, $question)) {
                 throw $exception;
             }
-        
+
             return $this->classNew->generate($src, $variant, true);
         }
     }

--- a/lib/Extension/CodeTransformExtra/Rpc/GenerateMethodHandler.php
+++ b/lib/Extension/CodeTransformExtra/Rpc/GenerateMethodHandler.php
@@ -48,7 +48,7 @@ class GenerateMethodHandler extends AbstractHandler
         );
 
         $originalSource = $this->determineOriginalSource($textDocumentEdits->uri(), $arguments);
-        
+
         return UpdateFileSourceResponse::fromPathOldAndNewSource(
             $textDocumentEdits->uri()->path(),
             $originalSource,

--- a/lib/Extension/Completion/CompletionExtension.php
+++ b/lib/Extension/Completion/CompletionExtension.php
@@ -29,7 +29,7 @@ class CompletionExtension implements Extension
     public const PARAM_DEDUPE_MATCH_SHORT_DESCRIPTION = 'completion.dedupe_match_short_description';
     public const PARAM_LIMIT = 'completion.limit';
 
-    
+
     public function configure(Resolver $schema): void
     {
         $schema->setDefaults([
@@ -44,7 +44,7 @@ class CompletionExtension implements Extension
         ]);
     }
 
-    
+
     public function load(ContainerBuilder $container): void
     {
         $this->registerCompletion($container);

--- a/lib/Extension/CompletionExtra/CompletionExtraExtension.php
+++ b/lib/Extension/CompletionExtra/CompletionExtraExtension.php
@@ -18,7 +18,7 @@ class CompletionExtraExtension implements Extension
 {
     const CLASS_COMPLETOR_LIMIT = 'completion.completor.class.limit';
 
-    
+
     public function load(ContainerBuilder $container): void
     {
         $this->registerCommands($container);
@@ -26,7 +26,7 @@ class CompletionExtraExtension implements Extension
         $this->registerRpc($container);
     }
 
-    
+
     public function configure(Resolver $schema): void
     {
     }

--- a/lib/Extension/CompletionRpc/CompletionRpcExtension.php
+++ b/lib/Extension/CompletionRpc/CompletionRpcExtension.php
@@ -16,7 +16,7 @@ class CompletionRpcExtension implements Extension
     {
     }
 
-    
+
     public function load(ContainerBuilder $container): void
     {
         $container->register('completion_rpc.handler', function (Container $container) {

--- a/lib/Extension/CompletionRpc/Tests/Unit/CompletionRpcExtensionTest.php
+++ b/lib/Extension/CompletionRpc/Tests/Unit/CompletionRpcExtensionTest.php
@@ -32,7 +32,7 @@ class CompletionRpcExtensionTest extends TestCase
             CompletionExtension::class,
             LoggingExtension::class,
         ]);
-        
+
         return $container->get(RpcExtension::SERVICE_REQUEST_HANDLER);
     }
 }

--- a/lib/Extension/CompletionWorse/CompletionWorseExtension.php
+++ b/lib/Extension/CompletionWorse/CompletionWorseExtension.php
@@ -76,7 +76,7 @@ class CompletionWorseExtension implements Extension
         $this->registerSignatureHelper($container);
     }
 
-    
+
     public function configure(Resolver $schema): void
     {
         $completors = array_merge($this->getOtherCompletors(), $this->getTolerantCompletors());

--- a/lib/Extension/ComposerAutoloader/ComposerAutoloaderExtension.php
+++ b/lib/Extension/ComposerAutoloader/ComposerAutoloaderExtension.php
@@ -22,7 +22,7 @@ class ComposerAutoloaderExtension implements Extension
     const PARAM_CLASS_MAPS_ONLY = 'composer.class_maps_only';
     const LOG_CHANNEL = 'COMPOSER';
 
-    
+
     public function configure(Resolver $resolver): void
     {
         $resolver->setDefaults([
@@ -39,7 +39,7 @@ class ComposerAutoloaderExtension implements Extension
         ]);
     }
 
-    
+
     public function load(ContainerBuilder $container): void
     {
         $container->register(self::SERVICE_AUTOLOADERS, function (Container $container) {
@@ -107,7 +107,7 @@ class ComposerAutoloaderExtension implements Extension
         foreach ($autoloaders as $autoloadFunction) {
             spl_autoload_unregister($autoloadFunction);
         }
-        
+
         foreach ($currentAutoloaders as $autoloader) {
             spl_autoload_register($autoloader);
         }

--- a/lib/Extension/Console/Tests/Unit/Example/InvalidExtension.php
+++ b/lib/Extension/Console/Tests/Unit/Example/InvalidExtension.php
@@ -16,7 +16,7 @@ class InvalidExtension implements Extension
         }, [ ConsoleExtension::TAG_COMMAND => [] ]);
     }
 
-    
+
     public function configure(Resolver $schema): void
     {
     }

--- a/lib/Extension/Console/Tests/Unit/Example/TestExtension.php
+++ b/lib/Extension/Console/Tests/Unit/Example/TestExtension.php
@@ -16,7 +16,7 @@ class TestExtension implements Extension
         }, [ ConsoleExtension::TAG_COMMAND => [ 'name' => 'test' ] ]);
     }
 
-    
+
     public function configure(Resolver $schema): void
     {
     }

--- a/lib/Extension/ContextMenu/ContextMenuExtension.php
+++ b/lib/Extension/ContextMenu/ContextMenuExtension.php
@@ -16,7 +16,7 @@ class ContextMenuExtension implements Extension
 {
     const SERVICE_REQUEST_HANDLER = 'rpc.request_handler';
 
-    
+
     public function load(ContainerBuilder $container): void
     {
         $container->register('rpc.handler.context_menu', function (Container $container) {
@@ -30,7 +30,7 @@ class ContextMenuExtension implements Extension
         }, [ RpcExtension::TAG_RPC_HANDLER => ['name' => ContextMenuHandler::NAME] ]);
     }
 
-    
+
     public function configure(Resolver $schema): void
     {
     }

--- a/lib/Extension/Core/Command/DebugContainerCommand.php
+++ b/lib/Extension/Core/Command/DebugContainerCommand.php
@@ -53,14 +53,14 @@ class DebugContainerCommand extends Command
         ]);
         foreach ($this->container->getServiceIds() as $serviceId) {
             $type = '<not found>';
-        
+
             try {
                 $value = $this->container->get($serviceId);
                 $type = is_object($value) ? get_class($value) : gettype($value);
             } catch (RuntimeException $exception) {
                 $table->addRow(['<error>Error: '.$serviceId.'</>', $exception->getMessage()]);
             }
-        
+
             $table->addRow([$serviceId, $type ]);
         }
         $table->render();

--- a/lib/Extension/Core/Model/ConfigManipulator.php
+++ b/lib/Extension/Core/Model/ConfigManipulator.php
@@ -75,7 +75,7 @@ final class ConfigManipulator
                 ));
             }
         }
-        
+
         $config = file_get_contents($this->configPath);
         if (false === $config) {
             throw new RuntimeException(sprintf(
@@ -83,7 +83,7 @@ final class ConfigManipulator
                 $this->configPath
             ));
         }
-        
+
         $json = json_decode($config);
         if (null === $json) {
             throw new RuntimeException(sprintf(

--- a/lib/Extension/FilePathResolver/FilePathResolverExtension.php
+++ b/lib/Extension/FilePathResolver/FilePathResolverExtension.php
@@ -35,7 +35,7 @@ class FilePathResolverExtension implements Extension
     const PARAM_APPLICATION_ROOT = 'file_path_resolver.application_root';
     const LOG_CHANNEL = 'FPR';
 
-    
+
     public function configure(Resolver $schema): void
     {
         $schema->setDefaults([
@@ -47,7 +47,7 @@ class FilePathResolverExtension implements Extension
         ]);
     }
 
-    
+
     public function load(ContainerBuilder $container): void
     {
         $this->registerPathResolver($container);
@@ -76,7 +76,7 @@ class FilePathResolverExtension implements Extension
             foreach (array_keys($container->getServiceIdsForTag(self::TAG_FILTER)) as $serviceId) {
                 $filters[] = $container->get($serviceId);
             }
-        
+
             $resolver = new FilteringPathResolver($filters);
 
             if ($container->getParameter(self::PARAM_ENABLE_CACHE)) {

--- a/lib/Extension/LanguageServer/EventDispatcher/LazyAggregateProvider.php
+++ b/lib/Extension/LanguageServer/EventDispatcher/LazyAggregateProvider.php
@@ -20,7 +20,7 @@ class LazyAggregateProvider implements ListenerProviderInterface
         $this->container = $container;
         $this->serviceIds = $serviceIds;
     }
-    
+
     public function getListenersForEvent(object $event): iterable
     {
         if (null === $this->aggregateProvider) {

--- a/lib/Extension/LanguageServer/Handler/DebugHandler.php
+++ b/lib/Extension/LanguageServer/Handler/DebugHandler.php
@@ -59,7 +59,7 @@ class DebugHandler implements Handler
         $this->statusProviders = $statusProviders;
     }
 
-    
+
     public function methods(): array
     {
         return [

--- a/lib/Extension/LanguageServer/LanguageServerExtension.php
+++ b/lib/Extension/LanguageServer/LanguageServerExtension.php
@@ -94,7 +94,7 @@ class LanguageServerExtension implements Extension
     public const LOG_CHANNEL = 'LSP';
     public const PARAM_SHUTDOWN_GRACE_PERIOD = 'language_server.shutdown_grace_period';
     public const PARAM_SELF_DESTRUCT_TIMEOUT = 'language_server.self_destruct_timeout';
-    
+
     public function configure(Resolver $schema): void
     {
         $schema->setDefaults([
@@ -134,7 +134,7 @@ class LanguageServerExtension implements Extension
         ]);
     }
 
-    
+
     public function load(ContainerBuilder $container): void
     {
         $this->registerServer($container);
@@ -373,13 +373,13 @@ class LanguageServerExtension implements Extension
 
         $container->register(Handlers::class, function (Container $container) {
             $handlers = [];
-        
+
             foreach (array_keys(
                 $container->getServiceIdsForTag(LanguageServerExtension::TAG_METHOD_HANDLER)
             ) as $serviceId) {
                 $handlers[] = $container->get($serviceId);
             }
-        
+
             return new Handlers(...$handlers);
         });
 

--- a/lib/Extension/LanguageServer/LanguageServerExtraExtension.php
+++ b/lib/Extension/LanguageServer/LanguageServerExtraExtension.php
@@ -25,7 +25,7 @@ class LanguageServerExtraExtension implements Extension
         ]);
     }
 
-    
+
     public function configure(Resolver $schema): void
     {
     }

--- a/lib/Extension/LanguageServer/LanguageServerSessionExtension.php
+++ b/lib/Extension/LanguageServer/LanguageServerSessionExtension.php
@@ -31,7 +31,7 @@ class LanguageServerSessionExtension implements Extension
         $this->initializeParams = $initializeParams;
     }
 
-    
+
     public function load(ContainerBuilder $container): void
     {
         $container->register(ClientCapabilities::class, function (Container $container) {
@@ -66,7 +66,7 @@ class LanguageServerSessionExtension implements Extension
         });
     }
 
-    
+
     public function configure(Resolver $schema): void
     {
     }

--- a/lib/Extension/LanguageServer/Listener/InvalidConfigListener.php
+++ b/lib/Extension/LanguageServer/Listener/InvalidConfigListener.php
@@ -22,7 +22,7 @@ class InvalidConfigListener implements ListenerProviderInterface
         $this->errors = $errors;
     }
 
-    
+
     public function getListenersForEvent(object $event): iterable
     {
         if ($event instanceof Initialized) {

--- a/lib/Extension/LanguageServer/Logger/ClientLogger.php
+++ b/lib/Extension/LanguageServer/Logger/ClientLogger.php
@@ -17,59 +17,59 @@ class ClientLogger implements LoggerInterface
         $this->client = $client;
     }
 
-    
+
     public function emergency($message, array $context = []): void
     {
         $this->client->window()->logMessage()->error($message);
         $this->innerLogger->emergency($message, $context);
     }
 
-    
+
     public function alert($message, array $context = []): void
     {
         $this->client->window()->logMessage()->error($message);
         $this->innerLogger->alert($message, $context);
     }
 
-    
+
     public function critical($message, array $context = []): void
     {
         $this->client->window()->logMessage()->error($message);
         $this->innerLogger->critical($message, $context);
     }
 
-    
+
     public function error($message, array $context = []): void
     {
         $this->client->window()->showMessage()->error($message);
         $this->innerLogger->error($message, $context);
     }
 
-    
+
     public function warning($message, array $context = []): void
     {
         $this->innerLogger->warning($message, $context);
     }
 
-    
+
     public function notice($message, array $context = []): void
     {
         $this->innerLogger->notice($message, $context);
     }
 
-    
+
     public function info($message, array $context = []): void
     {
         $this->innerLogger->info($message, $context);
     }
 
-    
+
     public function debug($message, array $context = []): void
     {
         $this->innerLogger->debug($message, $context);
     }
 
-    
+
     public function log($level, $message, array $context = []): void
     {
         $this->innerLogger->log($message, $context);

--- a/lib/Extension/LanguageServer/Service/OnDevelopWarningService.php
+++ b/lib/Extension/LanguageServer/Service/OnDevelopWarningService.php
@@ -23,7 +23,7 @@ class OnDevelopWarningService implements ServiceProvider
         $this->status = $status;
     }
 
-    
+
     public function services(): array
     {
         if (false === $this->warnOnDevelop) {

--- a/lib/Extension/LanguageServer/Tests/Example/TestExtension.php
+++ b/lib/Extension/LanguageServer/Tests/Example/TestExtension.php
@@ -101,7 +101,7 @@ class TestExtension implements Extension
                     ]);
                 }
 
-                
+
                 public function kinds(): array
                 {
                     return ['example'];
@@ -110,7 +110,7 @@ class TestExtension implements Extension
         }, [ LanguageServerExtension::TAG_CODE_ACTION_PROVIDER => []]);
     }
 
-    
+
     public function configure(Resolver $schema): void
     {
     }

--- a/lib/Extension/LanguageServer/Tests/Unit/LanguageServerTestCase.php
+++ b/lib/Extension/LanguageServer/Tests/Unit/LanguageServerTestCase.php
@@ -43,9 +43,9 @@ class LanguageServerTestCase extends TestCase
         $builder = $this->createContainer($config)->get(
             LanguageServerBuilder::class
         );
-        
+
         $this->assertInstanceOf(LanguageServerBuilder::class, $builder);
-        
+
         return $builder->tester($params ?? ProtocolFactory::initializeParams($this->workspace()->path('/')));
     }
 

--- a/lib/Extension/LanguageServerBridge/LanguageServerBridgeExtension.php
+++ b/lib/Extension/LanguageServerBridge/LanguageServerBridgeExtension.php
@@ -21,7 +21,7 @@ class LanguageServerBridgeExtension implements Extension
     {
     }
 
-    
+
     public function load(ContainerBuilder $container): void
     {
         $container->register(LocationConverter::class, function (Container $container) {

--- a/lib/Extension/LanguageServerBridge/Tests/Test/TestLanguageServerSessionExtension.php
+++ b/lib/Extension/LanguageServerBridge/Tests/Test/TestLanguageServerSessionExtension.php
@@ -22,13 +22,13 @@ class TestLanguageServerSessionExtension implements Extension
         );
     }
 
-    
+
     public function load(ContainerBuilder $container): void
     {
         $this->sessionExtension->load($container);
     }
 
-    
+
     public function configure(Resolver $schema): void
     {
         $this->sessionExtension->configure($schema);

--- a/lib/Extension/LanguageServerCodeTransform/CodeAction/CreateClassProvider.php
+++ b/lib/Extension/LanguageServerCodeTransform/CodeAction/CreateClassProvider.php
@@ -33,7 +33,7 @@ class CreateClassProvider implements DiagnosticsProvider, CodeActionProvider
         $this->parser = $parser;
     }
 
-    
+
     public function kinds(): array
     {
         return [
@@ -41,7 +41,7 @@ class CreateClassProvider implements DiagnosticsProvider, CodeActionProvider
         ];
     }
 
-    
+
     public function provideDiagnostics(TextDocumentItem $textDocument, CancellationToken $cancel): Promise
     {
         return new Success($this->getDiagnostics($textDocument));

--- a/lib/Extension/LanguageServerCodeTransform/CodeAction/ExtractConstantProvider.php
+++ b/lib/Extension/LanguageServerCodeTransform/CodeAction/ExtractConstantProvider.php
@@ -26,7 +26,7 @@ class ExtractConstantProvider implements CodeActionProvider
         $this->extractConstant = $extractConstant;
     }
 
-    
+
     public function kinds(): array
     {
         return [

--- a/lib/Extension/LanguageServerCodeTransform/CodeAction/ExtractExpressionProvider.php
+++ b/lib/Extension/LanguageServerCodeTransform/CodeAction/ExtractExpressionProvider.php
@@ -26,7 +26,7 @@ class ExtractExpressionProvider implements CodeActionProvider
         $this->extractExpression = $extractExpression;
     }
 
-    
+
     public function kinds(): array
     {
         return [
@@ -34,7 +34,7 @@ class ExtractExpressionProvider implements CodeActionProvider
         ];
     }
 
-    
+
     public function provideActionsFor(TextDocumentItem $textDocument, Range $range, CancellationToken $cancel): Promise
     {
         return call(function () use ($textDocument, $range) {

--- a/lib/Extension/LanguageServerCodeTransform/CodeAction/ExtractMethodProvider.php
+++ b/lib/Extension/LanguageServerCodeTransform/CodeAction/ExtractMethodProvider.php
@@ -26,7 +26,7 @@ class ExtractMethodProvider implements CodeActionProvider
         $this->extractMethod = $extractMethod;
     }
 
-    
+
     public function kinds(): array
     {
         return [

--- a/lib/Extension/LanguageServerCodeTransform/CodeAction/GenerateAccessorsProvider.php
+++ b/lib/Extension/LanguageServerCodeTransform/CodeAction/GenerateAccessorsProvider.php
@@ -27,14 +27,14 @@ class GenerateAccessorsProvider implements CodeActionProvider
         $this->reflector = $reflector;
     }
 
-    
+
     public function kinds(): array
     {
         return [
              self::KIND
          ];
     }
-    
+
     public function provideActionsFor(TextDocumentItem $textDocument, Range $range, CancellationToken $cancel): Promise
     {
         return call(function () use ($range, $textDocument) {

--- a/lib/Extension/LanguageServerCodeTransform/CodeAction/GenerateMethodProvider.php
+++ b/lib/Extension/LanguageServerCodeTransform/CodeAction/GenerateMethodProvider.php
@@ -31,7 +31,7 @@ class GenerateMethodProvider implements DiagnosticsProvider, CodeActionProvider
         $this->missingMethodFinder = $missingMethodFinder;
     }
 
-    
+
     public function kinds(): array
     {
         return [
@@ -39,13 +39,13 @@ class GenerateMethodProvider implements DiagnosticsProvider, CodeActionProvider
          ];
     }
 
-    
+
     public function provideDiagnostics(TextDocumentItem $textDocument, CancellationToken $cancel): Promise
     {
         return new Success($this->getDiagnostics($textDocument, $cancel));
     }
 
-    
+
     public function provideActionsFor(TextDocumentItem $textDocument, Range $range, CancellationToken $cancel): Promise
     {
         return call(function () use ($textDocument) {
@@ -102,11 +102,11 @@ class GenerateMethodProvider implements DiagnosticsProvider, CodeActionProvider
             if ($a->range->start->line > $b->range->start->line) {
                 return 1;
             }
-            
+
             if ($a->range->start->line < $b->range->start->line) {
                 return -1;
             }
-            
+
             if ($a->range->start->character > $b->range->start->character) {
                 return 1;
             }
@@ -114,7 +114,7 @@ class GenerateMethodProvider implements DiagnosticsProvider, CodeActionProvider
             if ($a->range->start->character < $b->range->start->character) {
                 return -1;
             }
-            
+
             return 0;
         });
 

--- a/lib/Extension/LanguageServerCodeTransform/CodeAction/ImportNameProvider.php
+++ b/lib/Extension/LanguageServerCodeTransform/CodeAction/ImportNameProvider.php
@@ -49,7 +49,7 @@ class ImportNameProvider implements CodeActionProvider, DiagnosticsProvider
         });
     }
 
-    
+
     public function kinds(): array
     {
         return [
@@ -57,7 +57,7 @@ class ImportNameProvider implements CodeActionProvider, DiagnosticsProvider
         ];
     }
 
-    
+
     public function provideDiagnostics(TextDocumentItem $textDocument, CancellationToken $cancel): Promise
     {
         return call(function () use ($textDocument) {

--- a/lib/Extension/LanguageServerCodeTransform/CodeAction/TransformerCodeActionPovider.php
+++ b/lib/Extension/LanguageServerCodeTransform/CodeAction/TransformerCodeActionPovider.php
@@ -34,7 +34,7 @@ class TransformerCodeActionPovider implements DiagnosticsProvider, CodeActionPro
         $this->name = $name;
     }
 
-    
+
     public function kinds(): array
     {
         return [
@@ -42,7 +42,7 @@ class TransformerCodeActionPovider implements DiagnosticsProvider, CodeActionPro
         ];
     }
 
-    
+
     public function provideDiagnostics(TextDocumentItem $textDocument, CancellationToken $cancel): Promise
     {
         return new Success($this->getDiagnostics($textDocument, $cancel));

--- a/lib/Extension/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
+++ b/lib/Extension/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
@@ -49,14 +49,14 @@ use Phpactor\TextDocument\TextDocumentLocator;
 class LanguageServerCodeTransformExtension implements Extension
 {
     public const PARAM_REPORT_NON_EXISTING_NAMES = 'language_server_code_transform.import_name.report_non_existing_names';
-    
+
     public function load(ContainerBuilder $container): void
     {
         $this->registerCommands($container);
         $this->registerCodeActions($container);
     }
 
-    
+
     public function configure(Resolver $schema): void
     {
         $schema->setDefaults([

--- a/lib/Extension/LanguageServerCodeTransform/LspCommand/ExtractConstantCommand.php
+++ b/lib/Extension/LanguageServerCodeTransform/LspCommand/ExtractConstantCommand.php
@@ -41,7 +41,7 @@ class ExtractConstantCommand implements Command
     public function __invoke(string $uri, int $offset): Promise
     {
         $textDocument = $this->workspace->get($uri);
-        
+
         try {
             $textEdits = $this->extractConstant->extractConstant(
                 SourceCode::fromStringAndPath($textDocument->text, $textDocument->uri),
@@ -52,7 +52,7 @@ class ExtractConstantCommand implements Command
             $this->clientApi->window()->showMessage()->warning($error->getMessage());
             return new Success(null);
         }
- 
+
         return $this->clientApi->workspace()->applyEdit(new WorkspaceEdit([
             $uri => TextEditConverter::toLspTextEdits($textEdits->textEdits(), $textDocument->text)
         ]), 'Extract constant');

--- a/lib/Extension/LanguageServerCodeTransform/LspCommand/ExtractExpressionCommand.php
+++ b/lib/Extension/LanguageServerCodeTransform/LspCommand/ExtractExpressionCommand.php
@@ -41,7 +41,7 @@ class ExtractExpressionCommand implements Command
     public function __invoke(string $uri, int $startOffset, int $endOffset): Promise
     {
         $textDocument = $this->workspace->get($uri);
-        
+
         try {
             $textEdits = $this->extractExpression->extractExpression(
                 SourceCode::fromStringAndPath($textDocument->text, $textDocument->uri),
@@ -53,7 +53,7 @@ class ExtractExpressionCommand implements Command
             $this->clientApi->window()->showMessage()->warning($error->getMessage());
             return new Success(null);
         }
- 
+
         return $this->clientApi->workspace()->applyEdit(new WorkspaceEdit([
             $uri => TextEditConverter::toLspTextEdits($textEdits, $textDocument->text)
         ]), 'Extract expression');

--- a/lib/Extension/LanguageServerCodeTransform/LspCommand/ExtractMethodCommand.php
+++ b/lib/Extension/LanguageServerCodeTransform/LspCommand/ExtractMethodCommand.php
@@ -41,7 +41,7 @@ class ExtractMethodCommand implements Command
     public function __invoke(string $uri, int $startOffset, int $endOffset): Promise
     {
         $textDocument = $this->workspace->get($uri);
-        
+
         try {
             $textEdits = $this->extractMethod->extractMethod(
                 SourceCode::fromStringAndPath($textDocument->text, $textDocument->uri),
@@ -53,7 +53,7 @@ class ExtractMethodCommand implements Command
             $this->clientApi->window()->showMessage()->warning($error->getMessage());
             return new Success(null);
         }
- 
+
         return $this->clientApi->workspace()->applyEdit(new WorkspaceEdit([
              $uri => TextEditConverter::toLspTextEdits($textEdits->textEdits(), $textDocument->text)
         ]), 'Extract method');

--- a/lib/Extension/LanguageServerCodeTransform/LspCommand/GenerateAccessorsCommand.php
+++ b/lib/Extension/LanguageServerCodeTransform/LspCommand/GenerateAccessorsCommand.php
@@ -41,7 +41,7 @@ class GenerateAccessorsCommand implements Command
     public function __invoke(string $uri, int $startOffset, array $propertyNames): Promise
     {
         $textDocument = $this->workspace->get($uri);
-        
+
         try {
             $textEdits = $this->generateAccessor->generate(
                 SourceCode::fromStringAndPath($textDocument->text, $textDocument->uri),
@@ -52,7 +52,7 @@ class GenerateAccessorsCommand implements Command
             $this->clientApi->window()->showMessage()->warning($error->getMessage());
             return new Success(null);
         }
- 
+
         return $this->clientApi->workspace()->applyEdit(new WorkspaceEdit([
              $uri => TextEditConverter::toLspTextEdits($textEdits, $textDocument->text)
         ]), 'Generate accessors');

--- a/lib/Extension/LanguageServerCodeTransform/Model/NameImport/CandidateFinder.php
+++ b/lib/Extension/LanguageServerCodeTransform/Model/NameImport/CandidateFinder.php
@@ -72,17 +72,17 @@ class CandidateFinder
             return;
         }
         assert($unresolvedName instanceof NameWithByteOffset);
-        
+
         $candidates = $this->findCandidates($unresolvedName);
-        
+
         foreach ($candidates as $candidate) {
             assert($candidate instanceof HasFullyQualifiedName);
-        
+
             // skip constants for now
             if ($candidate instanceof ConstantRecord) {
                 continue;
             }
-        
+
             $fqn = $candidate->fqn()->__toString();
             yield new NameCandidate($unresolvedName, $candidate->fqn());
         }

--- a/lib/Extension/LanguageServerCodeTransform/Tests/TestLanguageServerSessionExtension.php
+++ b/lib/Extension/LanguageServerCodeTransform/Tests/TestLanguageServerSessionExtension.php
@@ -22,13 +22,13 @@ class TestLanguageServerSessionExtension implements Extension
         );
     }
 
-    
+
     public function load(ContainerBuilder $container): void
     {
         $this->sessionExtension->load($container);
     }
 
-    
+
     public function configure(Resolver $schema): void
     {
         $this->sessionExtension->configure($schema);

--- a/lib/Extension/LanguageServerCodeTransform/Tests/Unit/CodeAction/ExtractConstantProviderTest.php
+++ b/lib/Extension/LanguageServerCodeTransform/Tests/Unit/CodeAction/ExtractConstantProviderTest.php
@@ -59,7 +59,7 @@ class ExtractConstantProviderTest extends TestCase
             ))
         );
     }
-     
+
     public function provideActionsData(): Generator
     {
         yield 'Fail' => [
@@ -86,7 +86,7 @@ class ExtractConstantProviderTest extends TestCase
             ]
         ];
     }
-    
+
     private function createProvider(): ExtractConstantProvider
     {
         return new ExtractConstantProvider($this->extractConstant->reveal());

--- a/lib/Extension/LanguageServerCodeTransform/Tests/Unit/CodeAction/ExtractExpressionProviderTest.php
+++ b/lib/Extension/LanguageServerCodeTransform/Tests/Unit/CodeAction/ExtractExpressionProviderTest.php
@@ -60,7 +60,7 @@ class ExtractExpressionProviderTest extends TestCase
             ))
         );
     }
-     
+
     public function provideActionsData(): Generator
     {
         yield 'Fail' => [
@@ -87,7 +87,7 @@ class ExtractExpressionProviderTest extends TestCase
             ]
         ];
     }
-    
+
     private function createProvider(): ExtractExpressionProvider
     {
         return new ExtractExpressionProvider($this->extractExpression->reveal());

--- a/lib/Extension/LanguageServerCodeTransform/Tests/Unit/LspCommand/CreateClassCommandTest.php
+++ b/lib/Extension/LanguageServerCodeTransform/Tests/Unit/LspCommand/CreateClassCommandTest.php
@@ -78,7 +78,7 @@ class TestGenerator implements GenerateNew
     public const EXAMPLE_TEXT = 'hello';
     public const EXAMPLE_PATH = '/path';
 
-    
+
     public function generateNew(ClassName $targetName): SourceCode
     {
         return SourceCode::fromStringAndPath(self::EXAMPLE_TEXT, self::EXAMPLE_PATH);

--- a/lib/Extension/LanguageServerCodeTransform/Tests/Unit/LspCommand/ExtractConstantCommandTest.php
+++ b/lib/Extension/LanguageServerCodeTransform/Tests/Unit/LspCommand/ExtractConstantCommandTest.php
@@ -73,11 +73,11 @@ class ExtractConstantCommandTest extends TestCase
         )
              ->shouldBeCalled()
              ->willThrow($exception);
- 
+
         [$tester, $builder] = $this->createTester($extractConstant);
         $tester->workspace()->executeCommand('extract_constant', [self::EXAMPLE_URI, self::EXAMPLE_OFFSET]);
         $showMessage = $builder->transmitter()->filterByMethod('window/showMessage')->shiftNotification();
- 
+
         self::assertNotNull($showMessage);
         self::assertEquals([
              'type' => MessageType::WARNING,
@@ -105,10 +105,10 @@ class ExtractConstantCommandTest extends TestCase
             $builder->workspace(),
             $extractConstant->reveal()
         ));
-         
+
         $tester = $builder->build();
         $tester->textDocument()->open(self::EXAMPLE_URI, self::EXAMPLE_SOURCE);
- 
+
         return [$tester, $builder];
     }
 }

--- a/lib/Extension/LanguageServerCodeTransform/Tests/Unit/LspCommand/ExtractExpressionCommandTest.php
+++ b/lib/Extension/LanguageServerCodeTransform/Tests/Unit/LspCommand/ExtractExpressionCommandTest.php
@@ -62,11 +62,11 @@ class ExtractExpressionCommandTest extends TestCase
         $extractExpression->extractExpression(Argument::type(SourceCode::class), 0, self::EXAMPLE_OFFSET, ExtractExpressionCommand::DEFAULT_VARIABLE_NAME)
              ->shouldBeCalled()
              ->willThrow($exception);
- 
+
         [$tester, $builder] = $this->createTester($extractExpression);
         $tester->workspace()->executeCommand('extract_expression', [self::EXAMPLE_URI, 0, self::EXAMPLE_OFFSET]);
         $showMessage = $builder->transmitter()->filterByMethod('window/showMessage')->shiftNotification();
- 
+
         self::assertNotNull($showMessage);
         self::assertEquals([
              'type' => MessageType::WARNING,
@@ -94,10 +94,10 @@ class ExtractExpressionCommandTest extends TestCase
             $builder->workspace(),
             $extractExpression->reveal()
         ));
-         
+
         $tester = $builder->build();
         $tester->textDocument()->open(self::EXAMPLE_URI, self::EXAMPLE_SOURCE);
- 
+
         return [$tester, $builder];
     }
 }

--- a/lib/Extension/LanguageServerCodeTransform/Tests/Unit/LspCommand/ExtractMethodCommandTest.php
+++ b/lib/Extension/LanguageServerCodeTransform/Tests/Unit/LspCommand/ExtractMethodCommandTest.php
@@ -67,11 +67,11 @@ class ExtractMethodCommandTest extends TestCase
         $extractMethod->extractMethod(Argument::type(SourceCode::class), 0, self::EXAMPLE_OFFSET, ExtractMethodCommand::DEFAULT_METHOD_NAME)
              ->shouldBeCalled()
              ->willThrow($exception);
- 
+
         [$tester, $builder] = $this->createTester($extractMethod);
         $tester->workspace()->executeCommand('extract_method', [self::EXAMPLE_URI, 0, self::EXAMPLE_OFFSET]);
         $showMessage = $builder->transmitter()->filterByMethod('window/showMessage')->shiftNotification();
- 
+
         self::assertNotNull($showMessage);
         self::assertEquals([
              'type' => MessageType::WARNING,
@@ -86,7 +86,7 @@ class ExtractMethodCommandTest extends TestCase
         ];
     }
 
-    
+
     private function createTester(ObjectProphecy $extractMethod): array
     {
         $builder = LanguageServerTesterBuilder::createBare()
@@ -97,10 +97,10 @@ class ExtractMethodCommandTest extends TestCase
             $builder->workspace(),
             $extractMethod->reveal()
         ));
-         
+
         $tester = $builder->build();
         $tester->textDocument()->open(self::EXAMPLE_URI, self::EXAMPLE_SOURCE);
- 
+
         return [$tester, $builder];
     }
 }

--- a/lib/Extension/LanguageServerCodeTransform/Tests/Unit/LspCommand/GenerateAccessorsCommandTest.php
+++ b/lib/Extension/LanguageServerCodeTransform/Tests/Unit/LspCommand/GenerateAccessorsCommandTest.php
@@ -81,7 +81,7 @@ class GenerateAccessorsCommandTest extends TestCase
                 TextDocumentBuilder::create('foobar')->uri(self::EXAMPLE_URI)->build()
             ])
         ));
-        
+
         $tester = $builder->build();
         $tester->textDocument()->open(self::EXAMPLE_URI, self::EXAMPLE_SOURCE);
 

--- a/lib/Extension/LanguageServerCodeTransform/Tests/Unit/LspCommand/GenerateMethodCommandTest.php
+++ b/lib/Extension/LanguageServerCodeTransform/Tests/Unit/LspCommand/GenerateMethodCommandTest.php
@@ -109,7 +109,7 @@ class GenerateMethodCommandTest extends TestCase
                 TextDocumentBuilder::create('foobar')->uri(self::EXAMPLE_URI)->build()
             ])
         ));
-        
+
         $tester = $builder->build();
         $tester->textDocument()->open(self::EXAMPLE_URI, self::EXAMPLE_SOURCE);
 

--- a/lib/Extension/LanguageServerCodeTransform/Tests/Unit/LspCommand/ImportAllUnresolvedNamesCommandTest.php
+++ b/lib/Extension/LanguageServerCodeTransform/Tests/Unit/LspCommand/ImportAllUnresolvedNamesCommandTest.php
@@ -117,7 +117,7 @@ class ImportAllUnresolvedNamesCommandTest extends TestCase
         $builder = LanguageServerTesterBuilder::createBare()
             ->enableCommands()
             ->enableTextDocuments();
-        
+
         $builder->addCommand(
             ImportAllUnresolvedNamesCommand::NAME,
             new ImportAllUnresolvedNamesCommand(

--- a/lib/Extension/LanguageServerCodeTransform/Tests/Unit/LspCommand/TransformCommandTest.php
+++ b/lib/Extension/LanguageServerCodeTransform/Tests/Unit/LspCommand/TransformCommandTest.php
@@ -57,7 +57,7 @@ class TestTransformer implements Transformer
         return TextEdits::none();
     }
 
-    
+
     public function diagnostics(SourceCode $code): Diagnostics
     {
         return Diagnostics::none();

--- a/lib/Extension/LanguageServerCompletion/Handler/SignatureHelpHandler.php
+++ b/lib/Extension/LanguageServerCompletion/Handler/SignatureHelpHandler.php
@@ -28,7 +28,7 @@ class SignatureHelpHandler implements Handler, CanRegisterCapabilities
         $this->helper = $helper;
     }
 
-    
+
     public function methods(): array
     {
         return [

--- a/lib/Extension/LanguageServerCompletion/LanguageServerCompletionExtension.php
+++ b/lib/Extension/LanguageServerCompletion/LanguageServerCompletionExtension.php
@@ -18,7 +18,7 @@ class LanguageServerCompletionExtension implements Extension
 {
     private const PARAM_TRIM_LEADING_DOLLAR = 'language_server_completion.trim_leading_dollar';
 
-    
+
     public function configure(Resolver $schema): void
     {
         $schema->setDefaults([
@@ -29,7 +29,7 @@ class LanguageServerCompletionExtension implements Extension
         ]);
     }
 
-    
+
     public function load(ContainerBuilder $container): void
     {
         $this->registerHandlers($container);

--- a/lib/Extension/LanguageServerCompletion/Tests/Unit/Handler/HoverHandlerTest.php
+++ b/lib/Extension/LanguageServerCompletion/Tests/Unit/Handler/HoverHandlerTest.php
@@ -53,13 +53,13 @@ class HoverHandlerTest extends IntegrationTestCase
 
         yield 'method with documentation' => [
             <<<'EOT'
-                <?php 
+                <?php
 
-                class A { 
-                    /** 
-                     * This is a method 
+                class A {
+                    /**
+                     * This is a method
                      */
-                    private function f<>oo():string {} 
+                    private function f<>oo():string {}
                 }
                 EOT
             ,
@@ -67,19 +67,19 @@ class HoverHandlerTest extends IntegrationTestCase
 
         yield 'method with parent documentation' => [
             <<<'EOT'
-                <?php 
+                <?php
 
                 class Foobar {
-                    /** 
+                    /**
                      * The original documentation
                      */
-                    private function foo():string {} 
+                    private function foo():string {}
                 }
-                class A extends Foobar { 
-                    /** 
-                     * This is a method 
+                class A extends Foobar {
+                    /**
+                     * This is a method
                      */
-                    private function f<>oo():string {} 
+                    private function f<>oo():string {}
                 }
                 EOT
             ,
@@ -87,19 +87,19 @@ class HoverHandlerTest extends IntegrationTestCase
 
         yield 'method on a union' => [
             <<<'EOT'
-                <?php 
+                <?php
 
                 class Barfoo {
-                    /** 
+                    /**
                      * The original documentation
                      */
-                    private function foo():string {} 
+                    private function foo():string {}
                 }
                 class Foobar {
-                    /** 
+                    /**
                      * The original documentation
                      */
-                    private function foo():string {} 
+                    private function foo():string {}
                 }
 
                 function foo(Barfoo|Foobar $foo) {

--- a/lib/Extension/LanguageServerDiagnostics/LanguageServerDiagnosticsExtension.php
+++ b/lib/Extension/LanguageServerDiagnostics/LanguageServerDiagnosticsExtension.php
@@ -27,7 +27,7 @@ class LanguageServerDiagnosticsExtension implements Extension
         ]);
     }
 
-    
+
     public function configure(Resolver $schema): void
     {
     }

--- a/lib/Extension/LanguageServerDiagnostics/Provider/PhpLintDiagnosticProvider.php
+++ b/lib/Extension/LanguageServerDiagnostics/Provider/PhpLintDiagnosticProvider.php
@@ -23,7 +23,7 @@ class PhpLintDiagnosticProvider implements DiagnosticsProvider
         $this->linter = $linter;
     }
 
-    
+
     public function provideDiagnostics(TextDocumentItem $textDocument, CancellationToken $cancel): Promise
     {
         return call(function () use ($textDocument) {

--- a/lib/Extension/LanguageServerHover/Handler/HoverHandler.php
+++ b/lib/Extension/LanguageServerHover/Handler/HoverHandler.php
@@ -74,7 +74,7 @@ class HoverHandler implements Handler, CanRegisterCapabilities
             $info = $this->infoFromReflecionOffset($offsetReflection);
             $string = new MarkupContent('markdown', $info);
             $symbolContext = $offsetReflection->symbolContext();
-            
+
             return new Hover($string, new Range(
                 PositionConverter::byteOffsetToPosition(
                     ByteOffset::fromInt($symbolContext->symbol()->position()->start()),

--- a/lib/Extension/LanguageServerIndexer/LanguageServerIndexerExtension.php
+++ b/lib/Extension/LanguageServerIndexer/LanguageServerIndexerExtension.php
@@ -28,7 +28,7 @@ class LanguageServerIndexerExtension implements Extension
 {
     public const WORKSPACE_SYMBOL_SEARCH_LIMIT = 'language_server_indexer.workspace_symbol_search_limit';
 
-    
+
     public function load(ContainerBuilder $container): void
     {
         $this->registerSessionHandler($container);

--- a/lib/Extension/LanguageServerIndexer/Listener/IndexerListener.php
+++ b/lib/Extension/LanguageServerIndexer/Listener/IndexerListener.php
@@ -18,7 +18,7 @@ class IndexerListener implements ListenerProviderInterface
         $this->manager = $manager;
     }
 
-    
+
     /**
      * @return Generator<callable>
      */

--- a/lib/Extension/LanguageServerIndexer/Tests/Extension/TestExtension.php
+++ b/lib/Extension/LanguageServerIndexer/Tests/Extension/TestExtension.php
@@ -24,7 +24,7 @@ class TestExtension implements Extension
         ]);
     }
 
-    
+
     public function configure(Resolver $schema): void
     {
     }

--- a/lib/Extension/LanguageServerIndexer/Watcher/LanguageServerWatcher.php
+++ b/lib/Extension/LanguageServerIndexer/Watcher/LanguageServerWatcher.php
@@ -37,13 +37,13 @@ class LanguageServerWatcher implements Watcher, WatcherProcess, ListenerProvider
         $this->clientCapabilities = $clientCapabilities;
     }
 
-    
+
     public function watch(): Promise
     {
         return new Success($this);
     }
 
-    
+
     public function isSupported(): Promise
     {
         if (!$this->clientCapabilities) {
@@ -55,13 +55,13 @@ class LanguageServerWatcher implements Watcher, WatcherProcess, ListenerProvider
         );
     }
 
-    
+
     public function describe(): string
     {
         return 'LSP file events';
     }
 
-    
+
     public function getListenersForEvent(object $event): iterable
     {
         if ($event instanceof FilesChanged) {
@@ -87,7 +87,7 @@ class LanguageServerWatcher implements Watcher, WatcherProcess, ListenerProvider
     {
     }
 
-    
+
     public function wait(): Promise
     {
         return call(function () {

--- a/lib/Extension/LanguageServerPhpstan/LanguageServerPhpstanExtension.php
+++ b/lib/Extension/LanguageServerPhpstan/LanguageServerPhpstanExtension.php
@@ -21,7 +21,7 @@ class LanguageServerPhpstanExtension implements Extension
     public const PARAM_PHPSTAN_BIN = 'language_server_phpstan.bin';
     public const PARAM_LEVEL = 'language_server_phpstan.level';
 
-    
+
     public function load(ContainerBuilder $container): void
     {
         $container->register(PhpstanDiagnosticProvider::class, function (Container $container) {
@@ -54,7 +54,7 @@ class LanguageServerPhpstanExtension implements Extension
         });
     }
 
-    
+
     public function configure(Resolver $schema): void
     {
         $schema->setDefaults([

--- a/lib/Extension/LanguageServerPhpstan/Provider/PhpstanDiagnosticProvider.php
+++ b/lib/Extension/LanguageServerPhpstan/Provider/PhpstanDiagnosticProvider.php
@@ -17,7 +17,7 @@ class PhpstanDiagnosticProvider implements DiagnosticsProvider
         $this->linter = $linter;
     }
 
-    
+
     public function provideDiagnostics(TextDocumentItem $textDocument, CancellationToken $cancel): Promise
     {
         return $this->linter->lint($textDocument->uri, $textDocument->text);

--- a/lib/Extension/LanguageServerPsalm/DiagnosticProvider/PsalmDiagnosticProvider.php
+++ b/lib/Extension/LanguageServerPsalm/DiagnosticProvider/PsalmDiagnosticProvider.php
@@ -17,7 +17,7 @@ class PsalmDiagnosticProvider implements DiagnosticsProvider
         $this->linter = $linter;
     }
 
-    
+
     public function provideDiagnostics(TextDocumentItem $textDocument, CancellationToken $cancel): Promise
     {
         return $this->linter->lint($textDocument->uri, $textDocument->text);

--- a/lib/Extension/LanguageServerPsalm/LanguageServerPsalmExtension.php
+++ b/lib/Extension/LanguageServerPsalm/LanguageServerPsalmExtension.php
@@ -20,7 +20,7 @@ class LanguageServerPsalmExtension implements Extension
     public const PARAM_PSALM_BIN = 'language_server_psalm.bin';
     public const PARAM_ENABLED = 'language_server_psalm.enabled';
 
-    
+
     public function load(ContainerBuilder $container): void
     {
         $container->register(PsalmDiagnosticProvider::class, function (Container $container) {
@@ -51,7 +51,7 @@ class LanguageServerPsalmExtension implements Extension
         });
     }
 
-    
+
     public function configure(Resolver $schema): void
     {
         $schema->setDefaults([

--- a/lib/Extension/LanguageServerReferenceFinder/Adapter/Indexer/WorkspaceUpdateReferenceFinder.php
+++ b/lib/Extension/LanguageServerReferenceFinder/Adapter/Indexer/WorkspaceUpdateReferenceFinder.php
@@ -27,7 +27,7 @@ class WorkspaceUpdateReferenceFinder implements ReferenceFinder
         $this->innerReferenceFinder = $innerReferenceFinder;
     }
 
-    
+
     public function findReferences(TextDocument $document, ByteOffset $byteOffset): Generator
     {
         $this->indexWorkspace();

--- a/lib/Extension/LanguageServerReferenceFinder/Handler/GotoImplementationHandler.php
+++ b/lib/Extension/LanguageServerReferenceFinder/Handler/GotoImplementationHandler.php
@@ -28,7 +28,7 @@ class GotoImplementationHandler implements Handler, CanRegisterCapabilities
         $this->locationConverter = $locationConverter;
     }
 
-    
+
     public function methods(): array
     {
         return [

--- a/lib/Extension/LanguageServerReferenceFinder/Handler/HighlightHandler.php
+++ b/lib/Extension/LanguageServerReferenceFinder/Handler/HighlightHandler.php
@@ -26,7 +26,7 @@ class HighlightHandler implements Handler, CanRegisterCapabilities
         $this->highlighter = $highlighter;
     }
 
-    
+
     public function methods(): array
     {
         return [

--- a/lib/Extension/LanguageServerReferenceFinder/Handler/ReferencesHandler.php
+++ b/lib/Extension/LanguageServerReferenceFinder/Handler/ReferencesHandler.php
@@ -53,7 +53,7 @@ class ReferencesHandler implements Handler, CanRegisterCapabilities
         $this->clientApi = $clientApi;
     }
 
-    
+
     public function methods(): array
     {
         return [

--- a/lib/Extension/LanguageServerReferenceFinder/LanguageServerReferenceFinderExtension.php
+++ b/lib/Extension/LanguageServerReferenceFinder/LanguageServerReferenceFinderExtension.php
@@ -25,7 +25,7 @@ class LanguageServerReferenceFinderExtension implements Extension
 {
     const PARAM_REFERENCE_TIMEOUT = 'language_server_reference_reference_finder.reference_timeout';
 
-    
+
     public function load(ContainerBuilder $container): void
     {
         $container->register(GotoDefinitionHandler::class, function (Container $container) {
@@ -81,7 +81,7 @@ class LanguageServerReferenceFinderExtension implements Extension
         }, [ LanguageServerExtension::TAG_METHOD_HANDLER => [] ]);
     }
 
-    
+
     public function configure(Resolver $schema): void
     {
         $schema->setDefaults([

--- a/lib/Extension/LanguageServerReferenceFinder/Model/Highlights.php
+++ b/lib/Extension/LanguageServerReferenceFinder/Model/Highlights.php
@@ -23,7 +23,7 @@ class Highlights implements IteratorAggregate, Countable
     {
         $this->highlights = $highlights;
     }
-    
+
     public function first(): DocumentHighlight
     {
         if (empty($this->highlights)) {
@@ -60,7 +60,7 @@ class Highlights implements IteratorAggregate, Countable
         return new self(...iterator_to_array($iterator));
     }
 
-    
+
     public function count(): int
     {
         return count($this->highlights);

--- a/lib/Extension/LanguageServerReferenceFinder/Tests/Extension/TestIndexerExtension.php
+++ b/lib/Extension/LanguageServerReferenceFinder/Tests/Extension/TestIndexerExtension.php
@@ -20,7 +20,7 @@ class TestIndexerExtension implements Extension
         });
     }
 
-    
+
     public function configure(Resolver $schema): void
     {
     }

--- a/lib/Extension/LanguageServerReferenceFinder/Tests/Unit/Handler/GotoDefinitionHandlerTest.php
+++ b/lib/Extension/LanguageServerReferenceFinder/Tests/Unit/Handler/GotoDefinitionHandlerTest.php
@@ -90,7 +90,7 @@ class GotoDefinitionHandlerTest extends TestCase
     private function createTester(array $locations): array
     {
         $builder = LanguageServerTesterBuilder::create();
-        
+
         $tester = $builder->addHandler(new GotoDefinitionHandler(
             $builder->workspace(),
             new TestDefinitionLocator(new TypeLocations($locations)),

--- a/lib/Extension/LanguageServerReferenceFinder/Tests/Unit/LanguageServerReferenceFinderExtensionTest.php
+++ b/lib/Extension/LanguageServerReferenceFinder/Tests/Unit/LanguageServerReferenceFinderExtensionTest.php
@@ -84,7 +84,7 @@ class LanguageServerReferenceFinderExtensionTest extends TestCase
             LanguageServerBridgeExtension::class,
             TestIndexerExtension::class,
         ]);
-        
+
         $builder = $container->get(LanguageServerBuilder::class);
         $this->assertInstanceOf(LanguageServerBuilder::class, $builder);
 

--- a/lib/Extension/LanguageServerRename/Handler/FileRenameHandler.php
+++ b/lib/Extension/LanguageServerRename/Handler/FileRenameHandler.php
@@ -30,7 +30,7 @@ class FileRenameHandler implements Handler, CanRegisterCapabilities
         $this->converter = $converter;
     }
 
-    
+
     public function methods(): array
     {
         return [

--- a/lib/Extension/LanguageServerRename/LanguageServerRenameExtension.php
+++ b/lib/Extension/LanguageServerRename/LanguageServerRenameExtension.php
@@ -20,7 +20,7 @@ class LanguageServerRenameExtension implements Extension
 {
     public const TAG_RENAMER = 'language_server_rename.renamer';
 
-    
+
     public function load(ContainerBuilder $container): void
     {
         $container->register(Renamer::class, function (Container $container) {
@@ -57,7 +57,7 @@ class LanguageServerRenameExtension implements Extension
         });
     }
 
-    
+
     public function configure(Resolver $schema): void
     {
     }

--- a/lib/Extension/LanguageServerRename/Tests/Extension/TestExtension.php
+++ b/lib/Extension/LanguageServerRename/Tests/Extension/TestExtension.php
@@ -32,7 +32,7 @@ class TestExtension implements Extension
         ]);
     }
 
-    
+
     public function configure(Resolver $schema): void
     {
         $schema->setDefaults([

--- a/lib/Extension/LanguageServerRename/Tests/Util/OffsetExtractor.php
+++ b/lib/Extension/LanguageServerRename/Tests/Util/OffsetExtractor.php
@@ -39,7 +39,7 @@ final class OffsetExtractor
             array_keys($this->rangeCloseMarkers),
         );
         $results = preg_split('/('. implode('|', $markers) .')/u', $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
-        
+
         if (!is_array($results)) {
             return $this;
         }
@@ -62,7 +62,7 @@ final class OffsetExtractor
                 $pointResults[$this->points[$result]][] = ByteOffset::fromInt($offset);
                 continue;
             }
-            
+
             if (isset($this->rangeOpenMarkers[$result])) {
                 $currentRangeStartOffset = $offset;
                 continue;
@@ -72,11 +72,11 @@ final class OffsetExtractor
                 $rangeResults[$this->rangeCloseMarkers[$result]][] = ByteOffsetRange::fromInts($currentRangeStartOffset, $offset);
                 continue;
             }
-            
+
             $offset += strlen($result);
             $newSource .= $result;
         }
-        
+
         return new OffsetExtractorResult($newSource, $pointResults, $rangeResults);
         ;
     }

--- a/lib/Extension/LanguageServerRename/Tests/Util/OffsetExtractorTest.php
+++ b/lib/Extension/LanguageServerRename/Tests/Util/OffsetExtractorTest.php
@@ -17,7 +17,7 @@ class OffsetExtractorTest extends TestCase
 
         $selection = $extractor->offset('selection');
         $newSource = $extractor->source();
-        
+
         $this->assertEquals(ByteOffset::fromInt(16), $selection);
         $this->assertEquals('Test string with selector', $newSource);
     }
@@ -30,7 +30,7 @@ class OffsetExtractorTest extends TestCase
 
         $selection = $extractor->offset();
         $newSource = $extractor->source();
-        
+
         $this->assertEquals(ByteOffset::fromInt(16), $selection);
         $this->assertEquals('Test string with selector', $newSource);
     }
@@ -43,7 +43,7 @@ class OffsetExtractorTest extends TestCase
 
         $selection = $extractor->offset('selection');
         $newSource = $extractor->source();
-        
+
         $this->assertEquals(ByteOffset::fromInt(19), $selection);
         $this->assertEquals('Test string 🐱    selector', $newSource);
     }
@@ -98,7 +98,7 @@ class OffsetExtractorTest extends TestCase
         ], $selection);
         $this->assertEquals('Test string with two selectors', $newSource);
     }
-    
+
     public function testRange(): void
     {
         $extractor = OffsetExtractor::create()

--- a/lib/Extension/LanguageServerSelectionRange/Handler/SelectionRangeHandler.php
+++ b/lib/Extension/LanguageServerSelectionRange/Handler/SelectionRangeHandler.php
@@ -27,7 +27,7 @@ class SelectionRangeHandler implements Handler, CanRegisterCapabilities
         $this->provider = $provider;
     }
 
-    
+
     public function methods(): array
     {
         return [

--- a/lib/Extension/LanguageServerSelectionRange/LanguageServerSelectionRangeExtension.php
+++ b/lib/Extension/LanguageServerSelectionRange/LanguageServerSelectionRangeExtension.php
@@ -28,7 +28,7 @@ class LanguageServerSelectionRangeExtension implements Extension
         });
     }
 
-    
+
     public function configure(Resolver $schema): void
     {
     }

--- a/lib/Extension/LanguageServerSymbolProvider/Handler/DocumentSymbolProviderHandler.php
+++ b/lib/Extension/LanguageServerSymbolProvider/Handler/DocumentSymbolProviderHandler.php
@@ -24,7 +24,7 @@ class DocumentSymbolProviderHandler implements Handler, CanRegisterCapabilities
         $this->provider = $provider;
     }
 
-    
+
     public function methods(): array
     {
         return [

--- a/lib/Extension/LanguageServerSymbolProvider/LanguageServerSymbolProviderExtension.php
+++ b/lib/Extension/LanguageServerSymbolProvider/LanguageServerSymbolProviderExtension.php
@@ -29,7 +29,7 @@ class LanguageServerSymbolProviderExtension implements Extension
         });
     }
 
-    
+
     public function configure(Resolver $schema): void
     {
     }

--- a/lib/Extension/LanguageServerWorseReflection/LanguageServerWorseReflectionExtension.php
+++ b/lib/Extension/LanguageServerWorseReflection/LanguageServerWorseReflectionExtension.php
@@ -18,7 +18,7 @@ class LanguageServerWorseReflectionExtension implements Extension
 {
     const PARAM_UPDATE_INTERVAL = 'language_server_worse_reflection.workspace_index.update_interval';
 
-    
+
     public function load(ContainerBuilder $container): void
     {
         $this->registerSourceLocator($container);

--- a/lib/Extension/LanguageServerWorseReflection/SourceLocator/WorkspaceSourceLocator.php
+++ b/lib/Extension/LanguageServerWorseReflection/SourceLocator/WorkspaceSourceLocator.php
@@ -17,7 +17,7 @@ class WorkspaceSourceLocator implements SourceCodeLocator
         $this->index = $index;
     }
 
-    
+
     public function locate(Name $name): SourceCode
     {
         if (null === $document = $this->index->documentForName($name)) {

--- a/lib/Extension/Logger/Formatter/PrettyFormatter.php
+++ b/lib/Extension/Logger/Formatter/PrettyFormatter.php
@@ -20,7 +20,7 @@ class PrettyFormatter implements FormatterInterface
         return $message."\n";
     }
 
-    
+
     public function formatBatch(array $records): void
     {
     }

--- a/lib/Extension/Logger/LoggerFactory.php
+++ b/lib/Extension/Logger/LoggerFactory.php
@@ -13,7 +13,7 @@ class LoggerFactory
     {
         $this->mainLogger = $mainLogger;
     }
-         
+
     public function get(string $name): LoggerInterface
     {
         return new ChannelLogger($name, $this->mainLogger);

--- a/lib/Extension/Logger/Tests/Unit/LoggingExtensionTest.php
+++ b/lib/Extension/Logger/Tests/Unit/LoggingExtensionTest.php
@@ -107,7 +107,7 @@ class ExampleExtension implements Extension
         }, [ LoggingExtension::TAG_FORMATTER => ['alias'=> 'json2']]);
     }
 
-    
+
     public function configure(Resolver $schema): void
     {
     }

--- a/lib/Extension/Navigation/NavigationExtension.php
+++ b/lib/Extension/Navigation/NavigationExtension.php
@@ -20,7 +20,7 @@ class NavigationExtension implements Extension
     const NAVIGATOR_AUTOCREATE = 'navigator.autocreate';
     const SERVICE_PATH_FINDER = 'navigation.path_finder';
 
-    
+
     public function load(ContainerBuilder $container): void
     {
         $this->registerPathFinder($container);
@@ -28,7 +28,7 @@ class NavigationExtension implements Extension
         $this->registerRpc($container);
     }
 
-    
+
     public function configure(Resolver $schema): void
     {
         $schema->setDefaults([
@@ -42,7 +42,7 @@ class NavigationExtension implements Extension
         $container->register(self::SERVICE_PATH_FINDER, function (Container $container) {
             return PathFinder::fromDestinations($container->getParameter(self::PATH_FINDER_DESTINATIONS));
         });
-        
+
         $container->register('application.navigator', function (Container $container) {
             return new Navigator(
                 $container->get('navigation.navigator.chain'),
@@ -68,13 +68,13 @@ class NavigationExtension implements Extension
             foreach ($container->getServiceIdsForTag('navigation.navigator') as $serviceId => $attrs) {
                 $navigators[] = $container->get($serviceId);
             }
-        
+
             return new ChainNavigator($navigators);
         });
         $container->register('navigation.navigator.path_finder', function (Container $container) {
             return new PathFinderNavigator($container->get(self::SERVICE_PATH_FINDER));
         }, [ 'navigation.navigator' => [] ]);
-        
+
         $container->register('navigation.navigator.worse_reflection', function (Container $container) {
             return new WorseReflectionNavigator($container->get(WorseReflectionExtension::SERVICE_REFLECTOR));
         }, [ 'navigation.navigator' => [] ]);

--- a/lib/Extension/ObjectRenderer/ObjectRendererBuilder.php
+++ b/lib/Extension/ObjectRenderer/ObjectRendererBuilder.php
@@ -27,20 +27,20 @@ final class ObjectRendererBuilder
      * @var array<string>
      */
     private array $templatePaths = [];
-    
+
     private string $suffix = '.twig';
-    
+
     private bool $renderEmptyOnNotFound = false;
-    
+
     private LoggerInterface $logger;
 
     /**
      * @var bool|string|callable
      */
     private $escaping = false;
-    
+
     private bool $enableAncestoralCandidates = false;
-    
+
     private bool $enableInterfaceCandidates = false;
 
     /**

--- a/lib/Extension/ObjectRenderer/ObjectRendererExtension.php
+++ b/lib/Extension/ObjectRenderer/ObjectRendererExtension.php
@@ -17,7 +17,7 @@ class ObjectRendererExtension implements Extension
 {
     public const PARAM_TEMPLATE_PATHS = 'object_renderer.template_paths.markdown';
     public const SERVICE_MARKDOWN_RENDERER = 'object_renderer.renderer.markdown';
-    
+
     public function configure(Resolver $schema): void
     {
         $schema->setDefaults([

--- a/lib/Extension/Php/Model/ChainResolver.php
+++ b/lib/Extension/Php/Model/ChainResolver.php
@@ -16,7 +16,7 @@ class ChainResolver implements PhpVersionResolver
         $this->versionResolvers = $versionResolvers;
     }
 
-    
+
     public function resolve(): ?string
     {
         foreach ($this->versionResolvers as $versionResolver) {

--- a/lib/Extension/Php/Model/ComposerPhpVersionResolver.php
+++ b/lib/Extension/Php/Model/ComposerPhpVersionResolver.php
@@ -11,7 +11,7 @@ class ComposerPhpVersionResolver implements PhpVersionResolver
         $this->composerJsonPath = $composerJsonPath;
     }
 
-    
+
     public function resolve(): ?string
     {
         if (!file_exists($this->composerJsonPath)) {

--- a/lib/Extension/Php/Model/ConstantPhpVersionResolver.php
+++ b/lib/Extension/Php/Model/ConstantPhpVersionResolver.php
@@ -11,7 +11,7 @@ class ConstantPhpVersionResolver implements PhpVersionResolver
         $this->version = $version;
     }
 
-    
+
     public function resolve(): ?string
     {
         return $this->version;

--- a/lib/Extension/Php/PhpExtension.php
+++ b/lib/Extension/Php/PhpExtension.php
@@ -17,7 +17,7 @@ class PhpExtension implements Extension
 {
     const PARAM_VERSION = 'php.version';
 
-    
+
     public function load(ContainerBuilder $container): void
     {
         $container->register(PhpVersionResolver::class, function (Container $container) {
@@ -32,7 +32,7 @@ class PhpExtension implements Extension
         });
     }
 
-    
+
     public function configure(Resolver $schema): void
     {
         $schema->setDefaults([

--- a/lib/Extension/ReferenceFinder/ReferenceFinderExtension.php
+++ b/lib/Extension/ReferenceFinder/ReferenceFinderExtension.php
@@ -26,7 +26,7 @@ class ReferenceFinderExtension implements Extension
     const TAG_REFERENCE_FINDER = 'reference_finder.reference_finder';
     const TAG_NAME_SEARCHER = 'reference_finder.name_searcher';
 
-    
+
     public function load(ContainerBuilder $container): void
     {
         $container->register(self::SERVICE_DEFINITION_LOCATOR, function (Container $container) {
@@ -78,7 +78,7 @@ class ReferenceFinderExtension implements Extension
         });
     }
 
-    
+
     public function configure(Resolver $schema): void
     {
     }

--- a/lib/Extension/ReferenceFinder/Tests/Example/SomeDefinitionLocator.php
+++ b/lib/Extension/ReferenceFinder/Tests/Example/SomeDefinitionLocator.php
@@ -16,7 +16,7 @@ class SomeDefinitionLocator implements DefinitionLocator
     const EXAMPLE_PATH = '/path/to.php';
     const EXAMPLE_OFFSET = 666;
 
-    
+
     public function locateDefinition(TextDocument $document, ByteOffset $byteOffset): TypeLocations
     {
         return new TypeLocations([

--- a/lib/Extension/ReferenceFinder/Tests/Example/SomeExtension.php
+++ b/lib/Extension/ReferenceFinder/Tests/Example/SomeExtension.php
@@ -24,7 +24,7 @@ class SomeExtension implements Extension
         }, [ ReferenceFinderExtension::TAG_IMPLEMENTATION_FINDER=> []]);
     }
 
-    
+
     public function configure(Resolver $schema): void
     {
     }

--- a/lib/Extension/ReferenceFinder/Tests/Example/SomeTypeLocator.php
+++ b/lib/Extension/ReferenceFinder/Tests/Example/SomeTypeLocator.php
@@ -16,7 +16,7 @@ class SomeTypeLocator implements TypeLocator
     const EXAMPLE_OFFSET = 1;
     const EXAMPLE_PATH = '/foobar';
 
-    
+
     public function locateTypes(TextDocument $document, ByteOffset $byteOffset): TypeLocations
     {
         return new TypeLocations([new TypeLocation(new MixedType(), new Location(

--- a/lib/Extension/ReferenceFinderRpc/Handler/GotoImplementationHandler.php
+++ b/lib/Extension/ReferenceFinderRpc/Handler/GotoImplementationHandler.php
@@ -83,7 +83,7 @@ class GotoImplementationHandler extends AbstractHandler
             $contents = $this->fileContents($location);
             $lineCol = (new LineColFromOffset())($contents, $location->offset()->toInt());
             $line = (new LineAtOffset())->__invoke($contents, $location->offset()->toInt());
-        
+
             $fileReferences = FileReferences::fromPathAndReferences(
                 $location->uri()->path(),
                 [

--- a/lib/Extension/ReferenceFinderRpc/ReferenceFinderRpcExtension.php
+++ b/lib/Extension/ReferenceFinderRpc/ReferenceFinderRpcExtension.php
@@ -29,7 +29,7 @@ class ReferenceFinderRpcExtension implements Extension
         }, [ RpcExtension::TAG_RPC_HANDLER => [ 'name' => 'goto_implementation' ]]);
     }
 
-    
+
     public function configure(Resolver $schema): void
     {
     }

--- a/lib/Extension/Rpc/RequestHandler/RequestHandler.php
+++ b/lib/Extension/Rpc/RequestHandler/RequestHandler.php
@@ -16,7 +16,7 @@ class RequestHandler implements CoreRequestHandler
     {
         $this->registry = $registry;
     }
-    
+
     public function handle(Request $request): Response
     {
         $counterActions = [];

--- a/lib/Extension/Rpc/Tests/Unit/RequestHandler/LoggingHandlerTest.php
+++ b/lib/Extension/Rpc/Tests/Unit/RequestHandler/LoggingHandlerTest.php
@@ -16,24 +16,24 @@ use Prophecy\PhpUnit\ProphecyTrait;
 class LoggingHandlerTest extends TestCase
 {
     use ProphecyTrait;
-    
+
     /**
      * @var ObjectProphecy<RequestHandler>
      */
     private ObjectProphecy $innerHandler;
 
     private LoggingHandler $loggingHandler;
-    
+
     /**
      * @var ObjectProphecy<Response>
      */
     private ObjectProphecy $response;
-    
+
     /**
      * @var ObjectProphecy<Request>
      */
     private ObjectProphecy $request;
-    
+
     /**
      * @var ObjectProphecy<LoggerInterface>
      */

--- a/lib/Extension/SourceCodeFilesystem/SourceCodeFilesystemExtension.php
+++ b/lib/Extension/SourceCodeFilesystem/SourceCodeFilesystemExtension.php
@@ -29,7 +29,7 @@ class SourceCodeFilesystemExtension implements Extension
     const SERVICE_FILESYSTEM_COMPOSER = 'source_code_filesystem.composer';
     const PARAM_PROJECT_ROOT = 'source_code_filesystem.project_root';
 
-    
+
     public function configure(Resolver $schema): void
     {
         $schema->setDefaults([
@@ -57,7 +57,7 @@ class SourceCodeFilesystemExtension implements Extension
                     ));
                 }
             }
-        
+
             return new FallbackFilesystemRegistry(
                 new MappedFilesystemRegistry($filesystems),
                 'simple'
@@ -66,24 +66,24 @@ class SourceCodeFilesystemExtension implements Extension
         $container->register(self::SERVICE_FILESYSTEM_GIT, function (Container $container) {
             return new GitFilesystem(FilePath::fromString($this->projectRoot($container)));
         }, [ 'source_code_filesystem.filesystem' => [ 'name' => self::FILESYSTEM_GIT ]]);
-        
+
         $container->register(self::SERVICE_FILESYSTEM_SIMPLE, function (Container $container) {
             return new SimpleFilesystem(FilePath::fromString($this->projectRoot($container)));
         }, [ 'source_code_filesystem.filesystem' => ['name' => self::FILESYSTEM_SIMPLE]]);
-        
+
         $container->register(self::SERVICE_FILESYSTEM_COMPOSER, function (Container $container) {
             $providers = [];
             $cwd = FilePath::fromString($this->projectRoot($container));
             $classLoaders = $container->get(ComposerAutoloaderExtension::SERVICE_AUTOLOADERS);
-        
+
             if (!$classLoaders) {
                 throw new NotSupported('No composer class loaders found/configured');
             }
-        
+
             foreach ($classLoaders as $classLoader) {
                 $providers[] = new ComposerFileListProvider($cwd, $classLoader);
             }
-        
+
             return new SimpleFilesystem($cwd, new ChainFileListProvider($providers));
         }, [ 'source_code_filesystem.filesystem' => [ 'name' => self::FILESYSTEM_COMPOSER ]]);
     }

--- a/lib/Extension/WorseReferenceFinder/WorseReferenceFinderExtension.php
+++ b/lib/Extension/WorseReferenceFinder/WorseReferenceFinderExtension.php
@@ -19,7 +19,7 @@ class WorseReferenceFinderExtension implements Extension
 {
     const PARAM_BREAK_CHARS = 'worse_reference_finder.plain_text_break_chars';
 
-    
+
     public function load(ContainerBuilder $container): void
     {
         $container->register('worse_reference_finder.definition_locator.reflection', function (Container $container) {
@@ -57,7 +57,7 @@ class WorseReferenceFinderExtension implements Extension
         }, [ ReferenceFinderExtension::TAG_REFERENCE_FINDER => []]);
     }
 
-    
+
     public function configure(Resolver $schema): void
     {
         $schema->setDefaults([

--- a/lib/Extension/WorseReflection/Tests/Unit/TestExtension.php
+++ b/lib/Extension/WorseReflection/Tests/Unit/TestExtension.php
@@ -25,7 +25,7 @@ class TestExtension implements Extension
         }, [ WorseReflectionExtension::TAG_FRAME_WALKER => []]);
     }
 
-    
+
     public function configure(Resolver $schema): void
     {
     }

--- a/lib/Extension/WorseReflection/WorseReflectionExtension.php
+++ b/lib/Extension/WorseReflection/WorseReflectionExtension.php
@@ -41,7 +41,7 @@ class WorseReflectionExtension implements Extension
     const TAG_DIAGNOSTIC_PROVIDER = 'worse_reflection.diagnostics_provider';
     const PARAM_IMPORT_GLOBALS = 'language_server_code_transform.import_globals';
     const PARAM_MIXIN_ENABLE = 'worse_reflection.mixins';
-    
+
     public function configure(Resolver $schema): void
     {
         $schema->setDefaults([
@@ -92,7 +92,7 @@ class WorseReflectionExtension implements Extension
                 $builder->enableCache();
                 $builder->withCache($container->get(Cache::class));
             }
-        
+
             foreach ($container->getServiceIdsForTag(self::TAG_SOURCE_LOCATOR) as $serviceId => $attrs) {
                 $builder->addLocator($container->get($serviceId), $attrs['priority'] ?? 0);
             }
@@ -111,11 +111,11 @@ class WorseReflectionExtension implements Extension
             foreach (array_keys($container->getServiceIdsForTag(self::TAG_DIAGNOSTIC_PROVIDER)) as $serviceId) {
                 $builder->addDiagnosticProvider($container->get($serviceId));
             }
-        
+
             $builder->withLogger(
                 LoggingExtension::channelLogger($container, 'wr')
             );
-        
+
             return $builder->build();
         });
 

--- a/lib/FilePathResolver/Expanders.php
+++ b/lib/FilePathResolver/Expanders.php
@@ -40,7 +40,7 @@ class Expanders implements IteratorAggregate
         return $this->expanders[$tokenName];
     }
 
-    
+
     public function getIterator(): Traversable
     {
         return new ArrayIterator($this->expanders);

--- a/lib/FilePathResolver/Tests/Unit/CachingPathResolverTest.php
+++ b/lib/FilePathResolver/Tests/Unit/CachingPathResolverTest.php
@@ -11,7 +11,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 class CachingPathResolverTest extends TestCase
 {
     use ProphecyTrait;
-    
+
     /**
      * @var ObjectProphecy<PathResolver>
      */

--- a/lib/FilePathResolver/Tests/Unit/Expander/CallbackExpanderTest.php
+++ b/lib/FilePathResolver/Tests/Unit/Expander/CallbackExpanderTest.php
@@ -14,7 +14,7 @@ class CallbackExpanderTest extends ExpanderTestCase
             return 'bar';
         });
     }
-    
+
     public function testExpandsCallbackValue(): void
     {
         $this->assertEquals('bar', $this->expand('%foo%'));

--- a/lib/FilePathResolver/Tests/Unit/Expander/Xdg/SuffixExpanderDecoratorTest.php
+++ b/lib/FilePathResolver/Tests/Unit/Expander/Xdg/SuffixExpanderDecoratorTest.php
@@ -11,7 +11,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 class SuffixExpanderDecoratorTest extends ExpanderTestCase
 {
     use ProphecyTrait;
-    
+
     /**
      * @var ObjectProphecy<Expander>
      */

--- a/lib/FilePathResolver/Tests/Unit/Expander/Xdg/XdgExpanderTest.php
+++ b/lib/FilePathResolver/Tests/Unit/Expander/Xdg/XdgExpanderTest.php
@@ -17,7 +17,7 @@ class XdgExpanderTest extends TestCase
     use ProphecyTrait;
 
     private TokenExpandingFilter $expander;
-    
+
     /**
      * @var ObjectProphecy<Xdg>
      */

--- a/lib/Filesystem/Tests/Adapter/workspace/vendor/composer/autoload_static.php
+++ b/lib/Filesystem/Tests/Adapter/workspace/vendor/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInit0fa171f0aafce99fa34ab3187961e5d7
 {
     public static $prefixLengthsPsr4 = array (
-        'A' => 
+        'A' =>
         array (
             'Acme\\' => 5,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'Acme\\' => 
+        'Acme\\' =>
         array (
             0 => __DIR__ . '/../..' . '/src',
         ),

--- a/lib/Filesystem/Tests/Unit/Domain/MappedFilesystemRegistryTest.php
+++ b/lib/Filesystem/Tests/Unit/Domain/MappedFilesystemRegistryTest.php
@@ -12,7 +12,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 class MappedFilesystemRegistryTest extends TestCase
 {
     use ProphecyTrait;
-    
+
     /**
      * @var ObjectProphecy<Filesystem>
      */

--- a/lib/Indexer/Adapter/Php/FileSearchIndex.php
+++ b/lib/Indexer/Adapter/Php/FileSearchIndex.php
@@ -38,7 +38,7 @@ class FileSearchIndex implements SearchIndex
         $this->path = $path;
     }
 
-    
+
     public function search(Criteria $criteria): Generator
     {
         $this->open();

--- a/lib/Indexer/Adapter/Php/Serialized/FileRepository.php
+++ b/lib/Indexer/Adapter/Php/Serialized/FileRepository.php
@@ -64,14 +64,14 @@ class FileRepository
             /** @phpstan-ignore-next-line */
             return $this->buffer[$bufferKey];
         }
-        
+
         $path = $this->pathFor($record);
 
         if (!file_exists($path)) {
             $this->remove($record);
             return null;
         }
-        
+
         try {
             $deserialized = $this->serializer->deserialize(file_get_contents($path));
         } catch (Throwable $corrupted) {

--- a/lib/Indexer/Adapter/Tolerant/Indexer/AbstractClassLikeIndexer.php
+++ b/lib/Indexer/Adapter/Tolerant/Indexer/AbstractClassLikeIndexer.php
@@ -24,11 +24,11 @@ abstract class AbstractClassLikeIndexer implements TolerantIndexer
     {
         foreach ($record->implements() as $implementedClass) {
             $implementedRecord = $index->get(ClassRecord::fromName($implementedClass));
-        
+
             if (false === $implementedRecord->removeImplementation($record->fqn())) {
                 continue;
             }
-        
+
             $index->write($implementedRecord);
         }
     }
@@ -45,10 +45,10 @@ abstract class AbstractClassLikeIndexer implements TolerantIndexer
             $record->addImplements(
                 FullyQualifiedName::fromString($interfaceName)
             );
-        
+
             assert($interfaceRecord instanceof ClassRecord);
             $interfaceRecord->addImplementation($record->fqn());
-        
+
             $index->write($interfaceRecord);
         }
     }

--- a/lib/Indexer/Adapter/Tolerant/Indexer/ClassLikeReferenceIndexer.php
+++ b/lib/Indexer/Adapter/Tolerant/Indexer/ClassLikeReferenceIndexer.php
@@ -50,7 +50,7 @@ class ClassLikeReferenceIndexer extends AbstractClassLikeIndexer
     public function index(Index $index, TextDocument $document, Node $node): void
     {
         assert($node instanceof QualifiedName);
-        
+
         $name =
             $node->parent->parent instanceof TraitUseClause ?
                 TolerantQualifiedNameResolver::getResolvedName($node) :

--- a/lib/Indexer/Adapter/Tolerant/Indexer/MemberIndexer.php
+++ b/lib/Indexer/Adapter/Tolerant/Indexer/MemberIndexer.php
@@ -152,7 +152,7 @@ class MemberIndexer implements TolerantIndexer
         assert($record instanceof MemberRecord);
         $record->addReference($document->uri()->path());
         $index->write($record);
-        
+
         $fileRecord = $index->get(FileRecord::fromPath($document->uri()->path()));
         assert($fileRecord instanceof FileRecord);
         $fileRecord->addReference(RecordReference::fromRecordAndOffsetAndContainerType($record, $offsetStart, $containerFqn));

--- a/lib/Indexer/Adapter/Worse/IndexerClassSourceLocator.php
+++ b/lib/Indexer/Adapter/Worse/IndexerClassSourceLocator.php
@@ -18,7 +18,7 @@ class IndexerClassSourceLocator implements SourceCodeLocator
         $this->index = $index;
     }
 
-    
+
     public function locate(Name $name): SourceCode
     {
         if (empty($name->__toString())) {

--- a/lib/Indexer/Adapter/Worse/IndexerFunctionSourceLocator.php
+++ b/lib/Indexer/Adapter/Worse/IndexerFunctionSourceLocator.php
@@ -18,7 +18,7 @@ class IndexerFunctionSourceLocator implements SourceCodeLocator
         $this->index = $index;
     }
 
-    
+
     public function locate(Name $name): SourceCode
     {
         if (empty($name->__toString())) {

--- a/lib/Indexer/Model/Index/SearchAwareIndex.php
+++ b/lib/Indexer/Model/Index/SearchAwareIndex.php
@@ -51,7 +51,7 @@ class SearchAwareIndex implements Index
         $this->search->flush();
     }
 
-    
+
     public function get(Record $record): Record
     {
         return $this->innerIndex->get($record);

--- a/lib/Indexer/Model/Record/ClassRecord.php
+++ b/lib/Indexer/Model/Record/ClassRecord.php
@@ -98,7 +98,7 @@ final class ClassRecord implements Record, HasFileReferences, HasPath, HasFullyQ
         return $this;
     }
 
-    
+
     public function recordType(): string
     {
         return self::RECORD_TYPE;

--- a/lib/Indexer/Model/Record/ConstantRecord.php
+++ b/lib/Indexer/Model/Record/ConstantRecord.php
@@ -15,7 +15,7 @@ final class ConstantRecord implements HasPath, Record, HasFullyQualifiedName
         return new self($name);
     }
 
-    
+
     public function recordType(): string
     {
         return self::RECORD_TYPE;

--- a/lib/Indexer/Model/Record/FileRecord.php
+++ b/lib/Indexer/Model/Record/FileRecord.php
@@ -32,7 +32,7 @@ class FileRecord implements HasPath, Record
         }
     }
 
-    
+
     public function recordType(): string
     {
         return self::RECORD_TYPE;

--- a/lib/Indexer/Model/Record/FunctionRecord.php
+++ b/lib/Indexer/Model/Record/FunctionRecord.php
@@ -16,7 +16,7 @@ final class FunctionRecord implements HasFileReferences, HasPath, Record, HasFul
         return new self($name);
     }
 
-    
+
     public function recordType(): string
     {
         return self::RECORD_TYPE;

--- a/lib/Indexer/Model/Record/MemberRecord.php
+++ b/lib/Indexer/Model/Record/MemberRecord.php
@@ -49,7 +49,7 @@ class MemberRecord implements HasFileReferences, Record, HasShortName
     {
         return new self($memberReference->type(), $memberReference->memberName(), $memberReference->containerType());
     }
-    
+
     public function recordType(): string
     {
         return self::RECORD_TYPE;

--- a/lib/Indexer/Model/SearchClient/HydratingSearchClient.php
+++ b/lib/Indexer/Model/SearchClient/HydratingSearchClient.php
@@ -19,7 +19,7 @@ class HydratingSearchClient implements SearchClient
         $this->index = $index;
     }
 
-    
+
     public function search(Criteria $criteria): Generator
     {
         foreach ($this->innerClient->search($criteria) as $record) {

--- a/lib/Indexer/Model/SearchIndex/FilteredSearchIndex.php
+++ b/lib/Indexer/Model/SearchIndex/FilteredSearchIndex.php
@@ -25,7 +25,7 @@ class FilteredSearchIndex implements SearchIndex
         $this->recordTypes = $recordTypes;
     }
 
-    
+
     public function search(Criteria $criteria): Generator
     {
         return $this->innerIndex->search($criteria);

--- a/lib/Indexer/Model/SearchIndex/ValidatingSearchIndex.php
+++ b/lib/Indexer/Model/SearchIndex/ValidatingSearchIndex.php
@@ -25,7 +25,7 @@ class ValidatingSearchIndex implements SearchIndex
         $this->logger = $logger;
     }
 
-    
+
     public function search(Criteria $criteria): Generator
     {
         foreach ($this->innerIndex->search($criteria) as $result) {

--- a/lib/Indexer/Tests/Adapter/IndexBuilderTestCase.php
+++ b/lib/Indexer/Tests/Adapter/IndexBuilderTestCase.php
@@ -77,7 +77,7 @@ abstract class IndexBuilderTestCase extends IntegrationTestCase
         yield 'interface referenced by alias from another namespace' => [
             <<<'EOT'
                 // File: project/test.php
-                <?php namespace Foobar; interface Barfoo {} 
+                <?php namespace Foobar; interface Barfoo {}
                 // File: project/test2.php
                 <?php namespace Barfoo;
                 use Foobar\Barfoo as BarBar;
@@ -381,7 +381,7 @@ abstract class IndexBuilderTestCase extends IntegrationTestCase
         yield 'namespaced function' => [
             <<<'EOT'
                 // File: project/test1.php
-                <?php 
+                <?php
                 namespace Barfoos;
                 foobar();
 
@@ -400,7 +400,7 @@ abstract class IndexBuilderTestCase extends IntegrationTestCase
         yield 'declaration is indexed' => [
             <<<'EOT'
                 // File: project/test1.php
-                <?php 
+                <?php
                 namespace Barfoos;
 
                 function foobar() {};

--- a/lib/Indexer/Tests/Adapter/ReferenceFinder/IndexedReferenceFinderTest.php
+++ b/lib/Indexer/Tests/Adapter/ReferenceFinder/IndexedReferenceFinderTest.php
@@ -102,7 +102,7 @@ class IndexedReferenceFinderTest extends IntegrationTestCase
             2
         ];
     }
-    
+
     /**
      * @return Generator<mixed>
      */

--- a/lib/Name/Names.php
+++ b/lib/Name/Names.php
@@ -20,7 +20,7 @@ class Names implements Countable, IteratorAggregate
         return new self(...$array);
     }
 
-    
+
     public function count(): int
     {
         return count($this->names);

--- a/lib/ReferenceFinder/DefinitionAndReferenceFinder.php
+++ b/lib/ReferenceFinder/DefinitionAndReferenceFinder.php
@@ -19,7 +19,7 @@ class DefinitionAndReferenceFinder implements ReferenceFinder
         $this->referenceFinder = $referenceFinder;
     }
 
-    
+
     public function findReferences(TextDocument $document, ByteOffset $byteOffset): Generator
     {
         try {

--- a/lib/ReferenceFinder/TestDefinitionLocator.php
+++ b/lib/ReferenceFinder/TestDefinitionLocator.php
@@ -24,7 +24,7 @@ class TestDefinitionLocator implements DefinitionLocator
         }
         return new self(new TypeLocations([ new TypeLocation($type, $location)]));
     }
-    
+
     public function locateDefinition(TextDocument $document, ByteOffset $byteOffset): TypeLocations
     {
         if (null === $this->location) {

--- a/lib/ReferenceFinder/TestReferenceFinder.php
+++ b/lib/ReferenceFinder/TestReferenceFinder.php
@@ -18,7 +18,7 @@ class TestReferenceFinder implements ReferenceFinder
         $this->locations = $locations;
     }
 
-    
+
     public function findReferences(TextDocument $document, ByteOffset $byteOffset): Generator
     {
         foreach ($this->locations as $location) {

--- a/lib/Rename/Adapter/ClassToFile/ClassToFileNameToUriConverter.php
+++ b/lib/Rename/Adapter/ClassToFile/ClassToFileNameToUriConverter.php
@@ -19,7 +19,7 @@ class ClassToFileNameToUriConverter implements NameToUriConverter
         $this->classToFile = $classToFile;
     }
 
-    
+
     public function convert(string $className): TextDocumentUri
     {
         try {

--- a/lib/Rename/Adapter/ReferenceFinder/AbstractReferenceRenamer.php
+++ b/lib/Rename/Adapter/ReferenceFinder/AbstractReferenceRenamer.php
@@ -86,9 +86,9 @@ abstract class AbstractReferenceRenamer implements Renamer
     protected function renameEdit(Location $location, ?ByteOffsetRange $range, string $originalName, string $newName): LocatedTextEdit
     {
         $referenceDocument = $this->locator->get($location->uri());
-        
+
         $range = $this->getRenameRange($referenceDocument, $location->offset());
-        
+
         if (null === $range) {
             throw new CouldNotRename(sprintf(
                 'Could not find corresponding reference to member name "%s" in document "%s" at offset %s',
@@ -97,7 +97,7 @@ abstract class AbstractReferenceRenamer implements Renamer
                 $location->offset()->toInt()
             ));
         }
-        
+
         $foundName = $this->rangeText($referenceDocument, $range);
         if ($foundName !== $originalName) {
             throw new CouldNotRename(sprintf(
@@ -107,7 +107,7 @@ abstract class AbstractReferenceRenamer implements Renamer
                 $originalName
             ));
         }
-        
+
         return new LocatedTextEdit(
             $location->uri(),
             PhpactorTextEdit::create(

--- a/lib/Rename/Adapter/WorseReflection/WorseNameToUriConverter.php
+++ b/lib/Rename/Adapter/WorseReflection/WorseNameToUriConverter.php
@@ -18,7 +18,7 @@ class WorseNameToUriConverter implements NameToUriConverter
         $this->reflector = $reflector;
     }
 
-    
+
     public function convert(string $className): TextDocumentUri
     {
         try {

--- a/lib/Rename/Model/FileRenamer/LoggingFileRenamer.php
+++ b/lib/Rename/Model/FileRenamer/LoggingFileRenamer.php
@@ -20,7 +20,7 @@ class LoggingFileRenamer implements FileRenamer
         $this->innerRenamer = $innerRenamer;
     }
 
-    
+
     public function renameFile(TextDocumentUri $from, TextDocumentUri $to): Promise
     {
         return call(function () use ($from, $to) {

--- a/lib/Rename/Model/Renamer/InMemoryRenamer.php
+++ b/lib/Rename/Model/Renamer/InMemoryRenamer.php
@@ -31,7 +31,7 @@ class InMemoryRenamer implements Renamer
     {
         return $this->range;
     }
-    
+
     public function rename(TextDocument $textDocument, ByteOffset $offset, string $newName): Generator
     {
         yield from $this->results;

--- a/lib/Rename/Tests/Adapter/ReferenceFinder/MemberRenamerTest.php
+++ b/lib/Rename/Tests/Adapter/ReferenceFinder/MemberRenamerTest.php
@@ -34,17 +34,17 @@ class MemberRenamerTest extends TestCase
             ->registerOffset('selection', '<>')
             ->registerRange('expectedRange', '{{', '}}')
             ->parse($source);
-        
+
         $selection = $extractor->offset('selection');
         $expectedRanges = $extractor->ranges('expectedRange');
         $newSource = $extractor->source();
-        
+
         $expectedRange = count($expectedRanges) > 0 ? $expectedRanges[0] : null;
 
         $document = TextDocumentBuilder::create($newSource)
             ->uri('file:///test/testDoc')
             ->build();
-        
+
         $variableRenamer = new MemberRenamer(
             new PredefinedReferenceFinder(...[]),
             InMemoryDocumentLocator::fromTextDocuments([]),
@@ -105,13 +105,13 @@ class MemberRenamerTest extends TestCase
         $implementations = $extractor->offsets('implementations');
         $resultEditRanges = $extractor->ranges('resultEditRanges');
         $newSource = $extractor->source();
-        
+
         $newName = 'newName';
 
         $textDocument = TextDocumentBuilder::create($newSource)
             ->uri(self::EXAMPLE_DOCUMENT_URI)
             ->build();
-        
+
         $renamer = new MemberRenamer(
             new PredefinedReferenceFinder(...array_map(function (ByteOffset $reference) use ($textDocument) {
                 return PotentialLocation::surely(new Location($textDocument->uri(), $reference));

--- a/lib/Rename/Tests/Adapter/ReferenceFinder/VariableRenamerTest.php
+++ b/lib/Rename/Tests/Adapter/ReferenceFinder/VariableRenamerTest.php
@@ -39,13 +39,13 @@ class VariableRenamerTest extends TestCase
         [ $selection ] = $extractor->offsets('selection');
         $expectedRanges = $extractor->ranges('expectedRange');
         $newSource = $extractor->source();
-        
+
         $expectedRange = count($expectedRanges) > 0 ? $expectedRanges[0] : null;
 
         $document = TextDocumentBuilder::create($newSource)
             ->uri('file:///test/testDoc')
             ->build();
-        
+
         $variableRenamer = $this->createRenamer([], null, []);
         $actualRange = $variableRenamer->getRenameRange($document, $selection);
         $this->assertEquals($expectedRange, $actualRange);

--- a/lib/TextDocument/ByteOffsetRange.php
+++ b/lib/TextDocument/ByteOffsetRange.php
@@ -5,7 +5,7 @@ namespace Phpactor\TextDocument;
 class ByteOffsetRange
 {
     private ByteOffset $start;
-    
+
     private ByteOffset $end;
 
     public function __construct(ByteOffset $start, ByteOffset $end)

--- a/lib/TextDocument/LineCol.php
+++ b/lib/TextDocument/LineCol.php
@@ -15,9 +15,9 @@ use RuntimeException;
 final class LineCol
 {
     private const NEWLINE_PATTERN = '\\r\\n|\\n|\\r';
-    
+
     private int $line;
-    
+
     private int $col;
 
     public function __construct(int $line, int $col)

--- a/lib/TextDocument/LineColRange.php
+++ b/lib/TextDocument/LineColRange.php
@@ -5,7 +5,7 @@ namespace Phpactor\TextDocument;
 final class LineColRange
 {
     private LineCol $start;
-    
+
     private LineCol $end;
 
     public function __construct(LineCol $start, LineCol $end)

--- a/lib/TextDocument/Location.php
+++ b/lib/TextDocument/Location.php
@@ -5,7 +5,7 @@ namespace Phpactor\TextDocument;
 class Location
 {
     private TextDocumentUri $uri;
-    
+
     private ByteOffset $offset;
 
     public function __construct(TextDocumentUri $uri, ByteOffset $offset)

--- a/lib/TextDocument/StandardTextDocument.php
+++ b/lib/TextDocument/StandardTextDocument.php
@@ -5,9 +5,9 @@ namespace Phpactor\TextDocument;
 class StandardTextDocument implements TextDocument
 {
     private string $text;
-    
+
     private ?TextDocumentUri $uri;
-    
+
     private TextDocumentLanguage $language;
 
     public function __construct(
@@ -19,19 +19,19 @@ class StandardTextDocument implements TextDocument
         $this->uri = $uri;
         $this->language = $language;
     }
-    
+
     public function __toString()
     {
         return $this->text;
     }
 
-    
+
     public function uri(): ?TextDocumentUri
     {
         return $this->uri;
     }
 
-    
+
     public function language(): TextDocumentLanguage
     {
         return $this->language;

--- a/lib/TextDocument/Tests/Unit/TextEditsTest.php
+++ b/lib/TextDocument/Tests/Unit/TextEditsTest.php
@@ -25,7 +25,7 @@ class TextEditsTest extends TestCase
         );
     }
 
-    
+
     public function provideMerge(): Generator
     {
         yield 'empty' => [

--- a/lib/TextDocument/TextDocumentBuilder.php
+++ b/lib/TextDocument/TextDocumentBuilder.php
@@ -9,9 +9,9 @@ use Webmozart\PathUtil\Path;
 final class TextDocumentBuilder
 {
     private ?TextDocumentUri $uri = null;
-    
+
     private ?TextDocumentLanguage $language = null;
-    
+
     private string $text;
 
     private function __construct(string $text)

--- a/lib/TextDocument/TextDocumentEdits.php
+++ b/lib/TextDocument/TextDocumentEdits.php
@@ -11,7 +11,7 @@ use IteratorAggregate;
 class TextDocumentEdits implements IteratorAggregate
 {
     private TextEdits $textEdits;
-    
+
     private TextDocumentUri $uri;
 
 
@@ -20,7 +20,7 @@ class TextDocumentEdits implements IteratorAggregate
         $this->textEdits = $textEdits;
         $this->uri = $uri;
     }
-    
+
     public function uri(): TextDocumentUri
     {
         return $this->uri;

--- a/lib/TextDocument/TextDocumentLanguage.php
+++ b/lib/TextDocument/TextDocumentLanguage.php
@@ -6,7 +6,7 @@ class TextDocumentLanguage
 {
     const LANGUAGE_UNDEFINED = 'undefined';
     const LANGUAGE_PHP = 'php';
-    
+
     private string $language;
 
     private function __construct(string $language)

--- a/lib/TextDocument/TextDocumentLocator/ChainDocumentLocator.php
+++ b/lib/TextDocument/TextDocumentLocator/ChainDocumentLocator.php
@@ -22,7 +22,7 @@ class ChainDocumentLocator implements TextDocumentLocator
         $this->locators = $locators;
     }
 
-    
+
     public function get(TextDocumentUri $uri): TextDocument
     {
         foreach ($this->locators as $workspace) {

--- a/lib/TextDocument/TextDocumentUri.php
+++ b/lib/TextDocument/TextDocumentUri.php
@@ -8,7 +8,7 @@ use Webmozart\PathUtil\Path;
 class TextDocumentUri
 {
     private string $scheme;
-    
+
     private string $path;
 
     final private function __construct(string $scheme, string $path)

--- a/lib/TextDocument/TextEdit.php
+++ b/lib/TextDocument/TextEdit.php
@@ -8,9 +8,9 @@ use OutOfRangeException;
 class TextEdit
 {
     private ByteOffset $start;
-    
+
     private int $length;
-    
+
     private string $replacement;
 
     private function __construct(ByteOffset $start, int $length, string $content)

--- a/lib/TextDocument/Util/WordAtOffset.php
+++ b/lib/TextDocument/Util/WordAtOffset.php
@@ -12,7 +12,7 @@ final class WordAtOffset
     // see https://www.php.net/manual/en/language.oop5.basic.php
     const SPLIT_PHP_NAME = '[^a-zA-Z0-9_\x80-\xff]';
     const SPLIT_QUALIFIED_PHP_NAME = '[^a-zA-Z0-9_\x80-\xff\\\]';
-    
+
     private string $splitPattern;
 
     public function __construct(string $splitPattern = self::SPLIT_WORD)

--- a/lib/WorseReferenceFinder/Tests/Unit/TolerantVariableReferenceFinderTest.php
+++ b/lib/WorseReferenceFinder/Tests/Unit/TolerantVariableReferenceFinderTest.php
@@ -27,7 +27,7 @@ class TolerantVariableReferenceFinderTest extends TestCase
             ->uri($uri)
             ->language('php')
             ->build();
-        
+
         $finder = new TolerantVariableReferenceFinder(new Parser(), $includeDefinition);
         $actualReferences = iterator_to_array($finder->findReferences($document, ByteOffset::fromInt($selectionOffset)), false);
 
@@ -183,7 +183,7 @@ class TolerantVariableReferenceFinderTest extends TestCase
     {
         $textDocumentUri = $uri !== null ? TextDocumentUri::fromString($uri) : null;
         $results = preg_split('/(<>|<sr>)/u', $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
-        
+
         $referenceLocations = [];
         $selectionOffset = null;
 
@@ -198,18 +198,18 @@ class TolerantVariableReferenceFinderTest extends TestCase
                 $selectionOffset = $offset;
                 continue;
             }
-            
+
             if ($result == '<sr>') {
                 $referenceLocations[] = PotentialLocation::surely(
                     new Location($textDocumentUri, ByteOffset::fromInt($offset))
                 );
                 continue;
             }
-            
+
             $newSource .= $result;
             $offset += mb_strlen($result);
         }
-        
+
         return [$newSource, $selectionOffset, $referenceLocations];
     }
 }

--- a/lib/WorseReferenceFinder/Tests/Unit/WorsePlainTextDefinitionLocatorTest.php
+++ b/lib/WorseReferenceFinder/Tests/Unit/WorsePlainTextDefinitionLocatorTest.php
@@ -54,7 +54,7 @@ class WorsePlainTextDefinitionLocatorTest extends DefinitionLocatorTestCase
         yield 'list' => [ '/** @return <>Foobar[]', 'Foobar.php' ];
         yield 'solid block of text' => [ 'Foob<>ar', 'Foobar.php' ];
         yield 'imported class 1' => [ <<<'EOT'
-            <?php 
+            <?php
             namespace Bar {
 
             use Barfoo\Barfoo;
@@ -67,7 +67,7 @@ class WorsePlainTextDefinitionLocatorTest extends DefinitionLocatorTestCase
             EOT
         , 'Barfoo.php' ];
         yield 'imported class 2' => [ <<<'EOT'
-            <?php 
+            <?php
 
             use Barfoo\Barfoo;
 
@@ -75,7 +75,7 @@ class WorsePlainTextDefinitionLocatorTest extends DefinitionLocatorTestCase
             EOT
         , 'Barfoo.php' ];
         yield 'relative class' => [ <<<'EOT'
-            <?php 
+            <?php
 
             namespace Barfoo;
 
@@ -83,7 +83,7 @@ class WorsePlainTextDefinitionLocatorTest extends DefinitionLocatorTestCase
             EOT
         , 'Barfoo.php' ];
         yield 'imported class' => [ <<<'EOT'
-            <?php 
+            <?php
 
             namespace Barfoo;
 

--- a/lib/WorseReferenceFinder/Tests/Unit/WorseReflectionDefinitionLocatorTest.php
+++ b/lib/WorseReferenceFinder/Tests/Unit/WorseReflectionDefinitionLocatorTest.php
@@ -104,9 +104,9 @@ class WorseReflectionDefinitionLocatorTest extends DefinitionLocatorTestCase
         $this->expectExceptionMessage('No definition(s) found');
         $location = $this->locate(<<<'EOT'
             // File: Foobar.php
-            <?php 
+            <?php
 
-            class Foobar 
+            class Foobar
             {
             }
             EOT

--- a/lib/WorseReferenceFinder/Tests/Unit/WorseReflectionTypeLocatorTest.php
+++ b/lib/WorseReferenceFinder/Tests/Unit/WorseReflectionTypeLocatorTest.php
@@ -26,7 +26,7 @@ class WorseReflectionTypeLocatorTest extends IntegrationTestCase
 
                 class Foo
                 {
-                    /** 
+                    /**
                      * @var One
                      */
                     private $one;
@@ -58,7 +58,7 @@ class WorseReflectionTypeLocatorTest extends IntegrationTestCase
 
                 class Foo
                 {
-                    /** 
+                    /**
                      * @var One[]
                      */
                     private $one;
@@ -111,7 +111,7 @@ class WorseReflectionTypeLocatorTest extends IntegrationTestCase
 
                 class Foo
                 {
-                    /** 
+                    /**
                      * @var One
                      */
                     private $one;
@@ -142,7 +142,7 @@ class WorseReflectionTypeLocatorTest extends IntegrationTestCase
 
                 class Foo
                 {
-                    /** 
+                    /**
                      * @var Two|One
                      */
                     private $one;
@@ -173,7 +173,7 @@ class WorseReflectionTypeLocatorTest extends IntegrationTestCase
 
                 class Foo
                 {
-                    /** 
+                    /**
                      * @var string|null|Two|One
                      */
                     private $one;

--- a/lib/WorseReferenceFinder/TolerantVariableDefintionLocator.php
+++ b/lib/WorseReferenceFinder/TolerantVariableDefintionLocator.php
@@ -22,7 +22,7 @@ class TolerantVariableDefintionLocator implements DefinitionLocator
         $this->finder = $finder;
     }
 
-    
+
     public function locateDefinition(TextDocument $document, ByteOffset $byteOffset): TypeLocations
     {
         foreach ($this->finder->findReferences($document, $byteOffset) as $reference) {

--- a/lib/WorseReferenceFinder/TolerantVariableReferenceFinder.php
+++ b/lib/WorseReferenceFinder/TolerantVariableReferenceFinder.php
@@ -38,7 +38,7 @@ class TolerantVariableReferenceFinder implements ReferenceFinder
         $this->includeDefinition = $includeDefinition;
     }
 
-    
+
     public function findReferences(TextDocument $document, ByteOffset $byteOffset): Generator
     {
         $sourceNode = $this->sourceNode($document->__toString());
@@ -46,7 +46,7 @@ class TolerantVariableReferenceFinder implements ReferenceFinder
         if ($variable === null) {
             return;
         }
-        
+
         $scopeNode = $this->scopeNode($variable);
         $referencesGenerator = $this->find($scopeNode, $this->variableName($variable), $document->uri());
 
@@ -151,7 +151,7 @@ class TolerantVariableReferenceFinder implements ReferenceFinder
             if ($node instanceof AnonymousFunctionCreationExpression && !$this->nameExistsInUseClause($name, $node)) {
                 continue;
             }
-            
+
             if ($node instanceof Variable && $name == $node->getName()) {
                 yield PotentialLocation::surely(
                     Location::fromPathAndOffset($uri, $node->getStartPosition())
@@ -204,7 +204,7 @@ class TolerantVariableReferenceFinder implements ReferenceFinder
         if ($variable instanceof CatchClause && $variable->variableName) {
             return substr((string)$variable->variableName->getText($variable->getFileContents()), 1);
         }
-        
+
         return null;
     }
 }

--- a/lib/WorseReferenceFinder/WorsePlainTextClassDefinitionLocator.php
+++ b/lib/WorseReferenceFinder/WorsePlainTextClassDefinitionLocator.php
@@ -38,7 +38,7 @@ class WorsePlainTextClassDefinitionLocator implements DefinitionLocator
         $this->parser = new Parser();
     }
 
-    
+
     public function locateDefinition(TextDocument $document, ByteOffset $byteOffset): TypeLocations
     {
         $word = $this->extractWord($document, $byteOffset);
@@ -169,7 +169,7 @@ class WorsePlainTextClassDefinitionLocator implements DefinitionLocator
         if (null === $name) {
             return '';
         }
-        
+
         return $name->__toString();
     }
 }

--- a/lib/WorseReferenceFinder/WorseReflectionDefinitionLocator.php
+++ b/lib/WorseReferenceFinder/WorseReflectionDefinitionLocator.php
@@ -36,7 +36,7 @@ class WorseReflectionDefinitionLocator implements DefinitionLocator
         $this->cache = $cache;
     }
 
-    
+
     public function locateDefinition(TextDocument $document, ByteOffset $byteOffset): TypeLocations
     {
         if (false === $document->language()->isPhp()) {

--- a/lib/WorseReferenceFinder/WorseReflectionTypeLocator.php
+++ b/lib/WorseReferenceFinder/WorseReflectionTypeLocator.php
@@ -28,7 +28,7 @@ class WorseReflectionTypeLocator implements TypeLocator
         $this->reflector = $reflector;
     }
 
-    
+
     public function locateTypes(TextDocument $document, ByteOffset $byteOffset): TypeLocations
     {
         if (false === $document->language()->isPhp()) {

--- a/lib/WorseReflection/Bridge/Composer/ComposerSourceLocator.php
+++ b/lib/WorseReflection/Bridge/Composer/ComposerSourceLocator.php
@@ -16,7 +16,7 @@ class ComposerSourceLocator implements SourceCodeLocator
     {
         $this->classLoader = $classLoader;
     }
-    
+
     public function locate(Name $className): SourceCode
     {
         $path = $this->classLoader->findFile((string) $className);

--- a/lib/WorseReflection/Bridge/Phpactor/ClassToFileSourceLocator.php
+++ b/lib/WorseReflection/Bridge/Phpactor/ClassToFileSourceLocator.php
@@ -17,7 +17,7 @@ class ClassToFileSourceLocator implements SourceCodeLocator
     {
         $this->converter = $converter;
     }
-    
+
     public function locate(Name $name): SourceCode
     {
         $candidates = $this->converter->classToFileCandidates(ClassName::fromString((string) $name));

--- a/lib/WorseReflection/Bridge/PsrLog/ArrayLogger.php
+++ b/lib/WorseReflection/Bridge/PsrLog/ArrayLogger.php
@@ -7,7 +7,7 @@ use Psr\Log\AbstractLogger;
 class ArrayLogger extends AbstractLogger
 {
     private $messages = [];
-    
+
     public function log($level, $message, array $context = [
     ]): void
     {

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UnusedImportProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UnusedImportProvider.php
@@ -88,7 +88,7 @@ class UnusedImportProvider implements DiagnosticProvider
             if ($this->usedByAnnotation($contents, $importedFqn, $imported)) {
                 continue;
             }
-                
+
             yield UnusedImportDiagnostic::for(
                 ByteOffsetRange::fromInts($imported->getStartPosition(), $imported->getEndPosition()),
                 $importedFqn

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/AbstractReflectionMethodCall.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/AbstractReflectionMethodCall.php
@@ -33,7 +33,7 @@ abstract class AbstractReflectionMethodCall implements CoreReflectionMethodCall
      * @var ScopedPropertyAccessExpression|MemberAccessExpression
      */
     private $node;
-    
+
     private ServiceLocator $services;
 
     /**

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionArgument.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionArgument.php
@@ -21,9 +21,9 @@ use Microsoft\PhpParser\Node\DelimitedList\ArgumentExpressionList;
 class ReflectionArgument implements CoreReflectionArgument
 {
     private ServiceLocator $services;
-    
+
     private ArgumentExpression $node;
-    
+
     private Frame $frame;
 
     public function __construct(ServiceLocator $services, Frame $frame, ArgumentExpression $node)

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionClass.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionClass.php
@@ -35,13 +35,13 @@ use Phpactor\WorseReflection\Core\Reflection\Collection\ReflectionMemberCollecti
 class ReflectionClass extends AbstractReflectionClass implements CoreReflectionClass
 {
     private ServiceLocator $serviceLocator;
-    
+
     private ClassDeclaration $node;
-    
+
     private SourceCode $sourceCode;
 
     private ?ReflectionInterfaceCollection $interfaces = null;
-    
+
     private ?CoreReflectionClass $parent = null;
 
     /**

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionConstant.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionConstant.php
@@ -18,11 +18,11 @@ use Phpactor\WorseReflection\TypeUtil;
 class ReflectionConstant extends AbstractReflectionClassMember implements CoreReflectionConstant
 {
     private ServiceLocator $serviceLocator;
-    
+
     private ConstElement $node;
-    
+
     private AbstractReflectionClass $class;
-    
+
     private ClassConstDeclaration $declaration;
 
     public function __construct(
@@ -74,7 +74,7 @@ class ReflectionConstant extends AbstractReflectionClassMember implements CoreRe
     {
         return false;
     }
-    
+
     public function value()
     {
         return TypeUtil::valueOrNull($this->serviceLocator()

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionEnum.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionEnum.php
@@ -25,9 +25,9 @@ use Phpactor\WorseReflection\Core\TypeResolver\ClassLikeTypeResolver;
 class ReflectionEnum extends AbstractReflectionClass implements CoreReflectionEnum
 {
     private ServiceLocator $serviceLocator;
-    
+
     private EnumDeclaration $node;
-    
+
     private SourceCode $sourceCode;
 
     public function __construct(

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionEnumCase.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionEnumCase.php
@@ -18,9 +18,9 @@ use Phpactor\WorseReflection\TypeUtil;
 class ReflectionEnumCase extends AbstractReflectionClassMember implements CoreReflectionEnumCase
 {
     private ServiceLocator $serviceLocator;
-    
+
     private EnumCaseDeclaration $node;
-    
+
     private ReflectionEnum $enum;
 
     public function __construct(
@@ -72,7 +72,7 @@ class ReflectionEnumCase extends AbstractReflectionClassMember implements CoreRe
     {
         return false;
     }
-    
+
     /**
      * @return mixed
      */

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionFunction.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionFunction.php
@@ -22,9 +22,9 @@ use Phpactor\WorseReflection\Core\Util\NodeUtil;
 class ReflectionFunction extends AbstractReflectedNode implements CoreReflectionFunction
 {
     private ServiceLocator $serviceLocator;
-    
+
     private FunctionDeclaration $node;
-    
+
     private SourceCode $sourceCode;
 
     public function __construct(SourceCode $sourceCode, ServiceLocator $serviceLocator, FunctionDeclaration $node)

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionInterface.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionInterface.php
@@ -30,9 +30,9 @@ use Phpactor\WorseReflection\Core\Reflection\Collection\ReflectionMemberCollecti
 class ReflectionInterface extends AbstractReflectionClass implements CoreReflectionInterface
 {
     private ServiceLocator $serviceLocator;
-    
+
     private InterfaceDeclaration $node;
-    
+
     private SourceCode $sourceCode;
 
     private ?ReflectionInterfaceCollection $parents = null;

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionMethod.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionMethod.php
@@ -25,13 +25,13 @@ use InvalidArgumentException;
 class ReflectionMethod extends AbstractReflectionClassMember implements CoreReflectionMethod
 {
     private ServiceLocator $serviceLocator;
-    
+
     private MethodDeclaration $node;
-    
+
     private ReflectionClassLike $class;
-    
+
     private MethodTypeResolver $returnTypeResolver;
-    
+
     private DeclaredMemberTypeResolver $memberTypeResolver;
 
     public function __construct(

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionOffset.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionOffset.php
@@ -9,7 +9,7 @@ use Phpactor\WorseReflection\Core\Reflection\ReflectionOffset as CoreReflectionO
 final class ReflectionOffset implements CoreReflectionOffset
 {
     private Frame $frame;
-    
+
     private NodeContext $symbolContext;
 
     private function __construct(Frame $frame, NodeContext $symbolContext)

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionParameter.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionParameter.php
@@ -18,9 +18,9 @@ use Phpactor\WorseReflection\TypeUtil;
 class ReflectionParameter extends AbstractReflectedNode implements CoreReflectionParameter
 {
     private ServiceLocator $serviceLocator;
-    
+
     private Parameter $parameter;
-    
+
     private DeclaredMemberTypeResolver $memberTypeResolver;
 
     private ReflectionFunctionLike $functionLike;

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionPromotedProperty.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionPromotedProperty.php
@@ -25,13 +25,13 @@ use InvalidArgumentException;
 class ReflectionPromotedProperty extends AbstractReflectionClassMember implements CoreReflectionProperty
 {
     private ServiceLocator $serviceLocator;
-    
+
     private ReflectionClassLike $class;
-    
+
     private PropertyTypeResolver $typeResolver;
-    
+
     private DeclaredMemberTypeResolver $memberTypeResolver;
-    
+
     private Parameter $parameter;
 
     public function __construct(

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionProperty.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionProperty.php
@@ -22,15 +22,15 @@ use InvalidArgumentException;
 class ReflectionProperty extends AbstractReflectionClassMember implements CoreReflectionProperty
 {
     private ServiceLocator $serviceLocator;
-    
+
     private PropertyDeclaration $propertyDeclaration;
-    
+
     private Variable $variable;
-    
+
     private ReflectionClassLike $class;
-    
+
     private PropertyTypeResolver $typeResolver;
-    
+
     private DeclaredMemberTypeResolver $memberTypeResolver;
 
     public function __construct(

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionTrait.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionTrait.php
@@ -25,9 +25,9 @@ use Phpactor\WorseReflection\Core\TypeResolver\ClassLikeTypeResolver;
 class ReflectionTrait extends AbstractReflectionClass implements CoreReflectionTrait
 {
     private ServiceLocator $serviceLocator;
-    
+
     private TraitDeclaration $node;
-    
+
     private SourceCode $sourceCode;
 
     /**

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/TraitImport/TraitImport.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/TraitImport/TraitImport.php
@@ -5,7 +5,7 @@ namespace Phpactor\WorseReflection\Bridge\TolerantParser\Reflection\TraitImport;
 class TraitImport
 {
     private $traitName;
-    
+
     private array $traitAliases = [];
 
     public function __construct(string $traitName, array $traitAliases = [])

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/TraitImport/TraitImports.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/TraitImport/TraitImports.php
@@ -41,7 +41,7 @@ final class TraitImports implements Countable, IteratorAggregate
             if ($memberDeclaration->traitNameList == null) {
                 continue;
             }
-                
+
             $traitNames = array_filter(array_map(function ($name) {
                 if (!$name instanceof QualifiedName) {
                     return null;
@@ -129,12 +129,12 @@ final class TraitImports implements Countable, IteratorAggregate
 
         return $this->imports[$name];
     }
-    
+
     public function count(): int
     {
         return count($this->imports);
     }
-    
+
     public function getIterator(): Traversable
     {
         return new ArrayIterator($this->imports);

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/TypeResolver/DeclaredMemberTypeResolver.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/TypeResolver/DeclaredMemberTypeResolver.php
@@ -19,7 +19,7 @@ class DeclaredMemberTypeResolver
     {
         $this->reflector = $reflector;
     }
-    
+
     /**
      * @param mixed $declaredTypes
      */

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflector/TolerantSourceCodeReflector.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflector/TolerantSourceCodeReflector.php
@@ -34,7 +34,7 @@ class TolerantSourceCodeReflector implements SourceCodeReflector
         $this->serviceLocator = $serviceLocator;
         $this->parser = $parser;
     }
-    
+
     /**
      * @param array<string,bool> $visited
      */
@@ -44,7 +44,7 @@ class TolerantSourceCodeReflector implements SourceCodeReflector
         $node = $this->parseSourceCode($sourceCode);
         return TolerantReflectionClassCollection::fromNode($this->serviceLocator, $sourceCode, $node, $visited);
     }
-    
+
     public function reflectOffset($sourceCode, $offset): ReflectionOffset
     {
         $sourceCode = SourceCode::fromUnknown($sourceCode);
@@ -96,7 +96,7 @@ class TolerantSourceCodeReflector implements SourceCodeReflector
 
         return $reflection;
     }
-    
+
     public function reflectFunctionsIn($sourceCode): CoreReflectionFunctionCollection
     {
         $sourceCode = SourceCode::fromUnknown($sourceCode);

--- a/lib/WorseReflection/Core/Cache/TtlCache.php
+++ b/lib/WorseReflection/Core/Cache/TtlCache.php
@@ -16,7 +16,7 @@ class TtlCache implements Cache
      * @var array<string, float>
      */
     private array $expires = [];
-    
+
     private float $lifetime;
 
     private ?float $lifetimeStart = null;

--- a/lib/WorseReflection/Core/Deprecation.php
+++ b/lib/WorseReflection/Core/Deprecation.php
@@ -5,7 +5,7 @@ namespace Phpactor\WorseReflection\Core;
 class Deprecation
 {
     private ?string $message;
-    
+
     private bool $isDefined;
 
     public function __construct(bool $isDefined, ?string $message = null)

--- a/lib/WorseReflection/Core/DocBlock/DocBlockVar.php
+++ b/lib/WorseReflection/Core/DocBlock/DocBlockVar.php
@@ -7,7 +7,7 @@ use Phpactor\WorseReflection\Core\Type;
 class DocBlockVar
 {
     private string $name;
-    
+
     private Type $type;
 
     public function __construct(string $name, Type $type)

--- a/lib/WorseReflection/Core/DocBlock/DocBlockVars.php
+++ b/lib/WorseReflection/Core/DocBlock/DocBlockVars.php
@@ -36,7 +36,7 @@ class DocBlockVars implements IteratorAggregate
 
         return TypeFactory::undefined();
     }
-    
+
     public function getIterator(): Traversable
     {
         return new ArrayIterator($this->vars);

--- a/lib/WorseReflection/Core/Inference/Assignments.php
+++ b/lib/WorseReflection/Core/Inference/Assignments.php
@@ -140,7 +140,7 @@ abstract class Assignments implements Countable, IteratorAggregate
 
         return $last;
     }
-    
+
     public function count(): int
     {
         return count($this->variables);

--- a/lib/WorseReflection/Core/Inference/Frame.php
+++ b/lib/WorseReflection/Core/Inference/Frame.php
@@ -10,9 +10,9 @@ use Phpactor\WorseReflection\Core\Type\VoidType;
 class Frame
 {
     private PropertyAssignments $properties;
-    
+
     private LocalAssignments $locals;
-    
+
     private Problems $problems;
 
     /**
@@ -24,7 +24,7 @@ class Frame
      * @var Frame[]
      */
     private array $children = [];
-    
+
     private string $name;
 
     private ?Type $returnType = null;

--- a/lib/WorseReflection/Core/Inference/FunctionStubRegistry.php
+++ b/lib/WorseReflection/Core/Inference/FunctionStubRegistry.php
@@ -17,7 +17,7 @@ final class FunctionStubRegistry
         $this->functionMap = $functionMap;
     }
 
-    
+
     public function get(string $name): ?FunctionStub
     {
         if (!isset($this->functionMap[$name])) {

--- a/lib/WorseReflection/Core/Inference/MemberTypeResolver.php
+++ b/lib/WorseReflection/Core/Inference/MemberTypeResolver.php
@@ -16,7 +16,7 @@ class MemberTypeResolver
     const TYPE_METHODS = 'methods';
     const TYPE_CONSTANTS = 'constants';
     const TYPE_PROPERTIES = 'properties';
-    
+
     private ClassReflector $reflector;
 
     public function __construct(ClassReflector $reflector)

--- a/lib/WorseReflection/Core/Inference/NodeContext.php
+++ b/lib/WorseReflection/Core/Inference/NodeContext.php
@@ -10,7 +10,7 @@ use Phpactor\WorseReflection\Core\Reflection\ReflectionScope;
 final class NodeContext
 {
     private Type $type;
-    
+
     private Symbol $symbol;
 
     private TypeAssertions $typeAssertions;

--- a/lib/WorseReflection/Core/Inference/NodeContextResolver.php
+++ b/lib/WorseReflection/Core/Inference/NodeContextResolver.php
@@ -16,9 +16,9 @@ use Psr\Log\LoggerInterface;
 class NodeContextResolver
 {
     private Reflector $reflector;
-    
+
     private LoggerInterface $logger;
-    
+
     /**
      * @var array<class-name,Resolver>
      */
@@ -27,7 +27,7 @@ class NodeContextResolver
     private Cache $cache;
 
     private DocBlockFactory $docblockFactory;
-    
+
     /**
      * @param array<class-name,Resolver> $resolverMap
      */

--- a/lib/WorseReflection/Core/Inference/NodeToTypeConverter.php
+++ b/lib/WorseReflection/Core/Inference/NodeToTypeConverter.php
@@ -90,7 +90,7 @@ class NodeToTypeConverter
         if ($this->isFunctionCall($node)) {
             return TypeFactory::unknown();
         }
-        
+
         if ($this->isUseDefinition($node)) {
             return TypeFactory::fromStringWithReflector((string) $type, $this->reflector);
         }

--- a/lib/WorseReflection/Core/Inference/Resolver/CallExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/CallExpressionResolver.php
@@ -86,7 +86,7 @@ class CallExpressionResolver implements Resolver
                 FunctionArguments::fromList($resolver, $frame, $node->argumentExpressionList)
             ));
         }
-        
+
         if ($context->symbol()->symbolType() === Symbol::FUNCTION) {
             $function = $resolver->reflector()->reflectFunction($context->symbol()->name());
             return $context->withType($type->evaluate(

--- a/lib/WorseReflection/Core/Inference/Resolver/ForeachStatementResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/ForeachStatementResolver.php
@@ -44,11 +44,11 @@ class ForeachStatementResolver implements Resolver
     private function processValue(NodeContextResolver $resolver, ForeachStatement $node, Frame $frame, NodeContext $nodeContext): void
     {
         $itemName = $node->foreachValue;
-        
+
         if (!$itemName instanceof ForeachValue) {
             return;
         }
-        
+
         $expression = $itemName->expression;
         if ($expression instanceof Variable) {
             $this->valueFromVariable($expression, $node, $nodeContext, $frame);
@@ -63,16 +63,16 @@ class ForeachStatementResolver implements Resolver
     private function processKey(NodeContextResolver $resolver, ForeachStatement $node, Frame $frame, Type $type): void
     {
         $itemName = $node->foreachKey;
-        
+
         if (!$itemName instanceof ForeachKey) {
             return;
         }
-        
+
         $expression = $itemName->expression;
         if (!$expression instanceof Variable) {
             return;
         }
-        
+
         /** @phpstan-ignore-next-line */
         $itemName = $expression->name->getText($node->getFileContents());
 
@@ -91,14 +91,14 @@ class ForeachStatementResolver implements Resolver
         if ($type instanceof IterableType) {
             $context = $context->withType($this->resolveKeyType($type));
         }
-        
+
         $frame->locals()->set(WorseVariable::fromSymbolContext($context));
     }
 
     private function valueFromVariable(Variable $expression, ForeachStatement $node, NodeContext $nodeContext, Frame $frame): void
     {
         $itemName = $expression->getText();
-        
+
         if (!is_string($itemName)) {
             return;
         }
@@ -113,14 +113,14 @@ class ForeachStatementResolver implements Resolver
                 'symbol_type' => Symbol::VARIABLE,
             ]
         );
-        
+
         if ($type instanceof ReflectedClassType) {
             $context = $context->withType($type->iterableValueType());
         }
         if ($type instanceof IterableType) {
             $context = $context->withType($this->resolveValueType($type));
         }
-        
+
         $frame->locals()->set(WorseVariable::fromSymbolContext($context));
     }
 

--- a/lib/WorseReflection/Core/Inference/Resolver/TernaryExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/TernaryExpressionResolver.php
@@ -27,7 +27,7 @@ class TernaryExpressionResolver implements Resolver
             $frame->applyTypeAssertions($condition->typeAssertions(), $node->ifExpression->getStartPosition());
             $left = $resolver->resolveNode($frame, $node->ifExpression);
         }
-        
+
         /** @phpstan-ignore-next-line */
         if (!$node->ifExpression) {
             $left = $condition;

--- a/lib/WorseReflection/Core/Inference/Symbol.php
+++ b/lib/WorseReflection/Core/Inference/Symbol.php
@@ -19,14 +19,14 @@ final class Symbol
     public const BOOLEAN = 'boolean';
     public const ARRAY = 'array';
     public const UNKNOWN = '<unknown>';
-    
+
     /**
      * @var Symbol::*
      */
     private string $symbolType;
-    
+
     private string $name;
-    
+
     private Position $position;
 
     /**

--- a/lib/WorseReflection/Core/Inference/Walker/FunctionLikeWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/FunctionLikeWalker.php
@@ -194,7 +194,7 @@ class FunctionLikeWalker implements Walker
                 'symbol_type' => Symbol::VARIABLE,
             ]
         );
-        
+
         // add this and self
         $frame->locals()->set(Variable::fromSymbolContext($context));
 

--- a/lib/WorseReflection/Core/Inference/Walker/IncludeWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/IncludeWalker.php
@@ -20,7 +20,7 @@ use Webmozart\PathUtil\Path;
 class IncludeWalker implements Walker
 {
     private Parser $parser;
-    
+
     private LoggerInterface $logger;
 
     public function __construct(LoggerInterface $logger, Parser $parser = null)
@@ -29,7 +29,7 @@ class IncludeWalker implements Walker
         $this->logger = $logger;
     }
 
-    
+
     public function nodeFqns(): array
     {
         return [ScriptInclusionExpression::class];
@@ -91,19 +91,19 @@ class IncludeWalker implements Walker
         $return = $sourceNode->getFirstDescendantNode(ReturnStatement::class);
         assert($return instanceof ReturnStatement);
         $returnValueContext = $resolver->resolveNode($frame->new('required'), $return->expression);
-        
+
         if (!$parentNode->leftOperand instanceof Variable) {
             return $frame;
         }
-        
+
         $name = $parentNode->leftOperand->name;
-        
+
         if (!$name instanceof Token) {
             return $frame;
         }
-        
+
         $name = $name->getText($node->getFileContents());
-        
+
         foreach ($frame->locals()->byName((string)$name) as $variable) {
             $frame->locals()->replace(
                 $variable,

--- a/lib/WorseReflection/Core/Inference/Walker/VariableWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/VariableWalker.php
@@ -18,14 +18,14 @@ use Phpactor\WorseReflection\Core\TypeResolver\DefaultTypeResolver;
 class VariableWalker implements Walker
 {
     private DocBlockFactory $docblockFactory;
-    
+
     public function __construct(
         DocBlockFactory $docblockFactory
     ) {
         $this->docblockFactory = $docblockFactory;
     }
 
-    
+
     public function nodeFqns(): array
     {
         return [];

--- a/lib/WorseReflection/Core/Position.php
+++ b/lib/WorseReflection/Core/Position.php
@@ -5,9 +5,9 @@ namespace Phpactor\WorseReflection\Core;
 final class Position
 {
     private int $fullStart;
-    
+
     private int $start;
-    
+
     private int $end;
 
     private function __construct(

--- a/lib/WorseReflection/Core/Reflection/Collection/ChainReflectionMemberCollection.php
+++ b/lib/WorseReflection/Core/Reflection/Collection/ChainReflectionMemberCollection.php
@@ -226,7 +226,7 @@ final class ChainReflectionMemberCollection implements ReflectionMemberCollectio
         /** @phpstan-ignore-next-line It's _fine_ */
         return HomogeneousReflectionMemberCollection::fromReflections($items);
     }
-    
+
     /**
      * @param ReflectionMember::TYPE_* $type
      */

--- a/lib/WorseReflection/Core/Reflection/TypeResolver/MethodTypeResolver.php
+++ b/lib/WorseReflection/Core/Reflection/TypeResolver/MethodTypeResolver.php
@@ -12,7 +12,7 @@ use Phpactor\WorseReflection\Core\Reflection\ReflectionInterface;
 class MethodTypeResolver
 {
     private ReflectionMethod $method;
-    
+
     public function __construct(ReflectionMethod $method)
     {
         $this->method = $method;

--- a/lib/WorseReflection/Core/Reflection/TypeResolver/PropertyTypeResolver.php
+++ b/lib/WorseReflection/Core/Reflection/TypeResolver/PropertyTypeResolver.php
@@ -9,7 +9,7 @@ use Phpactor\WorseReflection\Core\Type;
 class PropertyTypeResolver
 {
     private ReflectionProperty $property;
-    
+
     public function __construct(ReflectionProperty $property)
     {
         $this->property = $property;

--- a/lib/WorseReflection/Core/Reflector/ClassReflector/MemonizedReflector.php
+++ b/lib/WorseReflection/Core/Reflector/ClassReflector/MemonizedReflector.php
@@ -24,13 +24,13 @@ class MemonizedReflector implements ClassReflector, FunctionReflector
     private const TRAIT_PREFIX = '__trait__';
     private const ENUM_PREFIX = '__enum__';
     private const CLASS_LIKE_PREFIX = '__class_like__';
-    
+
     private ClassReflector $classReflector;
-    
+
     private FunctionReflector $functionReflector;
-    
+
     private ClassReflector $innerReflector;
-    
+
     private Cache $cache;
 
     public function __construct(ClassReflector $innerReflector, FunctionReflector $functionReflector, Cache $cache)
@@ -40,35 +40,35 @@ class MemonizedReflector implements ClassReflector, FunctionReflector
         $this->innerReflector = $innerReflector;
         $this->cache = $cache;
     }
-    
+
     public function reflectClass($className): ReflectionClass
     {
         return $this->getOrSet(self::CLASS_PREFIX.$className, function () use ($className) {
             return $this->classReflector->reflectClass($className);
         });
     }
-    
+
     public function reflectInterface($className, array $visited = []): ReflectionInterface
     {
         return $this->getOrSet(self::INTERFACE_PREFIX.$className, function () use ($className, $visited) {
             return $this->classReflector->reflectInterface($className, $visited);
         });
     }
-    
+
     public function reflectTrait($className, array $visited = []): ReflectionTrait
     {
         return $this->getOrSet(self::TRAIT_PREFIX.$className, function () use ($className, $visited) {
             return $this->classReflector->reflectTrait($className, $visited);
         });
     }
-    
+
     public function reflectEnum($className): ReflectionEnum
     {
         return $this->getOrSet(self::ENUM_PREFIX.$className, function () use ($className) {
             return $this->classReflector->reflectEnum($className);
         });
     }
-    
+
     public function reflectClassLike($className, $visited = []): ReflectionClassLike
     {
         if (isset($visited[(string)$className])) {
@@ -88,14 +88,14 @@ class MemonizedReflector implements ClassReflector, FunctionReflector
             return $this->functionReflector->reflectFunction($name);
         });
     }
-    
+
     public function sourceCodeForFunction($name): SourceCode
     {
         return $this->getOrSet(self::FUNC_PREFIX.'source_code'.$name, function () use ($name) {
             return $this->functionReflector->sourceCodeForFunction($name);
         });
     }
-    
+
     public function sourceCodeForClassLike($name): SourceCode
     {
         return $this->getOrSet(self::CLASS_LIKE_PREFIX.'source_code'.$name, function () use ($name) {

--- a/lib/WorseReflection/Core/Reflector/CompositeReflector.php
+++ b/lib/WorseReflection/Core/Reflector/CompositeReflector.php
@@ -60,22 +60,22 @@ class CompositeReflector implements Reflector
     {
         return $this->classReflector->reflectClassLike($className, $visited);
     }
-    
+
     public function reflectClassesIn($sourceCode, array $visited = []): ReflectionClassLikeCollection
     {
         return $this->sourceCodeReflector->reflectClassesIn($sourceCode, $visited);
     }
-    
+
     public function reflectOffset($sourceCode, $offset): ReflectionOffset
     {
         return $this->sourceCodeReflector->reflectOffset($sourceCode, $offset);
     }
-    
+
     public function reflectMethodCall($sourceCode, $offset): ReflectionMethodCall
     {
         return $this->sourceCodeReflector->reflectMethodCall($sourceCode, $offset);
     }
-    
+
     public function reflectFunctionsIn($sourceCode): ReflectionFunctionCollection
     {
         return $this->sourceCodeReflector->reflectFunctionsIn($sourceCode);
@@ -90,12 +90,12 @@ class CompositeReflector implements Reflector
     {
         return $this->functionReflector->reflectFunction($name);
     }
-    
+
     public function sourceCodeForClassLike($className): SourceCode
     {
         return $this->classReflector->sourceCodeForClassLike($className);
     }
-    
+
     public function sourceCodeForFunction($name): SourceCode
     {
         return $this->functionReflector->sourceCodeForFunction($name);

--- a/lib/WorseReflection/Core/Reflector/CoreReflector.php
+++ b/lib/WorseReflection/Core/Reflector/CoreReflector.php
@@ -30,7 +30,7 @@ use Phpactor\WorseReflection\Core\Reflection\Collection\ReflectionFunctionCollec
 class CoreReflector implements ClassReflector, SourceCodeReflector, FunctionReflector
 {
     private SourceCodeReflector $sourceReflector;
-    
+
     private SourceCodeLocator $sourceLocator;
 
     public function __construct(SourceCodeReflector $sourceReflector, SourceCodeLocator $sourceLocator)
@@ -111,7 +111,7 @@ class CoreReflector implements ClassReflector, SourceCodeReflector, FunctionRefl
 
         return $class;
     }
-    
+
     public function reflectEnum($className): ReflectionEnum
     {
         $className = ClassName::fromUnknown($className);
@@ -187,7 +187,7 @@ class CoreReflector implements ClassReflector, SourceCodeReflector, FunctionRefl
     {
         return $this->sourceReflector->reflectMethodCall($sourceCode, $offset);
     }
-    
+
     public function reflectFunctionsIn($sourceCode): ReflectionFunctionCollection
     {
         return $this->sourceReflector->reflectFunctionsIn($sourceCode);
@@ -232,12 +232,12 @@ class CoreReflector implements ClassReflector, SourceCodeReflector, FunctionRefl
 
         return $function;
     }
-    
+
     public function sourceCodeForFunction($name): SourceCode
     {
         return $this->sourceLocator->locate(Name::fromUnknown($name));
     }
-    
+
     public function sourceCodeForClassLike($name): SourceCode
     {
         return $this->sourceLocator->locate(Name::fromUnknown($name));

--- a/lib/WorseReflection/Core/Reflector/SourceCode/ContextualSourceCodeReflector.php
+++ b/lib/WorseReflection/Core/Reflector/SourceCode/ContextualSourceCodeReflector.php
@@ -16,7 +16,7 @@ use Phpactor\WorseReflection\Core\Reflection\Collection\ReflectionClassLikeColle
 class ContextualSourceCodeReflector implements SourceCodeReflector
 {
     private SourceCodeReflector $innerReflector;
-    
+
     private TemporarySourceLocator $locator;
 
     public function __construct(SourceCodeReflector $innerReflector, TemporarySourceLocator $locator)
@@ -24,7 +24,7 @@ class ContextualSourceCodeReflector implements SourceCodeReflector
         $this->innerReflector = $innerReflector;
         $this->locator = $locator;
     }
-    
+
     public function reflectClassesIn($sourceCode, array $visited = []): ReflectionClassLikeCollection
     {
         $sourceCode = SourceCode::fromUnknown($sourceCode);
@@ -34,7 +34,7 @@ class ContextualSourceCodeReflector implements SourceCodeReflector
 
         return $collection;
     }
-    
+
     public function reflectOffset($sourceCode, $offset): ReflectionOffset
     {
         $sourceCode = SourceCode::fromUnknown($sourceCode);
@@ -54,7 +54,7 @@ class ContextualSourceCodeReflector implements SourceCodeReflector
 
         return $offset;
     }
-    
+
     public function reflectFunctionsIn($sourceCode): ReflectionFunctionCollection
     {
         $sourceCode = SourceCode::fromUnknown($sourceCode);

--- a/lib/WorseReflection/Core/ServiceLocator.php
+++ b/lib/WorseReflection/Core/ServiceLocator.php
@@ -30,11 +30,11 @@ use Psr\Log\LoggerInterface;
 class ServiceLocator
 {
     private SourceCodeLocator $sourceLocator;
-    
+
     private LoggerInterface $logger;
-    
+
     private Reflector $reflector;
-    
+
     private DocBlockFactory $docblockFactory;
 
     /**

--- a/lib/WorseReflection/Core/SourceCode.php
+++ b/lib/WorseReflection/Core/SourceCode.php
@@ -86,7 +86,7 @@ class SourceCode implements TextDocument
     {
         return new self($source, $filePath);
     }
-    
+
     public function uri(): ?TextDocumentUri
     {
         if (!$this->path) {
@@ -107,7 +107,7 @@ class SourceCode implements TextDocument
 
         return $uri;
     }
-    
+
     public function language(): TextDocumentLanguage
     {
         return TextDocumentLanguage::fromString('php');

--- a/lib/WorseReflection/Core/SourceCodeLocator/BruteForceSourceLocator.php
+++ b/lib/WorseReflection/Core/SourceCodeLocator/BruteForceSourceLocator.php
@@ -14,7 +14,7 @@ use SplFileInfo;
 final class BruteForceSourceLocator implements SourceCodeLocator
 {
     private Reflector $reflector;
-    
+
     private string $path;
 
     /**
@@ -91,7 +91,7 @@ final class BruteForceSourceLocator implements SourceCodeLocator
         $functions = $this->reflector->reflectClassesIn(
             SourceCode::fromPath($file)
         );
-        
+
         foreach ($functions as $function) {
             $map[(string) $function->name()] = (string) $file;
         }
@@ -108,7 +108,7 @@ final class BruteForceSourceLocator implements SourceCodeLocator
         $functions = $this->reflector->reflectFunctionsIn(
             SourceCode::fromPath($file)
         );
-        
+
         foreach ($functions as $function) {
             $map[(string) $function->name()] = (string) $file;
         }

--- a/lib/WorseReflection/Core/SourceCodeLocator/ChainSourceLocator.php
+++ b/lib/WorseReflection/Core/SourceCodeLocator/ChainSourceLocator.php
@@ -15,7 +15,7 @@ class ChainSourceLocator implements SourceCodeLocator
      * @var SourceCodeLocator[]
      */
     private array $locators = [];
-    
+
     private LoggerInterface $logger;
 
     public function __construct(array $sourceLocators, ?LoggerInterface $logger = null)

--- a/lib/WorseReflection/Core/SourceCodeLocator/StubSourceLocator.php
+++ b/lib/WorseReflection/Core/SourceCodeLocator/StubSourceLocator.php
@@ -13,9 +13,9 @@ use RecursiveIteratorIterator;
 final class StubSourceLocator implements SourceCodeLocator
 {
     private string $cacheDir;
-    
+
     private Reflector $reflector;
-    
+
     private string $stubPath;
 
     public function __construct(Reflector $reflector, string $stubPath, string $cacheDir)
@@ -87,7 +87,7 @@ final class StubSourceLocator implements SourceCodeLocator
         $functions = $this->reflector->reflectClassesIn(
             SourceCode::fromPath($file)
         );
-        
+
         foreach ($functions as $function) {
             $map[(string) $function->name()] = (string) $file;
         }
@@ -100,7 +100,7 @@ final class StubSourceLocator implements SourceCodeLocator
         $functions = $this->reflector->reflectFunctionsIn(
             SourceCode::fromPath($file)
         );
-        
+
         foreach ($functions as $function) {
             $map[(string) $function->name()] = (string) $file;
         }

--- a/lib/WorseReflection/Core/SourceCodeLocator/TemporarySourceLocator.php
+++ b/lib/WorseReflection/Core/SourceCodeLocator/TemporarySourceLocator.php
@@ -32,9 +32,9 @@ use Phpactor\WorseReflection\Core\Reflector\SourceCodeReflector;
 class TemporarySourceLocator implements SourceCodeLocator
 {
     private ?SourceCode $source = null;
-    
+
     private SourceCodeReflector $reflector;
-    
+
     private bool $locateFunctions;
 
     public function __construct(SourceCodeReflector $reflector, bool $locateFunctions = false)
@@ -47,7 +47,7 @@ class TemporarySourceLocator implements SourceCodeLocator
     {
         $this->source = $source;
     }
-    
+
     public function locate(Name $name): SourceCode
     {
         if (null === $this->source) {

--- a/lib/WorseReflection/Core/Type/ArrayLiteral.php
+++ b/lib/WorseReflection/Core/Type/ArrayLiteral.php
@@ -67,7 +67,7 @@ class ArrayLiteral extends ArrayType implements Literal, Generalizable, ArrayAcc
         return range(0, count($this->typeMap) - 1) === array_keys($this->typeMap);
     }
 
-    
+
     public function value()
     {
         return array_map(

--- a/lib/WorseReflection/Core/Type/StringLiteralType.php
+++ b/lib/WorseReflection/Core/Type/StringLiteralType.php
@@ -20,7 +20,7 @@ class StringLiteralType extends StringType implements Literal, Generalizable, Co
     {
         return sprintf('"%s"', $this->value);
     }
-    
+
     /**
      * @return mixed
      */

--- a/lib/WorseReflection/Core/TypeFactory.php
+++ b/lib/WorseReflection/Core/TypeFactory.php
@@ -426,7 +426,7 @@ class TypeFactory
         return self::class(ClassName::fromString($type), $reflector);
     }
 
-    
+
     private static function convertNumericStringToInternalType(string $value): NumericType
     {
         if (1 === preg_match('/^[1-9][0-9]*$/', $value)) {

--- a/lib/WorseReflection/Core/Util/OriginalMethodResolver.php
+++ b/lib/WorseReflection/Core/Util/OriginalMethodResolver.php
@@ -39,14 +39,14 @@ class OriginalMethodResolver
     private function resolveClass(ReflectionClass $classLike, ReflectionMember $member): ReflectionMember
     {
         $parent = $classLike->parent();
-        
+
         if ($parent !== null) {
             $member = $this->doResolveOriginalMember(
                 $classLike->parent(),
                 $member
             );
         }
-        
+
         foreach ($classLike->interfaces() as $interface) {
             $member = $this->doResolveOriginalMember(
                 $interface,

--- a/lib/WorseReflection/Core/Virtual/VirtualReflectionInterfaceDecorator.php
+++ b/lib/WorseReflection/Core/Virtual/VirtualReflectionInterfaceDecorator.php
@@ -21,7 +21,7 @@ class VirtualReflectionInterfaceDecorator extends VirtualReflectionClassLikeDeco
      * @var ReflectionMemberProvider[]
      */
     private array $memberProviders;
-    
+
     private ServiceLocator $serviceLocator;
 
     public function __construct(ServiceLocator $serviceLocator, ReflectionInterface $interface, array $memberProviders = [])

--- a/lib/WorseReflection/Core/Virtual/VirtualReflectionMember.php
+++ b/lib/WorseReflection/Core/Virtual/VirtualReflectionMember.php
@@ -16,25 +16,25 @@ use Phpactor\WorseReflection\Core\Visibility;
 abstract class VirtualReflectionMember implements ReflectionMember
 {
     private Position $position;
-    
+
     private ReflectionClassLike $declaringClass;
-    
+
     private ReflectionClassLike $class;
-    
+
     private string $name;
-    
+
     private Frame $frame;
-    
+
     private DocBlock $docblock;
-    
+
     private ReflectionScope $scope;
-    
+
     private Visibility $visibility;
-    
+
     private Type $inferredType;
-    
+
     private Type $type;
-    
+
     private Deprecation $deprecation;
 
     public function __construct(

--- a/lib/WorseReflection/Core/Virtual/VirtualReflectionMethod.php
+++ b/lib/WorseReflection/Core/Virtual/VirtualReflectionMethod.php
@@ -18,13 +18,13 @@ use Phpactor\WorseReflection\Core\Visibility;
 class VirtualReflectionMethod extends VirtualReflectionMember implements ReflectionMethod
 {
     private ReflectionParameterCollection $parameters;
-    
+
     private NodeText $body;
-    
+
     private Type $type;
-    
+
     private bool $isAbstract;
-    
+
     private bool $isStatic;
 
     public function __construct(
@@ -81,7 +81,7 @@ class VirtualReflectionMethod extends VirtualReflectionMember implements Reflect
     {
         return $this->body;
     }
-    
+
     public function returnType(): Type
     {
         return $this->type();

--- a/lib/WorseReflection/Core/Virtual/VirtualReflectionParameter.php
+++ b/lib/WorseReflection/Core/Virtual/VirtualReflectionParameter.php
@@ -12,19 +12,19 @@ use Phpactor\WorseReflection\Core\Type;
 class VirtualReflectionParameter implements ReflectionParameter
 {
     private string $name;
-    
+
     private ReflectionFunctionLike $functionLike;
-    
+
     private Type $inferredType;
-    
+
     private Type $type;
-    
+
     private DefaultValue $default;
-    
+
     private bool $byReference;
-    
+
     private ReflectionScope $scope;
-    
+
     private Position $position;
 
     private int $index;
@@ -65,7 +65,7 @@ class VirtualReflectionParameter implements ReflectionParameter
     {
         return $this->name;
     }
-    
+
     public function method(): ReflectionFunctionLike
     {
         return $this->functionLike;

--- a/lib/WorseReflection/ReflectorBuilder.php
+++ b/lib/WorseReflection/ReflectorBuilder.php
@@ -31,11 +31,11 @@ final class ReflectorBuilder
      * @var SourceCodeLocator[]
      */
     private array $locators = [];
-    
+
     private bool $contextualSourceLocation = false;
-    
+
     private bool $enableCache = false;
-    
+
     private bool $enableContextualSourceLocation = false;
 
     /**
@@ -52,9 +52,9 @@ final class ReflectorBuilder
      * @var ReflectionMemberProvider[]
      */
     private array $memberProviders = [];
-    
+
     private float $cacheLifetime = 5.0;
-    
+
     private ?Cache $cache = null;
 
     /**

--- a/lib/WorseReflection/Tests/Benchmarks/Examples/PropertyClass.php
+++ b/lib/WorseReflection/Tests/Benchmarks/Examples/PropertyClass.php
@@ -5,6 +5,6 @@ namespace Phpactor\WorseReflection\Tests\Benchmarks\Examples;
 class PropertyClass
 {
     public $noType;
-    
+
     public MethodClass $withType;
 }

--- a/lib/WorseReflection/Tests/Inference/TestAssertWalker.php
+++ b/lib/WorseReflection/Tests/Inference/TestAssertWalker.php
@@ -169,7 +169,7 @@ class TestAssertWalker implements Walker
             if (!$expression instanceof ArgumentExpression) {
                 continue;
             }
-        
+
             $args[] = $resolver->resolveNode($frame, $expression);
         }
         return $args;

--- a/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Diagonstics/UnresolvableNameProviderTest.php
+++ b/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Diagonstics/UnresolvableNameProviderTest.php
@@ -137,7 +137,7 @@ class UnresolvableNameProviderTest extends DiagnosticsTestCase
         yield 'multiple unresolvable classes' => [
             <<<'EOT'
                 // File: test.php
-                <?php 
+                <?php
 
                 new Bar\NotFound();
 
@@ -153,7 +153,7 @@ class UnresolvableNameProviderTest extends DiagnosticsTestCase
         yield 'interface not found' => [
             <<<'EOT'
                 // File: test.php
-                <?php 
+                <?php
 
                 class Bar implements Sugar {}
                 EOT
@@ -170,7 +170,7 @@ class UnresolvableNameProviderTest extends DiagnosticsTestCase
 
                 interface Sugar {}
                 // File: test.php
-                <?php 
+                <?php
 
                 class Bar implements Sugar {}
                 EOT
@@ -184,7 +184,7 @@ class UnresolvableNameProviderTest extends DiagnosticsTestCase
 
                 Sugar::class;
                 // File: test.php
-                <?php 
+                <?php
 
                 class Bar implements Sugar {}
                 EOT
@@ -197,7 +197,7 @@ class UnresolvableNameProviderTest extends DiagnosticsTestCase
         yield 'parent' => [
             <<<'EOT'
                 // File: test.php
-                <?php 
+                <?php
 
                 class Bar extends Sugar {}
                 EOT
@@ -209,7 +209,7 @@ class UnresolvableNameProviderTest extends DiagnosticsTestCase
         yield 'unresolvable trait' => [
             <<<'EOT'
                 // File: test.php
-                <?php 
+                <?php
 
                 class Bar {
                     use Sugar;
@@ -227,7 +227,7 @@ class UnresolvableNameProviderTest extends DiagnosticsTestCase
 
                 trait Sugar {}
                 // File: test.php
-                <?php 
+                <?php
 
                 class Bar {
                     use Sugar;
@@ -243,7 +243,7 @@ class UnresolvableNameProviderTest extends DiagnosticsTestCase
 
                 namespace Foobar;
 
-                class Barfoo { 
+                class Barfoo {
                     public function foo(): Baz {}
                 }
                 EOT
@@ -256,7 +256,7 @@ class UnresolvableNameProviderTest extends DiagnosticsTestCase
         yield 'resolvable fully qualified trait' => [
             <<<'EOT'
                 // File: test.php
-                <?php 
+                <?php
 
                 namespace Test;
 
@@ -264,7 +264,7 @@ class UnresolvableNameProviderTest extends DiagnosticsTestCase
                     use \App\Sugar;
                 }
                 // File: Sugar.php
-                <?php 
+                <?php
 
                 namespace App;
 
@@ -277,7 +277,7 @@ class UnresolvableNameProviderTest extends DiagnosticsTestCase
         yield 'resolvable partially qualified trait' => [
             <<<'EOT'
                 // File: test.php
-                <?php 
+                <?php
 
                 namespace Test;
 
@@ -287,7 +287,7 @@ class UnresolvableNameProviderTest extends DiagnosticsTestCase
                     use App\Sugar;
                 }
                 // File: Sugar.php
-                <?php 
+                <?php
 
                 namespace App;
 
@@ -300,7 +300,7 @@ class UnresolvableNameProviderTest extends DiagnosticsTestCase
         yield 'resolvable unqualified trait' => [
             <<<'EOT'
                 // File: test.php
-                <?php 
+                <?php
 
                 namespace Test;
 
@@ -310,7 +310,7 @@ class UnresolvableNameProviderTest extends DiagnosticsTestCase
                     use Sugar;
                 }
                 // File: Sugar.php
-                <?php 
+                <?php
 
                 namespace App;
 
@@ -323,7 +323,7 @@ class UnresolvableNameProviderTest extends DiagnosticsTestCase
         yield 'resolvable alias trait' => [
             <<<'EOT'
                 // File: test.php
-                <?php 
+                <?php
 
                 namespace Test;
 
@@ -333,7 +333,7 @@ class UnresolvableNameProviderTest extends DiagnosticsTestCase
                     use SweetSugar;
                 }
                 // File: Sugar.php
-                <?php 
+                <?php
 
                 namespace App;
 
@@ -352,7 +352,7 @@ class UnresolvableNameProviderTest extends DiagnosticsTestCase
 
                 class Barfoo {}
                 // File: test.php
-                <?php 
+                <?php
 
                 use Foobar\Barfoo;
 
@@ -368,7 +368,7 @@ class UnresolvableNameProviderTest extends DiagnosticsTestCase
 
                 namespace Foobar;
 
-                class Barfoo { 
+                class Barfoo {
                     public function foo(): self {}
                     public function bar(): {
                         static::foo();
@@ -388,7 +388,7 @@ class UnresolvableNameProviderTest extends DiagnosticsTestCase
                     namespace Foobar;
 
                     #[NotResolvable()]
-                    class Barfoo { 
+                    class Barfoo {
                     }
                     EOT
                     ,  function (Diagnostics $diagnostics): void {

--- a/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Diagonstics/UnresolvableNameProviderTest.php
+++ b/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Diagonstics/UnresolvableNameProviderTest.php
@@ -102,7 +102,7 @@ class UnresolvableNameProviderTest extends DiagnosticsTestCase
                 self::assertCount(1, $diagnostics);
             }
         ];
-        
+
         yield 'class imported in list' => [
             <<<'EOT'
                 // File: test.php

--- a/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Reflection/ReflectionPromotedPropertyTest.php
+++ b/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Reflection/ReflectionPromotedPropertyTest.php
@@ -85,7 +85,7 @@ class ReflectionPromotedPropertyTest extends IntegrationTestCase
 
         yield 'With docblock' => [
             <<<'EOT'
-                <?php class Barfoo { 
+                <?php class Barfoo {
                     public function __construct(
                         /** @var Foobar */
                         private $foobar

--- a/lib/WorseReflection/Tests/Integration/Core/FunctionReflectorTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/FunctionReflectorTest.php
@@ -48,7 +48,7 @@ class FunctionReflectorTest extends IntegrationTestCase
         yield 'fallback to global function' => [
             <<<'EOT'
                 // File: project/global.php
-                <?php 
+                <?php
                 function hello() {}
                 EOT
             ,
@@ -61,7 +61,7 @@ class FunctionReflectorTest extends IntegrationTestCase
         yield 'namespaced function' => [
             <<<'EOT'
                 // File: project/global.php
-                <?php 
+                <?php
                 namespace Foo;
                 function hello() {}
                 EOT

--- a/lib/WorseReflection/Tests/Integration/Core/Inference/NodeContextResolverTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/Inference/NodeContextResolverTest.php
@@ -696,7 +696,7 @@ class NodeContextResolverTest extends IntegrationTestCase
                         'container_type' => 'Foobar',
                     ],
                 ];
-        
+
         yield 'Static property access 2' => [
                     <<<'EOT'
                         <?php

--- a/lib/WorseReflection/Tests/Unit/Bridge/Phpactor/DocblockParser/DocblockParserFactoryTest.php
+++ b/lib/WorseReflection/Tests/Unit/Bridge/Phpactor/DocblockParser/DocblockParserFactoryTest.php
@@ -177,11 +177,11 @@ class DocblockParserFactoryTest extends IntegrationTestCase
 
         yield 'multiline array shape' => [
             <<<'EOT'
-                /** 
+                /**
                  * @return array{
                  *   foo:int,
                  *   bar:string
-                 * } 
+                 * }
                  */
                 EOT
                 ,
@@ -238,10 +238,10 @@ class DocblockParserFactoryTest extends IntegrationTestCase
     public function testClassConstant(): void
     {
         $source = <<<'EOT'
-                        <?php 
+                        <?php
                         namespace Bar;
 
-                        class Foo { 
+                        class Foo {
                             const BAR = "baz";
                         }
             EOT;
@@ -256,8 +256,8 @@ class DocblockParserFactoryTest extends IntegrationTestCase
     public function testClassConstantGlob(): void
     {
         $source = <<<'EOT'
-                        <?php 
-                        class Foo { 
+                        <?php
+                        class Foo {
                             const BAZ = "baz";
                             const BAR = "bar";
                             const ZED = "zed";
@@ -273,8 +273,8 @@ class DocblockParserFactoryTest extends IntegrationTestCase
     public function testClassConstantGlobInArrayShape(): void
     {
         $source = <<<'EOT'
-                        <?php 
-                        class Foo { 
+                        <?php
+                        class Foo {
                             const BAZ = "baz";
                             const BAR = "bar";
                             const ZED = "zed";

--- a/lib/WorseReflection/Tests/Unit/Core/Inference/SymbolFactoryTest.php
+++ b/lib/WorseReflection/Tests/Unit/Core/Inference/SymbolFactoryTest.php
@@ -15,7 +15,7 @@ use RuntimeException;
 class SymbolFactoryTest extends TestCase
 {
     use ProphecyTrait;
-    
+
     private NodeContextFactory $factory;
 
     /**

--- a/lib/WorseReflection/Tests/Unit/Core/Reflection/Collection/ChainReflectionMemberCollectionTest.php
+++ b/lib/WorseReflection/Tests/Unit/Core/Reflection/Collection/ChainReflectionMemberCollectionTest.php
@@ -17,11 +17,11 @@ use Traversable;
 class ChainReflectionMemberCollectionTest extends TestCase
 {
     use ProphecyTrait;
-    
+
     private ObjectProphecy $collection1;
-    
+
     private ObjectProphecy $collection2;
-    
+
     private ObjectProphecy $member1;
 
     public function setUp(): void

--- a/lib/WorseReflection/Tests/Unit/Core/Reflector/ClassReflector/MemonizedClassReflectorTest.php
+++ b/lib/WorseReflection/Tests/Unit/Core/Reflector/ClassReflector/MemonizedClassReflectorTest.php
@@ -29,7 +29,7 @@ class MemonizedClassReflectorTest extends TestCase
      * @var ObjectProphecy|FunctionReflector
      */
     private $innerFunctionReflector;
-    
+
     private ClassName $className;
 
     public function setUp(): void

--- a/lib/WorseReflection/Tests/Unit/Core/Reflector/SourceCode/ContextualSourceCodeReflectorTest.php
+++ b/lib/WorseReflection/Tests/Unit/Core/Reflector/SourceCode/ContextualSourceCodeReflectorTest.php
@@ -16,7 +16,7 @@ class ContextualSourceCodeReflectorTest extends TestCase
     use ProphecyTrait;
     const TEST_SOURCE_CODE = '<?php echo "hello";';
     const TEST_OFFSET = 1;
-    
+
     private ContextualSourceCodeReflector $reflector;
 
     private $code;

--- a/lib/WorseReflection/Tests/Unit/Core/SourceCodeLocator/TemporarySourceLocatorTest.php
+++ b/lib/WorseReflection/Tests/Unit/Core/SourceCodeLocator/TemporarySourceLocatorTest.php
@@ -14,7 +14,7 @@ use Prophecy\PhpUnit\ProphecyTrait;
 class TemporarySourceLocatorTest extends TestCase
 {
     use ProphecyTrait;
-    
+
     private TemporarySourceLocator $locator;
 
     private Reflector $reflector;

--- a/lib/WorseReflection/Tests/Unit/Core/Type/ArrayLiteralTypeTest.php
+++ b/lib/WorseReflection/Tests/Unit/Core/Type/ArrayLiteralTypeTest.php
@@ -16,7 +16,7 @@ class ArrayLiteralTypeTest extends TestCase
     {
         self::assertEquals($expected, $type->generalize()->__toString());
     }
-        
+
     /**
      * @return Generator<mixed>
      */

--- a/lib/WorseReflection/Tests/Unit/Core/Type/ArrayShapeTypeTest.php
+++ b/lib/WorseReflection/Tests/Unit/Core/Type/ArrayShapeTypeTest.php
@@ -16,7 +16,7 @@ class ArrayShapeTypeTest extends TestCase
     {
         self::assertEquals($expected, $type->generalize()->__toString());
     }
-        
+
     /**
      * @return Generator<mixed>
      */

--- a/lib/WorseReflection/Tests/Unit/Core/Type/ArrayTypeTest.php
+++ b/lib/WorseReflection/Tests/Unit/Core/Type/ArrayTypeTest.php
@@ -17,7 +17,7 @@ class ArrayTypeTest extends TestCase
     {
         self::assertEquals($expected, $type->__toString());
     }
-        
+
     /**
      * @return Generator<mixed>
      */

--- a/lib/WorseReflection/Tests/Unit/Core/Virtual/VirtualReflectionParameterTest.php
+++ b/lib/WorseReflection/Tests/Unit/Core/Virtual/VirtualReflectionParameterTest.php
@@ -20,19 +20,19 @@ class VirtualReflectionParameterTest extends TestCase
     use ProphecyTrait;
 
     private $position;
-    
+
     private ObjectProphecy $class;
-    
+
     private string $name;
-    
+
     private ObjectProphecy $frame;
-    
+
     private ObjectProphecy $scope;
 
     private Type $type;
-    
+
     private ObjectProphecy $method;
-    
+
     private DefaultValue $defaults;
 
     public function setUp(): void

--- a/tests/Unit/Extension/Core/Console/Prompt/ChainPromptTest.php
+++ b/tests/Unit/Extension/Core/Console/Prompt/ChainPromptTest.php
@@ -17,7 +17,7 @@ class ChainPromptTest extends TestCase
      * @var ObjectProphecy<Prompt>
      */
     private ObjectProphecy $prompt1;
-    
+
     /**
      * @var ObjectProphecy<Prompt>
      */


### PR DESCRIPTION
Empty lines are now really empty and don't contain any whitespaces.
And no useless space at the end of the line.


I have my vim set up to trim whitespaces at the end of the line anyways so why not do it all in one go and set up a linting rule for that.