### PR TITLE
Prophecy Extension

### DIFF
--- a/doc/integrations/prophecy.rst
+++ b/doc/integrations/prophecy.rst
@@ -1,0 +1,12 @@
+Prophecy
+========
+
+`Prophecy <https://github.com/phpspec/prophecy>`_ is a highly opinionated yet very powerful and flexible PHP object mocking framework. Though initially it was created to fulfil phpspec2 needs, it is flexible enough to be used inside any testing framework out there with minimal effort.
+
+Phpactor can integrate with Prophecy to provide completion for mocks.
+
+To do so you set :ref:`param_prophecy.enabled`:
+
+.. code-block:: bash
+
+   $ phpactor config:set prophecy.enabled true

--- a/doc/reference/configuration.rst
+++ b/doc/reference/configuration.rst
@@ -1776,3 +1776,26 @@ Enable/disable the Symfony completor - depends on Symfony extension being enable
 
 **Default**: ``true``
 
+
+.. _ProphecyExtension:
+
+
+ProphecyExtension
+-----------------
+
+
+.. _param_prophecy.enabled:
+
+
+``prophecy.enabled``
+""""""""""""""""""""
+
+
+Type: boolean
+
+
+Enable or disable this extension
+
+
+**Default**: ``false``
+

--- a/lib/ClassMover/Tests/Unit/ClassMoverTest.php
+++ b/lib/ClassMover/Tests/Unit/ClassMoverTest.php
@@ -4,72 +4,12 @@ namespace Phpactor\ClassMover\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Phpactor\ClassMover\Domain\ClassFinder;
-use Phpactor\ClassMover\Domain\ClassReplacer;
-use Phpactor\ClassMover\ClassMover;
-use Phpactor\ClassMover\Domain\Reference\NamespacedClassReferences;
-use Phpactor\ClassMover\FoundReferences;
-use Phpactor\ClassMover\Domain\Name\FullyQualifiedName;
-use Phpactor\TextDocument\TextDocumentBuilder;
-use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
 
 class ClassMoverTest extends TestCase
 {
-    use ProphecyTrait;
-
-    private $mover;
-
-    private $finder;
-
-    private $replacer;
-
     public function setUp(): void
     {
         $this->finder = $this->prophesize(ClassFinder::class);
-        $this->replacer = $this->prophesize(ClassReplacer::class);
-
-        $this->mover = new ClassMover(
-            $this->finder->reveal(),
-            $this->replacer->reveal()
-        );
-    }
-
-    /**
-     * It should delgate to the finder to find references.
-     */
-    public function testFindReferences()
-    {
-        $source = TextDocumentBuilder::create('<?php echo "hello";')->build();
-        $fullName = 'Something';
-        $refList = NamespacedClassReferences::empty();
-
-        $this->finder->findIn($source)->willReturn($refList);
-
-        $references = $this->mover->findReferences($source, $fullName);
-
-        $this->assertInstanceOf(FoundReferences::class, $references);
-        $this->assertEquals($source, (string) $references->source());
-        $this->assertEquals($fullName, (string) $references->targetName());
-        $this->assertEquals([], iterator_to_array($references->references()));
-
-        return $references;
-    }
-
-    /**
-     * It should replace references.
-     *
-     * @depends testFindReferences
-     */
-    public function testReplaceReferences(FoundReferences $references): void
-    {
-        $newFqn = 'SomethingElse';
-
-        $this->replacer->replaceReferences(
-            $references->source(),
-            $references->references(),
-            $references->targetName(),
-            FullyQualifiedName::fromString($newFqn)
-        )->shouldBeCalled();
-
-        $this->mover->replaceReferences($references, $newFqn);
     }
 }

