### PR TITLE
Fixing missing `false` default in json schema generation

### DIFF
--- a/lib/Extension/Core/Model/JsonSchemaBuilder.php
+++ b/lib/Extension/Core/Model/JsonSchemaBuilder.php
@@ -56,7 +56,7 @@ class JsonSchemaBuilder
                 if ($definition->types()) {
                     $meta['type'] = $this->mapTypes($definition->types());
                 }
-                if ($definition->defaultValue()) {
+                if (null !== $definition->defaultValue()) {
                     $meta['default'] = $definition->defaultValue();
                 }
                 if ([] !== $definition->enum()) {

--- a/lib/Extension/Core/Tests/Unit/Model/JsonSchemaBuilderTest.php
+++ b/lib/Extension/Core/Tests/Unit/Model/JsonSchemaBuilderTest.php
@@ -47,6 +47,13 @@ class JsonSchemaBuilderTest extends TestCase
                             "string"
                         ],
                         "default": "bar"
+                    },
+                    "bloob": {
+                        "description": "Testing boolean defaults",
+                        "type": [
+                            "boolean"
+                        ],
+                        "default": false
                     }
                 }
             }
@@ -62,6 +69,7 @@ class JsonSchemaBuilderTest extends TestCase
                 $resolver->setDefaults([
                     'bar.foo' => 1234,
                     'foo.bar' => 'bar',
+                    'bloob' => false
                 ]);
                 $resolver->setRequired([
                     'bar.foo',
@@ -69,9 +77,11 @@ class JsonSchemaBuilderTest extends TestCase
                 $resolver->setTypes([
                     'bar.foo' => 'string',
                     'foo.bar' => 'string',
+                    'bloob' => 'bool'
                 ]);
                 $resolver->setDescriptions([
                     'bar.foo' => 'This does something',
+                    'bloob' => 'Testing boolean defaults'
                 ]);
                 $resolver->setEnums([
                     'bar.foo' => ['one', 'two'],


### PR DESCRIPTION
Before when a command had a default value of false, it would have been not visible in the json.

### Before:
```json
         "logging.fingers_crossed": {
             "description": null,
             "type": [
                 "boolean"
             ]
         },
```

### After
```json
         "logging.fingers_crossed": {
             "description": null,
             "type": [
                 "boolean"
             ],
             "default": false
         },
```