### PR TITLE
Using php8 string functions

### DIFF
--- a/lib/ClassMover/Domain/Name/NameImportTable.php
+++ b/lib/ClassMover/Domain/Name/NameImportTable.php
@@ -54,7 +54,7 @@ class NameImportTable
             }
         }
 
-        if (0 === strpos($name->__toString(), '\\')) {
+        if (str_starts_with($name->__toString(), '\\')) {
             return FullyQualifiedName::fromString($name->__toString());
         }
 

--- a/lib/CodeBuilder/Adapter/WorseReflection/TypeRenderer/WorseTypeRendererFactory.php
+++ b/lib/CodeBuilder/Adapter/WorseReflection/TypeRenderer/WorseTypeRendererFactory.php
@@ -14,7 +14,7 @@ final class WorseTypeRendererFactory
     public function rendererFor(string $phpVersion): WorseTypeRenderer
     {
         foreach ($this->versionToRendererMap as $version => $renderer) {
-            if (0 === strpos($phpVersion, $version)) {
+            if (str_starts_with($phpVersion, $version)) {
                 return $renderer;
             }
         }

--- a/lib/CodeBuilder/Domain/Prototype/Type.php
+++ b/lib/CodeBuilder/Domain/Prototype/Type.php
@@ -48,7 +48,7 @@ final class Type extends Prototype
             return null;
         }
 
-        if (substr($type, 0, 1) === '?') {
+        if (str_starts_with($type, '?')) {
             $type = substr($type, 1);
         }
 

--- a/lib/Completion/Bridge/TolerantParser/SourceCodeFilesystem/ScfClassCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/SourceCodeFilesystem/ScfClassCompletor.php
@@ -44,7 +44,7 @@ class ScfClassCompletor implements TolerantCompletor, TolerantQualifiable
 
         if ($node instanceof QualifiedName) {
             $files = $files->filter(function (SplFileInfo $file) use ($node) {
-                return 0 === strpos($file->getFilename(), $node->getText());
+                return str_starts_with($file->getFilename(), $node->getText());
             });
         }
 

--- a/lib/Completion/Bridge/TolerantParser/TypeSuggestionProvider.php
+++ b/lib/Completion/Bridge/TolerantParser/TypeSuggestionProvider.php
@@ -49,7 +49,7 @@ class TypeSuggestionProvider
                 continue;
             }
 
-            $wasAbsolute = strpos($search, '\\') === 0;
+            $wasAbsolute = str_starts_with($search, '\\');
             yield Suggestion::createWithOptions($result->name()->head(), [
                 'short_description' => $result->name()->__toString(),
                 'name_import' => $wasAbsolute ? null : $result->name()->__toString(),

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/AbstractParameterCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/AbstractParameterCompletor.php
@@ -105,7 +105,7 @@ abstract class AbstractParameterCompletor
         // if we have a trailing comma, e.g. the argument list is `$foobar, `
         // then the above elements will contain only `$foobar` but the param
         // index should be incremented.
-        if (substr(trim($argumentList->getText()), -1, 1) === ',') {
+        if (str_ends_with(trim($argumentList->getText()), ',')) {
             return $index + 1;
         }
 

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/DocblockCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/DocblockCompletor.php
@@ -76,7 +76,7 @@ class DocblockCompletor implements TolerantCompletor
         }
 
         foreach (self::SUPPORTED_TAGS as $supportedTag) {
-            if (0 === strpos($supportedTag, $tag)) {
+            if (str_starts_with($supportedTag, $tag)) {
                 yield Suggestion::createWithOptions(
                     $supportedTag,
                     [

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/DoctrineAnnotationCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/DoctrineAnnotationCompletor.php
@@ -119,7 +119,7 @@ class DoctrineAnnotationCompletor extends NameSearcherCompletor implements Compl
             $reflectionClass = $this->reflector->reflectClass($suggestion->classImport());
             $docblock = $reflectionClass->docblock();
 
-            return false !== strpos($docblock->raw(), '@Annotation');
+            return str_contains($docblock->raw(), '@Annotation');
         } catch (NotFound) {
             return false;
         }

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseDeclaredClassCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseDeclaredClassCompletor.php
@@ -30,7 +30,7 @@ class WorseDeclaredClassCompletor implements TolerantCompletor, TolerantQualifia
         $classes = get_declared_classes();
         $classes = array_filter($classes, function ($class) use ($node) {
             $name = Name::fromString($class);
-            return 0 === strpos($name->short(), $node->getText());
+            return str_starts_with($name->short(), $node->getText());
         });
 
         foreach ($classes as $class) {

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseFunctionCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseFunctionCompletor.php
@@ -88,7 +88,7 @@ class WorseFunctionCompletor implements TolerantCompletor
         foreach ($functions as $type => $functionNames) {
             foreach ($functionNames as $functionName) {
                 $functionName = Name::fromString($functionName);
-                if (0 === strpos($functionName->short(), $partialName)) {
+                if (str_starts_with($functionName->short(), $partialName)) {
                     yield $functionName;
                 }
             }

--- a/lib/Completion/Core/Completor/NameSearcherCompletor.php
+++ b/lib/Completion/Core/Completor/NameSearcherCompletor.php
@@ -24,7 +24,7 @@ abstract class NameSearcherCompletor
     protected function completeName(string $name, ?TextDocumentUri $sourceUri = null, ?Node $node = null): Generator
     {
         foreach ($this->nameSearcher->search($name) as $result) {
-            $wasAbsolute = strpos($name, '\\') === 0;
+            $wasAbsolute = str_starts_with($name, '\\');
             $options = $this->createSuggestionOptions($result, $sourceUri, $node, $wasAbsolute);
             yield $this->createSuggestion(
                 $result,

--- a/lib/DocblockParser/Lexer.php
+++ b/lib/DocblockParser/Lexer.php
@@ -102,11 +102,11 @@ final class Lexer
 
     private function resolveType(string $value): string
     {
-        if (false !== strpos($value, '/*')) {
+        if (str_contains($value, '/*')) {
             return Token::T_PHPDOC_OPEN;
         }
 
-        if (false !== strpos($value, '*/')) {
+        if (str_contains($value, '*/')) {
             return Token::T_PHPDOC_CLOSE;
         }
 
@@ -119,7 +119,7 @@ final class Lexer
         }
 
         if (is_numeric($value)) {
-            if (false !== strpos($value, '.')) {
+            if (str_contains($value, '.')) {
                 return Token::T_FLOAT;
             }
             return Token::T_INTEGER;

--- a/lib/DocblockParser/Parser.php
+++ b/lib/DocblockParser/Parser.php
@@ -544,7 +544,7 @@ final class Parser
             if ($this->tokens->current->type === Token::T_ASTERISK) {
                 break;
             }
-            if (false !== strpos($this->tokens->current->value, "\n")) {
+            if (str_contains($this->tokens->current->value, "\n")) {
                 break;
             }
             $text[] = $this->tokens->chomp();

--- a/lib/Extension/ClassMover/Application/ClassCopy.php
+++ b/lib/Extension/ClassMover/Application/ClassCopy.php
@@ -47,7 +47,7 @@ class ClassCopy
     public function copyFile(ClassCopyLogger $logger, string $srcPath, string $destPath): void
     {
         $srcPath = Phpactor::normalizePath($srcPath);
-        if (substr($destPath, -1, 1) === '/') {
+        if (str_ends_with($destPath, '/')) {
             $destPath = $destPath . basename($srcPath);
         }
 

--- a/lib/Extension/ClassMover/Application/ClassMover.php
+++ b/lib/Extension/ClassMover/Application/ClassMover.php
@@ -83,7 +83,7 @@ class ClassMover
     {
         $filesystem = $this->filesystemRegistry->get($filesystemName);
         $destPath = Phpactor::normalizePath($destPath);
-        if (substr($destPath, -1, 1) === '/') {
+        if (str_ends_with($destPath, '/')) {
             $destPath = $destPath . basename($srcPath);
         }
 

--- a/lib/Extension/Core/Application/Status.php
+++ b/lib/Extension/Core/Application/Status.php
@@ -94,7 +94,7 @@ class Status
 
         return [
             'phpactor_version' => $matches[1],
-            'phpactor_is_develop' => $this->warnOnDevelop && (false !== strpos($matches[2], 'develop'))
+            'phpactor_is_develop' => $this->warnOnDevelop && (str_contains($matches[2], 'develop'))
         ];
     }
 }

--- a/lib/Extension/Core/Model/JsonSchemaBuilder.php
+++ b/lib/Extension/Core/Model/JsonSchemaBuilder.php
@@ -85,7 +85,7 @@ class JsonSchemaBuilder
                 return 'number';
             }
 
-            if (substr($type, -2) === '[]') {
+            if (str_ends_with($type, '[]')) {
                 return 'array';
             }
 

--- a/lib/Extension/LanguageServerCompletion/Tests/Unit/Util/PhpactorToLspCompletionTypeTest.php
+++ b/lib/Extension/LanguageServerCompletion/Tests/Unit/Util/PhpactorToLspCompletionTypeTest.php
@@ -13,7 +13,7 @@ class PhpactorToLspCompletionTypeTest extends TestCase
     {
         $reflection = new ReflectionClass(Suggestion::class);
         foreach ($reflection->getConstants() as $name => $constantValue) {
-            if (0 !== strpos($name, 'TYPE')) {
+            if (!str_starts_with($name, 'TYPE')) {
                 continue;
             }
             $this->assertNotNull(PhpactorToLspCompletionType::fromPhpactorType($constantValue), $constantValue);

--- a/lib/Extension/LanguageServerReferenceFinder/Model/Highlighter.php
+++ b/lib/Extension/LanguageServerReferenceFinder/Model/Highlighter.php
@@ -206,7 +206,7 @@ class Highlighter
             return yield from $this->methods($rootNode, $memberName);
         }
 
-        if (false !== strpos($node->getText(), '$')) {
+        if (str_contains($node->getText(), '$')) {
             return yield from $this->properties($rootNode, $memberName);
         }
 

--- a/lib/FilePathResolver/Filter/TokenExpandingFilter.php
+++ b/lib/FilePathResolver/Filter/TokenExpandingFilter.php
@@ -13,7 +13,7 @@ class TokenExpandingFilter implements Filter
 
     public function apply(string $path): string
     {
-        if (false === strpos($path, '%')) {
+        if (!str_contains($path, '%')) {
             return $path;
         }
 

--- a/lib/Filesystem/Adapter/Composer/ComposerFileListProvider.php
+++ b/lib/Filesystem/Adapter/Composer/ComposerFileListProvider.php
@@ -57,7 +57,7 @@ class ComposerFileListProvider implements FileListProvider
                 //
                 // TODO: This could be more efficient.
                 foreach ($seenPaths as $seenPath) {
-                    if (0 === strpos($path, $seenPath)) {
+                    if (str_starts_with($path, $seenPath)) {
                         continue 2;
                     }
                 }

--- a/lib/Filesystem/Domain/FileList.php
+++ b/lib/Filesystem/Domain/FileList.php
@@ -178,7 +178,7 @@ class FileList implements Iterator
                 return false;
             }
 
-            return false !== strpos($contents, $string);
+            return str_contains($contents, $string);
         });
     }
 }

--- a/lib/Filesystem/Domain/FilePath.php
+++ b/lib/Filesystem/Domain/FilePath.php
@@ -54,7 +54,7 @@ final class FilePath
     public static function fromParts(array $parts): FilePath
     {
         $path = Path::join(...$parts);
-        if (substr($path, 0, 1) !== '/') {
+        if (!str_starts_with($path, '/')) {
             $path = '/'.$path;
         }
 
@@ -131,7 +131,7 @@ final class FilePath
 
     public function isWithin(FilePath $path)
     {
-        return 0 === strpos($this->path(), $path->path().'/');
+        return str_starts_with($this->path(), $path->path().'/');
     }
 
     public function isWithinOrSame(FilePath $path)

--- a/lib/Indexer/Adapter/ReferenceFinder/IndexedNameSearcher.php
+++ b/lib/Indexer/Adapter/ReferenceFinder/IndexedNameSearcher.php
@@ -28,7 +28,7 @@ class IndexedNameSearcher implements NameSearcher
             return;
         }
 
-        $fullyQualified = substr($name, 0, 1) === '\\';
+        $fullyQualified = str_starts_with($name, '\\');
 
         if ($fullyQualified) {
             $criteria = Criteria::fqnBeginsWith(substr($name, 1));

--- a/lib/Indexer/Model/Query/Criteria/FqnBeginsWith.php
+++ b/lib/Indexer/Model/Query/Criteria/FqnBeginsWith.php
@@ -22,6 +22,6 @@ class FqnBeginsWith extends Criteria
             return false;
         }
 
-        return 0 === strpos($record->fqn()->__toString(), $this->name);
+        return str_starts_with($record->fqn()->__toString(), $this->name);
     }
 }

--- a/lib/Indexer/Model/Query/Criteria/ShortNameBeginsWith.php
+++ b/lib/Indexer/Model/Query/Criteria/ShortNameBeginsWith.php
@@ -22,6 +22,6 @@ class ShortNameBeginsWith extends Criteria
             return false;
         }
 
-        return 0 === strpos($record->shortName(), $this->name);
+        return str_starts_with($record->shortName(), $this->name);
     }
 }

--- a/lib/Phpactor.php
+++ b/lib/Phpactor.php
@@ -259,7 +259,7 @@ class Phpactor
 
     public static function relativizePath(string $path): string
     {
-        if (0 === strpos($path, (string)getcwd())) {
+        if (str_starts_with($path, (string)getcwd())) {
             return substr($path, strlen(getcwd()) + 1);
         }
 

--- a/lib/ReferenceFinder/Search/PredefinedNameSearcher.php
+++ b/lib/ReferenceFinder/Search/PredefinedNameSearcher.php
@@ -20,7 +20,7 @@ class PredefinedNameSearcher implements NameSearcher
     public function search(string $search, ?string $type = null): Generator
     {
         foreach ($this->results as $result) {
-            if (0 !== strpos($result->name()->head()->__toString(), $search)) {
+            if (!str_starts_with($result->name()->head()->__toString(), $search)) {
                 continue;
             }
             yield $result;

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UnusedImportProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UnusedImportProvider.php
@@ -135,7 +135,7 @@ class UnusedImportProvider implements DiagnosticProvider
     private function usedByAnnotation(string $contents, string $imported, $node): bool
     {
         $imported = explode(':', $imported)[1];
-        return false !== strpos($contents, '@' . $imported);
+        return str_contains($contents, '@' . $imported);
     }
 
     private function lastPart(string $name): string

--- a/lib/WorseReflection/Core/DocBlock/PlainDocblock.php
+++ b/lib/WorseReflection/Core/DocBlock/PlainDocblock.php
@@ -30,7 +30,7 @@ class PlainDocblock implements DocBlock
 
     public function inherits(): bool
     {
-        return false !== strpos($this->raw, '@inheritDoc');
+        return str_contains($this->raw, '@inheritDoc');
     }
 
     public function vars(): DocBlockVars
@@ -52,13 +52,13 @@ class PlainDocblock implements DocBlock
     {
         $lines = [];
         foreach (explode("\n", $this->raw) as $line) {
-            if (false !== strpos($line, '@')) {
+            if (str_contains($line, '@')) {
                 continue;
             }
-            if (false !== strpos($line, '/*')) {
+            if (str_contains($line, '/*')) {
                 continue;
             }
-            if (false !== strpos($line, '*/')) {
+            if (str_contains($line, '*/')) {
                 continue;
             }
             $line = trim(preg_replace('{\s+\*}', '', $line, 1));

--- a/lib/WorseReflection/Core/Inference/Resolver/MemberAccess/NodeContextFromMemberAccess.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/MemberAccess/NodeContextFromMemberAccess.php
@@ -70,7 +70,7 @@ class NodeContextFromMemberAccess
             Symbol::PROPERTY === $memberTypeName
             && $node instanceof ScopedPropertyAccessExpression
             && is_string($memberName)
-            && substr($memberName, 0, 1) !== '$'
+            && !str_starts_with($memberName, '$')
         ) {
             $memberTypeName = Symbol::CONSTANT;
         }

--- a/lib/WorseReflection/Core/Name.php
+++ b/lib/WorseReflection/Core/Name.php
@@ -22,7 +22,7 @@ class Name
 
     public static function fromString(string $string): Name
     {
-        $fullyQualified = 0 === strpos($string, '\\');
+        $fullyQualified = str_starts_with($string, '\\');
         $parts = explode('\\', trim($string, '\\'));
 
         return new static($parts, $fullyQualified);

--- a/lib/WorseReflection/Core/TypeFactory.php
+++ b/lib/WorseReflection/Core/TypeFactory.php
@@ -56,7 +56,7 @@ class TypeFactory
 
     public static function fromString(string $type, Reflector $reflector = null): Type
     {
-        if ('?' === substr($type, 0, 1)) {
+        if (str_starts_with($type, '?')) {
             return self::nullable(self::typeFromString(substr($type, 1)));
         }
 
@@ -464,7 +464,7 @@ class TypeFactory
             return new BinLiteralType($value);
         }
 
-        if (false === strpos($value, '.')) {
+        if (!str_contains($value, '.')) {
             return self::intLiteral((int)$value);
         }
 


### PR DESCRIPTION
In php8 you can use `str_contains`, `str_ends_with` and `str_starts_with` to replace calls to the `str_pos` function and make the code much more readable.

Sadly there isn't a rule for that in phpcs.