### PR TITLE
Constant inference

### DIFF
--- a/lib/Completion/Bridge/WorseReflection/SuggestionDocumentor/WorseSuggestionDocumentor.php
+++ b/lib/Completion/Bridge/WorseReflection/SuggestionDocumentor/WorseSuggestionDocumentor.php
@@ -59,6 +59,20 @@ class WorseSuggestionDocumentor implements SuggestionDocumentor
                 ));
             }
 
+            if ($suggestion->type() === Suggestion::TYPE_CONSTANT) {
+                try {
+                    $reflectionConstant = $this->reflector->reflectConstant($fqn);
+                } catch (NotFound $notFound) {
+                    return $suggestion->documentation();
+                }
+
+                return $this->renderer->render(new ItemDocumentation(
+                    $reflectionConstant->name(),
+                    $reflectionConstant->docblock()->formatted(),
+                    $reflectionConstant
+                ));
+            }
+
             return $suggestion->documentation();
         };
     }

--- a/lib/Completion/Core/Completor/NameSearcherCompletor.php
+++ b/lib/Completion/Core/Completor/NameSearcherCompletor.php
@@ -84,6 +84,10 @@ abstract class NameSearcherCompletor
             return Suggestion::TYPE_FUNCTION;
         }
 
+        if ($result->type()->isConstant()) {
+            return Suggestion::TYPE_CONSTANT;
+        }
+
         return null;
     }
 

--- a/lib/Completion/Tests/Integration/Bridge/TolerantParser/ReferenceFinder/ExpressionNameCompletorTest.php
+++ b/lib/Completion/Tests/Integration/Bridge/TolerantParser/ReferenceFinder/ExpressionNameCompletorTest.php
@@ -76,11 +76,24 @@ class ExpressionNameCompletorTest extends TolerantCompletorTestCase
                 ]
             ]
         ];
+
+        yield 'constant' => [
+            '<?php define("FOO", "BAR"); FO<>', [
+                [
+                    'type'              => Suggestion::TYPE_CONSTANT,
+                    'name'              => 'FOO',
+                    'short_description' => 'FOO',
+                ]
+            ]
+        ];
     }
 
     protected function createTolerantCompletor(TextDocument $source): TolerantCompletor
     {
         $searcher = $this->prophesize(NameSearcher::class);
+        $searcher->search('FO')->willYield([
+            NameSearchResult::create('constant', 'FOO')
+        ]);
         $searcher->search('Foo')->willYield([
             NameSearchResult::create('class', 'Foobar')
         ]);

--- a/lib/Completion/Tests/Unit/Adapter/WorseReflection/SuggestionDocumentor/WorseSuggestionDocumentorTest.php
+++ b/lib/Completion/Tests/Unit/Adapter/WorseReflection/SuggestionDocumentor/WorseSuggestionDocumentorTest.php
@@ -29,6 +29,20 @@ class WorseSuggestionDocumentorTest extends TestCase
         self::assertNotEmpty($documentation);
     }
 
+    public function testConstantSuggestion(): void
+    {
+        $documentation = $this->createDocumentor('<?php /** Documentation */define("foobar", "barfoo");')->document(
+            Suggestion::createWithOptions(
+                'foobar',
+                [
+                    'type' => Suggestion::TYPE_CONSTANT,
+                    'name_import' => 'foobar'
+                ]
+            )
+        );
+        self::assertNotEmpty($documentation);
+    }
+
     public function testOtherSuggestion(): void
     {
         $documentation = $this->createDocumentor('<?php /** Documentation */function boo() {}')->document(Suggestion::createWithOptions('Foobar', [

--- a/lib/Extension/LanguageServerCompletion/Tests/Integration/MarkdownObjectRendererTest.php
+++ b/lib/Extension/LanguageServerCompletion/Tests/Integration/MarkdownObjectRendererTest.php
@@ -59,6 +59,7 @@ class MarkdownObjectRendererTest extends IntegrationTestCase
      * @dataProvider provideTrait
      * @dataProvider provideFunction
      * @dataProvider provideSymbolOffset
+     * @dataProvider provideDeclaredConstant
      * @dataProvider provideType
      * @dataProvider provideMemberDocblock
      */
@@ -655,6 +656,25 @@ class MarkdownObjectRendererTest extends IntegrationTestCase
                 )->first();
             },
             'function2.md',
+        ];
+    }
+
+    /**
+     * @return Generator<mixed>
+     */
+    public function provideDeclaredConstant(): Generator
+    {
+        yield 'define constant' => [
+            '',
+            function (Reflector $reflector) {
+                return $reflector->reflectConstantsIn(
+                    <<<'EOT'
+                        <?php
+                        define('FOO', 'bar');
+                        EOT
+                )->first();
+            },
+            'declared_constant1.md',
         ];
     }
 

--- a/lib/Extension/LanguageServerCompletion/Tests/Integration/expected/declared_constant1.md
+++ b/lib/Extension/LanguageServerCompletion/Tests/Integration/expected/declared_constant1.md
@@ -1,0 +1,1 @@
+define FOO = "bar"

