### PR TITLE
Blackfire Profiler Extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
         "phpstan/phpstan-phpunit": "^1.0",
         "jangregor/phpstan-prophecy": "^1.0",
         "phpstan/extension-installer": "^1.1",
-        "vimeo/psalm": "^4.22"
+        "vimeo/psalm": "^4.22",
+        "blackfire/php-sdk": "^1.31"
     },
     "replace": {
         "phpactor/class-mover": "0.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a3f6ed06c4eb1c5e4e79299266295315",
+    "content-hash": "81189a2aefd810db555a6ae8de1fb068",
     "packages": [
         {
             "name": "amphp/amp",
@@ -3865,6 +3865,160 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "blackfire/php-sdk",
+            "version": "v1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/blackfireio/php-sdk.git",
+                "reference": "cec036e106d349d66db565c172ffc8f4beece6ae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/blackfireio/php-sdk/zipball/cec036e106d349d66db565c172ffc8f4beece6ae",
+                "reference": "cec036e106d349d66db565c172ffc8f4beece6ae",
+                "shasum": ""
+            },
+            "require": {
+                "composer/ca-bundle": "^1.0",
+                "php": ">=5.2.0"
+            },
+            "require-dev": {
+                "behat/behat": "^3.8",
+                "friends-of-behat/mink-browserkit-driver": "^1.4",
+                "friends-of-behat/mink-extension": "^2.5",
+                "guzzlehttp/psr7": "^1.6",
+                "illuminate/console": "^8.81",
+                "illuminate/queue": "^8.81",
+                "illuminate/support": "^8.81",
+                "laravel/octane": "^1.2",
+                "phpunit/phpunit": "^9.5",
+                "psr/http-message": "^1.0",
+                "symfony/browser-kit": "^5.1",
+                "symfony/framework-bundle": "^5.1",
+                "symfony/http-client": "^5.1",
+                "symfony/messenger": "^5.1",
+                "symfony/panther": "^1.0",
+                "symfony/phpunit-bridge": "^5.2"
+            },
+            "suggest": {
+                "ext-blackfire": "The C version of the Blackfire probe",
+                "ext-zlib": "To push config to remote profiling targets",
+                "symfony/panther": "To use Symfony web test cases with Blackfire"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.27.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/autostart.php"
+                ],
+                "psr-4": {
+                    "Blackfire\\": "src/Blackfire"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Blackfire.io",
+                    "email": "support@blackfire.io"
+                }
+            ],
+            "description": "Blackfire.io PHP SDK",
+            "keywords": [
+                "performance",
+                "profiler",
+                "uprofiler",
+                "xhprof"
+            ],
+            "support": {
+                "issues": "https://github.com/blackfireio/php-sdk/issues",
+                "source": "https://github.com/blackfireio/php-sdk/tree/v1.31.0"
+            },
+            "time": "2022-06-14T08:06:33+00:00"
+        },
+        {
+            "name": "composer/ca-bundle",
+            "version": "1.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/ca-bundle.git",
+                "reference": "30897edbfb15e784fe55587b4f73ceefd3c4d98c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/30897edbfb15e784fe55587b4f73ceefd3c4d98c",
+                "reference": "30897edbfb15e784fe55587b4f73ceefd3c4d98c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "ext-pcre": "*",
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12.55",
+                "psr/log": "^1.0",
+                "symfony/phpunit-bridge": "^4.2 || ^5",
+                "symfony/process": "^2.5 || ^3.0 || ^4.0 || ^5.0 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\CaBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Lets you find a path to the system CA bundle, and includes a fallback to the Mozilla CA bundle.",
+            "keywords": [
+                "cabundle",
+                "cacert",
+                "certificate",
+                "ssl",
+                "tls"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/ca-bundle/issues",
+                "source": "https://github.com/composer/ca-bundle/tree/1.3.3"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-07-20T07:14:26+00:00"
+        },
         {
             "name": "composer/semver",
             "version": "3.3.2",

--- a/doc/lsp/vim-lsp.rst
+++ b/doc/lsp/vim-lsp.rst
@@ -11,6 +11,8 @@ Neovim does not support LSP progress notifications out-of-the-box.
 
 Install a dedicated plugin such as `fidget <https://github.com/j-hui/fidget.nvim>`_
 
+.. _nvim_configuration_snippet_commands:
+
 Phpactor Commands
 -----------------
 
@@ -24,6 +26,11 @@ This configuration snippet enables the following commands:
 - ``:LspPhpactorReindex``: Reindex the current project
 - ``:LspPhpactorStatus``: Show some useful information and statistics
 - ``:LspPhpactorConfig``: Show the config in a floating window
+
+If you want to profile Phpactor for debugging purposes:
+
+- ``:LspPhpactorBlackfireStart``: Start :ref:`developing_blackfire_profiling` (if enabled with :ref:`param_blackfire.enable`)
+- ``:LspPhpactorBlackfireFinish``: Finish profiling and get the profiling URL
 
 .. code-block:: lua
 

--- a/doc/lsp/vim-lsp.rst
+++ b/doc/lsp/vim-lsp.rst
@@ -36,6 +36,8 @@ This configuration snippet enables the following commands:
           autocmd Filetype php command! -nargs=0 LspPhpactorReindex lua vim.lsp.buf_notify(0, "phpactor/indexer/reindex",{})
           autocmd Filetype php command! -nargs=0 LspPhpactorConfig lua LspPhpactorDumpConfig()
           autocmd Filetype php command! -nargs=0 LspPhpactorStatus lua LspPhpactorStatus()
+          autocmd Filetype php command! -nargs=0 LspPhpactorBlackfireStart lua LspPhpactorBlackfireStart()
+          autocmd Filetype php command! -nargs=0 LspPhpactorBlackfireFinish lua LspPhpactorBlackfireFinish()
         augroup END
     ]])
 
