### PR TITLE
Phpunit extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Bug fixes:
   - Allow class completion within constant declaration in class #1985 @przepompownia
   - Do not suggest return type on `__destruct` #1992
 
+Features:
+
+  - Reintroduce the PHPUnit extension
 
 ## 2022.12.12
 

--- a/doc/integrations/phpunit.rst
+++ b/doc/integrations/phpunit.rst
@@ -1,5 +1,5 @@
-Prophecy
-========
+PHPUnit
+=======
 
 `PHPUnit <https://github.com/phpunit/phpunit>`_ is a programmer-oriented
 testing framework for PHP. It is an instance of the xUnit architecture for

--- a/doc/integrations/phpunit.rst
+++ b/doc/integrations/phpunit.rst
@@ -1,0 +1,17 @@
+Prophecy
+========
+
+`PHPUnit <https://github.com/phpunit/phpunit>`_ is a programmer-oriented
+testing framework for PHP. It is an instance of the xUnit architecture for
+unit testing frameworks. 
+
+Phpactor can integrate with PHPUnit to provide:
+
+- Type inference from assertions.
+- Generate test case.
+
+To do so you set :ref:`param_phpunit.enabled`:
+
+.. code-block:: bash
+
+   $ phpactor config:set phpunit.enabled true

--- a/doc/reference/configuration.rst
+++ b/doc/reference/configuration.rst
@@ -1851,3 +1851,26 @@ Enable or disable this extension
 
 **Default**: ``false``
 
+
+.. _PHPUnitExtension:
+
+
+PHPUnitExtension
+----------------
+
+
+.. _param_phpunit.enabled:
+
+
+``phpunit.enabled``
+"""""""""""""""""""
+
+
+Type: boolean
+
+
+Enable or disable this extension
+
+
+**Default**: ``false``
+

--- a/lib/ClassMover/Tests/Unit/ClassMoverTest.php
+++ b/lib/ClassMover/Tests/Unit/ClassMoverTest.php
@@ -47,6 +47,7 @@ class ClassMoverTest extends TestCase
         $references = $this->mover->findReferences($source, $fullName);
 
         $this->assertInstanceOf(FoundReferences::class, $references);
+
         $this->assertEquals($source, (string) $references->source());
         $this->assertEquals($fullName, (string) $references->targetName());
         $this->assertEquals([], iterator_to_array($references->references()));