--- a/lib/Extension/LanguageServerHover/Handler/HoverHandler.php
+++ b/lib/Extension/LanguageServerHover/Handler/HoverHandler.php
@@ -119,6 +119,8 @@ class HoverHandler implements Handler, CanRegisterCapabilities
         switch ($symbolContext->symbol()->symbolType()) {
             case Symbol::METHOD:
             case Symbol::PROPERTY:
+            case Symbol::DECLARED_CONSTANT:
+                return $this->renderDeclaredConstant($symbolContext->type());
             case Symbol::CONSTANT:
                 return $this->renderMember($symbolContext);
             case Symbol::CLASS_:
@@ -200,6 +202,15 @@ class HoverHandler implements Handler, CanRegisterCapabilities
                 $class->docblock()->formatted(),
                 $class
             ));
+        } catch (NotFound $e) {
+            return $e->getMessage();
+        }
+    }
+
+    private function renderDeclaredConstant(Type $type): ?string
+    {
+        try {
+            return $this->renderer->render($type);
         } catch (NotFound $e) {
             return $e->getMessage();
         }

--- a/lib/Extension/LanguageServerHover/Handler/HoverHandler.php
+++ b/lib/Extension/LanguageServerHover/Handler/HoverHandler.php
@@ -213,7 +213,7 @@ class HoverHandler implements Handler, CanRegisterCapabilities
             $constant = $this->reflector->reflectConstant($context->symbol()->name());
             return $this->renderer->render(new HoverInformation(
                 $context->symbol()->name(),
-                '',
+                $constant->docblock()->formatted(),
                 $constant
             ));
         } catch (NotFound $e) {

--- a/lib/Extension/LanguageServerHover/Handler/HoverHandler.php
+++ b/lib/Extension/LanguageServerHover/Handler/HoverHandler.php
@@ -73,15 +73,15 @@ class HoverHandler implements Handler, CanRegisterCapabilities
             $offsetReflection = $this->reflector->reflectOffset($document, $offset);
             $info = $this->infoFromReflecionOffset($offsetReflection);
             $string = new MarkupContent('markdown', $info);
-            $symbolContext = $offsetReflection->symbolContext();
+            $nodeContext = $offsetReflection->symbolContext();
 
             return new Hover($string, new Range(
                 PositionConverter::byteOffsetToPosition(
-                    ByteOffset::fromInt($symbolContext->symbol()->position()->start()),
+                    ByteOffset::fromInt($nodeContext->symbol()->position()->start()),
                     $document->__toString()
                 ),
                 PositionConverter::byteOffsetToPosition(
-                    ByteOffset::fromInt($symbolContext->symbol()->position()->end()),
+                    ByteOffset::fromInt($nodeContext->symbol()->position()->end()),
                     $document->__toString()
                 )
             ));
@@ -95,47 +95,47 @@ class HoverHandler implements Handler, CanRegisterCapabilities
 
     private function infoFromReflecionOffset(ReflectionOffset $offset): string
     {
-        $symbolContext = $offset->symbolContext();
+        $nodeContext = $offset->symbolContext();
 
-        if ($info = $this->infoFromSymbolContext($symbolContext)) {
+        if ($info = $this->infoFromSymbolContext($nodeContext)) {
             return $info;
         }
 
         return $this->renderer->render($offset);
     }
 
-    private function infoFromSymbolContext(NodeContext $symbolContext): ?string
+    private function infoFromSymbolContext(NodeContext $nodeContext): ?string
     {
         try {
-            return $this->renderSymbolContext($symbolContext);
+            return $this->renderSymbolContext($nodeContext);
         } catch (CouldNotFormat $e) {
         }
 
         return null;
     }
 
-    private function renderSymbolContext(NodeContext $symbolContext): ?string
+    private function renderSymbolContext(NodeContext $nodeContext): ?string
     {
-        switch ($symbolContext->symbol()->symbolType()) {
+        switch ($nodeContext->symbol()->symbolType()) {
             case Symbol::METHOD:
             case Symbol::PROPERTY:
             case Symbol::DECLARED_CONSTANT:
-                return $this->renderDeclaredConstant($symbolContext->type());
+                return $this->renderDeclaredConstant($nodeContext);
             case Symbol::CONSTANT:
-                return $this->renderMember($symbolContext);
+                return $this->renderMember($nodeContext);
             case Symbol::CLASS_:
-                return $this->renderClass($symbolContext->type());
+                return $this->renderClass($nodeContext->type());
             case Symbol::FUNCTION:
-                return $this->renderFunction($symbolContext);
+                return $this->renderFunction($nodeContext);
         }
 
         return null;
     }
 
-    private function renderMember(NodeContext $symbolContext): string
+    private function renderMember(NodeContext $nodeContext): string
     {
-        $name = $symbolContext->symbol()->name();
-        $container = $symbolContext->containerType();
+        $name = $nodeContext->symbol()->name();
+        $container = $nodeContext->containerType();
         $infos = [];
 
         foreach ($container->classNamedTypes() as $namedType) {
@@ -148,7 +148,7 @@ class HoverHandler implements Handler, CanRegisterCapabilities
                 // methods but not all have constants or properties, so we play safe
                 // with members() which is first-come-first-serve, rather than risk
                 // a fatal error because of a non-existing method.
-                $symbolType = $symbolContext->symbol()->symbolType();
+                $symbolType = $nodeContext->symbol()->symbolType();
                 switch ($symbolType) {
                     case Symbol::METHOD:
                         $member = $class->methods()->get($name);
@@ -181,9 +181,9 @@ class HoverHandler implements Handler, CanRegisterCapabilities
         return implode("\n", $infos);
     }
 
-    private function renderFunction(NodeContext $symbolContext): string
+    private function renderFunction(NodeContext $nodeContext): string
     {
-        $name = $symbolContext->symbol()->name();
+        $name = $nodeContext->symbol()->name();
         try {
             $function = $this->reflector->reflectFunction($name);
         } catch (NotFound $notFound) {
@@ -207,10 +207,15 @@ class HoverHandler implements Handler, CanRegisterCapabilities
         }
     }
 
-    private function renderDeclaredConstant(Type $type): ?string
+    private function renderDeclaredConstant(NodeContext $context): ?string
     {
         try {
-            return $this->renderer->render($type);
+            $constant = $this->reflector->reflectConstant($context->symbol()->name());
+            return $this->renderer->render(new HoverInformation(
+                $context->symbol()->name(),
+                '',
+                $constant
+            ));
         } catch (NotFound $e) {
             return $e->getMessage();
         }

--- a/lib/Indexer/Adapter/Worse/IndexerConstantSourceLocator.php
+++ b/lib/Indexer/Adapter/Worse/IndexerConstantSourceLocator.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Phpactor\Indexer\Adapter\Worse;
+
+use Phpactor\Indexer\Model\IndexAccess;
+use Phpactor\Indexer\Model\Record\ConstantRecord;
+use Phpactor\WorseReflection\Core\Exception\SourceNotFound;
+use Phpactor\WorseReflection\Core\Name;
+use Phpactor\WorseReflection\Core\SourceCode;
+use Phpactor\WorseReflection\Core\SourceCodeLocator;
+
+class IndexerConstantSourceLocator implements SourceCodeLocator
+{
+    private IndexAccess $index;
+
+    public function __construct(IndexAccess $index)
+    {
+        $this->index = $index;
+    }
+
+
+    public function locate(Name $name): SourceCode
+    {
+        if (empty($name->__toString())) {
+            throw new SourceNotFound('Name is empty');
+        }
+
+        $record = $this->index->get(
+            ConstantRecord::fromName($name->__toString())
+        );
+
+        $filePath = $record->filePath();
+        if (null === $filePath) {
+            throw new SourceNotFound('constant not indexed');
+        }
+
+        if (!file_exists($filePath)) {
+            throw new SourceNotFound(sprintf(
+                'Constant "%s" is indexed, but it does not exist at path "%s"!',
+                $name->full(),
+                $filePath
+            ));
+        }
+
+        return SourceCode::fromPath($filePath);
+    }
+}

--- a/lib/Indexer/Extension/IndexerExtension.php
+++ b/lib/Indexer/Extension/IndexerExtension.php
@@ -26,6 +26,7 @@ use Phpactor\FilePathResolver\PathResolver;
 use Phpactor\Indexer\Adapter\ReferenceFinder\IndexedNameSearcher;
 use Phpactor\Indexer\Adapter\ReferenceFinder\Util\ContainerTypeResolver;
 use Phpactor\Indexer\Adapter\Worse\IndexerClassSourceLocator;
+use Phpactor\Indexer\Adapter\Worse\IndexerConstantSourceLocator;
 use Phpactor\Indexer\Adapter\Worse\IndexerFunctionSourceLocator;
 use Phpactor\Indexer\Adapter\ReferenceFinder\IndexedReferenceFinder;
 use Phpactor\Indexer\Adapter\Worse\WorseRecordReferenceEnhancer;
@@ -141,6 +142,13 @@ class IndexerExtension implements Extension
         }, [
             WorseReflectionExtension::TAG_SOURCE_LOCATOR => [
                 'priority' => 128,
+            ],
+        ]);
+        $container->register(IndexerConstantSourceLocator::class, function (Container $container) {
+            return new IndexerConstantSourceLocator($container->get(IndexAccess::class));
+        }, [
+            WorseReflectionExtension::TAG_SOURCE_LOCATOR => [
+                'priority' => 100,
             ],
         ]);
     }

--- a/lib/ReferenceFinder/Search/NameSearchResultType.php
+++ b/lib/ReferenceFinder/Search/NameSearchResultType.php
@@ -39,4 +39,9 @@ final class NameSearchResultType
     {
         return $this->type === self::TYPE_FUNCTION;
     }
+
+    public function isConstant(): bool
+    {
+        return $this->type === self::TYPE_CONSTANT;
+    }
 }

--- a/lib/WorseReferenceFinder/Tests/Unit/WorseReflectionDefinitionLocatorTest.php
+++ b/lib/WorseReferenceFinder/Tests/Unit/WorseReflectionDefinitionLocatorTest.php
@@ -125,6 +125,17 @@ class WorseReflectionDefinitionLocatorTest extends DefinitionLocatorTestCase
         $this->assertEquals(21, $location->first()->location()->offset()->toInt());
     }
 
+    public function testLocatesToConstant(): void
+    {
+        $location = $this->locate(<<<'EOT'
+            // File: Foobar.php
+            <?php define('FOOBAR', 123); }
+            EOT
+        , '<?php FOO<>BAR;');
+
+        $this->assertEquals($this->workspace->path('Foobar.php'), (string) $location->first()->location()->uri()->path());
+    }
+
     public function testLocatesToMethodOnUnionTypeWithOneTypeMissingTheMethod(): void
     {
         $location = $this->locate(<<<'EOT'

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionDeclaredConstant.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionDeclaredConstant.php
@@ -24,7 +24,9 @@ class ReflectionDeclaredConstant extends AbstractReflectedNode implements Phpact
      * @var Node\Expression\CallExpression
      */
     private CallExpression $node;
+
     private string $name;
+
     private ArgumentExpression $value;
 
     public function __construct(
@@ -36,6 +38,36 @@ class ReflectionDeclaredConstant extends AbstractReflectedNode implements Phpact
         $this->sourceCode = $sourceCode;
         $this->node = $node;
         $this->bindArguments();
+    }
+
+    public function name(): Name
+    {
+        return Name::fromString($this->name);
+    }
+
+    public function type(): Type
+    {
+        return $this->serviceLocator->symbolContextResolver()->resolveNode(new Frame(''), $this->value)->type();
+    }
+
+    public function sourceCode(): SourceCode
+    {
+        return $this->sourceCode;
+    }
+
+    public function docblock(): DocBlock
+    {
+        return $this->serviceLocator->docblockFactory()->create($this->node->getLeadingCommentAndWhitespaceText(), $this->scope());
+    }
+
+    protected function node(): Node
+    {
+        return $this->node;
+    }
+
+    protected function serviceLocator(): ServiceLocator
+    {
+        return $this->serviceLocator;
     }
 
     private function bindArguments(): void
@@ -59,35 +91,5 @@ class ReflectionDeclaredConstant extends AbstractReflectedNode implements Phpact
         if (isset($arguments[1]) && $arguments[1] instanceof ArgumentExpression) {
             $this->value = $arguments[1];
         }
-    }
-
-    public function name(): Name
-    {
-        return Name::fromString($this->name);
-    }
-
-    public function type(): Type
-    {
-        return $this->serviceLocator->symbolContextResolver()->resolveNode(new Frame(''), $this->value)->type();
-    }
-
-    protected function node(): Node
-    {
-        return $this->node;
-    }
-
-    protected function serviceLocator(): ServiceLocator
-    {
-        return $this->serviceLocator;
-    }
-
-    public function sourceCode(): SourceCode
-    {
-        return $this->sourceCode;
-    }
-
-    public function docblock(): DocBlock
-    {
-        return $this->serviceLocator->docblockFactory()->create($this->node->getLeadingCommentAndWhitespaceText(), $this->scope());
     }
 }

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionDeclaredConstant.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionDeclaredConstant.php
@@ -8,6 +8,7 @@ use Microsoft\PhpParser\Node\StringLiteral;
 use Phpactor\WorseReflection\Core\Inference\Frame;
 use Phpactor\WorseReflection\Core\Name;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionDeclaredConstant as PhpactorReflectionDeclaredConstant;