@@ -72,4 +74,11 @@ This configuration snippet enables the following commands:
         for _, res in pairs(results or {}) do
             showWindow("Phpactor Status", "markdown", res["result"])
         end
+    end
+
+    function LspPhpactorBlackfireStart()
+        local _, _ = vim.lsp.buf_request_sync(0, "blackfire/start", {})
+    end
+    function LspPhpactorBlackfireFinish()
+        local _, _ = vim.lsp.buf_request_sync(0, "blackfire/finish", {})
     end

--- a/doc/other/developing.rst
+++ b/doc/other/developing.rst
@@ -1,6 +1,11 @@
 Development
 ===========
 
+.. contents::
+   :depth: 2
+   :backlinks: none
+   :local:
+
 Package Structure
 -----------------
 
@@ -152,3 +157,14 @@ Use the following command to both install vimdoc and build the documentation:
 .. code:: sh
 
     make vimdoc
+
+.. _developing_blackfire_profiling:
+
+Profiling the Language Server
+-----------------------------
+
+You can selectively profile the language server using `Blackfire <https://blackfire.io>`_.
+
+- Enable the blackfire via. :ref:`param_blackfire.enable`
+- Call the LSP methods `blackfire/start` and `blackfire/finish`, for NVIM see
+  :ref:`nvim_configuration_snippet_commands`

--- a/doc/reference/configuration.rst
+++ b/doc/reference/configuration.rst
@@ -804,7 +804,7 @@ FilePathResolverExtension
 """""""""""""""""""""""""""""""""""
 
 
-**Default**: ``"\/home\/daniel\/www\/phpactor\/phpactor2"``
+**Default**: ``"\/home\/daniel\/www\/phpactor\/phpactor"``
 
 
 .. _param_file_path_resolver.app_name:
@@ -1436,6 +1436,29 @@ Path to pslam if different from vendor/bin/psalm
 
 ``language_server_psalm.enabled``
 """""""""""""""""""""""""""""""""
+
+
+**Default**: ``false``
+
+
+.. _LanguageServerBlackfireExtension:
+
+
+LanguageServerBlackfireExtension
+--------------------------------
+
+
+.. _param_blackfire.enable:
+
+
+``blackfire.enable``
+""""""""""""""""""""
+
+
+Type: boolean
+
+
+Enable Blackfire profiles to be captured via. blackfire/start and blackfire/finish LSP method calls
 
 
 **Default**: ``false``

