### PR TITLE
Removing unused catch variables (php 8 feature)

### DIFF
--- a/lib/ClassMover/Adapter/WorseTolerant/WorseTolerantMemberFinder.php
+++ b/lib/ClassMover/Adapter/WorseTolerant/WorseTolerantMemberFinder.php
@@ -322,7 +322,7 @@ class WorseTolerantMemberFinder implements MemberFinder
     {
         try {
             return $this->reflector->reflectClassLike($className);
-        } catch (NotFound $e) {
+        } catch (NotFound) {
             return null;
         }
     }

--- a/lib/CodeTransform/Adapter/TolerantParser/ClassToFile/Transformer/ClassNameFixerTransformer.php
+++ b/lib/CodeTransform/Adapter/TolerantParser/ClassToFile/Transformer/ClassNameFixerTransformer.php
@@ -68,7 +68,7 @@ class ClassNameFixerTransformer implements Transformer
         $rootNode = $this->parser->parseSourceFile((string) $code);
         try {
             $classFqn = $this->determineClassFqn($code);
-        } catch (RuntimeException $couldNotFindCandidate) {
+        } catch (RuntimeException) {
             return Diagnostics::none();
         }
         $correctClassName = $classFqn->name();

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseExtractConstant.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseExtractConstant.php
@@ -53,7 +53,7 @@ class WorseExtractConstant implements ExtractConstant
         $targetNode = $node->getDescendantNodeAtPosition($offset);
         try {
             $this->getComparableValue($targetNode);
-        } catch (TransformException $e) {
+        } catch (TransformException) {
             return false;
         }
         return true;

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseFillObject.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseFillObject.php
@@ -74,7 +74,7 @@ class WorseFillObject implements FillObject
 
         try {
             $constructor = $offset->class()->methods()->get('__construct');
-        } catch (NotFound $notFound) {
+        } catch (NotFound) {
             return TextEdits::none();
         }
 

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseGenerateConstructor.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseGenerateConstructor.php
@@ -47,7 +47,7 @@ class WorseGenerateConstructor implements GenerateConstructor
         }
         try {
             $newObject = $this->reflector->reflectNode($document, $node->getStartPosition());
-        } catch (NotFound $notFound) {
+        } catch (NotFound) {
             return WorkspaceEdits::none();
         }
 
@@ -59,7 +59,7 @@ class WorseGenerateConstructor implements GenerateConstructor
             if ($newObject->class()->methods()->has('__construct')) {
                 return WorkspaceEdits::none();
             }
-        } catch (NotFound $notFound) {
+        } catch (NotFound) {
             return WorkspaceEdits::none();
         }
 

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/DoctrineAnnotationCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/DoctrineAnnotationCompletor.php
@@ -124,7 +124,7 @@ class DoctrineAnnotationCompletor extends NameSearcherCompletor implements Compl
             $docblock = $reflectionClass->docblock();
 
             return false !== strpos($docblock->raw(), '@Annotation');
-        } catch (NotFound $error) {
+        } catch (NotFound) {
             return false;
         }
     }

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/Helper/VariableCompletionHelper.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/Helper/VariableCompletionHelper.php
@@ -36,7 +36,7 @@ class VariableCompletionHelper
 
         try {
             $reflectionOffset = $this->reflector->reflectOffset($source, $offset);
-        } catch (NotFound $notFound) {
+        } catch (NotFound) {
             return [];
         }
 

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletor.php
@@ -136,7 +136,7 @@ class WorseClassMemberCompletor implements TolerantCompletor, TolerantQualifiabl
 
         try {
             $classReflection = $this->reflector->reflectClassLike($type->name());
-        } catch (NotFound $notFound) {
+        } catch (NotFound) {
             return;
         }
 

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseConstructorCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseConstructorCompletor.php
@@ -50,7 +50,7 @@ class WorseConstructorCompletor extends AbstractParameterCompletor implements To
 
         try {
             $reflectionClass = $this->reflectClass($source, $creationExpression);
-        } catch (NotFound $notFound) {
+        } catch (NotFound) {
             return true;
         }
 

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseDeclaredClassCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseDeclaredClassCompletor.php
@@ -40,7 +40,7 @@ class WorseDeclaredClassCompletor implements TolerantCompletor, TolerantQualifia
         foreach ($classes as $class) {
             try {
                 $reflectionClass = $this->reflector->reflectClass($class);
-            } catch (NotFound $e) {
+            } catch (NotFound) {
                 continue;
             }
 

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseFunctionCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseFunctionCompletor.php
@@ -109,7 +109,7 @@ class WorseFunctionCompletor implements TolerantCompletor
         foreach ($functionNames as $functionName) {
             try {
                 yield $this->reflector->reflectFunction($functionName);
-            } catch (NotFound $e) {
+            } catch (NotFound) {
             }
         }
     }

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseNamedParameterCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseNamedParameterCompletor.php
@@ -78,7 +78,7 @@ class WorseNamedParameterCompletor implements TolerantCompletor
 
         try {
             $class = $this->reflector->reflectClass((string)$type->getResolvedName());
-        } catch (NotFound $e) {
+        } catch (NotFound) {
             return true;
         }
 