+use Phpactor\WorseReflection\Core\SourceCode;
 use Phpactor\WorseReflection\Core\Type;
 use Phpactor\WorseReflection\Core\ServiceLocator;
 
@@ -19,14 +20,18 @@ class ReflectionDeclaredConstant extends AbstractReflectedNode implements Phpact
 
     private ArgumentExpression $value;
 
+    private SourceCode $sourceCode;
+
     public function __construct(
         ServiceLocator $serviceLocator,
+        SourceCode $sourceCode,
         StringLiteral $name,
         ArgumentExpression $value
     ) {
         $this->serviceLocator = $serviceLocator;
         $this->name = $name;
         $this->value = $value;
+        $this->sourceCode = $sourceCode;
     }
 
     public function name(): Name
@@ -47,5 +52,10 @@ class ReflectionDeclaredConstant extends AbstractReflectedNode implements Phpact
     protected function serviceLocator(): ServiceLocator
     {
         return $this->serviceLocator;
+    }
+
+    public function sourceCode(): SourceCode
+    {
+        return $this->sourceCode;
     }
 }

--- a/lib/WorseReflection/Core/Inference/NodeContext.php
+++ b/lib/WorseReflection/Core/Inference/NodeContext.php
@@ -103,6 +103,17 @@ final class NodeContext
     }
 
     /**
+     * @param Symbol::* $symbolType
+     */
+    public function withSymbolType($symbolType): self
+    {
+        $new = clone $this;
+        $new->symbol = $this->symbol->withSymbolType($symbolType);
+
+        return $new;
+    }
+
+    /**
      * @deprecated
      */
     public function type(): Type