--- a/lib/Extension/LanguageServer/LanguageServerExtension.php
+++ b/lib/Extension/LanguageServer/LanguageServerExtension.php
@@ -7,6 +7,8 @@ use Phly\EventDispatcher\EventDispatcher;
 use Phpactor\Container\Container;
 use Phpactor\Container\ContainerBuilder;
 use Phpactor\Container\Extension;
+use Phpactor\Extension\LanguageServerBlackfire\BlackfireProfiler;
+use Phpactor\Extension\LanguageServerBlackfire\Middleware\BlackfireMiddleware;
 use Phpactor\Extension\LanguageServer\Dispatcher\PhpactorDispatcherFactory;
 use Phpactor\Extension\LanguageServer\EventDispatcher\LazyAggregateProvider;
 use Phpactor\Extension\LanguageServer\Handler\DebugHandler;
@@ -77,6 +79,7 @@ class LanguageServerExtension implements Extension
     public const TAG_CODE_ACTION_DIAGNOSTICS_PROVIDER = 'language_server.code_action_diagnostics_provider';
     public const TAG_STATUS_PROVIDER = 'language_server.status_provvder';
     public const TAG_DIAGNOSTICS_PROVIDER = 'language_server.diagnostics_provider';
+    public const TAG_MIDDLEWARE = 'language_server.middleware';
     public const PARAM_SESSION_PARAMETERS = 'language_server.session_parameters';
     public const PARAM_CLIENT_CAPABILITIES = 'language_server.client_capabilities';
     public const PARAM_ENABLE_WORKPACE = 'language_server.enable_workspace';
@@ -326,6 +329,15 @@ class LanguageServerExtension implements Extension
             if ($container->getParameter(self::PARAM_PROFILE)) {
                 $stack[] = new ProfilerMiddleware($this->logger($container));
             }
+
+            foreach ($container->getServiceIdsForTag(self::TAG_MIDDLEWARE) as $serviceId => $_) {
+                $service = $container->get($serviceId);
+                if (null === $service) {
+                    continue;
+                }
+                $stack[] = $service;
+            }
+
             if ($container->getParameter(self::PARAM_TRACE)) {
                 $stack[] = new TraceMiddleware($this->logger($container));
             }
@@ -377,7 +389,11 @@ class LanguageServerExtension implements Extension
             foreach (array_keys(
                 $container->getServiceIdsForTag(LanguageServerExtension::TAG_METHOD_HANDLER)
             ) as $serviceId) {
-                $handlers[] = $container->get($serviceId);
+                $handler = $container->get($serviceId);
+                if (null === $handler) {
+                    continue;
+                }
+                $handlers[] = $handler;
             }
 
             return new Handlers(...$handlers);

--- a/lib/Extension/LanguageServer/LanguageServerExtension.php
+++ b/lib/Extension/LanguageServer/LanguageServerExtension.php
@@ -7,8 +7,6 @@ use Phly\EventDispatcher\EventDispatcher;
 use Phpactor\Container\Container;
 use Phpactor\Container\ContainerBuilder;
 use Phpactor\Container\Extension;
-use Phpactor\Extension\LanguageServerBlackfire\BlackfireProfiler;
-use Phpactor\Extension\LanguageServerBlackfire\Middleware\BlackfireMiddleware;
 use Phpactor\Extension\LanguageServer\Dispatcher\PhpactorDispatcherFactory;
 use Phpactor\Extension\LanguageServer\EventDispatcher\LazyAggregateProvider;
 use Phpactor\Extension\LanguageServer\Handler\DebugHandler;

