### PR TITLE
Adding a code action for expading classes

### DIFF
--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseExpandClass.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseExpandClass.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Phpactor\CodeTransform\Adapter\WorseReflection\Refactor;
+
+use Microsoft\PhpParser\Node\QualifiedName;
+use Microsoft\PhpParser\Parser;
+use Phpactor\CodeTransform\Domain\Refactor\ExpandClass;
+use Phpactor\CodeTransform\Domain\SourceCode;
+use Phpactor\TextDocument\TextDocumentEdits;
+use Phpactor\TextDocument\TextEdit;
+use Phpactor\TextDocument\TextEdits;
+use Phpactor\WorseReflection\Core\Type\ClassType;
+use Phpactor\WorseReflection\Reflector;
+
+class WorseExpandClass implements ExpandClass
+{
+    private Reflector $reflector;
+
+    private Parser $parser;
+
+    public function __construct(
+        Reflector $reflector,
+        Parser $parser = null
+    ) {
+        $this->reflector = $reflector;
+        $this->parser = $parser ?: new Parser();
+    }
+
+    public function getTextEdits(SourceCode $sourceCode, int $offset): TextDocumentEdits
+    {
+        $symbolContext = $this->reflector
+            ->reflectOffset($sourceCode->__toString(), $offset)
+            ->symbolContext();
+        $type = $symbolContext->type();
+
+        if (!$type instanceof ClassType) {
+            return new TextDocumentEdits($sourceCode->uri(), TextEdits::none());
+        }
+
+        $newClassName = $type->name()->__toString();
+        $position = $symbolContext->symbol()->position();
+
+        return new TextDocumentEdits($sourceCode->uri(), TextEdits::fromTextEdits([
+            TextEdit::create($position->start(), $position->end() - $position->start(), $newClassName)
+        ]));
+    }
+
+    public function canExpandClassName(SourceCode $source, int $offset): bool
+    {
+        $node = $this->parser->parseSourceFile($source->__toString());
+        $targetNode = $node->getDescendantNodeAtPosition($offset);
+
+        if (!$targetNode instanceof QualifiedName) {
+            return false;
+        }
+
+        return $targetNode->isRelativeName();
+    }
+}

--- a/lib/CodeTransform/Domain/Refactor/ExpandClass.php
+++ b/lib/CodeTransform/Domain/Refactor/ExpandClass.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Phpactor\CodeTransform\Domain\Refactor;
+
+use Phpactor\CodeTransform\Domain\SourceCode;
+use Phpactor\TextDocument\TextDocumentEdits;
+
+interface ExpandClass
+{
+    public function getTextEdits(SourceCode $sourceCode, int $offset): TextDocumentEdits;
+
+    public function canExpandClassName(SourceCode $sourceCode, int $offset): bool;
+}

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/WorseExpandClassTest.php
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/WorseExpandClassTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Phpactor\CodeTransform\Tests\Adapter\WorseReflection\Refactor;
+
+use Phpactor\CodeTransform\Adapter\WorseReflection\Refactor\WorseExpandClass;
+use Phpactor\CodeTransform\Tests\Adapter\WorseReflection\WorseTestCase;
+use Phpactor\CodeTransform\Domain\SourceCode;
+
+class WorseExpandClassTest extends WorseTestCase
+{
+    /**
+     * @dataProvider provideExpandClass
+     */
+    public function testExpandingClass(string $test): void
+    {
+        [$source, $expected, $offset] = $this->sourceExpectedAndOffset(__DIR__ . '/fixtures/' . $test);
+
+        $extractConstant = new WorseExpandClass(
+            $this->reflectorForWorkspace($source)
+        );
+        $textDocumentEdits = $extractConstant->getTextEdits(
+            SourceCode::fromStringAndPath($source, 'file:///source'),
+            $offset
+        );
+        $sourceCode = SourceCode::fromStringAndPath($source, 'file:///source');
+        $transformed = SourceCode::fromStringAndPath(
+            (string) $textDocumentEdits->textEdits()->apply($sourceCode),
+            $textDocumentEdits->uri()->path()
+        );
+
+        $this->assertEquals(trim($expected), trim($transformed));
+    }
+
+    /**
+     * @return array<string,array<string>>
+     */
+    public function provideExpandClass(): array
+    {
+        return [
+            'in an expression' => [ 'expandClass1.test' ],
+            'in a parameter' => [ 'expandClass2.test' ],
+        ];
+    }
+}

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/fixtures/expandClass1.test
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/fixtures/expandClass1.test
@@ -1,0 +1,11 @@
+// File: source
+<?php
+use SomeNamespace\Foo;
+
+echo 'Debugging ' . F<>oo::class;
+
+// File: expected
+<?php
+use SomeNamespace\Foo;
+
+echo 'Debugging ' . SomeNamespace\Foo::class;

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/fixtures/expandClass2.test
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/fixtures/expandClass2.test
@@ -1,0 +1,12 @@
+// File: source
+<?php
+use SomeNamespace\Foo;
+
+function test(F<>oo $foo) { }
+
+// File: expected
+<?php
+use SomeNamespace\Foo;
+
+function test(SomeNamespace\Foo $foo) { }
+