--- a/lib/ClassMover/Tests/Unit/ClassMoverTest.php
+++ b/lib/ClassMover/Tests/Unit/ClassMoverTest.php
@@ -4,12 +4,72 @@ namespace Phpactor\ClassMover\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Phpactor\ClassMover\Domain\ClassFinder;
-use Prophecy\Prophecy\ObjectProphecy;
+use Phpactor\ClassMover\Domain\ClassReplacer;
+use Phpactor\ClassMover\ClassMover;
+use Phpactor\ClassMover\Domain\Reference\NamespacedClassReferences;
+use Phpactor\ClassMover\FoundReferences;
+use Phpactor\ClassMover\Domain\Name\FullyQualifiedName;
+use Phpactor\TextDocument\TextDocumentBuilder;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class ClassMoverTest extends TestCase
 {
+    use ProphecyTrait;
+
+    private $mover;
+
+    private $finder;
+
+    private $replacer;
+
     public function setUp(): void
     {
         $this->finder = $this->prophesize(ClassFinder::class);
+        $this->replacer = $this->prophesize(ClassReplacer::class);
+
+        $this->mover = new ClassMover(
+            $this->finder->reveal(),
+            $this->replacer->reveal()
+        );
+    }
+
+    /**
+     * It should delgate to the finder to find references.
+     */
+    public function testFindReferences()
+    {
+        $source = TextDocumentBuilder::create('<?php echo "hello";')->build();
+        $fullName = 'Something';
+        $refList = NamespacedClassReferences::empty();
+
+        $this->finder->findIn($source)->willReturn($refList);
+
+        $references = $this->mover->findReferences($source, $fullName);
+
+        $this->assertInstanceOf(FoundReferences::class, $references);
+        $this->assertEquals($source, (string) $references->source());
+        $this->assertEquals($fullName, (string) $references->targetName());
+        $this->assertEquals([], iterator_to_array($references->references()));
+
+        return $references;
+    }
+
+    /**
+     * It should replace references.
+     *
+     * @depends testFindReferences
+     */
+    public function testReplaceReferences(FoundReferences $references): void
+    {
+        $newFqn = 'SomethingElse';
+
+        $this->replacer->replaceReferences(
+            $references->source(),
+            $references->references(),
+            $references->targetName(),
+            FullyQualifiedName::fromString($newFqn)
+        )->shouldBeCalled();
+
+        $this->mover->replaceReferences($references, $newFqn);
     }
 }

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletor.php
@@ -209,7 +209,7 @@ class WorseClassMemberCompletor implements TolerantCompletor, TolerantQualifiabl
         }
 
         if ($classReflection instanceof ReflectionEnum) {
-            foreach ($members->cases() as $case) {
+            foreach ($members->enumCases() as $case) {
                 yield Suggestion::createWithOptions($case->name(), [
                     'type' => Suggestion::TYPE_ENUM,
                     'short_description' => fn () => $this->formatter->format($case),

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletor.php
@@ -20,6 +20,7 @@ use Phpactor\WorseReflection\Core\Reflection\ReflectionClass;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionEnum;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionProperty;
 use Phpactor\WorseReflection\Core\Type;
+use Phpactor\WorseReflection\Core\Type\ClassType;
 use Phpactor\WorseReflection\Reflector;
 use Phpactor\Completion\Core\Suggestion;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionInterface;
@@ -119,6 +120,12 @@ class WorseClassMemberCompletor implements TolerantCompletor, TolerantQualifiabl
             return;
         }
 
+        if (!$type instanceof ClassType) {
+            return;
+        }
+
+        $members = $type->members();
+
         if (!$isParent && $static) {
             yield Suggestion::createWithOptions('class', [
                 'type' => Suggestion::TYPE_CONSTANT,
@@ -133,7 +140,7 @@ class WorseClassMemberCompletor implements TolerantCompletor, TolerantQualifiabl
             return;
         }
 
-        foreach ($classReflection->methods() as $method) {
+        foreach ($members->methods() as $method) {
             if (false === $isParent && $method->name() === '__construct') {
                 continue;
             }
@@ -161,7 +168,7 @@ class WorseClassMemberCompletor implements TolerantCompletor, TolerantQualifiabl
 
         if ($classReflection instanceof ReflectionClass) {
             /** @var ReflectionProperty $property */
-            foreach ($classReflection->properties() as $property) {
+            foreach ($members->properties() as $property) {
                 if ($publicOnly && false === $property->visibility()->isPublic()) {
                     continue;
                 }
@@ -192,7 +199,7 @@ class WorseClassMemberCompletor implements TolerantCompletor, TolerantQualifiabl
         if (false === $isInstance && $classReflection instanceof ReflectionClass ||
             $classReflection instanceof ReflectionInterface
         ) {
-            foreach ($classReflection->constants() as $constant) {
+            foreach ($members->constants() as $constant) {
                 yield Suggestion::createWithOptions($constant->name(), [
                     'type' => Suggestion::TYPE_CONSTANT,
                     'short_description' => fn () => $this->formatter->format($constant),
@@ -202,7 +209,7 @@ class WorseClassMemberCompletor implements TolerantCompletor, TolerantQualifiabl
         }
 
         if ($classReflection instanceof ReflectionEnum) {
-            foreach ($classReflection->cases() as $case) {
+            foreach ($members->cases() as $case) {
                 yield Suggestion::createWithOptions($case->name(), [
                     'type' => Suggestion::TYPE_ENUM,
                     'short_description' => fn () => $this->formatter->format($case),

--- a/lib/Extension/Prophecy/ProphecyExtension.php
+++ b/lib/Extension/Prophecy/ProphecyExtension.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Phpactor\Extension\Prophecy;
+
+use Phpactor\Container\Container;
+use Phpactor\Container\ContainerBuilder;
+use Phpactor\Container\OptionalExtension;
+use Phpactor\Extension\Prophecy\WorseReflection\ProphecyMemberContextResolver;
+use Phpactor\Extension\Prophecy\WorseReflection\ProphecyStubLocator;
+use Phpactor\Extension\WorseReflection\WorseReflectionExtension;
+use Phpactor\MapResolver\Resolver;
+use Phpactor\WorseReflection\Core\SourceCodeLocator;
+
+class ProphecyExtension implements OptionalExtension
+{
+    public function load(ContainerBuilder $container): void
+    {
+        $container->register(ProphecyMemberContextResolver::class, function (Container $container) {
+            return new ProphecyMemberContextResolver();
+        }, [ WorseReflectionExtension::TAG_MEMBER_TYPE_RESOLVER => []]);
+        $container->register(SourceCodeLocator::class, function (Container $container) {
+            return new ProphecyStubLocator();
+        }, [ WorseReflectionExtension::TAG_SOURCE_LOCATOR => [
+            'priority' => 290 
+        ]]);
+    }
+
+    public function configure(Resolver $schema): void
+    {
+    }
+
+    public function name(): string
+    {
+        return 'prophecy';
+    }
+}

--- a/lib/Extension/Prophecy/ProphecyExtension.php
+++ b/lib/Extension/Prophecy/ProphecyExtension.php
@@ -21,7 +21,7 @@ class ProphecyExtension implements OptionalExtension
         $container->register(SourceCodeLocator::class, function (Container $container) {
             return new ProphecyStubLocator();
         }, [ WorseReflectionExtension::TAG_SOURCE_LOCATOR => [
-            'priority' => 290 
+            'priority' => 290
         ]]);
     }
 

--- a/lib/Extension/Prophecy/Tests/Integration/WorseReflection/ProphecyMemberContextResolverTest.php
+++ b/lib/Extension/Prophecy/Tests/Integration/WorseReflection/ProphecyMemberContextResolverTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Phpactor\Extension\Prophecy\Tests\Integration\WorseReflection;
+
+use Phpactor\Extension\Prophecy\WorseReflection\ProphecyMemberContextResolver;
+use Phpactor\Extension\Prophecy\WorseReflection\ProphecyStubLocator;
+use Phpactor\Extension\Symfony\Tests\IntegrationTestCase;
+use Phpactor\WorseReflection\Core\Inference\Walker\TestAssertWalker;
+use Phpactor\WorseReflection\ReflectorBuilder;
+
+class ProphecyMemberContextResolverTest extends IntegrationTestCase
+{
+    public function testProphesize(): void
+    {
+        $this->resolve(
+            <<<'EOT'
+                <?php
+                class Hello {
+                    public function bar(): string
+                    {
+                    }
+                }
+
+                class Foobar {
+                    public function prophesize(string $class): \Prophecy\Prophecy\ObjectProphecy
+                    {
+                    }
+                }
+
+                $prophet = (new Foobar())->prophesize(Hello::class);
+                wrAssertType('Prophecy\Prophecy\ObjectProphecy<Hello>', $prophet);
+                wrAssertType('Prophecy\Prophecy\MethodProphecy<string>', $prophet->bar());
+                wrAssertType('Hello', $prophet->reveal());
+                EOT
+            ,
+        );
+    }
+
+    public function testProphesizeFromProperty(): void
+    {
+        $this->resolve(
+            <<<'EOT'
+                <?php
+                class Hello {
+                    public function bar(): string
+                    {
+                    }
+                }
+
+                class TestCase {
+                    /**
+                     * @var ObjectProphecy<Hello>
+                     */
+                    private $hello;
+                   
+                    public function hello(): void
+                    {
+                        wrAssertType('ObjectProphecy<Hello>', $this->hello);
+                        wrAssertType('MethodProphecy<string>', $this->hello->bar());
+                    }
+                }
+                EOT
+            ,
+        );
+    }
+
+    public function resolve(string $sourceCode): void
+    {
+        $reflector = ReflectorBuilder::create()
+            ->addFrameWalker(new TestAssertWalker($this))
+            ->addLocator(new ProphecyStubLocator())
+            ->addSource($sourceCode)
+            ->addMemberContextResolver(new ProphecyMemberContextResolver())
+            ->build();
+
+        $reflector->reflectOffset($sourceCode, mb_strlen($sourceCode));
+    }
+}

--- a/lib/Extension/Prophecy/Tests/Integration/WorseReflection/ProphecyMemberContextResolverTest.php
+++ b/lib/Extension/Prophecy/Tests/Integration/WorseReflection/ProphecyMemberContextResolverTest.php
@@ -65,6 +65,34 @@ class ProphecyMemberContextResolverTest extends IntegrationTestCase
         );
     }
 
+    public function testProphesizeFromMethod(): void
+    {
+        $this->resolve(
+            <<<'EOT'
+                <?php
+                use Prophecy\Prophecy\ObjectProphecy;
+                class Hello {
+                    public function bar(): string
+                    {
+                    }
+                }
+
+                class TestCase {
+                    /**
+                     * @return ObjectProphecy<Hello>
+                     */
+                    public function foobar(): ObjectProphecy
+                   
+                    public function hello(): void
+                    {
+                        wrAssertType('Prophecy\Prophecy\ObjectProphecy<Hello>', $this->foobar());
+                    }
+                }
+                EOT
+            ,
+        );
+    }
+
     public function resolve(string $sourceCode): void
     {
         $reflector = ReflectorBuilder::create()

--- a/lib/Extension/Prophecy/Tests/Integration/WorseReflection/ProphecyMemberContextResolverTest.php
+++ b/lib/Extension/Prophecy/Tests/Integration/WorseReflection/ProphecyMemberContextResolverTest.php
@@ -41,6 +41,7 @@ class ProphecyMemberContextResolverTest extends IntegrationTestCase
         $this->resolve(
             <<<'EOT'
                 <?php
+                use Prophecy\Prophecy\ObjectProphecy;
                 class Hello {
                     public function bar(): string
                     {
@@ -55,8 +56,8 @@ class ProphecyMemberContextResolverTest extends IntegrationTestCase
                    
                     public function hello(): void
                     {
-                        wrAssertType('ObjectProphecy<Hello>', $this->hello);
-                        wrAssertType('MethodProphecy<string>', $this->hello->bar());
+                        wrAssertType('Prophecy\Prophecy\ObjectProphecy<Hello>', $this->hello);
+                        wrAssertType('Prophecy\Prophecy\MethodProphecy<string>', $this->hello->bar());
                     }
                 }
                 EOT

--- a/lib/Extension/Prophecy/WorseReflection/ProphecyMemberContextResolver.php
+++ b/lib/Extension/Prophecy/WorseReflection/ProphecyMemberContextResolver.php
@@ -10,10 +10,10 @@ use Phpactor\WorseReflection\Core\Reflection\ReflectionMethod;
 use Phpactor\WorseReflection\Core\Type;
 use Phpactor\WorseReflection\Core\TypeFactory;
 use Phpactor\WorseReflection\Core\Type\ClassStringType;
+use Phpactor\WorseReflection\Core\Type\ClassType;
 use Phpactor\WorseReflection\Core\Type\GenericClassType;
 use Phpactor\WorseReflection\Core\Virtual\VirtualReflectionMethod;
 use Phpactor\WorseReflection\Reflector;
-use Prophecy\Prophecy\MethodProphecy;
 
 class ProphecyMemberContextResolver implements MemberContextResolver
 {
@@ -21,16 +21,27 @@ class ProphecyMemberContextResolver implements MemberContextResolver
 
     public function resolveMemberContext(
         Reflector $reflector,
-        string $memberType,
-        string $memberName,
-        Type $containerType,
+        ReflectionMember $member,
         ?FunctionArguments $arguments
     ): ?Type {
-        if ($memberType !== ReflectionMember::TYPE_METHOD) {
+        $memberType = $member->inferredType();
+        if ($memberType instanceof GenericClassType && $memberType->instanceof(TypeFactory::reflectedClass($reflector, 'Prophecy\Prophecy\ObjectProphecy'))->isTrue()) {
+            return $this->fromGeneric($reflector, $memberType);
+        }
+
+        return $this->fromProphesize($reflector, $member, $arguments);
+    }
+
+    private function fromProphesize(
+        Reflector $reflector,
+        ReflectionMember $member,
+        ?FunctionArguments $arguments
+    ): ?Type {
+        if (!$member instanceof ReflectionMethod) {
             return null;
         }
 
-        if ($memberName !== 'prophesize') {
+        if ($member->name() !== 'prophesize') {
             return null;
         }
 
@@ -45,12 +56,18 @@ class ProphecyMemberContextResolver implements MemberContextResolver
         }
 
         $innerType = TypeFactory::class($arg->className());
+
+        $type = new GenericClassType($reflector, ClassName::fromString('Prophecy\Prophecy\ObjectProphecy'), [$innerType]);
+
+        return $this->fromGeneric($reflector, $type);
+    }
+
+    private function fromGeneric(Reflector $reflector, GenericClassType $type): Type {
+        $innerType = $type->arguments()[0];
+        if (!$innerType instanceof ClassType) {
+            return TypeFactory::undefined();
+        }
         $innerReflection = $reflector->reflectClassLike($innerType->name());
-
-        $type = new GenericClassType($reflector, ClassName::fromString('Prophecy\Prophecy\ObjectProphecy'), [
-            $innerType
-        ]);
-
         return $type->mergeMembers($innerReflection->members()->map(function (ReflectionMember $member) use ($reflector) {
             if (!$member instanceof ReflectionMethod) {
                 return $member;

--- a/lib/Extension/Prophecy/WorseReflection/ProphecyMemberContextResolver.php
+++ b/lib/Extension/Prophecy/WorseReflection/ProphecyMemberContextResolver.php
@@ -50,7 +50,7 @@ class ProphecyMemberContextResolver implements MemberContextResolver
         }
 
         $arg = $arguments->at(0)->type();
-        
+
         if (!$arg instanceof ClassStringType) {
             return null;
         }
@@ -62,7 +62,8 @@ class ProphecyMemberContextResolver implements MemberContextResolver
         return $this->fromGeneric($reflector, $type);
     }
 
-    private function fromGeneric(Reflector $reflector, GenericClassType $type): Type {
+    private function fromGeneric(Reflector $reflector, GenericClassType $type): Type
+    {
         $innerType = $type->arguments()[0];
         if (!$innerType instanceof ClassType) {
             return TypeFactory::undefined();

--- a/lib/Extension/Prophecy/WorseReflection/ProphecyMemberContextResolver.php
+++ b/lib/Extension/Prophecy/WorseReflection/ProphecyMemberContextResolver.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Phpactor\Extension\Prophecy\WorseReflection;
+
+use Phpactor\WorseReflection\Core\ClassName;
+use Phpactor\WorseReflection\Core\Inference\FunctionArguments;
+use Phpactor\WorseReflection\Core\Inference\Resolver\MemberAccess\MemberContextResolver;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionMember;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionMethod;
+use Phpactor\WorseReflection\Core\Type;
+use Phpactor\WorseReflection\Core\TypeFactory;
+use Phpactor\WorseReflection\Core\Type\ClassStringType;
+use Phpactor\WorseReflection\Core\Type\GenericClassType;
+use Phpactor\WorseReflection\Core\Virtual\VirtualReflectionMethod;
+use Phpactor\WorseReflection\Reflector;
+use Prophecy\Prophecy\MethodProphecy;
+
+class ProphecyMemberContextResolver implements MemberContextResolver
+{
+    const PROPHECY_CLASS = 'Prophecy\Prophecy\ProphecyInterface';
+
+    public function resolveMemberContext(
+        Reflector $reflector,
+        string $memberType,
+        string $memberName,
+        Type $containerType,
+        ?FunctionArguments $arguments
+    ): ?Type {
+        if ($memberType !== ReflectionMember::TYPE_METHOD) {
+            return null;
+        }
+
+        if ($memberName !== 'prophesize') {
+            return null;
+        }
+
+        if ($arguments->count() !== 1) {
+            return null;
+        }
+
+        $arg = $arguments->at(0)->type();
+        
+        if (!$arg instanceof ClassStringType) {
+            return null;
+        }
+
+        $innerType = TypeFactory::class($arg->className());
+        $innerReflection = $reflector->reflectClassLike($innerType->name());
+
+        $type = new GenericClassType($reflector, ClassName::fromString('Prophecy\Prophecy\ObjectProphecy'), [
+            $innerType
+        ]);
+
+        return $type->mergeMembers($innerReflection->members()->map(function (ReflectionMember $member) use ($reflector) {
+            if (!$member instanceof ReflectionMethod) {
+                return $member;
+            }
+            return VirtualReflectionMethod::fromReflectionMethod($member)->withInferredType(
+                new GenericClassType($reflector, ClassName::fromString('Prophecy\Prophecy\MethodProphecy'), [
+                    $member->inferredType()
+                ])
+            );
+        }));
+    }
+}

--- a/lib/Extension/Prophecy/WorseReflection/ProphecyStubLocator.php
+++ b/lib/Extension/Prophecy/WorseReflection/ProphecyStubLocator.php
@@ -9,7 +9,6 @@ use Phpactor\WorseReflection\Core\SourceCodeLocator\InternalLocator;
 
 class ProphecyStubLocator implements SourceCodeLocator
 {
-
     private InternalLocator $locator;
 
     public function __construct()
@@ -19,6 +18,7 @@ class ProphecyStubLocator implements SourceCodeLocator
             'Prophecy\Prophecy\MethodProphecy' => __DIR__ . '/../stubs/Prophecy.stub'
         ]);
     }
+
     public function locate(Name $name): SourceCode
     {
         return $this->locator->locate($name);

--- a/lib/Extension/Prophecy/WorseReflection/ProphecyStubLocator.php
+++ b/lib/Extension/Prophecy/WorseReflection/ProphecyStubLocator.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Phpactor\Extension\Prophecy\WorseReflection;
+
+use Phpactor\WorseReflection\Core\Name;
+use Phpactor\WorseReflection\Core\SourceCode;
+use Phpactor\WorseReflection\Core\SourceCodeLocator;
+use Phpactor\WorseReflection\Core\SourceCodeLocator\InternalLocator;
+
+class ProphecyStubLocator implements SourceCodeLocator
+{
+    /**
+     * @var InternalLocator
+     */
+    private InternalLocator $locator;
+
+    public function __construct()
+    {
+        $this->locator = new InternalLocator([
+            'Prophecy\Prophecy\ObjectProphecy' => __DIR__ . '/../stubs/Prophecy.stub',
+            'Prophecy\Prophecy\MethodProphecy' => __DIR__ . '/../stubs/Prophecy.stub'
+        ]);
+    }
+    public function locate(Name $name): SourceCode
+    {
+        return $this->locator->locate($name);
+    }
+}

--- a/lib/Extension/Prophecy/WorseReflection/ProphecyStubLocator.php
+++ b/lib/Extension/Prophecy/WorseReflection/ProphecyStubLocator.php
@@ -9,9 +9,7 @@ use Phpactor\WorseReflection\Core\SourceCodeLocator\InternalLocator;
 
 class ProphecyStubLocator implements SourceCodeLocator
 {
-    /**
-     * @var InternalLocator
-     */
+
     private InternalLocator $locator;
 
     public function __construct()

--- a/lib/Extension/Prophecy/stubs/Prophecy.stub
+++ b/lib/Extension/Prophecy/stubs/Prophecy.stub
@@ -14,9 +14,9 @@ use ReflectionType;
 use ReflectionUnionType;
 
 /**
- * @template T of object
+ * @template T
  */
-class ObjectProphecy implements ProphecyInterface
+class ObjectProphecy
 {
     /**
      * @return T

--- a/lib/Extension/Prophecy/stubs/Prophecy.stub
+++ b/lib/Extension/Prophecy/stubs/Prophecy.stub
@@ -1,0 +1,310 @@
+<?php
+
+namespace Prophecy\Prophecy;
+
+use Prophecy\Argument;
+use Prophecy\Prophet;
+use Prophecy\Promise;
+use Prophecy\Prediction;
+use Prophecy\Exception\Doubler\MethodNotFoundException;
+use Prophecy\Exception\InvalidArgumentException;
+use Prophecy\Exception\Prophecy\MethodProphecyException;
+use ReflectionNamedType;
+use ReflectionType;
+use ReflectionUnionType;
+
+/**
+ * @template T of object
+ */
+class ObjectProphecy implements ProphecyInterface
+{
+    /**
+     * @return T
+     */
+    public function reveal()
+    {
+    }
+}
+
+/**
+ * @template T
+ */
+class MethodProphecy
+{
+    /**
+     * Sets argument wildcard.
+     *
+     * @param array|Argument\ArgumentsWildcard $arguments
+     *
+     * @return $this
+     *
+     * @throws \Prophecy\Exception\InvalidArgumentException
+     */
+    public function withArguments($arguments)
+    {
+    }
+
+    /**
+     * Sets custom promise to the prophecy.
+     *
+     * @param callable|Promise\PromiseInterface $promise
+     *
+     * @return $this
+     *
+     * @throws \Prophecy\Exception\InvalidArgumentException
+     */
+    public function will($promise)
+    {
+    }
+
+    /**
+     * Sets return promise to the prophecy.
+     *
+     * @see \Prophecy\Promise\ReturnPromise
+     *
+     * @return $this
+     */
+    public function willReturn()
+    {
+    }
+
+    /**
+     * @param array $items
+     * @param mixed $return
+     *
+     * @return $this
+     *
+     * @throws \Prophecy\Exception\InvalidArgumentException
+     */
+    public function willYield($items, $return = null)
+    {
+    }
+
+    /**
+     * Sets return argument promise to the prophecy.
+     *
+     * @param int $index The zero-indexed number of the argument to return
+     *
+     * @see \Prophecy\Promise\ReturnArgumentPromise
+     *
+     * @return $this
+     */
+    public function willReturnArgument($index = 0)
+    {
+    }
+
+    /**
+     * Sets throw promise to the prophecy.
+     *
+     * @see \Prophecy\Promise\ThrowPromise
+     *
+     * @param string|\Exception $exception Exception class or instance
+     *
+     * @return $this
+     */
+    public function willThrow($exception)
+    {
+    }
+
+    /**
+     * Sets custom prediction to the prophecy.
+     *
+     * @param callable|Prediction\PredictionInterface $prediction
+     *
+     * @return $this
+     *
+     * @throws \Prophecy\Exception\InvalidArgumentException
+     */
+    public function should($prediction)
+    {
+    }
+
+    /**
+     * Sets call prediction to the prophecy.
+     *
+     * @see \Prophecy\Prediction\CallPrediction
+     *
+     * @return $this
+     */
+    public function shouldBeCalled()
+    {
+    }
+
+    /**
+     * Sets no calls prediction to the prophecy.
+     *
+     * @see \Prophecy\Prediction\NoCallsPrediction
+     *
+     * @return $this
+     */
+    public function shouldNotBeCalled()
+    {
+    }
+
+    /**
+     * Sets call times prediction to the prophecy.
+     *
+     * @see \Prophecy\Prediction\CallTimesPrediction
+     *
+     * @param $count
+     *
+     * @return $this
+     */
+    public function shouldBeCalledTimes($count)
+    {
+    }
+
+    /**
+     * Sets call times prediction to the prophecy.
+     *
+     * @see \Prophecy\Prediction\CallTimesPrediction
+     *
+     * @return $this
+     */
+    public function shouldBeCalledOnce()
+    {
+    }
+
+    /**
+     * Checks provided prediction immediately.
+     *
+     * @param callable|Prediction\PredictionInterface $prediction
+     *
+     * @return $this
+     *
+     * @throws \Prophecy\Exception\InvalidArgumentException
+     */
+    public function shouldHave($prediction)
+    {
+    }
+
+    /**
+     * Checks call prediction.
+     *
+     * @see \Prophecy\Prediction\CallPrediction
+     *
+     * @return $this
+     */
+    public function shouldHaveBeenCalled()
+    {
+        return $this->shouldHave(new Prediction\CallPrediction);
+    }
+
+    /**
+     * Checks no calls prediction.
+     *
+     * @see \Prophecy\Prediction\NoCallsPrediction
+     *
+     * @return $this
+     */
+    public function shouldNotHaveBeenCalled()
+    {
+        return $this->shouldHave(new Prediction\NoCallsPrediction);
+    }
+
+    /**
+     * Checks no calls prediction.
+     *
+     * @see \Prophecy\Prediction\NoCallsPrediction
+     * @deprecated
+     *
+     * @return $this
+     */
+    public function shouldNotBeenCalled()
+    {
+        return $this->shouldNotHaveBeenCalled();
+    }
+
+    /**
+     * Checks call times prediction.
+     *
+     * @see \Prophecy\Prediction\CallTimesPrediction
+     *
+     * @param int $count
+     *
+     * @return $this
+     */
+    public function shouldHaveBeenCalledTimes($count)
+    {
+        return $this->shouldHave(new Prediction\CallTimesPrediction($count));
+    }
+
+    /**
+     * Checks call times prediction.
+     *
+     * @see \Prophecy\Prediction\CallTimesPrediction
+     *
+     * @return $this
+     */
+    public function shouldHaveBeenCalledOnce()
+    {
+    }
+
+    /**
+     * Checks currently registered [with should(...)] prediction.
+     */
+    public function checkPrediction()
+    {
+    }
+
+    /**
+     * Returns currently registered promise.
+     *
+     * @return null|Promise\PromiseInterface
+     */
+    public function getPromise()
+    {
+    }
+
+    /**
+     * Returns currently registered prediction.
+     *
+     * @return null|Prediction\PredictionInterface
+     */
+    public function getPrediction()
+    {
+    }
+
+    /**
+     * Returns predictions that were checked on this object.
+     *
+     * @return Prediction\PredictionInterface[]
+     */
+    public function getCheckedPredictions()
+    {
+    }
+
+    /**
+     * Returns object prophecy this method prophecy is tied to.
+     *
+     * @return ObjectProphecy
+     */
+    public function getObjectProphecy()
+    {
+    }
+
+    /**
+     * Returns method name.
+     *
+     * @return string
+     */
+    public function getMethodName()
+    {
+    }
+
+    /**
+     * Returns arguments wildcard.
+     *
+     * @return Argument\ArgumentsWildcard
+     */
+    public function getArgumentsWildcard()
+    {
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasReturnVoid()
+    {
+    }
+}

--- a/lib/Phpactor.php
+++ b/lib/Phpactor.php
@@ -26,6 +26,7 @@ use Phpactor\Extension\LanguageServerWorseReflection\LanguageServerWorseReflecti
 use Phpactor\Extension\LanguageServer\LanguageServerExtension;
 use Phpactor\Extension\LanguageServer\LanguageServerExtraExtension;
 use Phpactor\Extension\ObjectRenderer\ObjectRendererExtension;
+use Phpactor\Extension\Prophecy\ProphecyExtension;
 use Phpactor\Extension\Symfony\SymfonyExtension;
 use Phpactor\Extension\WorseReflectionAnalyse\WorseReflectionAnalyseExtension;
 use Phpactor\Indexer\Extension\IndexerExtension;
@@ -157,6 +158,7 @@ class Phpactor
             LanguageServerPhpCsFixerExtension::class,
             BehatExtension::class,
             SymfonyExtension::class,
+            ProphecyExtension::class,
         ];
 
         if (class_exists(DebugExtension::class)) {


### PR DESCRIPTION
This is an experiment that shows how support for Prophecy can be realised:

![image](https://user-images.githubusercontent.com/530801/196809888-40ad721b-bcef-4dfb-9920-8e50c79207fa.png)

- calls to `prophesize()` with a `class-string` argument resolved to `ObjectProphecy<1st-argumnet-type>`
- methods from `1st-argument-type` _added_ to the generic type as virtual methods, wrapping the types with the `MethodProphecy` generic.

I think this would also facilitate integration with PHPSpec cc @camilledejoye 

things that need to be worked on:

- allowing extensions to add stubs
- allowing the methods to be found by the reference finder (???)
- ...?