### PR TITLE
Removing extension commands from vim

### DIFF
--- a/autoload/phpactor.vim
+++ b/autoload/phpactor.vim
@@ -284,26 +284,6 @@ function! phpactor#OffsetTypeInfo()
     call phpactor#rpc("offset_info", { "offset": phpactor#_offset(), "source": phpactor#_source()})
 endfunction
 
-function! phpactor#ExtensionList()
-    call phpactor#rpc("extension_list", {})
-endfunction
-
-function! phpactor#ExtensionInstall(...)
-    if v:false != get(a:,1, v:false)
-        call phpactor#rpc("extension_install", {"extension_name":get(a:,1)})
-        return
-    endif
-    call phpactor#rpc("extension_install", {})
-endfunction
-
-function! phpactor#ExtensionRemove(...)
-    if v:false != get(a:,1, v:false)
-        call phpactor#rpc("extension_remove", {"extension_name":get(a:,1)})
-        return
-    endif
-    call phpactor#rpc("extension_remove", {})
-endfunction
-
 function! phpactor#Transform(...)
     let transform = get(a:, 1, '')
 

--- a/doc/phpactor.txt
+++ b/doc/phpactor.txt
@@ -167,15 +167,6 @@ COMMANDS                                                   *phpactor-commands*
 :PhpactorConfig                                              *:PhpactorConfig*
   Dump Phpactor's configuration
 
-:PhpactorExtensionList                                *:PhpactorExtensionList*
-  List all installed extensions
-
-:PhpactorExtensionInstall                          *:PhpactorExtensionInstall*
-  Install an extension
-
-:PhpactorExtensionRemove                            *:PhpactorExtensionRemove*
-  Remove an extension
-
 :PhpactorClassExpand                                    *:PhpactorClassExpand*
   Expand the class name under the cursor to it's fully-qualified-name
 

--- a/plugin/phpactor.vim
+++ b/plugin/phpactor.vim
@@ -73,18 +73,6 @@ command! -nargs=0 PhpactorStatus call phpactor#Status()
 command! -nargs=0 PhpactorConfig call phpactor#Config()
 
 ""
-" List all installed extensions
-command! -nargs=0 PhpactorExtensionList call phpactor#ExtensionList()
-
-""
-" Install an extension
-command! -nargs=1 PhpactorExtensionInstall call phpactor#ExtensionInstall(<q-args>)
-
-""
-" Remove an extension
-command! -nargs=1 PhpactorExtensionRemove call phpactor#ExtensionRemove(<q-args>)
-
-""
 " Expand the class name under the cursor to it's fully-qualified-name
 command! -nargs=0 PhpactorClassExpand call phpactor#ClassExpand()
 


### PR DESCRIPTION
Since the phpactor binary doesn't support extensions anymore it doesn't make sense to have vim commands for it.