### PR TITLE
Gh 1942: Fix container completion on open quote

### DIFF
--- a/lib/Completion/Bridge/TolerantParser/ChainTolerantCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/ChainTolerantCompletor.php
@@ -9,7 +9,6 @@ use Phpactor\Completion\Core\Completor;
 use Phpactor\Completion\Core\Util\OffsetHelper;
 use Phpactor\TextDocument\ByteOffset;
 use Phpactor\TextDocument\TextDocument;
-use Phpactor\WorseReflection\Core\Util\NodeUtil;
 
 class ChainTolerantCompletor implements Completor
 {
@@ -78,7 +77,7 @@ class ChainTolerantCompletor implements Completor
         $truncatedSource = mb_substr($source, 0, $characterOffset);
 
         // the parser will get very confused if there is an unterminated open quote,
-        // if the very last non-whitepsace char is a quote, then add another to 
+        // if the very last non-whitepsace char is a quote, then add another to
         // create a string literal.
         if ($lastChar === '\'' || $lastChar === '"') {
             $truncatedSource .= $lastChar;

--- a/lib/Completion/Bridge/TolerantParser/ChainTolerantCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/ChainTolerantCompletor.php
@@ -9,6 +9,7 @@ use Phpactor\Completion\Core\Completor;
 use Phpactor\Completion\Core\Util\OffsetHelper;
 use Phpactor\TextDocument\ByteOffset;
 use Phpactor\TextDocument\TextDocument;
+use Phpactor\WorseReflection\Core\Util\NodeUtil;
 
 class ChainTolerantCompletor implements Completor
 {
@@ -71,8 +72,17 @@ class ChainTolerantCompletor implements Completor
         // determine the last non-whitespace _character_ offset
         $characterOffset = OffsetHelper::lastNonWhitespaceCharacterOffset($truncatedSource);
 
+        $lastChar = mb_substr($source, $characterOffset - 1, 1);
+
         // truncate the source at the character offset
         $truncatedSource = mb_substr($source, 0, $characterOffset);
+
+        // the parser will get very confused if there is an unterminated open quote,
+        // if the very last non-whitepsace char is a quote, then add another to 
+        // create a string literal.
+        if ($lastChar === '\'' || $lastChar === '"') {
+            $truncatedSource .= $lastChar;
+        }
 
         return $truncatedSource;
     }

--- a/lib/Extension/Symfony/Completor/SymfonyContainerCompletor.php
+++ b/lib/Extension/Symfony/Completor/SymfonyContainerCompletor.php
@@ -6,8 +6,6 @@ use Generator;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\Expression\CallExpression;
 use Microsoft\PhpParser\Node\Expression\MemberAccessExpression;
-use Microsoft\PhpParser\Node\SourceFileNode;
-use Microsoft\PhpParser\Node\Statement\CompoundStatementNode;
 use Microsoft\PhpParser\Node\StringLiteral;
 use Phpactor\Completion\Bridge\TolerantParser\TolerantCompletor;
 use Phpactor\Completion\Core\Suggestion;

--- a/lib/WorseReflection/Core/Util/NodeUtil.php
+++ b/lib/WorseReflection/Core/Util/NodeUtil.php
@@ -183,7 +183,7 @@ class NodeUtil
                 str_repeat('  ', $level) . $node->getNodeKindName(),
                 $node->getStartPosition(),
                 $node->getEndPosition(),
-                str_replace("\n", "\\n", $node->getText()),
+                str_replace("\n", '\\n', $node->getText()),
             )
         ];
 

--- a/lib/WorseReflection/Core/Util/NodeUtil.php
+++ b/lib/WorseReflection/Core/Util/NodeUtil.php
@@ -179,10 +179,11 @@ class NodeUtil
     {
         $out = [
             sprintf(
-                '%s %d:%d',
+                '%s %d:%d - %s',
                 str_repeat('  ', $level) . $node->getNodeKindName(),
                 $node->getStartPosition(),
-                $node->getEndPosition()
+                $node->getEndPosition(),
+                str_replace("\n", "\\n", $node->getText()),
             )
         ];
 
@@ -290,6 +291,25 @@ class NodeUtil
         }
 
         return $node;
+    }
+    public static function lastDescendantNodeBeforeOffsetOfType(Node $node, int $offset, string $fqn): Node
+    {
+        $best = null;
+        $bestPos = null;
+        foreach ($node->getDescendantNodes() as $descendant) {
+            if (!$descendant instanceof $fqn) {
+                continue;
+            }
+            if ($descendant->getEndPosition() > $offset) {
+                continue;
+            }
+            if (null === $bestPos || $descendant->getEndPosition() > $bestPos) {
+                $best = $descendant;
+                $bestPos = $descendant->getEndPosition();
+            }
+        }
+
+        return $best ?? $node;
     }
 
     public static function previousSibling(Node $node): ?Node


### PR DESCRIPTION
This fixes the quotation completion for the Symfont DI container, and artificially "fixes" the AST when the last char is an unterminated open quote.

Fixes #1942 