--- a/lib/WorseReflection/Core/Inference/NodeContext.php
+++ b/lib/WorseReflection/Core/Inference/NodeContext.php
@@ -113,6 +113,14 @@ final class NodeContext
         return $new;
     }
 
+    public function withSymbolName(string $symbolName): self
+    {
+        $new = clone $this;
+        $new->symbol = $this->symbol->withSymbolName($symbolName);
+
+        return $new;
+    }
+
     /**
      * @deprecated
      */

--- a/lib/WorseReflection/Core/Inference/Resolver/QualifiedNameResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/QualifiedNameResolver.php
@@ -121,16 +121,23 @@ class QualifiedNameResolver implements Resolver
 
         if ($type instanceof ReflectedClassType) {
             try {
+                // fast but inaccurate check to see if class exists
                 $this->reflector->sourceCodeForClassLike($type->name());
+                // accurate check to see if class exists
+                $this->reflector->reflectClassLike($type->name());
                 return $type;
             } catch (NotFound $notFound) {
+                // resolve the name of the potnatial constant
                 [$_, $_, $constImportTable] = $node->getImportTablesForCurrentScope();
-                $name = $type->name()->full();
                 if ($resolved = NodeUtil::resolveNameFromImportTable($node, $constImportTable)) {
                     $name = $resolved->__toString();
+                } else {
+                    $name = $type->name()->full();
                 }
                 try {
+                    // fast but inaccurate check to see if class exists
                     $sourceCode = $this->reflector->sourceCodeForConstant($name);
+                    // accurate check to see if constant exists
                     $constant = $this->reflector->reflectConstant($name);
                     return $constant->type();
                 } catch (NotFound $e) {

--- a/lib/WorseReflection/Core/Inference/Resolver/QualifiedNameResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/QualifiedNameResolver.php
@@ -16,7 +16,6 @@ use Phpactor\WorseReflection\Core\Inference\Resolver;
 use Phpactor\WorseReflection\Core\Inference\Symbol;
 use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
 use Phpactor\WorseReflection\Core\Name;
-use Phpactor\WorseReflection\Core\Type;
 use Phpactor\WorseReflection\Core\TypeFactory;
 use Phpactor\WorseReflection\Core\Type\ReflectedClassType;
 use Phpactor\WorseReflection\Core\Util\NodeUtil;
@@ -92,32 +91,32 @@ class QualifiedNameResolver implements Resolver
         }
 
 
-        return NodeContextFactory::create(
+        return $this->resolveContext($node);
+    }
+
+    private function resolveContext(QualifiedName $node): NodeContext
+    {
+        $context = NodeContextFactory::create(
             $node->getText(),
             $node->getStartPosition(),
             $node->getEndPosition(),
             [
-                'type' => $this->resolveType($node),
-                'symbol_type' => Symbol::CLASS_,
+                'symbol_type' => Symbol::CLASS_
             ]
         );
-    }
 
-    private function resolveType(QualifiedName $node): Type
-    {
         $text = $node->getText();
 
         // magic constants
         if ($text === '__DIR__') {
             // TODO: [TP] tolerant parser `getUri` returns NULL or string but only declares NULL
             if (!$node->getRoot()->uri) {
-                return TypeFactory::string();
+                return $context->withType(TypeFactory::string());
             }
-            return TypeFactory::stringLiteral(dirname($node->getUri()));
+            return $context->withType(TypeFactory::stringLiteral(dirname($node->getUri())));
         }
 
         $type = $this->nodeTypeConverter->resolve($node);
-
 
         if ($type instanceof ReflectedClassType) {
             try {
@@ -125,7 +124,7 @@ class QualifiedNameResolver implements Resolver
                 $this->reflector->sourceCodeForClassLike($type->name());
                 // accurate check to see if class exists
                 $this->reflector->reflectClassLike($type->name());
-                return $type;
+                return $context->withType($type);
             } catch (NotFound $notFound) {
                 // resolve the name of the potnatial constant
                 [$_, $_, $constImportTable] = $node->getImportTablesForCurrentScope();
@@ -139,12 +138,12 @@ class QualifiedNameResolver implements Resolver
                     $sourceCode = $this->reflector->sourceCodeForConstant($name);
                     // accurate check to see if constant exists
                     $constant = $this->reflector->reflectConstant($name);
-                    return $constant->type();
+                    return $context->withType($constant->type())->withSymbolType(Symbol::DECLARED_CONSTANT);
                 } catch (NotFound $e) {
                 }
             }
         }
 
-        return $type;
+        return $context->withType($type);
     }
 }