--- a/lib/Extension/CodeTransform/CodeTransformExtension.php
+++ b/lib/Extension/CodeTransform/CodeTransformExtension.php
@@ -24,6 +24,7 @@ use Phpactor\CodeTransform\Adapter\TolerantParser\Refactor\TolerantExtractExpres
 use Phpactor\CodeTransform\Adapter\WorseReflection\GenerateFromExisting\InterfaceFromExistingGenerator;
 use Phpactor\CodeTransform\Adapter\TolerantParser\Refactor\TolerantRenameVariable;
 use Phpactor\CodeTransform\Adapter\WorseReflection\Helper\WorseMissingMethodFinder;
+use Phpactor\CodeTransform\Adapter\WorseReflection\Refactor\WorseExpandClass;
 use Phpactor\CodeTransform\Adapter\WorseReflection\Refactor\WorseExtractMethod;
 use Phpactor\CodeTransform\Adapter\WorseReflection\Refactor\WorseFillObject;
 use Phpactor\CodeTransform\Adapter\WorseReflection\Refactor\WorseGenerateConstructor;
@@ -44,6 +45,7 @@ use Phpactor\CodeTransform\Domain\Generators;
 use Phpactor\CodeTransform\Domain\Helper\InterestingOffsetFinder;
 use Phpactor\CodeTransform\Domain\Helper\MissingMethodFinder;
 use Phpactor\CodeTransform\Domain\Refactor\ChangeVisiblity;
+use Phpactor\CodeTransform\Domain\Refactor\ExpandClass;
 use Phpactor\CodeTransform\Domain\Refactor\ExtractConstant;
 use Phpactor\CodeTransform\Domain\Refactor\ExtractExpression;
 use Phpactor\CodeTransform\Domain\Refactor\ExtractMethod;