@@ -137,7 +137,7 @@ class WorseNamedParameterCompletor implements TolerantCompletor
                     $callableExpression->getNamespacedName()->__toString()
                 );
                 yield from $this->fromFunction($function);
-            } catch (NotFound $e) {
+            } catch (NotFound) {
                 return true;
             }
 
@@ -150,7 +150,7 @@ class WorseNamedParameterCompletor implements TolerantCompletor
                 $callableExpression->getEndPosition()
             );
             yield from $this->fromMethod($classLike->class(), $classLike->name());
-        } catch (NotFound $e) {
+        } catch (NotFound) {
             return true;
         }
 

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseParameterCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseParameterCompletor.php
@@ -52,7 +52,7 @@ class WorseParameterCompletor extends AbstractParameterCompletor implements Tole
 
         try {
             $reflectionFunctionLike = $this->reflectFunctionLike($source, $callableExpression);
-        } catch (NotFound $exception) {
+        } catch (NotFound) {
             return true;
         }
 

--- a/lib/Completion/Bridge/WorseReflection/SuggestionDocumentor/WorseSuggestionDocumentor.php
+++ b/lib/Completion/Bridge/WorseReflection/SuggestionDocumentor/WorseSuggestionDocumentor.php
@@ -34,7 +34,7 @@ class WorseSuggestionDocumentor implements SuggestionDocumentor
             if ($suggestion->type() === Suggestion::TYPE_CLASS) {
                 try {
                     $reflectionClass = $this->reflector->reflectClassLike($fqn);
-                } catch (NotFound $notFound) {
+                } catch (NotFound) {
                     return $suggestion->documentation();
                 }
 
@@ -48,7 +48,7 @@ class WorseSuggestionDocumentor implements SuggestionDocumentor
             if ($suggestion->type() === Suggestion::TYPE_FUNCTION) {
                 try {
                     $reflectionFunction = $this->reflector->reflectFunction($fqn);
-                } catch (NotFound $notFound) {
+                } catch (NotFound) {
                     return $suggestion->documentation();
                 }
 
@@ -62,7 +62,7 @@ class WorseSuggestionDocumentor implements SuggestionDocumentor
             if ($suggestion->type() === Suggestion::TYPE_CONSTANT) {
                 try {
                     $reflectionConstant = $this->reflector->reflectConstant($fqn);
-                } catch (NotFound $notFound) {
+                } catch (NotFound) {
                     return $suggestion->documentation();
                 }
 

--- a/lib/Extension/Behat/Behat/ContextClassResolver/ChainContextClassResolver.php
+++ b/lib/Extension/Behat/Behat/ContextClassResolver/ChainContextClassResolver.php
@@ -25,7 +25,7 @@ class ChainContextClassResolver implements ContextClassResolver
         foreach ($this->contextClassResolvers as $resolver) {
             try {
                 return $resolver->resolve($className);
-            } catch (CouldNotResolverContextClass $couldNot) {
+            } catch (CouldNotResolverContextClass) {
             }
         }
 

--- a/lib/Extension/Behat/Behat/Step.php
+++ b/lib/Extension/Behat/Behat/Step.php
@@ -57,7 +57,7 @@ class Step
         foreach ($policies as $policy) {
             try {
                 $regex = $policy->transformPatternToRegex($this->pattern);
-            } catch (InvalidPatternException $invalid) {
+            } catch (InvalidPatternException) {
                 continue;
             }
 

--- a/lib/Extension/ClassMover/Application/ClassMover.php
+++ b/lib/Extension/ClassMover/Application/ClassMover.php
@@ -44,7 +44,7 @@ class ClassMover
             return array_filter($this->pathFinder->destinationsFor($src), function (string $filePath) {
                 return (bool) file_exists($filePath);
             });
-        } catch (NoMatchingSourceException $e) {
+        } catch (NoMatchingSourceException) {
             // TODO: Make pathfinder return it's own exception here, this is the class-to-file exception
             return [];
         }

--- a/lib/Extension/CodeTransformExtra/Command/ClassInflectCommand.php
+++ b/lib/Extension/CodeTransformExtra/Command/ClassInflectCommand.php
@@ -66,7 +66,7 @@ class ClassInflectCommand extends Command
 
         try {
             $response['path'] = $this->classInflect->generateFromExisting($src, $dest, $variant, $input->getOption('force'));
-        } catch (FileAlreadyExists $exception) {
+        } catch (FileAlreadyExists) {
             $questionHelper = new QuestionHelper();
             $question = new ConfirmationQuestion('<question>File already exists, overwrite? [y/n]</>', false);
 

--- a/lib/Extension/CodeTransformExtra/Command/ClassNewCommand.php
+++ b/lib/Extension/CodeTransformExtra/Command/ClassNewCommand.php
@@ -60,7 +60,7 @@ class ClassNewCommand extends Command
 
         try {
             $sourceCode = $this->generateSourceCode($src, $variant, $input, $output);
-        } catch (FileAlreadyExists $exception) {
+        } catch (FileAlreadyExists) {
             return [
                 'src' => $src,
                 'path' => null,

--- a/lib/Extension/CodeTransformExtra/Rpc/AbstractClassGenerateHandler.php
+++ b/lib/Extension/CodeTransformExtra/Rpc/AbstractClassGenerateHandler.php
@@ -73,7 +73,7 @@ abstract class AbstractClassGenerateHandler extends AbstractHandler
 
         try {
             $code = $this->generate($arguments);
-        } catch (FileAlreadyExists $e) {
+        } catch (FileAlreadyExists) {
             return InputCallbackResponse::fromCallbackAndInputs(
                 Request::fromNameAndParameters(
                     $this->name(),

--- a/lib/Extension/CompletionExtra/Rpc/HoverHandler.php
+++ b/lib/Extension/CompletionExtra/Rpc/HoverHandler.php
@@ -143,7 +143,7 @@ class HoverHandler implements Handler
     {
         try {
             return $this->renderSymbolContext($symbolContext);
-        } catch (CouldNotFormat $e) {
+        } catch (CouldNotFormat) {
         }
 
         return null;

--- a/lib/Extension/Core/Command/ConfigSetCommand.php
+++ b/lib/Extension/Core/Command/ConfigSetCommand.php
@@ -39,7 +39,7 @@ class ConfigSetCommand extends Command
         if ($value !== null) {
             try {
                 $this->manipulator->set($key, json_decode($value, true, 512, JSON_THROW_ON_ERROR));
-            } catch (JsonException $e) {
+            } catch (JsonException) {
                 $output->writeln(sprintf('<error>Could not decode JSON value: %s</>', $value));
                 return 1;
             }

--- a/lib/Extension/LanguageServerBridge/Converter/LocationConverter.php
+++ b/lib/Extension/LanguageServerBridge/Converter/LocationConverter.php
@@ -25,9 +25,9 @@ class LocationConverter
         foreach ($locations as $location) {
             try {
                 $lspLocations[] = $this->toLspLocation($location);
-            } catch (TextDocumentNotFound $notFound) {
+            } catch (TextDocumentNotFound) {
                 continue;
-            } catch (CouldNotLoadFileContents $couldNotLoad) {
+            } catch (CouldNotLoadFileContents) {
                 continue;
             }
         }

--- a/lib/Extension/LanguageServerBridge/TextDocument/WorkspaceTextDocumentLocator.php
+++ b/lib/Extension/LanguageServerBridge/TextDocument/WorkspaceTextDocumentLocator.php
@@ -23,7 +23,7 @@ class WorkspaceTextDocumentLocator implements TextDocumentLocator
     {
         try {
             return TextDocumentConverter::fromLspTextItem($this->workspace->get($uri->__toString()));
-        } catch (UnknownDocument $unknown) {
+        } catch (UnknownDocument) {
         }
 
         throw TextDocumentNotFound::fromUri($uri);

--- a/lib/Extension/LanguageServerCodeTransform/Model/NameImport/CandidateFinder.php
+++ b/lib/Extension/LanguageServerCodeTransform/Model/NameImport/CandidateFinder.php
@@ -99,7 +99,7 @@ class CandidateFinder
                 $unresolvedName->name()->head()->__toString()
             );
             return true;
-        } catch (NotFound $notFound) {
+        } catch (NotFound) {
         }
 
         return false;

--- a/lib/Extension/LanguageServerCompletion/Handler/CompletionHandler.php
+++ b/lib/Extension/LanguageServerCompletion/Handler/CompletionHandler.php
@@ -132,7 +132,7 @@ class CompletionHandler implements Handler, CanRegisterCapabilities
 
                 try {
                     $token->throwIfRequested();
-                } catch (CancelledException $cancellation) {
+                } catch (CancelledException) {
                     $this->resolve = [];
                     $isIncomplete = true;
                     break;

--- a/lib/Extension/LanguageServerCompletion/Handler/SignatureHelpHandler.php
+++ b/lib/Extension/LanguageServerCompletion/Handler/SignatureHelpHandler.php
@@ -50,7 +50,7 @@ class SignatureHelpHandler implements Handler, CanRegisterCapabilities
                     TextDocumentBuilder::create($textDocument->text)->language($languageId)->uri($textDocument->uri)->build(),
                     PositionConverter::positionToByteOffset($position, $textDocument->text)
                 ));
-            } catch (CouldNotHelpWithSignature $couldNotHelp) {
+            } catch (CouldNotHelpWithSignature) {
                 return null;
             }
         });

--- a/lib/Extension/LanguageServerHover/Handler/HoverHandler.php
+++ b/lib/Extension/LanguageServerHover/Handler/HoverHandler.php
@@ -108,7 +108,7 @@ class HoverHandler implements Handler, CanRegisterCapabilities
     {
         try {
             return $this->renderSymbolContext($nodeContext);
-        } catch (CouldNotFormat $e) {
+        } catch (CouldNotFormat) {
         }
 
         return null;
@@ -173,7 +173,7 @@ class HoverHandler implements Handler, CanRegisterCapabilities
                     ),
                     $member
                 ));
-            } catch (NotFound $e) {
+            } catch (NotFound) {
                 continue;
             }
         }

--- a/lib/Extension/LanguageServerIndexer/Handler/IndexerHandler.php
+++ b/lib/Extension/LanguageServerIndexer/Handler/IndexerHandler.php
@@ -106,7 +106,7 @@ class IndexerHandler implements Handler, ServiceProvider
 
                 try {
                     $cancel->throwIfRequested();
-                } catch (CancelledException $cancelled) {
+                } catch (CancelledException) {
                     break;
                 }
 
@@ -162,7 +162,7 @@ class IndexerHandler implements Handler, ServiceProvider
             while (null !== $file = yield $process->wait()) {
                 try {
                     $cancel->throwIfRequested();
-                } catch (CancelledException $cancelled) {
+                } catch (CancelledException) {
                     $process->stop();
                     break;
                 }
@@ -170,7 +170,7 @@ class IndexerHandler implements Handler, ServiceProvider
                 try {
                     $this->logger->debug(sprintf('Indexing %s', $file->path()));
                     $this->indexer->index(TextDocumentBuilder::fromUri($file->path())->build());
-                } catch (TextDocumentNotFound $error) {
+                } catch (TextDocumentNotFound) {
                     $this->logger->warning(sprintf(
                         'Trired to index non-existing file "%s"',
                         $file->path()

--- a/lib/Extension/LanguageServerReferenceFinder/Adapter/Indexer/WorkspaceUpdateReferenceFinder.php
+++ b/lib/Extension/LanguageServerReferenceFinder/Adapter/Indexer/WorkspaceUpdateReferenceFinder.php
@@ -44,7 +44,7 @@ class WorkspaceUpdateReferenceFinder implements ReferenceFinder
                 $this->indexer->indexDirty(
                     TextDocumentBuilder::fromUri($document->uri)->text($document->text)->build()
                 );
-            } catch (TextDocumentNotFound $e) {
+            } catch (TextDocumentNotFound) {
             }
         }
     }

--- a/lib/Extension/LanguageServerReferenceFinder/Handler/GotoDefinitionHandler.php
+++ b/lib/Extension/LanguageServerReferenceFinder/Handler/GotoDefinitionHandler.php
@@ -66,7 +66,7 @@ class GotoDefinitionHandler implements Handler, CanRegisterCapabilities
                     )->build(),
                     $offset
                 );
-            } catch (CouldNotLocateDefinition $couldNotLocateDefinition) {
+            } catch (CouldNotLocateDefinition) {
                 return null;
             }
 