--- a/lib/WorseReflection/Core/Inference/Resolver/QualifiedNameResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/QualifiedNameResolver.php
@@ -118,17 +118,23 @@ class QualifiedNameResolver implements Resolver
 
         $type = $this->nodeTypeConverter->resolve($node);
 
+
         if ($type instanceof ReflectedClassType) {
-            [$_, $_, $constImportTable] = $node->getImportTablesForCurrentScope();
-            $name = $type->name()->full();
-            if ($resolved = NodeUtil::resolveNameFromImportTable($node, $constImportTable)) {
-                $name = $resolved->__toString();
-            }
             try {
-                $sourceCode = $this->reflector->sourceCodeForConstant($name);
-                $constant = $this->reflector->reflectConstant($name);
-                return $constant->type();
-            } catch (NotFound $e) {
+                $this->reflector->sourceCodeForClassLike($type->name());
+                return $type;
+            } catch (NotFound $notFound) {
+                [$_, $_, $constImportTable] = $node->getImportTablesForCurrentScope();
+                $name = $type->name()->full();
+                if ($resolved = NodeUtil::resolveNameFromImportTable($node, $constImportTable)) {
+                    $name = $resolved->__toString();
+                }
+                try {
+                    $sourceCode = $this->reflector->sourceCodeForConstant($name);
+                    $constant = $this->reflector->reflectConstant($name);
+                    return $constant->type();
+                } catch (NotFound $e) {
+                }
             }
         }
 

