### PR TITLE
Do not attempt to search for things which are not php "names"

### DIFF
--- a/lib/Indexer/Adapter/ReferenceFinder/IndexedNameSearcher.php
+++ b/lib/Indexer/Adapter/ReferenceFinder/IndexedNameSearcher.php
@@ -27,7 +27,7 @@ class IndexedNameSearcher implements NameSearcher
      */
     public function search(string $name, ?string $type = null): Generator
     {
-        if (false === PhpNameMatcher::isClassName($name)) {
+        if (false === PhpNameMatcher::isPhpName($name)) {
             return;
         }
         $criteria = Criteria::shortNameBeginsWith($name);

--- a/lib/Indexer/Adapter/ReferenceFinder/IndexedNameSearcher.php
+++ b/lib/Indexer/Adapter/ReferenceFinder/IndexedNameSearcher.php
@@ -6,6 +6,7 @@ use Generator;
 use Phpactor\Indexer\Model\Query\Criteria;
 use Phpactor\Indexer\Model\Record\HasPath;
 use Phpactor\Indexer\Model\SearchClient;
+use Phpactor\Indexer\Util\PhpNameMatcher;
 use Phpactor\Name\FullyQualifiedName;
 use Phpactor\ReferenceFinder\NameSearcher;
 use Phpactor\ReferenceFinder\NameSearcherType;
@@ -26,6 +27,9 @@ class IndexedNameSearcher implements NameSearcher
      */
     public function search(string $name, ?string $type = null): Generator
     {
+        if (false === PhpNameMatcher::isClassName($name)) {
+            return;
+        }
         $criteria = Criteria::shortNameBeginsWith($name);
 
         $typeCriteria = $this->resolveTypeCriteria($type);

--- a/lib/Indexer/Tests/Unit/Util/PhpNameMatcherTest.php
+++ b/lib/Indexer/Tests/Unit/Util/PhpNameMatcherTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Phpactor\Indexer\Tests\Unit\Util;
+
+use PHPUnit\Framework\TestCase;
+use Phpactor\Indexer\Util\PhpNameMatcher;
+
+class PhpNameMatcherTest extends TestCase
+{
+    public function testMatch(): void
+    {
+        self::assertTrue(PhpNameMatcher::isPhpName('Foobar'));
+        self::assertTrue(PhpNameMatcher::isPhpName('foobar'));
+        self::assertFalse(PhpNameMatcher::isPhpName('$foobar'));
+    }
+}

--- a/lib/Indexer/Util/PhpNameMatcher.php
+++ b/lib/Indexer/Util/PhpNameMatcher.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Phpactor\Indexer\Util;
+
+class PhpNameMatcher
+{
+    public static function isClassName(string $name): bool
+    {
+        // https://www.php.net/manual/en/language.oop5.basic.php
+        return (bool)preg_match('{^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$}', $name);
+    }
+}

--- a/lib/Indexer/Util/PhpNameMatcher.php
+++ b/lib/Indexer/Util/PhpNameMatcher.php
@@ -4,7 +4,7 @@ namespace Phpactor\Indexer\Util;
 
 class PhpNameMatcher
 {
-    public static function isClassName(string $name): bool
+    public static function isPhpName(string $name): bool
     {
         // https://www.php.net/manual/en/language.oop5.basic.php
         return (bool)preg_match('{^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$}', $name);


### PR DESCRIPTION
Previously it was searching the name index (i.e. checking 20k+ entries) for every completion request regardless of if the input was a valid name (e.g. `$name` would search the index for functions/classes starting with `$name`)