--- a/lib/Extension/LanguageServerReferenceFinder/Handler/ReferencesHandler.php
+++ b/lib/Extension/LanguageServerReferenceFinder/Handler/ReferencesHandler.php
@@ -83,7 +83,7 @@ class ReferencesHandler implements Handler, CanRegisterCapabilities
                 try {
                     $potentialLocation = $this->definitionLocator->locateDefinition($phpactorDocument, $offset)->first()->location();
                     $locations[] = new Location($potentialLocation->uri(), $potentialLocation->offset());
-                } catch (CouldNotLocateDefinition $notFound) {
+                } catch (CouldNotLocateDefinition) {
                 }
             }
 

--- a/lib/Extension/LanguageServerReferenceFinder/Handler/TypeDefinitionHandler.php
+++ b/lib/Extension/LanguageServerReferenceFinder/Handler/TypeDefinitionHandler.php
@@ -67,7 +67,7 @@ class TypeDefinitionHandler implements Handler, CanRegisterCapabilities
                     TextDocumentBuilder::create($textDocument->text)->uri($textDocument->uri)->language('php')->build(),
                     $offset
                 );
-            } catch (CouldNotLocateType $type) {
+            } catch (CouldNotLocateType) {
                 return null;
             }
 

--- a/lib/Extension/Navigation/Navigator/PathFinderNavigator.php
+++ b/lib/Extension/Navigation/Navigator/PathFinderNavigator.php
@@ -18,7 +18,7 @@ class PathFinderNavigator implements Navigator
     {
         try {
             return $this->pathFinder->destinationsFor($path);
-        } catch (NoMatchingSourceException $e) {
+        } catch (NoMatchingSourceException) {
             return [];
         }
     }