--- a/lib/WorseReflection/Core/Inference/Resolver/QualifiedNameResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/QualifiedNameResolver.php
@@ -126,7 +126,7 @@ class QualifiedNameResolver implements Resolver
                 $this->reflector->reflectClassLike($type->name());
                 return $context->withType($type);
             } catch (NotFound $notFound) {
-                // resolve the name of the potnatial constant
+                // resolve the name of the potential constant
                 [$_, $_, $constImportTable] = $node->getImportTablesForCurrentScope();
                 if ($resolved = NodeUtil::resolveNameFromImportTable($node, $constImportTable)) {
                     $name = $resolved->__toString();
@@ -134,7 +134,7 @@ class QualifiedNameResolver implements Resolver
                     $name = $type->name()->full();
                 }
                 try {
-                    // fast but inaccurate check to see if class exists
+                    // fast but inaccurate check to see if constant exists
                     $sourceCode = $this->reflector->sourceCodeForConstant($name);
                     // accurate check to see if constant exists
                     $constant = $this->reflector->reflectConstant($name);

--- a/lib/WorseReflection/Core/Inference/Resolver/QualifiedNameResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/QualifiedNameResolver.php
@@ -138,7 +138,10 @@ class QualifiedNameResolver implements Resolver
                     $sourceCode = $this->reflector->sourceCodeForConstant($name);
                     // accurate check to see if constant exists
                     $constant = $this->reflector->reflectConstant($name);
-                    return $context->withType($constant->type())->withSymbolType(Symbol::DECLARED_CONSTANT);
+                    return $context
+                        ->withSymbolName($name)
+                        ->withType($constant->type())
+                        ->withSymbolType(Symbol::DECLARED_CONSTANT);
                 } catch (NotFound $e) {
                 }
             }

--- a/lib/WorseReflection/Core/Inference/Resolver/QualifiedNameResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/QualifiedNameResolver.php
@@ -139,7 +139,7 @@ class QualifiedNameResolver implements Resolver
                     // accurate check to see if constant exists
                     $constant = $this->reflector->reflectConstant($name);
                     return $context
