### PR TITLE
Support lazily resolving documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Bug fixes:
 
 Improvements:
 
+  - [cmp] Show partial namespace to disambiguate class name suggestions
   - [wr] Markdown formatted member completion documentation
   - [ls] publish diagnostics on open and update
   - [ct] Add missing properties for array assignments #1640
@@ -76,9 +77,11 @@ Improvements:
   - [cb] Preserve `?` operator as distinct from a union type
   - [wr] Support for class-string type (not for type inference however)
   - [completion + location] Better support for union types
+  - [cs] Updated CS and converted property docblock types to actual types
 
 Features:
 
+  - [ls] Lazily resolve documentation for completion items
   - [ct] Generate constructor refactoring
   - [ct] Fill object refactoring
   - [ct] Remove unused imports diagnositcs and code transformation #1758
@@ -121,10 +124,6 @@ Features:
   - [reference-finder] Enum support (requires 8.1 PHP runtime)
   - [php8.1] Disable deprecation warnings unless `PHPACTOR_DEPRECATIONS`
     provided.
-
-Improvements:
-
-  - [cs] Updated CS and converted property docblock types to actual types
 
 ## 2022-01-03 (0.18.0)
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "phpactor/amp-fswatch": "^0.2.0",
         "thecodingmachine/safe": "^1.0",
         "phpactor/phly-event-dispatcher": "^2.0.0",
-        "phpactor/language-server": "^3.1.1",
+        "phpactor/language-server": "^3.2.0",
         "dantleech/object-renderer": "^0.1.1",
         "phpactor/language-server-protocol": "~0.3.0",
         "monolog/monolog": "^1.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "81189a2aefd810db555a6ae8de1fb068",