--- a/lib/Extension/SourceCodeFilesystemExtra/SourceCodeFilestem/Application/ClassSearch.php
+++ b/lib/Extension/SourceCodeFilesystemExtra/SourceCodeFilestem/Application/ClassSearch.php
@@ -65,7 +65,7 @@ class ClassSearch
     {
         try {
             $reflectionClass = $this->reflector->reflectClassLike($name);
-        } catch (NotFound $exception) {
+        } catch (NotFound) {
             return;
         }
 

--- a/lib/Indexer/Adapter/Php/Serialized/SerializedIndex.php
+++ b/lib/Indexer/Adapter/Php/Serialized/SerializedIndex.php
@@ -35,7 +35,7 @@ class SerializedIndex implements Index
     {
         try {
             $mtime = $fileInfo->getCTime();
-        } catch (RuntimeException $statFailed) {
+        } catch (RuntimeException) {
             // file likely doesn't exist
             return false;
         }

--- a/lib/Indexer/Adapter/ReferenceFinder/IndexedImplementationFinder.php
+++ b/lib/Indexer/Adapter/ReferenceFinder/IndexedImplementationFinder.php
@@ -117,7 +117,7 @@ class IndexedImplementationFinder implements ClassImplementationFinder
             try {
                 $reflection = $this->reflector->reflectClassLike($implementation->__toString());
                 $member = $reflection->members()->byMemberType($symbolType)->belongingTo($reflection->name())->get($methodName);
-            } catch (NotFound $notFound) {
+            } catch (NotFound) {
                 continue;
             }
 

--- a/lib/Indexer/Adapter/ReferenceFinder/IndexedReferenceFinder.php
+++ b/lib/Indexer/Adapter/ReferenceFinder/IndexedReferenceFinder.php
@@ -46,7 +46,7 @@ class IndexedReferenceFinder implements ReferenceFinder
                 $document->__toString(),
                 $byteOffset->toInt()
             )->symbolContext();
-        } catch (NotFound $notFound) {
+        } catch (NotFound) {
             return;
         }
 