--- a/lib/Completion/Tests/Integration/Bridge/TolerantParser/Qualifier/ClassMemberQualifierTest.php
+++ b/lib/Completion/Tests/Integration/Bridge/TolerantParser/Qualifier/ClassMemberQualifierTest.php
@@ -42,8 +42,9 @@ class ClassMemberQualifierTest extends TolerantQualifierTestCase
 
         yield 'returns the scoped property access expression' => [
             '<?php Hello::<>',
-            function ($node): void {
-                $this->assertInstanceOf(ScopedPropertyAccessExpression::class, $node);
+            function (Node $node): void {
+                self::assertInstanceOf(ScopedPropertyAccessExpression::class, $node);
+                $node;
             }
         ];
 

--- a/lib/Completion/Tests/Integration/Bridge/TolerantParser/Qualifier/ClassMemberQualifierTest.php
+++ b/lib/Completion/Tests/Integration/Bridge/TolerantParser/Qualifier/ClassMemberQualifierTest.php
@@ -42,9 +42,8 @@ class ClassMemberQualifierTest extends TolerantQualifierTestCase
 
         yield 'returns the scoped property access expression' => [
             '<?php Hello::<>',
-            function (Node $node): void {
+            function ($node): void {
                 self::assertInstanceOf(ScopedPropertyAccessExpression::class, $node);
-                $node;
             }
         ];
 

--- a/lib/Extension/PHPUnit/CodeTransform/TestGenerator.php
+++ b/lib/Extension/PHPUnit/CodeTransform/TestGenerator.php
@@ -8,7 +8,6 @@ use Phpactor\CodeTransform\Domain\SourceCode;
 
 class TestGenerator implements GenerateNew
 {
-
     public function generateNew(ClassName $targetName): SourceCode
     {
         $namespace = $targetName->namespace();

--- a/lib/Extension/PHPUnit/CodeTransform/TestGenerator.php
+++ b/lib/Extension/PHPUnit/CodeTransform/TestGenerator.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Phpactor\Extension\PHPUnit\CodeTransform;
+
+use Phpactor\CodeTransform\Domain\ClassName;
+use Phpactor\CodeTransform\Domain\GenerateNew;
+use Phpactor\CodeTransform\Domain\SourceCode;
+
+class TestGenerator implements GenerateNew
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function generateNew(ClassName $targetName): SourceCode
+    {
+        $namespace = $targetName->namespace();
+        $name = $targetName->short();
+        $sourceCode = <<<EOT
+<?php
+
+namespace $namespace;
+
+use PHPUnit\Framework\TestCase;
+
+class $name extends TestCase
+{
+}
+EOT
+        ;
+
+        return SourceCode::fromString($sourceCode);
+    }
+}

--- a/lib/Extension/PHPUnit/CodeTransform/TestGenerator.php
+++ b/lib/Extension/PHPUnit/CodeTransform/TestGenerator.php
@@ -8,24 +8,22 @@ use Phpactor\CodeTransform\Domain\SourceCode;
 
 class TestGenerator implements GenerateNew
 {
-    /**
-     * {@inheritDoc}
-     */
+
     public function generateNew(ClassName $targetName): SourceCode
     {
         $namespace = $targetName->namespace();
         $name = $targetName->short();
         $sourceCode = <<<EOT
-<?php
+            <?php
 
-namespace $namespace;
+            namespace $namespace;
 
-use PHPUnit\Framework\TestCase;
+            use PHPUnit\Framework\TestCase;
 
-class $name extends TestCase
-{
-}
-EOT
+            class $name extends TestCase
+            {
+            }
+            EOT
         ;
 
         return SourceCode::fromString($sourceCode);

--- a/lib/Extension/PHPUnit/FrameWalker/AssertInstanceOfWalker.php
+++ b/lib/Extension/PHPUnit/FrameWalker/AssertInstanceOfWalker.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace Phpactor\Extension\PHPUnit\FrameWalker;
+
+use Microsoft\PhpParser\Node;
+use Microsoft\PhpParser\Node\DelimitedList\ArgumentExpressionList;
+use Microsoft\PhpParser\Node\Expression\ArgumentExpression;
+use Microsoft\PhpParser\Node\Expression\CallExpression;
+use Microsoft\PhpParser\Node\Expression\MemberAccessExpression;
+use Microsoft\PhpParser\Node\Expression\ScopedPropertyAccessExpression;
+use Microsoft\PhpParser\Node\Expression\Variable as ParserVariable;
+use Microsoft\PhpParser\Node\QualifiedName;
+use Microsoft\PhpParser\Node\StringLiteral;
+use Microsoft\PhpParser\Token;
+use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameBuilder;
+use Phpactor\WorseReflection\Core\Inference\FrameResolver;
+use Phpactor\WorseReflection\Core\Inference\NodeContextFactory;
+use Phpactor\WorseReflection\Core\Inference\Symbol;
+use Phpactor\WorseReflection\Core\Inference\Variable;
+use Phpactor\WorseReflection\Core\Inference\Walker;
+use Phpactor\WorseReflection\Core\Type;
+use Phpactor\WorseReflection\Core\TypeFactory;
+
+class AssertInstanceOfWalker implements Walker
+{
+    /**
+     * @var NodeContextFactory
+     */
+    private $symbolFactory;
+
+    public function __construct()
+    {
+        $this->symbolFactory = new NodeContextFactory();
+    }
+
+    public function nodeFqns(): array
+    {
+        return [
+            ScopedPropertyAccessExpression::class,
+            MemberAccessExpression::class,
+        ];
+    }
+
+    public function enter(FrameResolver $resolver, Frame $frame, Node $node): Frame
+    {
+        return $frame;
+    }
+
+    public function exit(FrameResolver $resolver, Frame $frame, Node $node): Frame
+    {
+        if (!$this->canWalk($node)) {
+            return $frame;
+        }
+
+        $callExpression = $node->parent;
+        if (!$callExpression instanceof CallExpression) {
+            return $frame;
+        }
+        $expresionList = $callExpression->argumentExpressionList;
+
+        if (!$expresionList instanceof ArgumentExpressionList) {
+            return $frame;
+        }
+
+        $elements = iterator_to_array($expresionList->getElements());
+
+        if (!isset($elements[0])) {
+            return $frame;
+        }
+
+        if (!isset($elements[1])) {
+            return $frame;
+        }
+
+        $type = $this->resolveType($elements[0]);
+
+        if (null === $type) {
+            return $frame;
+        }
+
+        $name = $this->resolveVariableName($elements[1]);
+
+        if (null === $name) {
+            return $frame;
+        }
+
+        $frame->locals()->add(Variable::fromSymbolContext(
+            $this->symbolFactory->create(
+                $name,
+                $node->getStartPosition(),
+                $node->getEndPosition(),
+                [
+                    'symbol_type' => Symbol::VARIABLE,
+                    'type' => $type,
+                ]
+            )
+        ), $node->getStartPosition());
+
+        return $frame;
+    }
+
+    private function canWalk(Node $node): bool
+    {
+        if ($node instanceof ScopedPropertyAccessExpression) {
+            $scopeResolutionQualifier = $node->scopeResolutionQualifier;
+
+            if (!$scopeResolutionQualifier instanceof QualifiedName) {
+                return false;
+            }
+
+            $resolvedName = $scopeResolutionQualifier->getResolvedName();
+            if ((string) $resolvedName !== 'PHPUnit\Framework\Assert') {
+                return false;
+            }
+
+            return true;
+        }
+
+        if ($node instanceof MemberAccessExpression) {
+            $memberName = $node->memberName;
+
+            if (!$memberName instanceof Token) {
+                return false;
+            }
+
+            // we havn't got the facility to check if we are extending the TestCase
+            // here, so just assume that any method named this way is belonging to
+            // PHPUnit
+            if ('assertInstanceOf' === $memberName->getText($node->getFileContents())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function walk(FrameResolver $builder, Frame $frame, Node $node): Frame
+    {
+    }
+
+    private function resolveType(ArgumentExpression $element): ?Type
+    {
+        $expression = $element->expression;
+        if ($expression instanceof ScopedPropertyAccessExpression) {
+            $memberName = $expression->memberName;
+
+            if (!$memberName instanceof Token) {
+                return null;
+            }
+
+            if ('class' === $memberName->getText($element->getFileContents())) {
+                $scopeResolutionQualifier = $expression->scopeResolutionQualifier;
+
+                if (!$scopeResolutionQualifier instanceof QualifiedName) {
+                    return null;
+                }
+
+                return TypeFactory::class((string) $scopeResolutionQualifier->getResolvedName());
+            }
+        }
+
+        if ($expression instanceof StringLiteral) {
+            return TypeFactory::class($expression->getStringContentsText());
+        }
+
+        return null;
+    }
+
+    private function resolveVariableName(ArgumentExpression $element): ?string
+    {
+        $expression = $element->expression;
+        if (!$expression instanceof ParserVariable) {
+            return null;
+        }
+
+        $name = $expression->name;
+
+        if (!$name instanceof Token) {
+            return null;
+        }
+
+        return substr((string) $name->getText($element->getFileContents()), 1);
+    }
+}

--- a/lib/Extension/PHPUnit/FrameWalker/AssertInstanceOfWalker.php
+++ b/lib/Extension/PHPUnit/FrameWalker/AssertInstanceOfWalker.php
@@ -68,11 +68,11 @@ class AssertInstanceOfWalker implements Walker
         $type = $args->at(0)->type();
 
         if ($type instanceof StringLiteralType) {
-            $type = TypeFactory::class($type->value());
+            $type = TypeFactory::reflectedClass($resolver->reflector(), $type->value());
         }
 
         if ($type instanceof ClassStringType) {
-            $type = TypeFactory::class($type->className()?->__toString());
+            $type = TypeFactory::reflectedClass($resolver->reflector(), $type->className()?->__toString());
         }
 
         if (!$type instanceof ClassType) {
@@ -81,9 +81,7 @@ class AssertInstanceOfWalker implements Walker
 
         $var = $args->at(1);
 
-        $frame->locals()->set(Variable::fromSymbolContext(
-            $var->withType(TypeFactory::class($type->__toString()))
-        ));
+        $frame->locals()->set(Variable::fromSymbolContext($var->withType($type)));
 
         return $frame;
     }

--- a/lib/Extension/PHPUnit/FrameWalker/AssertInstanceOfWalker.php
+++ b/lib/Extension/PHPUnit/FrameWalker/AssertInstanceOfWalker.php
@@ -11,7 +11,6 @@ use Microsoft\PhpParser\Token;
 use Phpactor\WorseReflection\Core\Inference\Frame;
 use Phpactor\WorseReflection\Core\Inference\FrameResolver;
 use Phpactor\WorseReflection\Core\Inference\FunctionArguments;
-use Phpactor\WorseReflection\Core\Inference\NodeContextFactory;
 use Phpactor\WorseReflection\Core\Inference\Variable;
 use Phpactor\WorseReflection\Core\Inference\Walker;
 use Phpactor\WorseReflection\Core\TypeFactory;
@@ -21,16 +20,6 @@ use Phpactor\WorseReflection\Core\Type\StringLiteralType;
 
 class AssertInstanceOfWalker implements Walker
 {
-    /**
-     * @var NodeContextFactory
-     */
-    private $symbolFactory;
-
-    public function __construct()
-    {
-        $this->symbolFactory = new NodeContextFactory();
-    }
-
     public function nodeFqns(): array
     {
         return [

--- a/lib/Extension/PHPUnit/PHPUnitExtension.php
+++ b/lib/Extension/PHPUnit/PHPUnitExtension.php
@@ -13,7 +13,6 @@ use Phpactor\MapResolver\Resolver;
 
 class PHPUnitExtension implements OptionalExtension
 {
-
     public function load(ContainerBuilder $container): void
     {
         $this->registerWorseReflection($container);

--- a/lib/Extension/PHPUnit/PHPUnitExtension.php
+++ b/lib/Extension/PHPUnit/PHPUnitExtension.php
@@ -4,29 +4,30 @@ namespace Phpactor\Extension\PHPUnit;
 
 use Phpactor\Container\ContainerBuilder;
 use Phpactor\Container\Container;
-use Phpactor\Container\Extension;
+use Phpactor\Container\OptionalExtension;
 use Phpactor\Extension\CodeTransform\CodeTransformExtension;
 use Phpactor\Extension\PHPUnit\CodeTransform\TestGenerator;
 use Phpactor\Extension\PHPUnit\FrameWalker\AssertInstanceOfWalker;
 use Phpactor\Extension\WorseReflection\WorseReflectionExtension;
 use Phpactor\MapResolver\Resolver;
 
-class PHPUnitExtension implements Extension
+class PHPUnitExtension implements OptionalExtension
 {
-    /**
-     * {@inheritDoc}
-     */
+
     public function load(ContainerBuilder $container): void
     {
         $this->registerWorseReflection($container);
         $this->registerCodeTransform($container);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+
     public function configure(Resolver $schema): void
     {
+    }
+
+    public function name(): string
+    {
+        return 'phpunit';
     }
 
     private function registerWorseReflection(ContainerBuilder $container): void

--- a/lib/Extension/PHPUnit/PHPUnitExtension.php
+++ b/lib/Extension/PHPUnit/PHPUnitExtension.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Phpactor\Extension\PHPUnit;
+
+use Phpactor\Container\ContainerBuilder;
+use Phpactor\Container\Container;
+use Phpactor\Container\Extension;
+use Phpactor\Extension\CodeTransform\CodeTransformExtension;
+use Phpactor\Extension\PHPUnit\CodeTransform\TestGenerator;
+use Phpactor\Extension\PHPUnit\FrameWalker\AssertInstanceOfWalker;
+use Phpactor\Extension\WorseReflection\WorseReflectionExtension;
+use Phpactor\MapResolver\Resolver;
+
+class PHPUnitExtension implements Extension
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function load(ContainerBuilder $container): void
+    {
+        $this->registerWorseReflection($container);
+        $this->registerCodeTransform($container);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function configure(Resolver $schema): void
+    {
+    }
+
+    private function registerWorseReflection(ContainerBuilder $container): void
+    {
+        $container->register('phpunit.frame_walker.assert_instance_of', function (Container $container) {
+            return new AssertInstanceOfWalker();
+        }, [ WorseReflectionExtension::TAG_FRAME_WALKER => [] ]);
+    }
+
+    private function registerCodeTransform(ContainerBuilder $container): void
+    {
+        $container->register('phpunit.code_transform.test_generator', function (Container $container) {
+            return new TestGenerator();
+        }, [CodeTransformExtension::TAG_NEW_CLASS_GENERATOR => ['name' => 'phpunit']]);
+    }
+}

--- a/lib/Extension/PHPUnit/Tests/Unit/FrameWalker/AssertInstanceOfWalkerTest.php
+++ b/lib/Extension/PHPUnit/Tests/Unit/FrameWalker/AssertInstanceOfWalkerTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Phpactor\Extension\PHPUnit\Tests\Unit\FrameWalker;
+
+use Closure;
+use Generator;
+use PHPUnit\Framework\TestCase;
+use Phpactor\Extension\PHPUnit\FrameWalker\AssertInstanceOfWalker;
+use Phpactor\TestUtils\ExtractOffset;
+use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Reflector;
+use Phpactor\WorseReflection\ReflectorBuilder;
+
+class AssertInstanceOfWalkerTest extends TestCase
+{
+    /**
+     * @dataProvider provideWalk
+     */
+    public function testWalk(string $source, Closure $assertion): void
+    {
+        list($source, $offset) = ExtractOffset::fromSource($source);
+        $reflector = $this->createReflector($source);
+        $reflectionOffset = $reflector->reflectOffset($source, $offset);
+        $assertion($reflectionOffset->frame(), $offset);
+    }
+
+    /**
+     * @return Generator<string,array{string,Closure(Frame): void}>
+     */
+    public function provideWalk(): Generator
+    {
+        yield 'no op' => [
+            <<<'EOT'
+<?php
+
+<>
+EOT
+            , function (Frame $frame) {
+                $this->assertCount(0, $frame->locals());
+            }
+        ];
+
+        yield 'static assert call with class constant' => [
+            <<<'EOT'
+<?php
+
+use PHPUnit\Framework\Assert;
+
+$foo;
+Assert::assertInstanceOf(stdClass::class, $foo);
+<>
+EOT
+            , function (Frame $frame) {
+                $variable = $frame->locals()->byName('foo')->last();
+                $this->assertEquals('stdClass', $variable->type()->__toString());
+            }
+        ];
+
+        yield 'static assert call with stirng' => [
+            <<<'EOT'
+<?php
+
+use PHPUnit\Framework\Assert;
+
+$foo;
+Assert::assertInstanceOf("stdClass", $foo);
+<>
+EOT
+            , function (Frame $frame) {
+                $variable = $frame->locals()->byName('foo')->last();
+                $this->assertEquals('stdClass', $variable->type()->__toString());
+            }
+        ];
+
+        yield 'member call' => [
+            <<<'EOT'
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class FoobarTest extends TestCase
+{
+    public function testFoobar()
+    {
+        $foo;
+        $this->assertInstanceOf('Bar\Foo', $foo);
+        <>
+    }
+}
+<>
+EOT
+            , function (Frame $frame) {
+                $variable = $frame->locals()->byName('foo')->last();
+                $this->assertEquals('Bar\\Foo', $variable->type()->__toString());
+            }
+        ];
+    }
+
+    private function createReflector($source): Reflector
+    {
+        return ReflectorBuilder::create()
+            ->addSource($source)
+            ->addFrameWalker(new AssertInstanceOfWalker())
+            ->build();
+    }
+}

--- a/lib/Extension/PHPUnit/Tests/Unit/FrameWalker/AssertInstanceOfWalkerTest.php
+++ b/lib/Extension/PHPUnit/Tests/Unit/FrameWalker/AssertInstanceOfWalkerTest.php
@@ -50,6 +50,22 @@ class AssertInstanceOfWalkerTest extends TestCase
             EOT);
     }
 
+    public function testInfersReflectedClass(): void
+    {
+        $this->resolve(<<<'EOT'
+            <?php
+
+            use PHPUnit\Framework\Assert;
+
+            class Bar { public function bar(): string {} }
+
+            function (Node $foo) {
+                Assert::assertInstanceOf(Bar::class, $foo);
+                wrAssertType('string', $foo->bar());
+            }
+            EOT);
+    }
+
     public function testInstanceCall(): void
     {
         $this->resolve(

--- a/lib/Extension/PHPUnit/Tests/Unit/FrameWalker/AssertInstanceOfWalkerTest.php
+++ b/lib/Extension/PHPUnit/Tests/Unit/FrameWalker/AssertInstanceOfWalkerTest.php
@@ -79,7 +79,6 @@ class AssertInstanceOfWalkerTest extends TestCase
                 wrAssertType('stdClass', $foo);
                 EOT
         );
-
     }
 
     public function resolve(string $sourceCode): void

--- a/lib/Extension/PHPUnit/Tests/Unit/PHPUnitExtensionTest.php
+++ b/lib/Extension/PHPUnit/Tests/Unit/PHPUnitExtensionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Phpactor\Extension\PHPUnit\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Phpactor\Container\PhpactorContainer;
+use Phpactor\Extension\ClassToFile\ClassToFileExtension;
+use Phpactor\Extension\ComposerAutoloader\ComposerAutoloaderExtension;
+use Phpactor\Extension\FilePathResolver\FilePathResolverExtension;
+use Phpactor\Extension\Logger\LoggingExtension;
+use Phpactor\Extension\PHPUnit\PHPUnitExtension;
+use Phpactor\Extension\WorseReflection\WorseReflectionExtension;
+use Phpactor\WorseReflection\Reflector;
+
+class PHPUnitExtensionTest extends TestCase
+{
+    public function testLoad(): void
+    {
+        $container = PhpactorContainer::fromExtensions([
+            WorseReflectionExtension::class,
+            PHPUnitExtension::class,
+            FilePathResolverExtension::class,
+            ClassToFileExtension::class,
+            ComposerAutoloaderExtension::class,
+            LoggingExtension::class,
+        ], [
+            FilePathResolverExtension::PARAM_APPLICATION_ROOT => __DIR__
+        ]);
+
+        $reflector = $container->get(WorseReflectionExtension::SERVICE_REFLECTOR);
+        $this->assertInstanceOf(Reflector::class, $reflector);
+    }
+}

--- a/lib/Extension/Prophecy/ProphecyExtension.php
+++ b/lib/Extension/Prophecy/ProphecyExtension.php
@@ -18,6 +18,7 @@ class ProphecyExtension implements OptionalExtension
         $container->register(ProphecyMemberContextResolver::class, function (Container $container) {
             return new ProphecyMemberContextResolver();
         }, [ WorseReflectionExtension::TAG_MEMBER_TYPE_RESOLVER => []]);
+
         $container->register(SourceCodeLocator::class, function (Container $container) {
             return new ProphecyStubLocator();
         }, [ WorseReflectionExtension::TAG_SOURCE_LOCATOR => [

--- a/lib/Phpactor.php
+++ b/lib/Phpactor.php
@@ -26,6 +26,7 @@ use Phpactor\Extension\LanguageServerWorseReflection\LanguageServerWorseReflecti
 use Phpactor\Extension\LanguageServer\LanguageServerExtension;
 use Phpactor\Extension\LanguageServer\LanguageServerExtraExtension;
 use Phpactor\Extension\ObjectRenderer\ObjectRendererExtension;
+use Phpactor\Extension\PHPUnit\PHPUnitExtension;
 use Phpactor\Extension\Prophecy\ProphecyExtension;
 use Phpactor\Extension\Symfony\SymfonyExtension;
 use Phpactor\Extension\WorseReflectionAnalyse\WorseReflectionAnalyseExtension;
@@ -159,6 +160,7 @@ class Phpactor
             BehatExtension::class,
             SymfonyExtension::class,
             ProphecyExtension::class,
+            PHPUnitExtension::class,
         ];
 
         if (class_exists(DebugExtension::class)) {

--- a/lib/WorseReflection/Core/Inference/FrameResolver.php
+++ b/lib/WorseReflection/Core/Inference/FrameResolver.php
@@ -99,6 +99,12 @@ final class FrameResolver
             }
         }
 
+        if (isset($this->nodeWalkers[$nodeClass])) {
+            foreach ($this->nodeWalkers[$nodeClass] as $walker) {
+                $frame = $walker->exit($this, $frame, $node);
+            }
+        }
+
         foreach ($this->globalWalkers as $walker) {
             $frame = $walker->exit($this, $frame, $node);
         }


### PR DESCRIPTION
This PR re-introduces and refactors the PHPUnit extension.

Currently it only provides `assertInstanceOf` type inference (which can be made redundant if we were to support `@psalm-assert`) and the ability to automatically generate a test case in an empty file.