+    "content-hash": "61851cace56f1ac58eb593d75481a521",
     "packages": [
         {
             "name": "amphp/amp",
@@ -1213,12 +1213,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/JetBrains/phpstorm-stubs.git",
-                "reference": "fcd660e2dbdcb04aa32a635a5d1fedb172d12db9"
+                "reference": "af2b2d4d77bc60dd6685e89bc27201256a8cd4f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/fcd660e2dbdcb04aa32a635a5d1fedb172d12db9",
-                "reference": "fcd660e2dbdcb04aa32a635a5d1fedb172d12db9",
+                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/af2b2d4d77bc60dd6685e89bc27201256a8cd4f9",
+                "reference": "af2b2d4d77bc60dd6685e89bc27201256a8cd4f9",
                 "shasum": ""
             },
             "require-dev": {
@@ -1254,7 +1254,7 @@
             "support": {
                 "source": "https://github.com/JetBrains/phpstorm-stubs/tree/master"
             },
-            "time": "2022-07-21T13:17:52+00:00"
+            "time": "2022-08-03T12:15:16+00:00"
         },
         {
             "name": "kelunik/certificate",
@@ -1680,16 +1680,16 @@
         },
         {
             "name": "phpactor/language-server",
-            "version": "3.1.1",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/language-server.git",
-                "reference": "094d6fc2f31160840f8962158dd9b51d0f588c6e"
+                "reference": "221ebc68d865b7ccc3f496755c18fb31f822052e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/language-server/zipball/094d6fc2f31160840f8962158dd9b51d0f588c6e",
-                "reference": "094d6fc2f31160840f8962158dd9b51d0f588c6e",
+                "url": "https://api.github.com/repos/phpactor/language-server/zipball/221ebc68d865b7ccc3f496755c18fb31f822052e",
+                "reference": "221ebc68d865b7ccc3f496755c18fb31f822052e",
                 "shasum": ""
             },
             "require": {
@@ -1740,9 +1740,9 @@
             "description": "Generic Language Server Platform",
             "support": {
                 "issues": "https://github.com/phpactor/language-server/issues",
-                "source": "https://github.com/phpactor/language-server/tree/3.1.1"
+                "source": "https://github.com/phpactor/language-server/tree/3.2.0"
             },
-            "time": "2022-07-17T10:52:27+00:00"
+            "time": "2022-08-04T14:40:19+00:00"
         },
         {
             "name": "phpactor/language-server-protocol",
@@ -2305,16 +2305,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.10",
+            "version": "v5.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "4d671ab4ddac94ee439ea73649c69d9d200b5000"
+                "reference": "535846c7ee6bc4dd027ca0d93220601456734b10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/4d671ab4ddac94ee439ea73649c69d9d200b5000",
-                "reference": "4d671ab4ddac94ee439ea73649c69d9d200b5000",
+                "url": "https://api.github.com/repos/symfony/console/zipball/535846c7ee6bc4dd027ca0d93220601456734b10",
+                "reference": "535846c7ee6bc4dd027ca0d93220601456734b10",
                 "shasum": ""
             },
             "require": {
@@ -2384,7 +2384,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.10"
+                "source": "https://github.com/symfony/console/tree/v5.4.11"
             },
             "funding": [
                 {
@@ -2400,7 +2400,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-26T13:00:04+00:00"
+            "time": "2022-07-22T10:42:43+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -2471,16 +2471,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.4.9",
+            "version": "v5.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "36a017fa4cce1eff1b8e8129ff53513abcef05ba"
+                "reference": "6699fb0228d1bc35b12aed6dd5e7455457609ddd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/36a017fa4cce1eff1b8e8129ff53513abcef05ba",
-                "reference": "36a017fa4cce1eff1b8e8129ff53513abcef05ba",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/6699fb0228d1bc35b12aed6dd5e7455457609ddd",
+                "reference": "6699fb0228d1bc35b12aed6dd5e7455457609ddd",
                 "shasum": ""
             },
             "require": {
@@ -2515,7 +2515,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.4.9"
+                "source": "https://github.com/symfony/filesystem/tree/v5.4.11"
             },
             "funding": [
                 {
@@ -2531,7 +2531,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-20T13:55:35+00:00"
+            "time": "2022-07-20T13:00:38+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -3182,16 +3182,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v5.4.8",
+            "version": "v5.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "597f3fff8e3e91836bb0bd38f5718b56ddbde2f3"
+                "reference": "6e75fe6874cbc7e4773d049616ab450eff537bf1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/597f3fff8e3e91836bb0bd38f5718b56ddbde2f3",
-                "reference": "597f3fff8e3e91836bb0bd38f5718b56ddbde2f3",
+                "url": "https://api.github.com/repos/symfony/process/zipball/6e75fe6874cbc7e4773d049616ab450eff537bf1",
+                "reference": "6e75fe6874cbc7e4773d049616ab450eff537bf1",
                 "shasum": ""
             },
             "require": {
@@ -3224,7 +3224,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v5.4.8"
+                "source": "https://github.com/symfony/process/tree/v5.4.11"
             },
             "funding": [
                 {
@@ -3240,7 +3240,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-08T05:07:18+00:00"
+            "time": "2022-06-27T16:58:25+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -3327,16 +3327,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v5.4.10",
+            "version": "v5.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "4432bc7df82a554b3e413a8570ce2fea90e94097"
+                "reference": "5eb661e49ad389e4ae2b6e4df8d783a8a6548322"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/4432bc7df82a554b3e413a8570ce2fea90e94097",
-                "reference": "4432bc7df82a554b3e413a8570ce2fea90e94097",
+                "url": "https://api.github.com/repos/symfony/string/zipball/5eb661e49ad389e4ae2b6e4df8d783a8a6548322",
+                "reference": "5eb661e49ad389e4ae2b6e4df8d783a8a6548322",
                 "shasum": ""
             },
             "require": {
@@ -3393,7 +3393,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.4.10"
+                "source": "https://github.com/symfony/string/tree/v5.4.11"
             },
             "funding": [
                 {
@@ -3409,20 +3409,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-26T15:57:47+00:00"
+            "time": "2022-07-24T16:15:25+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v5.4.10",
+            "version": "v5.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "04e42926429d9e8b39c174387ab990bf7817f7a2"
+                "reference": "05d4ea560f3402c6c116afd99fdc66e60eda227e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/04e42926429d9e8b39c174387ab990bf7817f7a2",
-                "reference": "04e42926429d9e8b39c174387ab990bf7817f7a2",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/05d4ea560f3402c6c116afd99fdc66e60eda227e",
+                "reference": "05d4ea560f3402c6c116afd99fdc66e60eda227e",
                 "shasum": ""
             },
             "require": {
@@ -3468,7 +3468,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v5.4.10"
+                "source": "https://github.com/symfony/yaml/tree/v5.4.11"
             },
             "funding": [
                 {
@@ -3484,7 +3484,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-20T11:50:59+00:00"
+            "time": "2022-06-27T16:58:25+00:00"
         },
         {
             "name": "thecodingmachine/safe",
@@ -7337,16 +7337,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v5.4.8",
+            "version": "v5.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "9b630f3427f3ebe7cd346c277a1408b00249dad9"
+                "reference": "7872a66f57caffa2916a584db1aa7f12adc76f8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/9b630f3427f3ebe7cd346c277a1408b00249dad9",
-                "reference": "9b630f3427f3ebe7cd346c277a1408b00249dad9",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/7872a66f57caffa2916a584db1aa7f12adc76f8c",
+                "reference": "7872a66f57caffa2916a584db1aa7f12adc76f8c",
                 "shasum": ""
             },
             "require": {
@@ -7380,7 +7380,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.4.8"
+                "source": "https://github.com/symfony/finder/tree/v5.4.11"
             },
             "funding": [
                 {
@@ -7396,20 +7396,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-15T08:07:45+00:00"
+            "time": "2022-07-29T07:37:50+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v5.4.3",
+            "version": "v5.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "cc1147cb11af1b43f503ac18f31aa3bec213aba8"
+                "reference": "54f14e36aa73cb8f7261d7686691fd4d75ea2690"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/cc1147cb11af1b43f503ac18f31aa3bec213aba8",
-                "reference": "cc1147cb11af1b43f503ac18f31aa3bec213aba8",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/54f14e36aa73cb8f7261d7686691fd4d75ea2690",
+                "reference": "54f14e36aa73cb8f7261d7686691fd4d75ea2690",
                 "shasum": ""
             },
             "require": {
@@ -7449,7 +7449,7 @@
                 "options"
             ],
             "support": {
-                "source": "https://github.com/symfony/options-resolver/tree/v5.4.3"
+                "source": "https://github.com/symfony/options-resolver/tree/v5.4.11"
             },
             "funding": [
                 {
@@ -7465,7 +7465,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:53:40+00:00"
+            "time": "2022-07-20T13:00:38+00:00"
         },
         {
             "name": "symfony/stopwatch",
@@ -7531,16 +7531,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v5.4.9",
+            "version": "v5.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "af52239a330fafd192c773795520dc2dd62b5657"
+                "reference": "b8f306d7b8ef34fb3db3305be97ba8e088fb4861"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/af52239a330fafd192c773795520dc2dd62b5657",
-                "reference": "af52239a330fafd192c773795520dc2dd62b5657",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/b8f306d7b8ef34fb3db3305be97ba8e088fb4861",
+                "reference": "b8f306d7b8ef34fb3db3305be97ba8e088fb4861",
                 "shasum": ""
             },
             "require": {
@@ -7600,7 +7600,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v5.4.9"
+                "source": "https://github.com/symfony/var-dumper/tree/v5.4.11"
             },
             "funding": [
                 {
@@ -7616,7 +7616,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-21T10:24:18+00:00"
+            "time": "2022-07-20T13:00:38+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -7670,16 +7670,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "4.24.0",
+            "version": "4.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "06dd975cb55d36af80f242561738f16c5f58264f"
+                "reference": "6998fabb2bf528b65777bf9941920888d23c03ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/06dd975cb55d36af80f242561738f16c5f58264f",
-                "reference": "06dd975cb55d36af80f242561738f16c5f58264f",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/6998fabb2bf528b65777bf9941920888d23c03ac",
+                "reference": "6998fabb2bf528b65777bf9941920888d23c03ac",
                 "shasum": ""
             },
             "require": {
@@ -7771,9 +7771,9 @@
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/4.24.0"
+                "source": "https://github.com/vimeo/psalm/tree/4.26.0"
             },
-            "time": "2022-06-26T11:47:54+00:00"
+            "time": "2022-07-31T13:10:26+00:00"
         }
     ],
     "aliases": [],

--- a/doc/reference/configuration.rst
+++ b/doc/reference/configuration.rst
@@ -600,14 +600,14 @@ If results should be de-duplicated
 **Default**: ``true``
 
 
-.. _param_completion.dedupe_match_short_description:
+.. _param_completion.dedupe_match_fqn:
 
 
-``completion.dedupe_match_short_description``
-"""""""""""""""""""""""""""""""""""""""""""""
+``completion.dedupe_match_fqn``
+"""""""""""""""""""""""""""""""
 
 
-If ``completion.dedupe``, match on completion description intead of name
+If ``completion.dedupe``, consider the class FQN in addition to the completion suggestion
 
 
 **Default**: ``true``

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletor.php
@@ -18,7 +18,6 @@ use Phpactor\WorseReflection\Core\Exception\NotFound;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionClass;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionEnum;
-use Phpactor\WorseReflection\Core\Reflection\ReflectionMethod;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionProperty;
 use Phpactor\WorseReflection\Core\Type;
 use Phpactor\WorseReflection\Reflector;
@@ -178,7 +177,7 @@ class WorseClassMemberCompletor implements TolerantCompletor, TolerantQualifiabl
 
                 yield Suggestion::createWithOptions($name, [
                     'type' => Suggestion::TYPE_PROPERTY,
-                    'short_description' => fn() => $this->formatter->format($property),
+                    'short_description' => fn () => $this->formatter->format($property),
                     'documentation' => function () use ($property) {
                         return $this->objectRenderer->render(new ItemDocumentation(sprintf(
                             '%s::%s',

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletor.php
@@ -134,7 +134,6 @@ class WorseClassMemberCompletor implements TolerantCompletor, TolerantQualifiabl
             return;
         }
 
-        /** @var ReflectionMethod $method */
         foreach ($classReflection->methods() as $method) {
             if ($method->name() === '__construct') {
                 continue;
@@ -149,7 +148,7 @@ class WorseClassMemberCompletor implements TolerantCompletor, TolerantQualifiabl
 
             yield Suggestion::createWithOptions($method->name(), [
                 'type' => Suggestion::TYPE_METHOD,
-                //'short_description' => $this->formatter->format($method),
+                'short_description' => fn () => $this->formatter->format($method),
                 'documentation' => function () use ($method) {
                     return $this->objectRenderer->render(new ItemDocumentation(sprintf(
                         '%s::%s',
@@ -179,7 +178,7 @@ class WorseClassMemberCompletor implements TolerantCompletor, TolerantQualifiabl
 
                 yield Suggestion::createWithOptions($name, [
                     'type' => Suggestion::TYPE_PROPERTY,
-                    //'short_description' => $this->formatter->format($property),
+                    'short_description' => fn() => $this->formatter->format($property),
                     'documentation' => function () use ($property) {
                         return $this->objectRenderer->render(new ItemDocumentation(sprintf(
                             '%s::%s',
@@ -197,7 +196,7 @@ class WorseClassMemberCompletor implements TolerantCompletor, TolerantQualifiabl
             foreach ($classReflection->constants() as $constant) {
                 yield Suggestion::createWithOptions($constant->name(), [
                     'type' => Suggestion::TYPE_CONSTANT,
-                    //'short_description' => $this->formatter->format($constant),
+                    'short_description' => fn () => $this->formatter->format($constant),
                     'documentation' => fn () => $constant->docblock()->formatted(),
                 ]);
             }
@@ -207,7 +206,7 @@ class WorseClassMemberCompletor implements TolerantCompletor, TolerantQualifiabl
             foreach ($classReflection->cases() as $case) {
                 yield Suggestion::createWithOptions($case->name(), [
                     'type' => Suggestion::TYPE_ENUM,
-                    //'short_description' => $this->formatter->format($case),
+                    'short_description' => fn () => $this->formatter->format($case),
                     'documentation' => fn () => $case->docblock()->formatted(),
                 ]);
             }

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletor.php
@@ -150,11 +150,13 @@ class WorseClassMemberCompletor implements TolerantCompletor, TolerantQualifiabl
             yield Suggestion::createWithOptions($method->name(), [
                 'type' => Suggestion::TYPE_METHOD,
                 'short_description' => $this->formatter->format($method),
-                'documentation' => $this->objectRenderer->render(new ItemDocumentation(sprintf(
-                    '%s::%s',
-                    $method->class()->name(),
-                    $method->name()
-                ), $method->docblock()->formatted(), $method)),
+                'documentation' => function () use ($method) {
+                    return $this->objectRenderer->render(new ItemDocumentation(sprintf(
+                        '%s::%s',
+                        $method->class()->name(),
+                        $method->name()
+                    ), $method->docblock()->formatted(), $method));
+                },
                 'snippet' => $completeOnlyName ? $method->name() : $this->snippetFormatter->format($method),
             ]);
         }
@@ -178,7 +180,7 @@ class WorseClassMemberCompletor implements TolerantCompletor, TolerantQualifiabl
                 yield Suggestion::createWithOptions($name, [
                     'type' => Suggestion::TYPE_PROPERTY,
                     'short_description' => $this->formatter->format($property),
-                    'documentation' => $property->docblock()->formatted()
+                    'documentation' => fn () => $property->docblock()->formatted()
                 ]);
             }
         }
@@ -190,7 +192,7 @@ class WorseClassMemberCompletor implements TolerantCompletor, TolerantQualifiabl
                 yield Suggestion::createWithOptions($constant->name(), [
                     'type' => Suggestion::TYPE_CONSTANT,
                     'short_description' => $this->formatter->format($constant),
-                    'documentation' => $constant->docblock()->formatted(),
+                    'documentation' => fn () => $constant->docblock()->formatted(),
                 ]);
             }
         }
@@ -200,7 +202,7 @@ class WorseClassMemberCompletor implements TolerantCompletor, TolerantQualifiabl
                 yield Suggestion::createWithOptions($case->name(), [
                     'type' => Suggestion::TYPE_ENUM,
                     'short_description' => $this->formatter->format($case),
-                    'documentation' => $case->docblock()->formatted(),
+                    'documentation' => fn () => $case->docblock()->formatted(),
                 ]);
             }
         }

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletor.php
@@ -149,7 +149,7 @@ class WorseClassMemberCompletor implements TolerantCompletor, TolerantQualifiabl
 
             yield Suggestion::createWithOptions($method->name(), [
                 'type' => Suggestion::TYPE_METHOD,
-                'short_description' => $this->formatter->format($method),
+                //'short_description' => $this->formatter->format($method),
                 'documentation' => function () use ($method) {
                     return $this->objectRenderer->render(new ItemDocumentation(sprintf(
                         '%s::%s',
@@ -179,8 +179,14 @@ class WorseClassMemberCompletor implements TolerantCompletor, TolerantQualifiabl
 
                 yield Suggestion::createWithOptions($name, [
                     'type' => Suggestion::TYPE_PROPERTY,
-                    'short_description' => $this->formatter->format($property),
-                    'documentation' => fn () => $property->docblock()->formatted()
+                    //'short_description' => $this->formatter->format($property),
+                    'documentation' => function () use ($property) {
+                        return $this->objectRenderer->render(new ItemDocumentation(sprintf(
+                            '%s::%s',
+                            $property->class()->name(),
+                            $property->name()
+                        ), $property->docblock()->formatted(), $property));
+                    },
                 ]);
             }
         }
@@ -191,7 +197,7 @@ class WorseClassMemberCompletor implements TolerantCompletor, TolerantQualifiabl
             foreach ($classReflection->constants() as $constant) {
                 yield Suggestion::createWithOptions($constant->name(), [
                     'type' => Suggestion::TYPE_CONSTANT,
-                    'short_description' => $this->formatter->format($constant),
+                    //'short_description' => $this->formatter->format($constant),
                     'documentation' => fn () => $constant->docblock()->formatted(),
                 ]);
             }
@@ -201,7 +207,7 @@ class WorseClassMemberCompletor implements TolerantCompletor, TolerantQualifiabl
             foreach ($classReflection->cases() as $case) {
                 yield Suggestion::createWithOptions($case->name(), [
                     'type' => Suggestion::TYPE_ENUM,
-                    'short_description' => $this->formatter->format($case),
+                    //'short_description' => $this->formatter->format($case),
                     'documentation' => fn () => $case->docblock()->formatted(),
                 ]);
             }

--- a/lib/Completion/Bridge/WorseReflection/Formatter/MethodFormatter.php
+++ b/lib/Completion/Bridge/WorseReflection/Formatter/MethodFormatter.php
@@ -32,19 +32,7 @@ class MethodFormatter implements Formatter
             array_unshift($info, 'abstract ');
         }
 
-        $paramInfos = [];
-
-        /** @var ReflectionParameter $parameter */
-        foreach ($method->parameters() as $parameter) {
-            $paramInfos[] = $formatter->format($parameter);
-        }
-        $info[] = '(' . implode(', ', $paramInfos) . ')';
-
-        $returnType = $method->inferredType();
-
-        if (($returnType->isDefined())) {
-            $info[] = ': ' . $formatter->format($returnType);
-        }
+        $info[] = '(...)';
 
         return implode('', $info);
     }

--- a/lib/Completion/Bridge/WorseReflection/Formatter/MethodFormatter.php
+++ b/lib/Completion/Bridge/WorseReflection/Formatter/MethodFormatter.php
@@ -32,7 +32,19 @@ class MethodFormatter implements Formatter
             array_unshift($info, 'abstract ');
         }
 
-        $info[] = '(...)';
+        $paramInfos = [];
+
+        /** @var ReflectionParameter $parameter */
+        foreach ($method->parameters() as $parameter) {
+            $paramInfos[] = $formatter->format($parameter);
+        }
+        $info[] = '(' . implode(', ', $paramInfos) . ')';
+
+        $returnType = $method->inferredType();
+
+        if (($returnType->isDefined())) {
+            $info[] = ': ' . $formatter->format($returnType);
+        }
 
         return implode('', $info);
     }

--- a/lib/Completion/Core/Completor/DedupeCompletor.php
+++ b/lib/Completion/Core/Completor/DedupeCompletor.php
@@ -11,12 +11,12 @@ class DedupeCompletor implements Completor
 {
     private Completor $innerCompletor;
 
-    private bool $matchShortDescription;
+    private bool $matchNameImport;
 
-    public function __construct(Completor $innerCompletor, bool $matchShortDescription = false)
+    public function __construct(Completor $innerCompletor, bool $matchNameImport = false)
     {
         $this->innerCompletor = $innerCompletor;
-        $this->matchShortDescription = $matchShortDescription;
+        $this->matchNameImport = $matchNameImport;
     }
 
 
@@ -27,8 +27,8 @@ class DedupeCompletor implements Completor
         foreach ($suggestions as $suggestion) {
             $key = $suggestion->name();
 
-            if ($this->matchShortDescription) {
-                $key .= $suggestion->shortDescription();
+            if ($this->matchNameImport) {
+                $key .= $suggestion->nameImport();
             }
 
             if (isset($seen[$key])) {

--- a/lib/Completion/Core/Suggestion.php
+++ b/lib/Completion/Core/Suggestion.php
@@ -183,7 +183,10 @@ class Suggestion
         return $this->shortDescription;
     }
 
-    public function withShortDescription(string $description): self
+    /**
+     * @param string|Closure $description
+     */
+    public function withShortDescription($description): self
     {
         $clone = clone $this;
         $clone->shortDescription = $description;
@@ -243,6 +246,16 @@ class Suggestion
     {
         $new = clone $this;
         $new->label = $label;
+        return $new;
+    }
+
+    /**
+     * @param null|string|Closure $documentation
+     */
+    public function withDocumentation($documentation): self
+    {
+        $new = clone $this;
+        $new->documentation = $documentation;
         return $new;
     }
 }

--- a/lib/Completion/Core/Suggestion.php
+++ b/lib/Completion/Core/Suggestion.php
@@ -37,7 +37,10 @@ class Suggestion
 
     private string $name;
 
-    private ?string $shortDescription;
+    /**
+     * @var null|string|Closure
+     */
+    private $shortDescription;
 
     private string $label;
 
@@ -56,11 +59,12 @@ class Suggestion
 
     /**
      * @param null|string|Closure $documentation
+     * @param null|string|Closure $shortDescription
      */
     private function __construct(
         string $name,
         ?string $type = null,
-        ?string $shortDescription = null,
+        $shortDescription = null,
         ?string $nameImport = null,
         ?string $label = null,
         $documentation = null,
@@ -86,8 +90,8 @@ class Suggestion
 
     /**
      * @param array{
-     *   short_description?:string|null,
-     *   documentation?:string|null|\Closure,
+     *   short_description?:string|null|Closure,
+     *   documentation?:string|null|Closure,
      *   type?:string|null,
      *   class_import?:string|null,
      *   name_import?:string|null,
@@ -134,6 +138,9 @@ class Suggestion
         );
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     public function toArray(): array
     {
         return [
@@ -147,16 +154,12 @@ class Suggestion
             'name_import' => $this->nameImport,
             'range' => $this->range ? $this->range->toArray() : null,
 
-            // deprecated: in favour of short_description, to be removed
-            // after 0.10.0
-            'info' => $this->shortDescription(),
+            // removed
+            'info' => '',
         ];
     }
 
-    /**
-     * @return string|null
-     */
-    public function type()
+    public function type(): ?string
     {
         return $this->type;
     }
@@ -173,6 +176,10 @@ class Suggestion
 
     public function shortDescription(): ?string
     {
+        if ($this->shortDescription instanceof Closure) {
+            $shortDescription = $this->shortDescription;
+            return $shortDescription();
+        }
         return $this->shortDescription;
     }
 

--- a/lib/Completion/Core/Suggestion.php
+++ b/lib/Completion/Core/Suggestion.php
@@ -2,6 +2,7 @@
 
 namespace Phpactor\Completion\Core;
 
+use Closure;
 use RuntimeException;
 
 class Suggestion
@@ -42,7 +43,10 @@ class Suggestion
 
     private ?Range $range;
 
-    private ?string $documentation;
+    /**
+     * @var null|string|Closure
+     */
+    private $documentation;
 
     private ?string $snippet;
 
@@ -50,13 +54,16 @@ class Suggestion
 
     private ?int $priority;
 
+    /**
+     * @param null|string|Closure $documentation
+     */
     private function __construct(
         string $name,
         ?string $type = null,
         ?string $shortDescription = null,
         ?string $nameImport = null,
         ?string $label = null,
-        ?string $documentation = null,
+        $documentation = null,
         ?Range $range = null,
         ?string $snippet = null,
         ?int $priority = null
@@ -80,7 +87,7 @@ class Suggestion
     /**
      * @param array{
      *   short_description?:string|null,
-     *   documentation?:string|null,
+     *   documentation?:string|null|\Closure,
      *   type?:string|null,
      *   class_import?:string|null,
      *   name_import?:string|null,
@@ -213,6 +220,10 @@ class Suggestion
 
     public function documentation(): ?string
     {
+        if ($this->documentation instanceof Closure) {
+            $documentation = $this->documentation;
+            return $documentation();
+        }
         return $this->documentation;
     }
 

--- a/lib/Completion/Tests/Unit/Core/Completor/DedupeCompletorTest.php
+++ b/lib/Completion/Tests/Unit/Core/Completor/DedupeCompletorTest.php
@@ -30,7 +30,7 @@ class DedupeCompletorTest extends TestCase
         $this->assertTrue($suggestions->getReturn());
     }
 
-    public function testDeduplicatesWithShortDescription(): void
+    public function testDeduplicatesWithFqn(): void
     {
         $source = TextDocumentBuilder::create('foobar')->build();
         $offset = ByteOffset::fromInt(10);
@@ -38,11 +38,11 @@ class DedupeCompletorTest extends TestCase
         $inner = new ArrayCompletor([
             Suggestion::create('foobar'),
             Suggestion::createWithOptions('barfoo', [
-                'short_description' => 'baf',
+                'name_import' => 'baf',
             ]),
             Suggestion::create('foobar'),
             Suggestion::createWithOptions('barfoo', [
-                'short_description' => 'bosh',
+                'name_import' => 'bosh',
             ]),
         ]);
         $dedupe = new DedupeCompletor($inner, true);
@@ -50,10 +50,10 @@ class DedupeCompletorTest extends TestCase
         self::assertEquals([
             Suggestion::create('foobar'),
             Suggestion::createWithOptions('barfoo', [
-                'short_description' => 'baf',
+                'name_import' => 'baf',
             ]),
             Suggestion::createWithOptions('barfoo', [
-                'short_description' => 'bosh',
+                'name_import' => 'bosh',
             ]),
         ], iterator_to_array($suggestions));
         $this->assertTrue($suggestions->getReturn());

--- a/lib/Completion/Tests/Unit/Core/SuggestionTest.php
+++ b/lib/Completion/Tests/Unit/Core/SuggestionTest.php
@@ -61,7 +61,7 @@ class SuggestionTest extends TestCase
             'name' => 'hello',
             'label' => 'hallo',
             'range' => [1, 2],
-            'info' => 'Foobar',
+            'info' => '',
             'snippet' => null,
             'name_import' => 'Namespace\\Foobar',
         ], $suggestion->toArray());

--- a/lib/Extension/Completion/CompletionExtension.php
+++ b/lib/Extension/Completion/CompletionExtension.php
@@ -29,7 +29,7 @@ class CompletionExtension implements Extension
     public const SERVICE_SNIPPET_FORMATTER = 'completion.snippet.formatter';
     public const KEY_COMPLETOR_TYPES = 'types';
     public const PARAM_DEDUPE = 'completion.dedupe';
-    public const PARAM_DEDUPE_MATCH_NAME_IMPORT = 'completion.dedupe_match_name_import';
+    public const PARAM_DEDUPE_MATCH_FQN = 'completion.dedupe_match_fqn';
     public const PARAM_LIMIT = 'completion.limit';
 
 
@@ -37,12 +37,12 @@ class CompletionExtension implements Extension
     {
         $schema->setDefaults([
             self::PARAM_DEDUPE => true,
-            self::PARAM_DEDUPE_MATCH_NAME_IMPORT => true,
+            self::PARAM_DEDUPE_MATCH_FQN => true,
             self::PARAM_LIMIT => null,
         ]);
         $schema->setDescriptions([
             self::PARAM_DEDUPE => 'If results should be de-duplicated',
-            self::PARAM_DEDUPE_MATCH_NAME_IMPORT => 'If ``' . self::PARAM_DEDUPE . '``, consider the class FQN in addition to the completion suggestion',
+            self::PARAM_DEDUPE_MATCH_FQN => 'If ``' . self::PARAM_DEDUPE . '``, consider the class FQN in addition to the completion suggestion',
             self::PARAM_LIMIT => 'Sets a limit on the number of completion suggestions for any request',
         ]);
     }
@@ -77,7 +77,7 @@ class CompletionExtension implements Extension
                 if ($container->getParameter(self::PARAM_DEDUPE)) {
                     $completors = new DedupeCompletor(
                         $completors,
-                        $container->getParameter(self::PARAM_DEDUPE_MATCH_NAME_IMPORT)
+                        $container->getParameter(self::PARAM_DEDUPE_MATCH_FQN)
                     );
                 }
 

--- a/lib/Extension/Completion/CompletionExtension.php
+++ b/lib/Extension/Completion/CompletionExtension.php
@@ -29,7 +29,7 @@ class CompletionExtension implements Extension
     public const SERVICE_SNIPPET_FORMATTER = 'completion.snippet.formatter';
     public const KEY_COMPLETOR_TYPES = 'types';
     public const PARAM_DEDUPE = 'completion.dedupe';
-    public const PARAM_DEDUPE_MATCH_SHORT_DESCRIPTION = 'completion.dedupe_match_short_description';
+    public const PARAM_DEDUPE_MATCH_NAME_IMPORT = 'completion.dedupe_match_name_import';
     public const PARAM_LIMIT = 'completion.limit';
 
 
@@ -37,12 +37,12 @@ class CompletionExtension implements Extension
     {
         $schema->setDefaults([
             self::PARAM_DEDUPE => true,
-            self::PARAM_DEDUPE_MATCH_SHORT_DESCRIPTION => true,
+            self::PARAM_DEDUPE_MATCH_NAME_IMPORT => true,
             self::PARAM_LIMIT => null,
         ]);
         $schema->setDescriptions([
             self::PARAM_DEDUPE => 'If results should be de-duplicated',
-            self::PARAM_DEDUPE_MATCH_SHORT_DESCRIPTION => 'If ``' . self::PARAM_DEDUPE . '``, match on completion description intead of name',
+            self::PARAM_DEDUPE_MATCH_NAME_IMPORT => 'If ``' . self::PARAM_DEDUPE . '``, consider the class FQN in addition to the completion suggestion',
             self::PARAM_LIMIT => 'Sets a limit on the number of completion suggestions for any request',
         ]);
     }
@@ -77,7 +77,7 @@ class CompletionExtension implements Extension
                 if ($container->getParameter(self::PARAM_DEDUPE)) {
                     $completors = new DedupeCompletor(
                         $completors,
-                        $container->getParameter(self::PARAM_DEDUPE_MATCH_SHORT_DESCRIPTION)
+                        $container->getParameter(self::PARAM_DEDUPE_MATCH_NAME_IMPORT)
                     );
                 }
 

--- a/lib/Extension/Completion/Tests/Unit/CompletionExtensionTest.php
+++ b/lib/Extension/Completion/Tests/Unit/CompletionExtensionTest.php
@@ -128,7 +128,7 @@ class CompletionExtensionTest extends TestCase
         return $builder->build([
             'logging.enabled' => false,
             CompletionExtension::PARAM_DEDUPE => false,
-            CompletionExtension::PARAM_DEDUPE_MATCH_SHORT_DESCRIPTION => false,
+            CompletionExtension::PARAM_DEDUPE_MATCH_NAME_IMPORT => false,
             CompletionExtension::PARAM_LIMIT => 10,
         ]);
     }

--- a/lib/Extension/Completion/Tests/Unit/CompletionExtensionTest.php
+++ b/lib/Extension/Completion/Tests/Unit/CompletionExtensionTest.php
@@ -128,7 +128,7 @@ class CompletionExtensionTest extends TestCase
         return $builder->build([
             'logging.enabled' => false,
             CompletionExtension::PARAM_DEDUPE => false,
-            CompletionExtension::PARAM_DEDUPE_MATCH_NAME_IMPORT => false,
+            CompletionExtension::PARAM_DEDUPE_MATCH_FQN => false,
             CompletionExtension::PARAM_LIMIT => 10,
         ]);
     }

--- a/lib/Extension/LanguageServerCompletion/Handler/CompletionHandler.php
+++ b/lib/Extension/LanguageServerCompletion/Handler/CompletionHandler.php
@@ -63,6 +63,7 @@ class CompletionHandler implements Handler, CanRegisterCapabilities
     {
         return [
             'textDocument/completion' => 'completion',
+            'completionItem/resolve' => 'resolveItem',
         ];
     }
 
@@ -124,10 +125,21 @@ class CompletionHandler implements Handler, CanRegisterCapabilities
         });
     }
 
+    /**
+     * @return Promise<CompletionItem>
+     */
+    public function resolveItem(RequestMessage $request): Promise
+    {
+        return call(function () use ($request) {
+            return $item;
+        });
+    }
+
     public function registerCapabiltiies(ServerCapabilities $capabilities): void
     {
         $capabilities->completionProvider = new CompletionOptions([':', '>', '$', '@']);
         $capabilities->signatureHelpProvider = new SignatureHelpOptions(['(', ',']);
+        $capabilities->completionProvider->resolveProvider = true;
     }
 
     /**

--- a/lib/Extension/LanguageServerCompletion/Tests/Unit/Handler/CompletionHandlerTest.php
+++ b/lib/Extension/LanguageServerCompletion/Tests/Unit/Handler/CompletionHandlerTest.php
@@ -62,7 +62,7 @@ class CompletionHandlerTest extends TestCase
             ]
         );
         $this->assertInstanceOf(CompletionList::class, $response->result);
-        $this->assertEquals([
+        $this->assertCompletion([
             self::completionItem('hello', null),
             self::completionItem('goodbye', null),
         ], $response->result->items);
@@ -83,7 +83,7 @@ class CompletionHandlerTest extends TestCase
             ]
         );
         $this->assertInstanceOf(CompletionList::class, $response->result);
-        $this->assertEquals([
+        $this->assertCompletion([
             self::completionItem('hello', null),
             self::completionItem('goodbye', null),
         ], $response->result->items);
@@ -102,7 +102,7 @@ class CompletionHandlerTest extends TestCase
                 'position' => ProtocolFactory::position(0, 0)
             ]
         );
-        $this->assertEquals([
+        $this->assertCompletion([
             self::completionItem('hello', null, ['textEdit' => new TextEdit(
                 new Range(new Position(0, 1), new Position(0, 2)),
                 'hello'
@@ -137,14 +137,14 @@ class CompletionHandlerTest extends TestCase
                 'position'     => ProtocolFactory::position(0, 0)
             ]
         );
-        $this->assertEquals(
+        $this->assertCompletion(
             [
                 self::completionItem(
                     'hello',
                     null,
                     [
                         'kind' => 7,
-                        'detail' => '↓ ',
+                        'detail' => null,
                         'insertText' => 'hello',
                         'textEdit'   => TextEdit::fromArray(
                             [
@@ -205,14 +205,14 @@ class CompletionHandlerTest extends TestCase
                 'position'     => ProtocolFactory::position(0, 0)
             ]
         );
-        $this->assertEquals(
+        $this->assertCompletion(
             [
                 self::completionItem(
                     'hello',
                     null,
                     [
                         'kind'       => 7,
-                        'detail'     => '↓ ',
+                        'detail'     => null,
                         'insertText' => 'FooBar',
                         'textEdit'   => TextEdit::fromArray(
                             [
@@ -283,7 +283,7 @@ class CompletionHandlerTest extends TestCase
                 'position' => ProtocolFactory::position(0, 0)
             ]
         );
-        $this->assertEquals([
+        $this->assertCompletion([
             self::completionItem('hello', 2),
             self::completionItem('goodbye', 2, ['insertText' => 'goodbye()', 'insertTextFormat' => 2]),
             self::completionItem('var', 6, [
@@ -315,7 +315,7 @@ class CompletionHandlerTest extends TestCase
                 'position' => ProtocolFactory::position(0, 0)
             ]
         );
-        $this->assertEquals([
+        $this->assertCompletion([
             self::completionItem('hello', 2),
             self::completionItem('goodbye', 2),
             self::completionItem('var', 6, [
@@ -351,7 +351,7 @@ class CompletionHandlerTest extends TestCase
             ]
         );
 
-        $this->assertEquals([
+        $this->assertCompletion([
             self::completionItem('hello', 2, [
                 'sortText' => '0064-hello',
             ]),
@@ -465,5 +465,17 @@ class CompletionHandlerTest extends TestCase
                 return !$this->isIncomplete;
             }
         };
+    }
+
+    /**
+     * @param CompletionItem[] $expectedItems
+     * @param CompletionItem[] $items
+     */
+    private function assertCompletion(array $expectedItems, array $items): void
+    {
+        foreach ($expectedItems as $index => $expected) {
+            $actual = $items[$index];
+            self::assertEquals($actual->detail, $expected->detail);
+        }
     }
 }

--- a/lib/Extension/LanguageServerCompletion/Tests/Unit/Handler/CompletionHandlerTest.php
+++ b/lib/Extension/LanguageServerCompletion/Tests/Unit/Handler/CompletionHandlerTest.php
@@ -69,6 +69,28 @@ class CompletionHandlerTest extends TestCase
         $this->assertFalse($response->result->isIncomplete);
     }
 
+    public function testResolveCompletionItem(): void
+    {
+        $tester = $this->create([
+            Suggestion::create('hello')->withShortDescription(fn () => 'this is a short description')->withDocumentation(fn () => 'documentation now'),
+        ]);
+        $response = $tester->requestAndWait(
+            'textDocument/completion',
+            [
+                'textDocument' => ProtocolFactory::textDocumentIdentifier(self::EXAMPLE_URI),
+                'position' => ProtocolFactory::position(0, 0)
+            ]
+        );
+        $this->assertInstanceOf(CompletionList::class, $response->result);
+        $response = $tester->requestAndWait(
+            'completionItem/resolve',
+            $response->result->items[0]
+        );
+        self::assertEquals('this is a short description', $response->result->detail);
+        self::assertEquals('documentation now', $response->result->documentation->value);
+
+    }
+
     public function testHandleAnIncompleteListOfSuggestions(): void
     {
         $tester = $this->create([

--- a/lib/Extension/LanguageServerCompletion/Tests/Unit/Handler/CompletionHandlerTest.php
+++ b/lib/Extension/LanguageServerCompletion/Tests/Unit/Handler/CompletionHandlerTest.php
@@ -513,6 +513,10 @@ class CompletionHandlerTest extends TestCase
         foreach ($expectedItems as $index => $expected) {
             $actual = $items[$index];
             self::assertEquals($actual->detail, $expected->detail);
+            self::assertEquals($actual->kind, $expected->kind);
+            self::assertEquals($actual->insertText, $expected->insertText);
+            self::assertEquals($actual->additionalTextEdits, $expected->additionalTextEdits);
+            self::assertEquals($actual->label, $expected->label);
         }
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1856,11 +1856,6 @@ parameters:
 			path: lib/Completion/Core/SignatureInformation.php
 
 		-
-			message: "#^Method Phpactor\\\\Completion\\\\Core\\\\Suggestion\\:\\:toArray\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Completion/Core/Suggestion.php
-
-		-
 			message: "#^Method Phpactor\\\\Completion\\\\Tests\\\\Benchmark\\\\CompletorBenchCase\\:\\:benchComplete\\(\\) has parameter \\$params with no type specified\\.$#"
 			count: 1
 			path: lib/Completion/Tests/Benchmark/CompletorBenchCase.php

--- a/tests/Benchmark/CompleteBench.php
+++ b/tests/Benchmark/CompleteBench.php
@@ -21,6 +21,6 @@ class CompleteBench extends BaseBenchCase
     public function benchComplete(): void
     {
         $output = $this->runCommand('complete tests/FoobarTest.php 145'); //145?
-        Assert::assertStringContainsString('info:pub', $output);
+        Assert::assertStringContainsString('short_description:pub', $output);
     }
 }


### PR DESCRIPTION
This PR adds support for LSP `completion/resolve` which allows us to calculate things like documentation only when the item is selected in the user interface.

This makes completion near instantaneous in some cases where there would otherwise be a significant delay.