--- a/lib/Indexer/Adapter/ReferenceFinder/Util/ContainerTypeResolver.php
+++ b/lib/Indexer/Adapter/ReferenceFinder/Util/ContainerTypeResolver.php
@@ -29,7 +29,7 @@ class ContainerTypeResolver
             $members = $classLike->members()->byMemberType($memberType);
 
             return $members->get($memberName)->original()->declaringClass()->name()->__toString();
-        } catch (NotFound $notFound) {
+        } catch (NotFound) {
             return $containerFqn;
         }
     }

--- a/lib/ReferenceFinder/DefinitionAndReferenceFinder.php
+++ b/lib/ReferenceFinder/DefinitionAndReferenceFinder.php
@@ -25,7 +25,7 @@ class DefinitionAndReferenceFinder implements ReferenceFinder
         try {
             $location = $this->locator->locateDefinition($document, $byteOffset);
             yield PotentialLocation::surely($location->first()->location());
-        } catch (CouldNotLocateDefinition $notFound) {
+        } catch (CouldNotLocateDefinition) {
         }
 
         foreach ($this->referenceFinder->findReferences($document, $byteOffset) as $reference) {

--- a/lib/Rename/Adapter/ClassMover/FileRenamer.php
+++ b/lib/Rename/Adapter/ClassMover/FileRenamer.php
@@ -68,7 +68,7 @@ class FileRenamer implements PhpactorFileRenamer
 
                 try {
                     $document = $this->locator->get($reference->location()->uri());
-                } catch (TextDocumentNotFound $notFound) {
+                } catch (TextDocumentNotFound) {
                     continue;
                 }
 

--- a/lib/TextDocument/TextDocumentLocator/ChainDocumentLocator.php
+++ b/lib/TextDocument/TextDocumentLocator/ChainDocumentLocator.php
@@ -28,7 +28,7 @@ class ChainDocumentLocator implements TextDocumentLocator
         foreach ($this->locators as $workspace) {
             try {
                 return $workspace->get($uri);
-            } catch (TextDocumentNotFound $notFound) {
+            } catch (TextDocumentNotFound) {
             }
         }
 

--- a/lib/WorseReferenceFinder/WorsePlainTextClassDefinitionLocator.php
+++ b/lib/WorseReferenceFinder/WorsePlainTextClassDefinitionLocator.php
@@ -121,7 +121,7 @@ class WorsePlainTextClassDefinitionLocator implements DefinitionLocator
     {
         try {
             return $node->getImportTablesForCurrentScope();
-        } catch (Exception $e) {
+        } catch (Exception) {
         }
 
         foreach ($node->getDescendantNodes() as $node) {
@@ -131,7 +131,7 @@ class WorsePlainTextClassDefinitionLocator implements DefinitionLocator
                     continue;
                 }
                 return $imports;
-            } catch (Exception $e) {
+            } catch (Exception) {
             }
         }
 
