### PR TITLE
Refactor unused import provider

### DIFF
--- a/lib/WorseReflection/Bridge/Phpactor/DocblockParser/ParsedDocblock.php
+++ b/lib/WorseReflection/Bridge/Phpactor/DocblockParser/ParsedDocblock.php
@@ -51,6 +51,12 @@ class ParsedDocblock implements DocBlock
         $this->typeConverter = $typeConverter;
     }
 
+
+    public function rawNode(): ParserDocblock
+    {
+        return $this->node;
+    }
+
     /**
      * @return Types<Type>
      */

--- a/lib/WorseReflection/Core/Name.php
+++ b/lib/WorseReflection/Core/Name.php
@@ -55,16 +55,32 @@ class Name
         ));
     }
 
+    /**
+     * Return with only last segment of the name of name
+     */
     public function head(): self
     {
         return new self([ reset($this->parts) ], false);
     }
 
+    /**
+     * Return without the last segment of the name
+     */
     public function tail(): self
     {
         $parts = $this->parts;
         array_shift($parts);
         return new self($parts, $this->wasFullyQualified);
+    }
+
+    /**
+     * Return with only the first segment of the name
+     */
+    public function base(): self
+    {
+        $parts = $this->parts;
+        $first = array_shift($parts);
+        return new self([$first], $this->wasFullyQualified);
     }
 
     public function namespace(): string

--- a/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Diagonstics/UnusedImportProvider/Gh1866.test
+++ b/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Diagonstics/UnusedImportProvider/Gh1866.test
@@ -1,0 +1,21 @@
+<?php
+
+namespace Phpactor\WorseReflection\Bridge\TolerantParser\Reflection;
+
+use Microsoft\PhpParser\Node\Expression\ArgumentExpression;
+use Phpactor\WorseReflection\Core\Name;
+use Phpactor\WorseReflection\Core\Type\StringLiteralType;
+
+class ReflectionDeclaredConstant
+{
+    private $name;
+    private ArgumentExpression $value;
+
+    public function name(): Name
+    {
+        if (!$this->name instanceof StringLiteralType) {
+        }
+        return Name::fromString($this->name);
+    }
+}
+

--- a/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Diagonstics/UnusedImportProvider/NamespacedUnusedImports.test
+++ b/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Diagonstics/UnusedImportProvider/NamespacedUnusedImports.test
@@ -3,7 +3,6 @@
 namespace Foo;
 
 use Bar\Foobar;
-use Foobar\Baz\Foobar;
 use Bag\Boo;
 
 new Boo();

--- a/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Diagonstics/UnusedImportProviderTest.php
+++ b/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Diagonstics/UnusedImportProviderTest.php
@@ -2,11 +2,9 @@
 
 namespace Phpactor\WorseReflection\Tests\Integration\Bridge\TolerantParser\Diagonstics;
 
-use Phpactor\WorseReflection\Bridge\Phpactor\DocblockParser\DocblockParserFactory;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\UnusedImportProvider;
 use Phpactor\WorseReflection\Core\DiagnosticProvider;
 use Phpactor\WorseReflection\Core\Diagnostics;
-use Phpactor\WorseReflection\ReflectorBuilder;
 
 class UnusedImportProviderTest extends DiagnosticsTestCase
 {

--- a/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Diagonstics/UnusedImportProviderTest.php
+++ b/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Diagonstics/UnusedImportProviderTest.php
@@ -23,7 +23,7 @@ class UnusedImportProviderTest extends DiagnosticsTestCase
 
     public function checkNamespacedUnusedImports(Diagnostics $diagnostics): void
     {
-        self::assertCount(2, $diagnostics);
+        self::assertCount(1, $diagnostics);
     }
 
     public function checkNamespacedUsedImports(Diagnostics $diagnostics): void
@@ -40,7 +40,7 @@ class UnusedImportProviderTest extends DiagnosticsTestCase
     public function checkCompactUseUnused(Diagnostics $diagnostics): void
     {
         self::assertCount(1, $diagnostics);
-        self::assertEquals('Name "Foobar\Barfoo" is imported but not used', $diagnostics->at(0)->message());
+        self::assertEquals('Name "Barfoo" is imported but not used', $diagnostics->at(0)->message());
     }
 
     public function checkAliasedImportForUsedClass(Diagnostics $diagnostics): void
@@ -51,7 +51,12 @@ class UnusedImportProviderTest extends DiagnosticsTestCase
     public function checkAliasedImportForUnusedClass(Diagnostics $diagnostics): void
     {
         self::assertCount(1, $diagnostics);
-        self::assertEquals('Name "Bagggg" is imported but not used', $diagnostics->at(0)->message());
+        self::assertEquals('Name "Bazgar" is imported but not used', $diagnostics->at(0)->message());
+    }
+
+    public function checkGh1866(Diagnostics $diagnostics): void
+    {
+        self::assertCount(0, $diagnostics);
     }
 
     public function checkUsedByAnnotation(Diagnostics $diagnostics): void
@@ -100,6 +105,6 @@ class UnusedImportProviderTest extends DiagnosticsTestCase
 
     protected function provider(): DiagnosticProvider
     {
-        return new UnusedImportProvider(new DocblockParserFactory(ReflectorBuilder::create()->build()));
+        return new UnusedImportProvider();
     }
 }


### PR DESCRIPTION
Refactor the unused import diagnostic provider to work based on the imported _name_ and not the FQN

- Works better with relative FQNs
- Docblock parser used directly to get relative type FQN


Fixes #1866 