### PR TITLE
Support for multiple workspaces

### DIFF
--- a/lib/Extension/LanguageServer/LanguageServerSessionExtension.php
+++ b/lib/Extension/LanguageServer/LanguageServerSessionExtension.php
@@ -31,7 +31,6 @@ class LanguageServerSessionExtension implements Extension
         $this->initializeParams = $initializeParams;
     }
 
-
     public function load(ContainerBuilder $container): void
     {
         $container->register(ClientCapabilities::class, function (Container $container) {

--- a/lib/Extension/LanguageServerIndexer/LanguageServerIndexerExtension.php
+++ b/lib/Extension/LanguageServerIndexer/LanguageServerIndexerExtension.php
@@ -15,6 +15,7 @@ use Phpactor\Extension\LanguageServerIndexer\Watcher\LanguageServerWatcher;
 use Phpactor\Extension\LanguageServer\LanguageServerExtension;
 use Phpactor\Extension\Logger\LoggingExtension;
 use Phpactor\Indexer\Extension\IndexerExtension;
+use Phpactor\Indexer\IndexAgentBuilder;
 use Phpactor\Indexer\Model\Indexer;
 use Phpactor\Indexer\Model\SearchClient;
 use Phpactor\LanguageServerProtocol\ClientCapabilities;
@@ -55,7 +56,10 @@ class LanguageServerIndexerExtension implements Extension
         ]);
 
         $container->register(IndexerStatusProvider::class, function (Container $container) {
-            return new IndexerStatusProvider($container->get(Watcher::class));
+            return new IndexerStatusProvider(
+                $container->get(Watcher::class),
+                $container->get(IndexAgentBuilder::class),
+            );
         }, [
             LanguageServerExtension::TAG_STATUS_PROVIDER => [],
         ]);

--- a/lib/Extension/LanguageServerIndexer/Status/IndexerStatusProvider.php
+++ b/lib/Extension/LanguageServerIndexer/Status/IndexerStatusProvider.php
@@ -4,14 +4,19 @@ namespace Phpactor\Extension\LanguageServerIndexer\Status;
 
 use Phpactor\AmpFsWatch\Watcher;
 use Phpactor\Extension\LanguageServer\Status\StatusProvider;
+use Phpactor\Indexer\IndexAgentBuilder;
 
 class IndexerStatusProvider implements StatusProvider
 {
     private Watcher $watcher;
 
-    public function __construct(Watcher $watcher)
+    private IndexAgentBuilder $builder;
+
+
+    public function __construct(Watcher $watcher, IndexAgentBuilder $builder)
     {
         $this->watcher = $watcher;
+        $this->builder = $builder;
     }
 
     public function title(): string
@@ -23,6 +28,9 @@ class IndexerStatusProvider implements StatusProvider
     {
         return [
             'watcher' => $this->watcher->describe(),
+            'paths' => implode(', ', $this->builder->paths()),
+            'include' => implode(', ', $this->builder->includePatterns()),
+            'exclude' => implode(', ', $this->builder->excludePatterns())
         ];
     }
 }

--- a/lib/Indexer/Extension/IndexerExtension.php
+++ b/lib/Indexer/Extension/IndexerExtension.php
@@ -430,7 +430,7 @@ class IndexerExtension implements Extension
 
             /** @phpstan-ignore-next-line Phpactor LSP does not deserialize WorkspaceFolder as an object */
             $workspacePaths = array_map(function (array $folder): string {
-                return $folder['uri'];
+                return TextDocumentUri::fromString($folder['uri'])->path();
             }, $params->workspaceFolders ?? []);
 
             if ($workspacePaths) {

--- a/lib/Indexer/Extension/IndexerExtension.php
+++ b/lib/Indexer/Extension/IndexerExtension.php
@@ -210,12 +210,13 @@ class IndexerExtension implements Extension
             $indexPath = $resolver->resolve(
                 $container->getParameter(self::PARAM_INDEX_PATH)
             );
-            return IndexAgentBuilder::create($indexPath, $this->projectRoot($container))
+            return IndexAgentBuilder::create($indexPath, ...array_merge([
+                $this->projectRoot($container)
+            ], $container->getParameter(self::PARAM_STUB_PATHS)))
                 ->setExcludePatterns($container->get(self::SERVICE_INDEXER_EXCLUDE_PATTERNS))
                 ->setIncludePatterns(
                     $container->get(self::SERVICE_INDEXER_INCLUDE_PATTERNS),
-                )
-                ->setStubPaths($container->getParameter(self::PARAM_STUB_PATHS));
+                );
         });
 
         $container->register(Indexer::class, function (Container $container) {

--- a/lib/Indexer/IndexAgentBuilder.php
+++ b/lib/Indexer/IndexAgentBuilder.php
@@ -60,8 +60,6 @@ final class IndexAgentBuilder
     private array $excludePatterns = [
     ];
 
-    private string $projectRoot;
-
     /**
      * @var array<TolerantIndexer>|null
      */
@@ -69,17 +67,16 @@ final class IndexAgentBuilder
 
     private LoggerInterface $logger;
 
-    private function __construct(string $indexRoot, string $projectRoot)
+    private function __construct(string $indexRoot)
     {
         $this->indexRoot = $indexRoot;
         $this->enhancer = new NullRecordReferenceEnhancer();
         $this->logger = new NullLogger();
-        $this->projectRoot = $projectRoot;
     }
 
-    public static function create(string $indexRootPath, string $projectRoot): self
+    public static function create(string $indexRootPath): self
     {
-        return new self($indexRootPath, $projectRoot);
+        return new self($indexRootPath);
     }
 
     public function setLogger(LoggerInterface $logger): self
@@ -89,7 +86,7 @@ final class IndexAgentBuilder
         return $this;
     }
 
-    public function addStubPath(string $path): self
+    public function addPath(string $path): self
     {
         $this->stubPaths[] = $path;
 

--- a/lib/Indexer/IndexAgentBuilder.php
+++ b/lib/Indexer/IndexAgentBuilder.php
@@ -52,7 +52,7 @@ final class IndexAgentBuilder
     /**
      * @var array<string>
      */
-    private array $stubPaths = [];
+    private array $paths = [];
 
     /**
      * @var array<string>
@@ -67,16 +67,20 @@ final class IndexAgentBuilder
 
     private LoggerInterface $logger;
 
-    private function __construct(string $indexRoot)
+    /**
+     * @param string[] $paths
+     */
+    private function __construct(string $indexRoot, array $paths)
     {
         $this->indexRoot = $indexRoot;
         $this->enhancer = new NullRecordReferenceEnhancer();
         $this->logger = new NullLogger();
+        $this->paths = $paths;
     }
 
-    public static function create(string $indexRootPath): self
+    public static function create(string $indexRootPath, string ...$paths): self
     {
-        return new self($indexRootPath);
+        return new self($indexRootPath, $paths);
     }
 
     public function setLogger(LoggerInterface $logger): self
@@ -88,7 +92,7 @@ final class IndexAgentBuilder
 
     public function addPath(string $path): self
     {
-        $this->stubPaths[] = $path;
+        $this->paths[] = $path;
 
         return $this;
     }
@@ -149,11 +153,11 @@ final class IndexAgentBuilder
     }
 
     /**
-     * @param array<string> $stubPaths
+     * @param array<string> $paths
      */
-    public function setStubPaths(array $stubPaths): self
+    public function setPaths(array $paths): self
     {
-        $this->stubPaths = $stubPaths;
+        $this->paths = $paths;
 
         return $this;
     }
@@ -231,17 +235,11 @@ final class IndexAgentBuilder
      */
     private function buildFileListProviders(): array
     {
-        $providers = [
-            new FilesystemFileListProvider(
-                $this->buildFilesystem($this->projectRoot),
+        foreach ($this->paths as $path) {
+            $providers[] = new FilesystemFileListProvider(
+                $this->buildFilesystem($path),
                 $this->includePatterns,
                 $this->excludePatterns
-            )
-        ];
-
-        foreach ($this->stubPaths as $stubPath) {
-            $providers[] = new FilesystemFileListProvider(
-                $this->buildFilesystem($stubPath)
             );
         }
 

--- a/lib/Indexer/IndexAgentBuilder.php
+++ b/lib/Indexer/IndexAgentBuilder.php
@@ -162,6 +162,30 @@ final class IndexAgentBuilder
         return $this;
     }
 
+    /**
+     * @return string[]
+     */
+    public function paths(): array
+    {
+        return $this->paths;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function includePatterns(): array
+    {
+        return $this->includePatterns;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function excludePatterns(): array
+    {
+        return $this->excludePatterns;
+    }
+
     private function buildIndex(): Index
     {
         $repository = new FileRepository(
@@ -251,29 +275,5 @@ final class IndexAgentBuilder
     private function buildDirtyTracker(): DirtyFileListProvider
     {
         return new DirtyFileListProvider($this->indexRoot . '/dirty');
-    }
-
-    /**
-     * @return string[]
-     */
-    public function paths(): array
-    {
-        return $this->paths;
-    }
-
-    /**
-     * @return string[]
-     */
-    public function includePatterns(): array
-    {
-        return $this->includePatterns;
-    }
-
-    /**
-     * @return string[]
-     */
-    public function excludePatterns(): array
-    {
-        return $this->excludePatterns;
     }
 }

--- a/lib/Indexer/IndexAgentBuilder.php
+++ b/lib/Indexer/IndexAgentBuilder.php
@@ -252,4 +252,28 @@ final class IndexAgentBuilder
     {
         return new DirtyFileListProvider($this->indexRoot . '/dirty');
     }
+
+    /**
+     * @return string[]
+     */
+    public function paths(): array
+    {
+        return $this->paths;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function includePatterns(): array
+    {
+        return $this->includePatterns;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function excludePatterns(): array
+    {
+        return $this->excludePatterns;
+    }
 }

--- a/lib/Indexer/Tests/Adapter/IndexBuilderTestCase.php
+++ b/lib/Indexer/Tests/Adapter/IndexBuilderTestCase.php
@@ -14,7 +14,7 @@ abstract class IndexBuilderTestCase extends IntegrationTestCase
 {
     protected function setUp(): void
     {
-        $this->workspace()->reset();
+        parent::setUp();
         $this->workspace()->loadManifest(file_get_contents(__DIR__ . '/Manifest/buildIndex.php.test'));
     }
 

--- a/lib/Indexer/Tests/Adapter/IndexTestCase.php
+++ b/lib/Indexer/Tests/Adapter/IndexTestCase.php
@@ -9,7 +9,7 @@ abstract class IndexTestCase extends IntegrationTestCase
 {
     protected function setUp(): void
     {
-        $this->workspace()->reset();
+        parent::setUp();
         $this->workspace()->loadManifest(file_get_contents(__DIR__ . '/Manifest/buildIndex.php.test'));
     }
 

--- a/lib/Indexer/Tests/Adapter/Php/FileSearchIndexTest.php
+++ b/lib/Indexer/Tests/Adapter/Php/FileSearchIndexTest.php
@@ -13,7 +13,7 @@ class FileSearchIndexTest extends IntegrationTestCase
 
     protected function setUp(): void
     {
-        $this->workspace()->reset();
+        parent::setUp();
         $this->index = new FileSearchIndex($this->workspace()->path('search'));
     }
 

--- a/lib/Indexer/Tests/Adapter/ReferenceFinder/IndexedImplementationFinderTest.php
+++ b/lib/Indexer/Tests/Adapter/ReferenceFinder/IndexedImplementationFinderTest.php
@@ -11,11 +11,6 @@ use Phpactor\TextDocument\TextDocumentBuilder;
 
 class IndexedImplementationFinderTest extends IntegrationTestCase
 {
-    protected function setUp(): void
-    {
-        $this->workspace()->reset();
-    }
-
     /**
      * @dataProvider provideClassLikes
      * @dataProvider provideClassMembers

--- a/lib/Indexer/Tests/Adapter/ReferenceFinder/IndexedReferenceFinderTest.php
+++ b/lib/Indexer/Tests/Adapter/ReferenceFinder/IndexedReferenceFinderTest.php
@@ -12,11 +12,6 @@ use Phpactor\TextDocument\TextDocumentBuilder;
 
 class IndexedReferenceFinderTest extends IntegrationTestCase
 {
-    protected function setUp(): void
-    {
-        $this->workspace()->reset();
-    }
-
     /**
      * @dataProvider provideClasses
      * @dataProvider provideTraits

--- a/lib/Indexer/Tests/Extension/Command/IndexBuildCommandTest.php
+++ b/lib/Indexer/Tests/Extension/Command/IndexBuildCommandTest.php
@@ -7,10 +7,6 @@ use Symfony\Component\Process\Process;
 
 class IndexBuildCommandTest extends IntegrationTestCase
 {
-    public function tearDown():void
-    {
-        $this->workspace()->reset();
-    }
     public function testRefreshIndex(): void
     {
         $this->initProject();

--- a/lib/Indexer/Tests/Extension/Command/IndexCleanCommandTest.php
+++ b/lib/Indexer/Tests/Extension/Command/IndexCleanCommandTest.php
@@ -10,6 +10,11 @@ class IndexCleanCommandTest extends IntegrationTestCase
 {
     private const CONSOLE_PATH = __DIR__ . '/../../bin/console';
 
+    public function setUp():void
+    {
+        $this->workspace()->reset();
+    }
+
     /**
      * @dataProvider provideAllIndexClean
      * @param array<string> $command

--- a/lib/Indexer/Tests/Extension/Command/IndexCleanCommandTest.php
+++ b/lib/Indexer/Tests/Extension/Command/IndexCleanCommandTest.php
@@ -10,11 +10,6 @@ class IndexCleanCommandTest extends IntegrationTestCase
 {
     private const CONSOLE_PATH = __DIR__ . '/../../bin/console';
 
-    public function setUp():void
-    {
-        $this->workspace()->reset();
-    }
-
     /**
      * @dataProvider provideAllIndexClean
      * @param array<string> $command

--- a/lib/Indexer/Tests/Extension/IndexerExtensionTest.php
+++ b/lib/Indexer/Tests/Extension/IndexerExtensionTest.php
@@ -26,6 +26,7 @@ class IndexerExtensionTest extends IntegrationTestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
         $this->initProject();
     }
 
@@ -53,6 +54,7 @@ class IndexerExtensionTest extends IntegrationTestCase
 
     public function testIndexDirtyFile(): void
     {
+        $this->workspace()->mkdir('cache');
         $container = $this->container();
         $indexer = $container->get(Indexer::class);
         $this->assertInstanceOf(Indexer::class, $indexer);

--- a/lib/Indexer/Tests/IntegrationTestCase.php
+++ b/lib/Indexer/Tests/IntegrationTestCase.php
@@ -30,6 +30,11 @@ use Symfony\Component\Process\Process;
 
 class IntegrationTestCase extends TestCase
 {
+    protected function setUp():void
+    {
+        $this->workspace()->reset();
+    }
+
     protected function workspace(): Workspace
     {
         return Workspace::create(__DIR__ . '/Workspace');

--- a/lib/Indexer/Tests/IntegrationTestCase.php
+++ b/lib/Indexer/Tests/IntegrationTestCase.php
@@ -32,6 +32,7 @@ class IntegrationTestCase extends TestCase
 {
     protected function setUp():void
     {
+        parent::setUp();
         $this->workspace()->reset();
     }
 

--- a/lib/Indexer/Tests/Unit/Adapter/Filesystem/FilesystemFileListProviderTest.php
+++ b/lib/Indexer/Tests/Unit/Adapter/Filesystem/FilesystemFileListProviderTest.php
@@ -24,9 +24,9 @@ class FilesystemFileListProviderTest extends IntegrationTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
         $this->filesystem = new SimpleFilesystem($this->workspace()->path());
         $this->provider = new FilesystemFileListProvider($this->filesystem);
-        $this->workspace()->reset();
         $this->index = $this->prophesize(Index::class);
     }
 

--- a/lib/Indexer/Tests/Unit/Model/SearchIndex/FilteredSearchIndexTest.php
+++ b/lib/Indexer/Tests/Unit/Model/SearchIndex/FilteredSearchIndexTest.php
@@ -24,6 +24,7 @@ class FilteredSearchIndexTest extends IntegrationTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
         $this->innerIndex = $this->prophesize(SearchIndex::class);
         $this->index = new FilteredSearchIndex($this->innerIndex->reveal(), [ClassRecord::RECORD_TYPE]);
     }

--- a/lib/Indexer/Tests/Unit/Model/SearchIndex/ValidatingSearchIndexTest.php
+++ b/lib/Indexer/Tests/Unit/Model/SearchIndex/ValidatingSearchIndexTest.php
@@ -22,6 +22,7 @@ class ValidatingSearchIndexTest extends IntegrationTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
         $this->innerSearchIndex = new InMemorySearchIndex();
         $this->index = new InMemoryIndex();
         $this->searchIndex = new ValidatingSearchIndex(


### PR DESCRIPTION
This PR is a probably failed attempt to "easily" add support for multiple worksapces.

It is failed because it will add the workspace to the current index instead of maintaining multiple indexes, which means:

- Workspace symbols can conflict with eachother (which would happen to some extent anyway but :shrug: )
- The index scope can be changed arbitrarily (e.g. adding new workspaces to a project) which means:
   -  Redundancy: indexes do not clean themselves, so adding another workspace can double, triple (etc and increasing over time) the normal size of the index as it contains multiple projects, 
   -  The necessity of restarting the LS eachtime the workspace config changes (at least if no major refactoring done to make paths dynamic).

On balance, it makes more sense to fully support multiple indexes - this would also solve the issue of sharing stubs between projects. Multiple indexes means:

- The need to indicate if they are read only or not (can re-use the "stub" paths to indicate read-only indexes)
- The neccisity of chaining indexes and search indexes togehter to provide the "illusion" of a single index.