@@ -145,13 +145,13 @@ class WorsePlainTextClassDefinitionLocator implements DefinitionLocator
     {
         try {
             return $this->namespaceFromNode($node);
-        } catch (Exception $e) {
+        } catch (Exception) {
         }
 
         foreach ($node->getDescendantNodes() as $node) {
             try {
                 return $this->namespaceFromNode($node);
-            } catch (Exception $e) {
+            } catch (Exception) {
             }
         }
 

--- a/lib/WorseReferenceFinder/WorseReflectionDefinitionLocator.php
+++ b/lib/WorseReferenceFinder/WorseReflectionDefinitionLocator.php
@@ -198,7 +198,7 @@ class WorseReflectionDefinitionLocator implements DefinitionLocator
         foreach ($containerType->classNamedTypes() as $namedType) {
             try {
                 $containingClass = $this->reflector->reflectClassLike($namedType->name());
-            } catch (NotFound $e) {
+            } catch (NotFound) {
                 continue;
             }
 
@@ -257,7 +257,7 @@ class WorseReflectionDefinitionLocator implements DefinitionLocator
     {
         try {
             $class = $this->reflector->reflectClass($symbolContext->classType()->name());
-        } catch (NotFound $notFound) {
+        } catch (NotFound) {
             return new TypeLocations([]);
         }
 

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/AssignmentToMissingPropertyProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/AssignmentToMissingPropertyProvider.php
@@ -77,7 +77,7 @@ class AssignmentToMissingPropertyProvider implements DiagnosticProvider
 
         try {
             $class = $resolver->reflector()->reflectClassLike($classNode->getNamespacedName()->__toString());
-        } catch (NotFound $notFound) {
+        } catch (NotFound) {
             return;
         }
 

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/MissingDocblockProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/MissingDocblockProvider.php
@@ -33,7 +33,7 @@ class MissingDocblockProvider implements DiagnosticProvider
                 return;
             }
             $method = $class->methods()->get($methodName);
-        } catch (NotFound $notFound) {
+        } catch (NotFound) {
             return;
         }
 

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/MissingMethodProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/MissingMethodProvider.php
@@ -55,7 +55,7 @@ class MissingMethodProvider implements DiagnosticProvider
         }
         try {
             $name = $class->methods()->get($methodName);
-        } catch (NotFound $notFound) {
+        } catch (NotFound) {
             yield new MissingMethodDiagnostic(
                 ByteOffsetRange::fromInts(
                     $memberName->getStartPosition(),

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UnresolvableNameProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UnresolvableNameProvider.php
@@ -124,7 +124,7 @@ class UnresolvableNameProvider implements DiagnosticProvider
             if (!$this->nameContainedInSource('function', $source, $fqn->head()->__toString())) {
                 throw new NotFound();
             }
-        } catch (NotFound $notFound) {
+        } catch (NotFound) {
             // if we are not importing globals then check the global namespace
             if (false === $this->importGlobals) {
                 try {
@@ -132,7 +132,7 @@ class UnresolvableNameProvider implements DiagnosticProvider
                     if ($this->nameContainedInSource('function', $source, $fqn->head()->__toString())) {
                         return;
                     }
-                } catch (NotFound $notFound) {
+                } catch (NotFound) {
                 }
             }
 
@@ -172,7 +172,7 @@ class UnresolvableNameProvider implements DiagnosticProvider
             if (!$this->nameContainedInSource('(class|trait|interface|enum)', $source, $fqn->head()->__toString())) {
                 throw new NotFound();
             }
-        } catch (NotFound $notFound) {
+        } catch (NotFound) {
             yield UnresolvableNameDiagnostic::forClass(
                 ByteOffsetRange::fromInts($name->getStartPosition(), $name->getEndPosition()),
                 $fqn,

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/AbstractReflectionClass.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/AbstractReflectionClass.php
@@ -81,7 +81,7 @@ abstract class AbstractReflectionClass extends AbstractReflectedNode implements 
         foreach ($traitImports as $traitImport) {
             try {
                 $trait = $traits->get($traitImport->name());
-            } catch (NotFound $notFound) {
+            } catch (NotFound) {
                 continue;
             }
 

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/AbstractReflectionMethodCall.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/AbstractReflectionMethodCall.php
@@ -147,7 +147,7 @@ abstract class AbstractReflectionMethodCall implements CoreReflectionMethodCall
             if ($class instanceof ReflectionClass) {
                 try {
                     return $class->methods()->get($method->getName());
-                } catch (ItemNotFound $notFound) {
+                } catch (ItemNotFound) {
                 }
             }
         }

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionClass.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionClass.php
@@ -197,7 +197,7 @@ class ReflectionClass extends AbstractReflectionClass implements CoreReflectionC
             $this->parent = $reflectedClass;
 
             return $reflectedClass;
-        } catch (NotFound $e) {
+        } catch (NotFound) {
             return null;
         }
     }

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionEnum.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionEnum.php
@@ -63,7 +63,7 @@ class ReflectionEnum extends AbstractReflectionClass implements CoreReflectionEn
             return $members->merge($enumMethods)->map(
                 fn (ReflectionMember $member) => $member->withClass($this)
             );
-        } catch (NotFound $notFound) {
+        } catch (NotFound) {
         }
 
         return $members;

--- a/lib/WorseReflection/Core/Inference/Resolver/MemberAccess/NodeContextFromMemberAccess.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/MemberAccess/NodeContextFromMemberAccess.php
@@ -143,7 +143,7 @@ class NodeContextFromMemberAccess
 
             try {
                 $reflection = $resolver->reflector()->reflectClassLike($subType->name());
-            } catch (NotFound $e) {
+            } catch (NotFound) {
                 continue;
             }
 
@@ -202,7 +202,7 @@ class NodeContextFromMemberAccess
                         $inferredType = $this->combineMethodTemplateVars($arguments, $templateMap, $declaringMember, $inferredType);
                     }
                 }