@@ -186,6 +188,12 @@ class CodeTransformExtension implements Extension
 
     private function registerRefactorings(ContainerBuilder $container): void
     {
+        $container->register(ExpandClass::class, function (Container $container) {
+            return new WorseExpandClass(
+                $container->get(WorseReflectionExtension::SERVICE_REFLECTOR),
+            );
+        });
+
         $container->register(ExtractConstant::class, function (Container $container) {
             return new WorseExtractConstant(
                 $container->get(WorseReflectionExtension::SERVICE_REFLECTOR),

--- a/lib/Extension/LanguageServerCodeTransform/CodeAction/ExpandClassProvider.php
+++ b/lib/Extension/LanguageServerCodeTransform/CodeAction/ExpandClassProvider.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerCodeTransform\CodeAction;
+
+use Amp\CancellationToken;
+use Amp\Promise;
+use Phpactor\CodeTransform\Domain\Refactor\ExpandClass;
+use Phpactor\CodeTransform\Domain\SourceCode;
+use Phpactor\Extension\LanguageServerBridge\Converter\PositionConverter;
+use Phpactor\Extension\LanguageServerCodeTransform\LspCommand\ExpandClassCommand;
+use Phpactor\LanguageServerProtocol\CodeAction;
+use Phpactor\LanguageServerProtocol\Command;
+use Phpactor\LanguageServerProtocol\Range;
+use Phpactor\LanguageServerProtocol\TextDocumentItem;
+use Phpactor\LanguageServer\Core\CodeAction\CodeActionProvider;
+use function Amp\call;
+
+class ExpandClassProvider implements CodeActionProvider
+{
+    public const KIND = 'refactor.class.expand';
+
+    private ExpandClass $expandClass;
+
+    public function __construct(ExpandClass $expandClass)
+    {
+        $this->expandClass = $expandClass;
+    }
+
+
+    public function kinds(): array
+    {
+        return [
+            self::KIND
+        ];
+    }
+
+    public function provideActionsFor(TextDocumentItem $textDocument, Range $range, CancellationToken $cancel): Promise
+    {
+        return call(function () use ($textDocument, $range) {
+            if (!$this->expandClass->canExpandClassName(
+                SourceCode::fromStringAndPath($textDocument->text, $textDocument->uri),
+                PositionConverter::positionToByteOffset($range->start, $textDocument->text)->toInt(),
+            )) {
+                return [];
+            }
+
+            return [
+                CodeAction::fromArray([
+                    'title' => 'Expand class name',
+                    'kind' => self::KIND,
+                    'diagnostics' => [],
+                    'command' => new Command(
+                        'Expand class',
+                        ExpandClassCommand::NAME,
+                        [
+                            $textDocument->uri,
+                            PositionConverter::positionToByteOffset($range->start, $textDocument->text)->toInt(),
+                        ]
+                    )
+                ])
+            ];
+        });
+    }
+}

--- a/lib/Extension/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
+++ b/lib/Extension/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
@@ -3,6 +3,7 @@
 namespace Phpactor\Extension\LanguageServerCodeTransform;
 
 use Phpactor\CodeTransform\Domain\Helper\MissingMethodFinder;
+use Phpactor\CodeTransform\Domain\Refactor\ExpandClass;
 use Phpactor\CodeTransform\Domain\Refactor\ExtractConstant;
 use Phpactor\CodeTransform\Domain\Refactor\ExtractExpression;
 use Phpactor\CodeTransform\Domain\Refactor\ExtractMethod;
@@ -31,6 +32,7 @@ use Phpactor\Extension\LanguageServerCodeTransform\CodeAction\GenerateMethodProv
 use Phpactor\Extension\LanguageServerCodeTransform\CodeAction\ImportNameProvider;
 use Phpactor\Extension\LanguageServerCodeTransform\CodeAction\TransformerCodeActionPovider;
 use Phpactor\Extension\LanguageServerCodeTransform\LspCommand\CreateClassCommand;
+use Phpactor\Extension\LanguageServerCodeTransform\LspCommand\ExpandClassCommand;
 use Phpactor\Extension\LanguageServerCodeTransform\LspCommand\ExtractConstantCommand;
 use Phpactor\Extension\LanguageServerCodeTransform\LspCommand\ExtractExpressionCommand;
 use Phpactor\Extension\LanguageServerCodeTransform\LspCommand\ExtractMethodCommand;
@@ -134,8 +136,21 @@ class LanguageServerCodeTransformExtension implements Extension
         }, [
             LanguageServerExtension::TAG_COMMAND => [
                 'name' => ExtractMethodCommand::NAME
+        ],
+        ]);
+
+        $container->register(ExpandClassCommand::class, function (Container $container) {
+            return new ExpandClassCommand(
+                $container->get(ClientApi::class),
+                $container->get(LanguageServerExtension::SERVICE_SESSION_WORKSPACE),
+                $container->get(ExpandClass::class)
+            );
+        }, [
+            LanguageServerExtension::TAG_COMMAND => [
+                'name' => ExpandClassCommand::NAME
             ],
         ]);
+
         $container->register(ExtractConstantCommand::class, function (Container $container) {
             return new ExtractConstantCommand(
                 $container->get(ClientApi::class),

--- a/lib/Extension/LanguageServerCodeTransform/LspCommand/ExpandClassCommand.php
+++ b/lib/Extension/LanguageServerCodeTransform/LspCommand/ExpandClassCommand.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerCodeTransform\LspCommand;
+
+use Amp\Promise;
+use Amp\Success;
+use Phpactor\CodeTransform\Adapter\WorseReflection\Refactor\WorseExpandClass;
+use Phpactor\CodeTransform\Domain\Exception\TransformException;
+use Phpactor\CodeTransform\Domain\SourceCode;
+use Phpactor\Extension\LanguageServerBridge\Converter\TextEditConverter;
+use Phpactor\LanguageServerProtocol\WorkspaceEdit;
+use Phpactor\LanguageServer\Core\Command\Command;
+use Phpactor\LanguageServer\Core\Server\ClientApi;
+use Phpactor\LanguageServer\Core\Workspace\Workspace;
+
+class ExpandClassCommand implements Command
+{
+    public const NAME = 'expand_class';
+
+    private ClientApi $clientApi;
+
+    private Workspace $workspace;
+
+    private WorseExpandClass $expandClass;
+
+    public function __construct(
+        ClientApi $clientApi,
+        Workspace $workspace,
+        WorseExpandClass $expandClass
+    ) {
+        $this->clientApi = $clientApi;
+        $this->workspace = $workspace;
+        $this->expandClass = $expandClass;
+    }
+
+    /**
+     * @return Promise<?ApplyWorkspaceEditResponse>
+     */
+    public function __invoke(string $uri, int $offset): Promise
+    {
+        $textDocument = $this->workspace->get($uri);
+
+        try {
+            $textEdits = $this->expandClass->getTextEdits(
+                SourceCode::fromStringAndPath($textDocument->text, $textDocument->uri),
+                $offset
+            );
+        } catch (TransformException $error) {
+            $this->clientApi->window()->showMessage()->warning($error->getMessage());
+            return new Success(null);
+        }
+
+        return $this->clientApi->workspace()->applyEdit(new WorkspaceEdit([
+            $uri => TextEditConverter::toLspTextEdits($textEdits, $textDocument->text)
+        ]), 'Expand Class');
+    }
+}

--- a/lib/Extension/LanguageServerCodeTransform/Tests/Unit/CodeAction/ExpandClassProviderTest.php
+++ b/lib/Extension/LanguageServerCodeTransform/Tests/Unit/CodeAction/ExpandClassProviderTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerCodeTransform\Tests\Unit\CodeAction;
+
+use Amp\CancellationTokenSource;
+use Generator;
+use PHPUnit\Framework\TestCase;
+use Phpactor\CodeTransform\Domain\Refactor\ExpandClass;
+use Phpactor\CodeTransform\Domain\SourceCode;
+use Phpactor\Extension\LanguageServerCodeTransform\CodeAction\ExpandClassProvider;
+use Phpactor\Extension\LanguageServerCodeTransform\LspCommand\ExpandClassCommand;
+use Phpactor\LanguageServerProtocol\CodeAction;
+use Phpactor\LanguageServerProtocol\Command;
+use Phpactor\LanguageServerProtocol\TextDocumentItem;
+use Phpactor\LanguageServer\Test\ProtocolFactory;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use function Amp\Promise\wait;
+
+class ExpandClassProviderTest extends TestCase
+{
+    use ProphecyTrait;
+    const EXAMPLE_SOURCE = 'foobar';
+    const EXAMPLE_FILE = 'file:///somefile.php';
+
+    /**
+     * @var ObjectProphecy<ExpandClass>
+     */
+    private ObjectProphecy $expandClass;
+
+    public function setUp(): void
+    {
+        $this->expandClass = $this->prophesize(ExpandClass::class);
+    }
+
+    /**
+     * @dataProvider provideActionsData
+     */
+    public function testProvideActions(bool $shouldSucceed, array $expectedValue): void
+    {
+        $textDocumentItem = new TextDocumentItem(self::EXAMPLE_FILE, 'php', 1, self::EXAMPLE_SOURCE);
+        $range = ProtocolFactory::range(0, 0, 0, 5);
+
+        $this->expandClass
+            ->canExpandClassName(
+                SourceCode::fromStringAndPath($textDocumentItem->text, $textDocumentItem->uri),
+                $range->start->character,
+            )
+            ->willReturn($shouldSucceed)
+            ->shouldBeCalled();
+
+        $cancel = (new CancellationTokenSource())->getToken();
+        $this->assertEquals(
+            $expectedValue,
+            wait($this->createProvider()->provideActionsFor(
+                $textDocumentItem,
+                $range,
+                $cancel
+            ))
+        );
+    }
+
+    public function provideActionsData(): Generator
+    {
+        yield 'Fail' => [
+            false,
+            []
+        ];
+        yield 'Success' => [
+            true,
+            [
+                CodeAction::fromArray([
+                    'title' => 'Expand class name',
+                    'kind' => ExpandClassProvider::KIND,
+                    'diagnostics' => [],
+                    'command' => new Command(
+                        'Expand class',
+                        ExpandClassCommand::NAME,
+                        [
+                            self::EXAMPLE_FILE,
+                            0
+                        ]
+                    )
+                ])
+            ]
+        ];
+    }
+
+    private function createProvider(): ExpandClassProvider
+    {
+        return new ExpandClassProvider($this->expandClass->reveal());
+    }
+}


### PR DESCRIPTION
Just as discussed in #1021 and #1258 we should add a command to the language server that allows us to expand the current class name under the cursor.