### PR TITLE
Adding command to copy the current class name to clipboard

### DIFF
--- a/autoload/phpactor.vim
+++ b/autoload/phpactor.vim
@@ -377,6 +377,16 @@ function! phpactor#GetClassFullName()
     return fileInfo['class']
 endfunction
 
+function! phpactor#CopyFullClassName()
+    let className = phpactor#GetClassFullName()
+    if empty(className)
+        echo "No class name found for the current file"
+    else
+        let @+ = className
+        echo printf("Class Name copied to clipboard: %s", className)
+    endif
+endfunction
+
 function! phpactor#ChangeVisibility()
     call phpactor#rpc("change_visibility", { "offset": phpactor#_offset(), "source": phpactor#_source(), "path": expand('%:p') })
 endfunction

--- a/doc/phpactor.txt
+++ b/doc/phpactor.txt
@@ -122,6 +122,9 @@ COMMANDS                                                   *phpactor-commands*
   Copy the current file - updating the namespace and class name according to
   the new file location and name
 
+:[N]PhpactorCopyClassName                             *:PhpactorCopyClassName*
+  Copy the current class FQN (based on current filename) to the clipboard
+
 :[N]PhpactorMoveFile                                       *:PhpactorMoveFile*
   Move the current file - updating the namespace and class name according to
   the new file location and name

--- a/ftplugin/php/commands.vim
+++ b/ftplugin/php/commands.vim
@@ -35,6 +35,10 @@ command! -buffer -nargs=0 PhpactorContextMenu call phpactor#ContextMenu()
 command! -buffer -nargs=0 PhpactorCopyFile call phpactor#CopyFile()
 
 ""
+" Copy the current class FQN (based on current filename) to the clipboard
+command! -buffer -nargs=0 PhpactorCopyClassName call phpactor#CopyFullClassName()
+
+""
 " Move the current file - updating the namespace and class name according to
 " the new file location and name
 command! -buffer -nargs=0 PhpactorMoveFile call phpactor#MoveFile()
@@ -65,3 +69,4 @@ command! -buffer -nargs=0 PhpactorGenerateAccessors call phpactor#GenerateAccess
 ""
 " Automatically add any missing properties to a class
 command! -buffer -nargs=0 PhpactorTransform call phpactor#Transform()
+


### PR DESCRIPTION
Fixes #922

First try at vim script, so please tell me if I made some mistakes.

This command assumes that the clipboard register is the `"+` register. Maybe we should make that configurable.