-            } catch (NotFound $e) {
+            } catch (NotFound) {
             }
         }
 

--- a/lib/WorseReflection/Core/Inference/Resolver/ObjectCreationExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/ObjectCreationExpressionResolver.php
@@ -48,7 +48,7 @@ class ObjectCreationExpressionResolver implements Resolver
     {
         try {
             $reflection = $resolver->reflector()->reflectClass($classType->name());
-        } catch (NotFound $notFound) {
+        } catch (NotFound) {
             return $classType;
         }
         if (!$reflection->methods()->has('__construct')) {

--- a/lib/WorseReflection/Core/Inference/Resolver/QualifiedNameResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/QualifiedNameResolver.php
@@ -125,7 +125,7 @@ class QualifiedNameResolver implements Resolver
                 // accurate check to see if class exists
                 $this->reflector->reflectClassLike($type->name());
                 return $context->withType($type);
-            } catch (NotFound $notFound) {
+            } catch (NotFound) {
                 // resolve the name of the potential constant
                 [$_, $_, $constImportTable] = $node->getImportTablesForCurrentScope();
                 if ($resolved = NodeUtil::resolveNameFromImportTable($node, $constImportTable)) {
@@ -142,7 +142,7 @@ class QualifiedNameResolver implements Resolver
                         ->withSymbolName($constant->name()->full())
                         ->withType($constant->type())
                         ->withSymbolType(Symbol::DECLARED_CONSTANT);
-                } catch (NotFound $e) {
+                } catch (NotFound) {
                 }
             }
         }

--- a/lib/WorseReflection/Core/Reflection/Collection/ReflectionInterfaceCollection.php
+++ b/lib/WorseReflection/Core/Reflection/Collection/ReflectionInterfaceCollection.php
@@ -64,7 +64,7 @@ class ReflectionInterfaceCollection extends AbstractReflectionCollection
                     $visited
                 );
                 $items[$interface->name()->full()] = $interface;