--- a/lib/Extension/LanguageServerBlackfire/BlackfireProfiler.php
+++ b/lib/Extension/LanguageServerBlackfire/BlackfireProfiler.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerBlackfire;
+
+use Blackfire\Client;
+use Blackfire\Probe;
+
+class BlackfireProfiler
+{
+    private Client $blackfire;
+    private ?Probe $probe = null;
+
+    private bool $profiling = false;
+    private bool $probing = false;
+
+    public function __construct(Client $blackfire)
+    {
+        $this->blackfire = $blackfire;
+    }
+
+    public function enable(): void
+    {
+        if ($this->probing) {
+            return;
+        }
+        if ($this->probe) {
+            $this->probe->enable();
+            $this->probing = true;
+        }
+    }
+
+    public function disable(): void
+    {
+        if ($this->probe && $this->probing) {
+            $this->probe->disable();
+            $this->probing = false;
+        }
+    }
+
+    /**
+     * Return URL of profile
+     */
+    public function done(): string
+    {
+        $profile = $this->blackfire->endProbe($this->probe);
+        $this->probing = false;
+        $this->probe = null;
+        return $profile->getUrl();
+    }
+
+    private function getProbe(): Probe
+    {
+        if ($this->probe) {
+            return $this->probe;
+        }
+
+        $this->probe = $this->blackfire->createProbe(null, false);
+        return $this->probe;
+    }
+
+    public function start(): void
+    {
+        $this->getProbe();
+        $this->profiling = true;
+    }
+
+    /** 
+     * Return true if profiling has been started
+     */
+    public function started(): bool
+    {
+        return $this->profiling;
+    }
+}
+

--- a/lib/Extension/LanguageServerBlackfire/BlackfireProfiler.php
+++ b/lib/Extension/LanguageServerBlackfire/BlackfireProfiler.php
@@ -8,9 +8,11 @@ use Blackfire\Probe;
 class BlackfireProfiler
 {
     private Client $blackfire;
+
     private ?Probe $probe = null;
 
     private bool $profiling = false;
+
     private bool $probing = false;
 
     public function __construct(Client $blackfire)
@@ -48,6 +50,20 @@ class BlackfireProfiler
         return $profile->getUrl();
     }
 
+    public function start(): void
+    {
+        $this->getProbe();
+        $this->profiling = true;
+    }
+
+    /**
+     * Return true if profiling has been started
+     */
+    public function started(): bool
+    {
+        return $this->profiling;
+    }
+
     private function getProbe(): Probe
     {
         if ($this->probe) {
@@ -57,19 +73,4 @@ class BlackfireProfiler
         $this->probe = $this->blackfire->createProbe(null, false);
         return $this->probe;
     }
-
-    public function start(): void
-    {
-        $this->getProbe();
-        $this->profiling = true;
-    }
-
-    /** 
-     * Return true if profiling has been started
-     */
-    public function started(): bool
-    {
-        return $this->profiling;
-    }
 }
-

--- a/lib/Extension/LanguageServerBlackfire/Handler/BlackfireHandler.php
+++ b/lib/Extension/LanguageServerBlackfire/Handler/BlackfireHandler.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerBlackfire\Handler;
+
+use Amp\Promise;
+use Amp\Success;
+use Blackfire\Client;
+use Blackfire\Probe;
+use Phpactor\LanguageServer\Core\Handler\Handler;
+use Phpactor\LanguageServer\Core\Server\ClientApi;
+use RuntimeException;
+
+class BlackfireHandler implements Handler
+{
+    private Client $blackfire;
+    private ClientApi $client;
+
+    private ?Probe $probe = null;
+
+    public function __construct(Client $blackfire, ClientApi $client)
+    {
+        $this->blackfire = $blackfire;
+        $this->client = $client;
+    }
+    public function methods(): array
+    {
+        return [
+            'blackfire/start' => 'start',
+            'blackfire/finish' => 'finish',
+        ];
+    }
+
+    /**
+     * @return Promise<null>
+     */
+    public function start(): Promise
+    {
+        if ($this->probe) {
+            throw new RuntimeException(sprintf('Probe already started'));
+        }
+        $this->client->window()->showMessage()->info(
+            'Blackfire probe enabled',
+        );
+
+        $this->probe = $this->blackfire->createProbe();
+        return new Success(null);
+    }
+
+    /**
+     * @return Promise<null>
+     */
+    public function finish(): Promise
+    {
+        $this->client->window()->showMessage()->info(
+            'Blackfire profile creating....',
+        );
+        $profile = $this->blackfire->endProbe($this->probe);
+        $this->client->window()->showMessage()->info(sprintf(
+            'Blackfire profile created: %s',
+            $profile->getUrl()
+        ));
+        $this->probe = null;
+        return new Success(null);
+    }
+
+}