-                        ->withSymbolName($name)
+                        ->withSymbolName($constant->name()->full())
                         ->withType($constant->type())
                         ->withSymbolType(Symbol::DECLARED_CONSTANT);
                 } catch (NotFound $e) {

--- a/lib/WorseReflection/Core/Inference/Resolver/QualifiedNameResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/QualifiedNameResolver.php
@@ -19,6 +19,7 @@ use Phpactor\WorseReflection\Core\Name;
 use Phpactor\WorseReflection\Core\Type;
 use Phpactor\WorseReflection\Core\TypeFactory;
 use Phpactor\WorseReflection\Core\Type\ReflectedClassType;
+use Phpactor\WorseReflection\Core\Util\NodeUtil;
 use Phpactor\WorseReflection\Reflector;
 
 class QualifiedNameResolver implements Resolver
@@ -118,7 +119,11 @@ class QualifiedNameResolver implements Resolver
         $type = $this->nodeTypeConverter->resolve($node);
 
         if ($type instanceof ReflectedClassType) {
+            [$_, $_, $constImportTable] = $node->getImportTablesForCurrentScope();
             $name = $type->name()->full();
+            if ($resolved = NodeUtil::resolveNameFromImportTable($node, $constImportTable)) {
+                $name = $resolved->__toString();
+            }
             try {
                 $sourceCode = $this->reflector->sourceCodeForConstant($name);
                 $constant = $this->reflector->reflectConstant($name);

--- a/lib/WorseReflection/Core/Inference/Symbol.php
+++ b/lib/WorseReflection/Core/Inference/Symbol.php
@@ -13,6 +13,7 @@ final class Symbol
     public const FUNCTION = 'function';
     public const PROPERTY = 'property';
     public const CONSTANT = 'constant';
+    public const DECLARED_CONSTANT = 'declared_constant';
     public const CASE = 'case';
     public const STRING = 'string';
     public const NUMBER = 'number';
@@ -93,6 +94,14 @@ final class Symbol
     public function position(): Position
     {
         return $this->position;
+    }
+
+    /**
+     * @param self::* $symbolType
+     */
+    public function withSymbolType(string $symbolType): self
+    {
+        return new self($symbolType, $this->name, $this->position);
     }
 
     /**

--- a/lib/WorseReflection/Core/Inference/Symbol.php
+++ b/lib/WorseReflection/Core/Inference/Symbol.php
@@ -104,6 +104,11 @@ final class Symbol
         return new self($symbolType, $this->name, $this->position);
     }
 
+    public function withSymbolName(string $symbolName): self
+    {
+        return new self($this->symbolType, $symbolName, $this->position);
+    }
+
     /**
      * @return array<array-key,self::*>
      */

--- a/lib/WorseReflection/Core/Reflection/Collection/ReflectionDeclaredConstantCollection.php
+++ b/lib/WorseReflection/Core/Reflection/Collection/ReflectionDeclaredConstantCollection.php
@@ -2,11 +2,9 @@
 
 namespace Phpactor\WorseReflection\Core\Reflection\Collection;
 
-use Microsoft\PhpParser\Node\Expression\ArgumentExpression;
 use Microsoft\PhpParser\Node\Expression\CallExpression;
 use Microsoft\PhpParser\Node\QualifiedName;
 use Microsoft\PhpParser\Node\SourceFileNode;
-use Microsoft\PhpParser\Node\StringLiteral;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Reflection\ReflectionDeclaredConstant as PhpactorReflectionDeclaredConstant;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionDeclaredConstant;
 use Phpactor\WorseReflection\Core\ServiceLocator;

--- a/lib/WorseReflection/Core/Reflection/Collection/ReflectionDeclaredConstantCollection.php
+++ b/lib/WorseReflection/Core/Reflection/Collection/ReflectionDeclaredConstantCollection.php
@@ -48,31 +48,12 @@ class ReflectionDeclaredConstantCollection extends AbstractReflectionCollection
                 continue;
             }
 
-            $arguments = $descendentNode->argumentExpressionList;
-            if (!$arguments) {
-                continue;
-            }
-            $arguments = iterator_to_array($arguments->getElements());
-            if (!is_array($arguments)) {
-                continue;
-            }
-            if (count($arguments) < 2) {
-                continue;
-            }
-
-            $name = $arguments[0];
-            $value = $arguments[1];
-
-            if (!$name instanceof ArgumentExpression && !$value instanceof ArgumentExpression) {
-                continue;
-            }
-
-            $name = $name->expression;
-            if (!$name instanceof StringLiteral) {
-                continue;
-            }
-
-            $items[(string) $name->getStringContentsText()] = new PhpactorReflectionDeclaredConstant($serviceLocator, $sourceCode, $name, $value);
+            $constant = new PhpactorReflectionDeclaredConstant(
+                $serviceLocator,
+                $sourceCode,
+                $descendentNode
+            );
+            $items[$constant->name()->__toString()] = $constant;
         }
 
         return new self($items);

--- a/lib/WorseReflection/Core/Reflection/Collection/ReflectionDeclaredConstantCollection.php
+++ b/lib/WorseReflection/Core/Reflection/Collection/ReflectionDeclaredConstantCollection.php
@@ -72,7 +72,7 @@ class ReflectionDeclaredConstantCollection extends AbstractReflectionCollection
                 continue;
             }
 
-            $items[(string) $name->getStringContentsText()] = new PhpactorReflectionDeclaredConstant($serviceLocator, $name, $value);
+            $items[(string) $name->getStringContentsText()] = new PhpactorReflectionDeclaredConstant($serviceLocator, $sourceCode, $name, $value);
         }
 
         return new self($items);

--- a/lib/WorseReflection/Core/Reflection/ReflectionDeclaredConstant.php
+++ b/lib/WorseReflection/Core/Reflection/ReflectionDeclaredConstant.php
@@ -2,6 +2,7 @@
 
 namespace Phpactor\WorseReflection\Core\Reflection;
 
+use Phpactor\WorseReflection\Core\DocBlock\DocBlock;
 use Phpactor\WorseReflection\Core\Name;
 use Phpactor\WorseReflection\Core\SourceCode;
 use Phpactor\WorseReflection\Core\Type;
@@ -11,4 +12,6 @@ interface ReflectionDeclaredConstant
     public function name(): Name;
     public function type(): Type;
     public function sourceCode(): SourceCode;