-            } catch (NotFound $e) {
+            } catch (NotFound) {
             }
         }
 

--- a/lib/WorseReflection/Core/Reflection/Collection/ReflectionTraitCollection.php
+++ b/lib/WorseReflection/Core/Reflection/Collection/ReflectionTraitCollection.php
@@ -32,7 +32,7 @@ class ReflectionTraitCollection extends AbstractReflectionCollection
                 $traitName = TolerantQualifiedNameResolver::getResolvedName($traitName);
                 try {
                     $items[(string) $traitName] = $serviceLocator->reflector()->reflectTrait(ClassName::fromString($traitName));
-                } catch (NotFound $notFound) {
+                } catch (NotFound) {
                 }
             }
         }
@@ -55,7 +55,7 @@ class ReflectionTraitCollection extends AbstractReflectionCollection
                 $traitName = TolerantQualifiedNameResolver::getResolvedName($traitName);
                 try {
                     $items[(string) $traitName] = $serviceLocator->reflector()->reflectTrait(ClassName::fromString($traitName), $visited);
-                } catch (NotFound $notFound) {
+                } catch (NotFound) {
                 }
             }
         }

--- a/lib/WorseReflection/Core/Reflector/CoreReflector.php
+++ b/lib/WorseReflection/Core/Reflector/CoreReflector.php
@@ -215,7 +215,7 @@ class CoreReflector implements ClassReflector, SourceCodeReflector, FunctionRefl
         // function
         try {
             $source = $this->sourceLocator->locate($name);
-        } catch (NotFound $notFound) {
+        } catch (NotFound) {
             $name = Name::fromString($name->short());
             $source = $this->sourceLocator->locate($name);
         }
@@ -267,7 +267,7 @@ class CoreReflector implements ClassReflector, SourceCodeReflector, FunctionRefl
         // function
         try {
             $source = $this->sourceLocator->locate($name);
-        } catch (NotFound $notFound) {
+        } catch (NotFound) {
             $name = Name::fromString($name->short());
             $source = $this->sourceLocator->locate($name);
         }
@@ -297,7 +297,7 @@ class CoreReflector implements ClassReflector, SourceCodeReflector, FunctionRefl
         // function
         try {
             $source = $this->sourceLocator->locate($name);
-        } catch (NotFound $notFound) {
+        } catch (NotFound) {
             $name = Name::fromString($name->short());
             $source = $this->sourceLocator->locate($name);
         }

--- a/lib/WorseReflection/Core/Type/ConditionalType.php
+++ b/lib/WorseReflection/Core/Type/ConditionalType.php
@@ -57,7 +57,7 @@ class ConditionalType extends Type
     {
         try {
             $parameter = $functionLike->parameters()->get(ltrim($this->variable, '$'));
-        } catch (NotFound $notFound) {
+        } catch (NotFound) {
             return TypeFactory::undefined();
         }
 

--- a/lib/WorseReflection/Core/Type/ReflectedClassType.php
+++ b/lib/WorseReflection/Core/Type/ReflectedClassType.php
@@ -83,7 +83,7 @@ class ReflectedClassType extends ClassType
 
         try {
             $reflectedThat = $this->reflector->reflectClassLike($type->name());
-        } catch (NotFound $e) {
+        } catch (NotFound) {
             return Trinary::maybe();
         }
 
@@ -111,7 +111,7 @@ class ReflectedClassType extends ClassType
     {
         try {
             return $this->reflector->reflectClassLike($this->name());
-        } catch (NotFound $notFound) {
+        } catch (NotFound) {
         }
         return null;
     }
@@ -210,7 +210,7 @@ class ReflectedClassType extends ClassType
 
         try {
             return $reflection->methods()->get('__invoke')->inferredType();
-        } catch (NotFound $notFound) {
+        } catch (NotFound) {
             return TypeFactory::undefined();
         }
     }

--- a/lib/WorseReflection/Tests/Integration/Core/SourceCodeLocator/StubSourceLocatorTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/SourceCodeLocator/StubSourceLocatorTest.php
@@ -52,7 +52,7 @@ class StubSourceLocatorTest extends IntegrationTestCase
         try {
             $code = $this->sourceLocator->locate(Name::fromString('hello_world'));
             $this->fail('Non PHP file parsed');
-        } catch (NotFound $notFound) {
+        } catch (NotFound) {
             $this->addToAssertionCount(1);
             return;
         }


### PR DESCRIPTION
In php8 you can omit the error variable if the catch body doesn't use it.