### PR TITLE
Replacing the class references to the webmozarts/path-util

### DIFF
--- a/lib/ConfigLoader/Adapter/PathCandidate/AbsolutePathCandidate.php
+++ b/lib/ConfigLoader/Adapter/PathCandidate/AbsolutePathCandidate.php
@@ -4,7 +4,7 @@ namespace Phpactor\ConfigLoader\Adapter\PathCandidate;
 
 use Phpactor\ConfigLoader\Core\PathCandidate;
 use RuntimeException;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class AbsolutePathCandidate implements PathCandidate
 {

--- a/lib/ConfigLoader/Adapter/PathCandidate/XdgPathCandidate.php
+++ b/lib/ConfigLoader/Adapter/PathCandidate/XdgPathCandidate.php
@@ -3,7 +3,7 @@
 namespace Phpactor\ConfigLoader\Adapter\PathCandidate;
 
 use Phpactor\ConfigLoader\Core\PathCandidate;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 use XdgBaseDir\Xdg;
 
 class XdgPathCandidate implements PathCandidate
@@ -26,7 +26,7 @@ class XdgPathCandidate implements PathCandidate
 
     public function path(): string
     {
-        return Path::join([$this->xdg->getHomeConfigDir(), $this->appName, $this->filename]);
+        return Path::join($this->xdg->getHomeConfigDir(), $this->appName, $this->filename);
     }
 
     public function loader(): string

--- a/lib/Extension/ClassMover/Application/ClassCopy.php
+++ b/lib/Extension/ClassMover/Application/ClassCopy.php
@@ -6,8 +6,8 @@ use Phpactor\ClassMover\ClassMover as ClassMoverFacade;
 use Phpactor\ClassMover\Domain\Name\FullyQualifiedName;
 use Phpactor\Filesystem\Domain\Filesystem;
 use Phpactor\Phpactor;
+use Symfony\Component\Filesystem\Path;
 use Webmozart\Glob\Glob;
-use Webmozart\PathUtil\Path;
 use Phpactor\Filesystem\Domain\CopyReport;
 use Phpactor\Extension\Core\Application\Helper\ClassFileNormalizer;
 use Phpactor\Extension\ClassMover\Application\Logger\ClassCopyLogger;
@@ -72,7 +72,7 @@ class ClassCopy
             // if the src is not the same as the globbed src, then it is a wildcard
             // and we want to append the filename to the destination
             if ($srcPath !== $globPath) {
-                $globDest = Path::join($destPath, Path::getFilename($globPath));
+                $globDest = Path::join($destPath, basename($globPath));
             }
 
             try {

--- a/lib/Extension/CodeTransform/Tests/Unit/Rpc/AbstractClassGenerateHandlerTest.php
+++ b/lib/Extension/CodeTransform/Tests/Unit/Rpc/AbstractClassGenerateHandlerTest.php
@@ -14,7 +14,7 @@ use Phpactor\Extension\Rpc\Response\Input\TextInput;
 use Phpactor\Extension\Rpc\Test\HandlerTester;
 use Phpactor\TestUtils\Workspace;
 use Prophecy\Prophecy\ObjectProphecy;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 abstract class AbstractClassGenerateHandlerTest extends TestCase
 {

--- a/lib/Extension/CodeTransformExtra/Application/Transformer.php
+++ b/lib/Extension/CodeTransformExtra/Application/Transformer.php
@@ -5,7 +5,7 @@ namespace Phpactor\Extension\CodeTransformExtra\Application;
 use Phpactor\CodeTransform\CodeTransform;
 use Phpactor\Extension\Core\Application\Helper\FilesystemHelper;
 use Phpactor\CodeTransform\Domain\SourceCode;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class Transformer
 {
@@ -23,7 +23,9 @@ class Transformer
     public function transform($source, array $transformations)
     {
         if (file_exists($source)) {
-            $source = Path::makeAbsolute($source, getcwd());
+            /** @var string $workDir */
+            $workDir = getcwd();
+            $source = Path::makeAbsolute($source, $workDir);
             $source = SourceCode::fromStringAndPath(file_get_contents($source), $source);
         }
 

--- a/lib/Extension/Core/Application/CacheClear.php
+++ b/lib/Extension/Core/Application/CacheClear.php
@@ -3,7 +3,7 @@
 namespace Phpactor\Extension\Core\Application;
 
 use Symfony\Component\Filesystem\Filesystem;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class CacheClear
 {

--- a/lib/Extension/Core/Application/Helper/FilesystemHelper.php
+++ b/lib/Extension/Core/Application/Helper/FilesystemHelper.php
@@ -2,8 +2,8 @@
 
 namespace Phpactor\Extension\Core\Application\Helper;
 
+use Symfony\Component\Filesystem\Path;
 use Webmozart\Glob\Glob;
-use Webmozart\PathUtil\Path;
 use InvalidArgumentException;
 use Generator;
 
@@ -38,7 +38,7 @@ final class FilesystemHelper
             // if the src is not the same as the globbed src, then it is a wildcard
             // and we want to append the filename to the destination
             if ($src !== $globSrc) {
-                $globDest = Path::join($dest, Path::getFilename($globSrc));
+                $globDest = Path::join($dest, basename($globSrc));
             }
 
             yield $globSrc => $globDest;

--- a/lib/Extension/WorseReflectionAnalyse/Model/Analyser.php
+++ b/lib/Extension/WorseReflectionAnalyse/Model/Analyser.php
@@ -9,8 +9,8 @@ use Phpactor\Filesystem\Domain\FilesystemRegistry;
 use Phpactor\WorseReflection\Core\Diagnostics;
 use Phpactor\WorseReflection\Core\Reflector\SourceCodeReflector;
 use RuntimeException;
+use Symfony\Component\Filesystem\Path;
 use Throwable;
-use Webmozart\PathUtil\Path;
 
 class Analyser
 {

--- a/lib/FilePathResolver/Filter/CanonicalizingPathFilter.php
+++ b/lib/FilePathResolver/Filter/CanonicalizingPathFilter.php
@@ -3,7 +3,7 @@
 namespace Phpactor\FilePathResolver\Filter;
 
 use Phpactor\FilePathResolver\Filter;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class CanonicalizingPathFilter implements Filter
 {

--- a/lib/Filesystem/Adapter/Composer/ComposerFileListProvider.php
+++ b/lib/Filesystem/Adapter/Composer/ComposerFileListProvider.php
@@ -7,12 +7,12 @@ use Phpactor\Filesystem\Domain\FilePath;
 use Composer\Autoload\ClassLoader;
 use Phpactor\Filesystem\Domain\FileListProvider;
 use AppendIterator;
-use Webmozart\PathUtil\Path;
 use SplFileInfo;
 use ArrayIterator;
 use Iterator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
+use Symfony\Component\Filesystem\Path;
 
 class ComposerFileListProvider implements FileListProvider
 {

--- a/lib/Filesystem/Adapter/Simple/SimpleFilesystem.php
+++ b/lib/Filesystem/Adapter/Simple/SimpleFilesystem.php
@@ -7,11 +7,11 @@ use Phpactor\Filesystem\Domain\FileList;
 use Phpactor\Filesystem\Domain\FilePath;
 use RuntimeException;
 use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
-use Webmozart\PathUtil\Path;
 use Phpactor\Filesystem\Domain\FileListProvider;
 use Phpactor\Filesystem\Domain\CopyReport;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
+use Symfony\Component\Filesystem\Path;
 
 class SimpleFilesystem implements Filesystem
 {

--- a/lib/Filesystem/Domain/FilePath.php
+++ b/lib/Filesystem/Domain/FilePath.php
@@ -4,8 +4,8 @@ namespace Phpactor\Filesystem\Domain;
 
 use RuntimeException;
 use SplFileInfo;
-use Webmozart\PathUtil\Path;
 use InvalidArgumentException;
+use Symfony\Component\Filesystem\Path;
 
 final class FilePath
 {
@@ -53,7 +53,7 @@ final class FilePath
 
     public static function fromParts(array $parts): FilePath
     {
-        $path = Path::join($parts);
+        $path = Path::join(...$parts);
         if (substr($path, 0, 1) !== '/') {
             $path = '/'.$path;
         }

--- a/lib/Indexer/Extension/Command/IndexBuildCommand.php
+++ b/lib/Indexer/Extension/Command/IndexBuildCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Phpactor\Indexer\Util\Cast;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class IndexBuildCommand extends Command
 {

--- a/lib/Indexer/Extension/IndexerExtension.php
+++ b/lib/Indexer/Extension/IndexerExtension.php
@@ -44,12 +44,10 @@ use Phpactor\Indexer\Model\QueryClient;
 use Phpactor\Indexer\Model\SearchClient;
 use Phpactor\Indexer\Model\Indexer;
 use Phpactor\TextDocument\TextDocumentUri;
-use Phpactor\WorseReflection\Reflector;
-use Phpactor\WorseReflection\ReflectorBuilder;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Symfony\Component\Filesystem\Filesystem;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class IndexerExtension implements Extension
 {
@@ -117,17 +115,6 @@ class IndexerExtension implements Extension
         $this->registerRpc($container);
         $this->registerReferenceFinderAdapters($container);
         $this->registerWatcher($container);
-    }
-
-    private function createReflector(Container $container): Reflector
-    {
-        $builder = ReflectorBuilder::create();
-        foreach (array_keys($container->getServiceIdsForTag(WorseReflectionExtension::TAG_SOURCE_LOCATOR)) as $serviceId) {
-            $builder->addLocator($container->get($serviceId), 128);
-        }
-        $builder->enableCache();
-
-        return $builder->build();
     }
 
     private function registerWorseAdapters(ContainerBuilder $container): void
@@ -231,7 +218,7 @@ class IndexerExtension implements Extension
         $container->register(self::SERVICE_INDEXER_EXCLUDE_PATTERNS, function (Container $container) {
             $projectRoot = $this->projectRoot($container);
             return array_map(function (string $pattern) use ($projectRoot) {
-                return Path::join([$projectRoot, $pattern]);
+                return Path::join($projectRoot, $pattern);
             }, $container->getParameter(self::PARAM_EXCLUDE_PATTERNS));
         });
 
@@ -239,7 +226,7 @@ class IndexerExtension implements Extension
             $projectRoot = $container->getParameter(FilePathResolverExtension::PARAM_PROJECT_ROOT);
 
             return array_map(function (string $pattern) use ($projectRoot) {
-                return Path::join([$projectRoot, $pattern]);
+                return Path::join($projectRoot, $pattern);
             }, $container->getParameter(self::PARAM_INCLUDE_PATTERNS));
         });
 

--- a/lib/Indexer/Model/IndexInfo.php
+++ b/lib/Indexer/Model/IndexInfo.php
@@ -3,8 +3,8 @@
 namespace Phpactor\Indexer\Model;
 
 use Phpactor\Indexer\Util\Filesystem;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\SplFileInfo;
-use Webmozart\PathUtil\Path;
 
 class IndexInfo
 {

--- a/lib/PathFinder/PathFinder.php
+++ b/lib/PathFinder/PathFinder.php
@@ -3,7 +3,7 @@
 namespace Phpactor\PathFinder;
 
 use Phpactor\PathFinder\Exception\NoMatchingSourceException;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class PathFinder
 {

--- a/lib/PathFinder/Pattern.php
+++ b/lib/PathFinder/Pattern.php
@@ -4,7 +4,7 @@ namespace Phpactor\PathFinder;
 
 use Phpactor\PathFinder\Exception\NoPlaceHoldersException;
 use RuntimeException;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class Pattern
 {

--- a/lib/TextDocument/TextDocumentBuilder.php
+++ b/lib/TextDocument/TextDocumentBuilder.php
@@ -4,7 +4,7 @@ namespace Phpactor\TextDocument;
 
 use Phpactor\TextDocument\Exception\TextDocumentNotFound;
 use RuntimeException;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 final class TextDocumentBuilder
 {

--- a/lib/TextDocument/TextDocumentUri.php
+++ b/lib/TextDocument/TextDocumentUri.php
@@ -3,7 +3,7 @@
 namespace Phpactor\TextDocument;
 
 use Phpactor\TextDocument\Exception\InvalidUriException;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class TextDocumentUri
 {

--- a/lib/WorseReflection/Core/Inference/Walker/IncludeWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/IncludeWalker.php
@@ -15,7 +15,7 @@ use Phpactor\WorseReflection\Core\Inference\FrameResolver;
 use Phpactor\WorseReflection\Core\Inference\Walker;
 use Phpactor\WorseReflection\TypeUtil;
 use Psr\Log\LoggerInterface;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class IncludeWalker implements Walker
 {
@@ -59,7 +59,7 @@ class IncludeWalker implements Walker
         }
 
         if (Path::isRelative($includeUri)) {
-            $includeUri = Path::join([dirname($uri), $includeUri]);
+            $includeUri = Path::join(dirname($uri), $includeUri);
         }
 
         if (!file_exists($includeUri)) {

--- a/lib/WorseReflection/Tests/Smoke/smoke_test.php
+++ b/lib/WorseReflection/Tests/Smoke/smoke_test.php
@@ -8,7 +8,7 @@ use Phpactor\WorseReflection\Core\Reflection\ReflectionClass;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionMethod;
 use Phpactor\WorseReflection\Core\SourceCodeLocator\StubSourceLocator;
 use Phpactor\WorseReflection\ReflectorBuilder;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 $autoload = require __DIR__ . '/../../vendor/autoload.php';
 $path = __DIR__ . '/../..';


### PR DESCRIPTION
Since we already remove the package dependency to the webmozarts/path-util package. We should also remove the references in code.

This isn't a big issue since the package is still in the pslam dependency. So it's still installed somehow.