--- a/lib/Extension/LanguageServerBlackfire/Handler/BlackfireHandler.php
+++ b/lib/Extension/LanguageServerBlackfire/Handler/BlackfireHandler.php
@@ -4,16 +4,14 @@ namespace Phpactor\Extension\LanguageServerBlackfire\Handler;
 
 use Amp\Promise;
 use Amp\Success;
-use Blackfire\Client;
-use Blackfire\Probe;
 use Phpactor\Extension\LanguageServerBlackfire\BlackfireProfiler;
 use Phpactor\LanguageServer\Core\Handler\Handler;
 use Phpactor\LanguageServer\Core\Server\ClientApi;
-use RuntimeException;
 
 class BlackfireHandler implements Handler
 {
     private ClientApi $client;
+
     private BlackfireProfiler $profiler;
 
     /**
@@ -63,5 +61,4 @@ class BlackfireHandler implements Handler
         ));
         return new Success(null);
     }
-
 }

--- a/lib/Extension/LanguageServerBlackfire/LanguageServerBlackfireExtension.php
+++ b/lib/Extension/LanguageServerBlackfire/LanguageServerBlackfireExtension.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerBlackfire;
+
+use Blackfire\Client;
+use Blackfire\ClientConfiguration;
+use Phpactor\Container\Container;
+use Phpactor\Container\ContainerBuilder;
+use Phpactor\Container\Extension;
+use Phpactor\Extension\LanguageServerBlackfire\Handler\BlackfireHandler;
+use Phpactor\Extension\LanguageServer\LanguageServerExtension;
+use Phpactor\LanguageServer\Core\Server\ClientApi;
+use Phpactor\MapResolver\Resolver;
+
+class LanguageServerBlackfireExtension implements Extension
+{
+    public function load(ContainerBuilder $container): void
+    {
+        $container->register(BlackfireHandler::class, function (Container $container) {
+            return new BlackfireHandler(
+                new Client(),
+                $container->get(ClientApi::class)
+            );
+        }, [ LanguageServerExtension::TAG_METHOD_HANDLER => []]);
+    }
+
+    public function configure(Resolver $schema): void
+    {
+    }
+}

--- a/lib/Extension/LanguageServerBlackfire/LanguageServerBlackfireExtension.php
+++ b/lib/Extension/LanguageServerBlackfire/LanguageServerBlackfireExtension.php
@@ -3,28 +3,55 @@
 namespace Phpactor\Extension\LanguageServerBlackfire;
 
 use Blackfire\Client;
-use Blackfire\ClientConfiguration;
 use Phpactor\Container\Container;
 use Phpactor\Container\ContainerBuilder;
 use Phpactor\Container\Extension;
 use Phpactor\Extension\LanguageServerBlackfire\Handler\BlackfireHandler;
+use Phpactor\Extension\LanguageServerBlackfire\Middleware\BlackfireMiddleware;
 use Phpactor\Extension\LanguageServer\LanguageServerExtension;
 use Phpactor\LanguageServer\Core\Server\ClientApi;
 use Phpactor\MapResolver\Resolver;
 
 class LanguageServerBlackfireExtension implements Extension
 {
+    const PARAM_BLACKFIRE_ENABLE = 'blackfire.enable';
+
     public function load(ContainerBuilder $container): void
     {
         $container->register(BlackfireHandler::class, function (Container $container) {
+            if (false === $container->getParameter(self::PARAM_BLACKFIRE_ENABLE)) {
+                return null;
+            }
             return new BlackfireHandler(
-                new Client(),
+                $container->get(BlackfireProfiler::class),
                 $container->get(ClientApi::class)
             );
         }, [ LanguageServerExtension::TAG_METHOD_HANDLER => []]);
+
+        $container->register(BlackfireProfiler::class, function (Container $container) {
+            return new BlackfireProfiler(new Client());
+        });
+
+        $container->register(BlackfireMiddleware::class, function (Container $container) {
+            if (false === $container->getParameter(self::PARAM_BLACKFIRE_ENABLE)) {
+                return null;
+            }
+            return new BlackfireMiddleware($container->get(BlackfireProfiler::class));
+        }, [
+            LanguageServerExtension::TAG_MIDDLEWARE => []
+        ]);
     }
 
     public function configure(Resolver $schema): void
     {
+        $schema->setDefaults([
+            self::PARAM_BLACKFIRE_ENABLE => false,
+        ]);
+        $schema->setDescriptions([
+            self::PARAM_BLACKFIRE_ENABLE => 'Enable Blackfire profiles to be captured via. blackfire/start and blackfire/finish LSP method calls'
+        ]);
+        $schema->setTypes([
+            self::PARAM_BLACKFIRE_ENABLE => 'boolean',
+        ]);
     }
 }

--- a/lib/Extension/LanguageServerBlackfire/Middleware/BlackfireMiddleware.php
+++ b/lib/Extension/LanguageServerBlackfire/Middleware/BlackfireMiddleware.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerBlackfire\Middleware;
+
+use Amp\Promise;
+use Phpactor\Extension\LanguageServerBlackfire\BlackfireProfiler;
+use Phpactor\LanguageServer\Core\Middleware\Middleware;
+use Phpactor\LanguageServer\Core\Middleware\RequestHandler;
+use Phpactor\LanguageServer\Core\Rpc\Message;
+use function Amp\call;
+
+class BlackfireMiddleware implements Middleware
+{
+    private BlackfireProfiler $profiler;
+
+    public function __construct(BlackfireProfiler $profiler)
+    {
+        $this->profiler = $profiler;
+    }
+
+    public function process(Message $request, RequestHandler $handler): Promise
+    {
+        return call(function () use ($request, $handler) {
+            if (!$this->profiler->started()) {
+                return $handler->handle($request);
+            }
+            $this->profiler->enable();
+
+            $response = yield $handler->handle($request);
+
+            if ($this->profiler->started()) {
+                $this->profiler->disable();
+            }
+            return $response;
+        });
+    }
+}

--- a/lib/Phpactor.php
+++ b/lib/Phpactor.php
@@ -6,6 +6,7 @@ use Phpactor\ClassMover\Extension\ClassMoverExtension as MainClassMoverExtension
 use Phpactor\Container\Container;
 use Phpactor\Extension\Behat\BehatExtension;
 use Phpactor\Extension\Debug\DebugExtension;
+use Phpactor\Extension\LanguageServerBlackfire\LanguageServerBlackfireExtension;
 use Phpactor\Extension\LanguageServerPhpstan\LanguageServerPhpstanExtension;
 use Phpactor\Extension\LanguageServerBridge\LanguageServerBridgeExtension;
 use Phpactor\Extension\LanguageServerCodeTransform\LanguageServerCodeTransformExtension;
@@ -152,6 +153,7 @@ class Phpactor
             LanguageServerRenameWorseExtension::class,
             LanguageServerPhpstanExtension::class,
             LanguageServerPsalmExtension::class,
+            LanguageServerBlackfireExtension::class,
             BehatExtension::class,
             IndexerExtension::class,
             ObjectRendererExtension::class

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Sphinx==2.4.3
-sphinx-tabs==1.1.13
-docutils==0.17
+docutils==0.18.1
+sphinx==5.0.0
+sphinx-tabs==3.4.1


### PR DESCRIPTION
This PR introduces a way to start and stop a black fire probe over LSP:

```
:command! -nargs=0 LspPhpactorBlackfireStart lua LspPhpactorBlackfireStart()
:command! -nargs=0 LspPhpactorBlackfireFinish lua LspPhpactorBlackfireFinish()
```
```
function LspPhpactorBlackfireStart()
    local _, _ = vim.lsp.buf_request_sync(0, "blackfire/start", {})
end
function LspPhpactorBlackfireFinish()
    local _, _ = vim.lsp.buf_request_sync(0, "blackfire/finish", {})
end
```

TODO:

- [x] Only enable profiling during requests: Currently it records all the idle time.