+
+    public function docblock(): DocBlock;
 }

--- a/lib/WorseReflection/Core/Reflection/ReflectionDeclaredConstant.php
+++ b/lib/WorseReflection/Core/Reflection/ReflectionDeclaredConstant.php
@@ -3,10 +3,12 @@
 namespace Phpactor\WorseReflection\Core\Reflection;
 
 use Phpactor\WorseReflection\Core\Name;
+use Phpactor\WorseReflection\Core\SourceCode;
 use Phpactor\WorseReflection\Core\Type;
 
 interface ReflectionDeclaredConstant
 {
     public function name(): Name;
     public function type(): Type;
+    public function sourceCode(): SourceCode;
 }

--- a/lib/WorseReflection/Core/Reflection/ReflectionDeclaredConstant.php
+++ b/lib/WorseReflection/Core/Reflection/ReflectionDeclaredConstant.php
@@ -4,6 +4,7 @@ namespace Phpactor\WorseReflection\Core\Reflection;
 
 use Phpactor\WorseReflection\Core\DocBlock\DocBlock;
 use Phpactor\WorseReflection\Core\Name;
+use Phpactor\WorseReflection\Core\Position;
 use Phpactor\WorseReflection\Core\SourceCode;
 use Phpactor\WorseReflection\Core\Type;
 
@@ -12,6 +13,6 @@ interface ReflectionDeclaredConstant
     public function name(): Name;
     public function type(): Type;
     public function sourceCode(): SourceCode;
-
     public function docblock(): DocBlock;
+    public function position(): Position;
 }

--- a/lib/WorseReflection/Core/Util/NodeUtil.php
+++ b/lib/WorseReflection/Core/Util/NodeUtil.php
@@ -14,6 +14,7 @@ use Microsoft\PhpParser\Node\QualifiedName;
 use Microsoft\PhpParser\Node\Statement\ClassDeclaration;
 use Microsoft\PhpParser\Node\Statement\InterfaceDeclaration;
 use Microsoft\PhpParser\Node\Statement\TraitDeclaration;
+use Microsoft\PhpParser\ResolvedName;
 use Microsoft\PhpParser\Token;
 use Microsoft\PhpParser\TokenKind;
 use Phpactor\WorseReflection\Core\ClassName;
@@ -30,6 +31,29 @@ class NodeUtil
         'iterable',
         'resource',
     ];
+
+    /**
+     * @param array<string, ResolvedName> $importTable
+     */
+    public static function resolveNameFromImportTable(Node $node, array $importTable): ?ResolvedName
+    {
+        if (!$node instanceof QualifiedName) {
+            return null;
+        }
+        $content = $node->getFileContents();
+        $nameParts = $node->getNameParts();
+        if (count($nameParts) === 0) {
+            return null;
+        }
+        $base = $nameParts[0]->getText($content);
+
+        if (isset($importTable[$base])) {
+            $resolvedName = $importTable[$base];
+            $resolvedName->addNameParts(\array_slice($node->getNameParts(), 1), $content);
+            return $resolvedName;
+        }
+        return null;
+    }
 
     public static function nodeContainerClassLikeType(Reflector $reflector, Node $node): Type
     {

--- a/lib/WorseReflection/Tests/Inference/constant/constant.test
+++ b/lib/WorseReflection/Tests/Inference/constant/constant.test
@@ -1,0 +1,6 @@
+<?php
+
+define('FOOBAR', 'foobar');
+
+$f = FOOBAR;
+wrAssertType('"foobar"', $f);

--- a/lib/WorseReflection/Tests/Inference/constant/constant_namespaced.test
+++ b/lib/WorseReflection/Tests/Inference/constant/constant_namespaced.test
@@ -1,0 +1,9 @@
+<?php
+
+namespace Foo;
+
+define('FOOBAR', 'foobar');
+
+$f = FOOBAR;
+
+wrAssertType('"foobar"', $f);

--- a/lib/WorseReflection/Tests/Inference/constant/constant_namespaced_imported.test
+++ b/lib/WorseReflection/Tests/Inference/constant/constant_namespaced_imported.test
@@ -1,0 +1,11 @@
+<?php
+
+namespace Foo;
+
+define('Barfoo\FOOBAR', 'foobar');
+
+use const Barfoo\FOOBAR;
+
+$f = FOOBAR;
+
+wrAssertType('"foobar"', $f);

--- a/templates/help/markdown/Phpactor/WorseReflection/Core/Reflection/ReflectionDeclaredConstant.twig
+++ b/templates/help/markdown/Phpactor/WorseReflection/Core/Reflection/ReflectionDeclaredConstant.twig
@@ -1,0 +1,1 @@
+define {{ object.name }} = {{ object.type }}


### PR DESCRIPTION
This PR adds support for:

- Goto definition for constants (`define("fo", 123)`)
- Inline completion documentation for the LS
- Constnat hover documentation
- Constant value inference
- 
Not done:

- Auto import
- Renaming