### PR TITLE
Docblock update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Features:
 
   - Reintroduce the PHPUnit extension
 
+Improvements:
+
+  - Add return tags to existing docblocks #1995
+
 ## 2022.12.12
 
 Breaking changes:

--- a/lib/CodeBuilder/Adapter/TolerantParser/Updater/AbstractMethodUpdater.php
+++ b/lib/CodeBuilder/Adapter/TolerantParser/Updater/AbstractMethodUpdater.php
@@ -261,7 +261,7 @@ abstract class AbstractMethodUpdater
     {
         $edits->add(TextEdit::create(
             $methodDeclaration->getFullStartPosition(),
-            $methodDeclaration->getStartPosition() - $methodDeclaration->getFullStartPosition(),
+            strlen($methodDeclaration->getLeadingCommentAndWhitespaceText()),
             $methodPrototype->docblock()->__toString()
         ));
     }

--- a/lib/CodeTransform/Adapter/DocblockParser/ParserDocblockUpdater.php
+++ b/lib/CodeTransform/Adapter/DocblockParser/ParserDocblockUpdater.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Phpactor\CodeTransform\Adapter\DocblockParser;
+
+use Phpactor\CodeTransform\Domain\DocBlockUpdater;
+use Phpactor\DocblockParser\Ast\Tag\ReturnTag;
+use Phpactor\DocblockParser\DocblockParser;
+use Phpactor\DocblockParser\Parser;
+use Phpactor\TextDocument\TextEdit;
+use Phpactor\TextDocument\TextEdits;
+use Phpactor\WorseReflection\Core\Type;
+
+class ParserDocblockUpdater implements DocBlockUpdater
+{
+    public function __construct(private DocblockParser $parser) {
+    }
+
+    public function setReturnType(string $docblockText, Type $type): string
+    {
+        $docblock = $this->parser->parse($docblockText);
+        $edits = [];
+        foreach ($docblock->descendantElements(ReturnTag::class) as $returnTag) {
+            $edits[] = TextEdit::create(
+                $returnTag->type()->start(),
+                $returnTag->type()->length(),
+                $type->__toString()
+            );
+        }
+
+        return TextEdits::fromTextEdits($edits)->apply($docblockText);
+    }
+}

--- a/lib/CodeTransform/Adapter/DocblockParser/ParserDocblockUpdater.php
+++ b/lib/CodeTransform/Adapter/DocblockParser/ParserDocblockUpdater.php
@@ -35,7 +35,17 @@ class ParserDocblockUpdater implements DocBlockUpdater
 
 
         if (count($edits) === 0) {
-            if ($open = $docblock->phpDocOpen()) {
+            if ($line = $docblock->lastMultilineContentToken()) {
+                $edits[] = TextEdit::create(
+                    $line->end(),
+                    0,
+                    sprintf(
+                        "* @return %s\n%s",
+                        $type->__toString(),
+                        str_repeat(' ', $docblock->indentationLevel()),
+                    ),
+                );
+            } elseif ($open = $docblock->phpDocOpen()) {
                 $edits[] = TextEdit::create(
                     $open->end(),
                     0,

--- a/lib/CodeTransform/Adapter/WorseReflection/Transformer/UpdateDocblockTransformer.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Transformer/UpdateDocblockTransformer.php
@@ -22,7 +22,7 @@ class UpdateDocblockTransformer implements Transformer
         private Updater $updater,
         private BuilderFactory $builderFactory,
         private TextFormat $format,
-        private ?DocBlockUpdater $docblockUpdater = null,
+        private DocBlockUpdater $docblockUpdater,
     ) {
     }
 

--- a/lib/CodeTransform/Adapter/WorseReflection/Transformer/UpdateDocblockTransformer.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Transformer/UpdateDocblockTransformer.php
@@ -55,6 +55,8 @@ class UpdateDocblockTransformer implements Transformer
                 ). "\n".$this->format->indent('', 1));
                 continue;
             }
+
+            $methodBuilder->docblock($method->docblock()->raw());
         }
 
         return $this->updater->textEditsFor($builder->build(), Code::fromString($code));

--- a/lib/CodeTransform/Adapter/WorseReflection/Transformer/UpdateDocblockTransformer.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Transformer/UpdateDocblockTransformer.php
@@ -22,7 +22,7 @@ class UpdateDocblockTransformer implements Transformer
         private Updater $updater,
         private BuilderFactory $builderFactory,
         private TextFormat $format,
-        private DocBlockUpdater $docblockUpdater,
+        private ?DocBlockUpdater $docblockUpdater = null,
     ) {
     }
 
@@ -91,14 +91,14 @@ class UpdateDocblockTransformer implements Transformer
     }
 
     /**
-     * @return array<int,MissingDocblockReturnTypeDiagnostic>
+     * @return MissingDocblockReturnTypeDiagnostic[]
      */
     private function methodsThatNeedFixing(SourceCode $code): array
     {
         $missingMethods = [];
         $diagnostics = $this->reflector->diagnostics($code->__toString())->byClass(MissingDocblockReturnTypeDiagnostic::class);
 
-        /** @var MissingDocblockDiagnostic $diagnostic */
+        /** @var MissingDocblockReturnTypeDiagnostic $diagnostic */
         foreach ($diagnostics as $diagnostic) {
             $missingMethods[] = $diagnostic;
         }

--- a/lib/CodeTransform/Adapter/WorseReflection/Transformer/UpdateDocblockTransformer.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Transformer/UpdateDocblockTransformer.php
@@ -8,6 +8,7 @@ use Phpactor\CodeBuilder\Domain\Updater;
 use Phpactor\CodeBuilder\Util\TextFormat;
 use Phpactor\CodeTransform\Domain\Diagnostic;
 use Phpactor\CodeTransform\Domain\Diagnostics;
+use Phpactor\CodeTransform\Domain\DocBlockUpdater;
 use Phpactor\CodeTransform\Domain\SourceCode;
 use Phpactor\CodeTransform\Domain\Transformer;
 use Phpactor\TextDocument\TextEdits;
@@ -20,7 +21,8 @@ class UpdateDocblockTransformer implements Transformer
         private Reflector $reflector,
         private Updater $updater,
         private BuilderFactory $builderFactory,
-        private TextFormat $format
+        private TextFormat $format,
+        private DocBlockUpdater $docblockUpdater,
     ) {
     }
 
@@ -56,7 +58,9 @@ class UpdateDocblockTransformer implements Transformer
                 continue;
             }
 
-            $methodBuilder->docblock($method->docblock()->raw());
+            $methodBuilder->docblock(
+                $this->docblockUpdater->setReturnType($method->docblock()->raw(), $localReplacement)
+            );
         }
 
         return $this->updater->textEditsFor($builder->build(), Code::fromString($code));
@@ -87,7 +91,7 @@ class UpdateDocblockTransformer implements Transformer
     }
 
     /**
-     * @return array<int,MissingDocblockDiagnostic>
+     * @return array<int,MissingDocblockReturnTypeDiagnostic>
      */
     private function methodsThatNeedFixing(SourceCode $code): array
     {

--- a/lib/CodeTransform/Domain/DocBlockUpdater.php
+++ b/lib/CodeTransform/Domain/DocBlockUpdater.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Phpactor\CodeTransform\Domain;
+
+use Phpactor\WorseReflection\Core\Type;
+
+interface DocBlockUpdater
+{
+    public function setReturnType(string $docblock, Type $type): string;
+}

--- a/lib/CodeTransform/Tests/Adapter/DocblockParser/ParserDocblockUpdaterTest.php
+++ b/lib/CodeTransform/Tests/Adapter/DocblockParser/ParserDocblockUpdaterTest.php
@@ -47,6 +47,21 @@ class ParserDocblockUpdaterTest extends TestCase
         ));
     }
 
+    public function testAddIfNotExistingMultiline0(): void
+    {
+        self::assertEquals(<<<'EOT'
+                /**
+                 * @return string
+                 */
+            EOT, 
+                $this->createUpdater()->setReturnType(<<<'EOT'
+                /**
+                 */
+            EOT,
+                TypeFactory::string()
+        ));
+    }
+
     public function testAddIfNotExistingMultiline(): void
     {
         self::assertEquals(<<<'EOT'

--- a/lib/CodeTransform/Tests/Adapter/DocblockParser/ParserDocblockUpdaterTest.php
+++ b/lib/CodeTransform/Tests/Adapter/DocblockParser/ParserDocblockUpdaterTest.php
@@ -47,6 +47,24 @@ class ParserDocblockUpdaterTest extends TestCase
         ));
     }
 
+    public function testAddIfNotExistingMultiline(): void
+    {
+        self::assertEquals(<<<'EOT'
+                /** 
+                 *
+                 * @return string
+                 */
+            EOT, 
+                $this->createUpdater()->setReturnType(<<<'EOT'
+                /** 
+                 *
+                 */
+            EOT,
+                TypeFactory::string()
+        ));
+    }
+
+
     private function createUpdater(): ParserDocblockUpdater
     {
         return (new ParserDocblockUpdater(DocblockParser::create()));

--- a/lib/CodeTransform/Tests/Adapter/DocblockParser/ParserDocblockUpdaterTest.php
+++ b/lib/CodeTransform/Tests/Adapter/DocblockParser/ParserDocblockUpdaterTest.php
@@ -19,24 +19,27 @@ class ParserDocblockUpdaterTest extends TestCase
 
     public function testUpdateReturnTypeWithMultipleTags(): void
     {
-        self::assertEquals(<<<'EOT'
+        self::assertEquals(
+            <<<'EOT'
                 /** 
                  * This is some text
                  * @param Foobar
                  * @return string 
                  * @return string 
-                 */
-                EOT, 
-                $this->createUpdater()->setReturnType(<<<'EOT'
-                /** 
-                 * This is some text
-                 * @param Foobar
-                 * @return Bazboo 
-                 * @return Foobar 
                  */
                 EOT,
+            $this->createUpdater()->setReturnType(
+                <<<'EOT'
+                    /** 
+                     * This is some text
+                     * @param Foobar
+                     * @return Bazboo 
+                     * @return Foobar 
+                     */
+                    EOT,
                 TypeFactory::string()
-        ));
+            )
+        );
     }
 
     public function testAddIfNotExisting(): void
@@ -49,34 +52,40 @@ class ParserDocblockUpdaterTest extends TestCase
 
     public function testAddIfNotExistingMultiline0(): void
     {
-        self::assertEquals(<<<'EOT'
-                /**
-                 * @return string
-                 */
-            EOT, 
-                $this->createUpdater()->setReturnType(<<<'EOT'
-                /**
-                 */
-            EOT,
+        self::assertEquals(
+            <<<'EOT'
+                    /**
+                     * @return string
+                     */
+                EOT,
+            $this->createUpdater()->setReturnType(
+                <<<'EOT'
+                        /**
+                         */
+                    EOT,
                 TypeFactory::string()
-        ));
+            )
+        );
     }
 
     public function testAddIfNotExistingMultiline(): void
     {
-        self::assertEquals(<<<'EOT'
-                /** 
-                 *
-                 * @return string
-                 */
-            EOT, 
-                $this->createUpdater()->setReturnType(<<<'EOT'
-                /** 
-                 *
-                 */
-            EOT,
+        self::assertEquals(
+            <<<'EOT'
+                    /** 
+                     *
+                     * @return string
+                     */
+                EOT,
+            $this->createUpdater()->setReturnType(
+                <<<'EOT'
+                        /** 
+                         *
+                         */
+                    EOT,
                 TypeFactory::string()
-        ));
+            )
+        );
     }
 
 

--- a/lib/CodeTransform/Tests/Adapter/DocblockParser/ParserDocblockUpdaterTest.php
+++ b/lib/CodeTransform/Tests/Adapter/DocblockParser/ParserDocblockUpdaterTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Phpactor\CodeTransform\Tests\Adapter\DocblockParser;
+
+use PHPUnit\Framework\TestCase;
+use Phpactor\CodeTransform\Adapter\DocblockParser\ParserDocblockUpdater;
+use Phpactor\DocblockParser\DocblockParser;
+use Phpactor\WorseReflection\Core\TypeFactory;
+
+class ParserDocblockUpdaterTest extends TestCase
+{
+    public function testUpdateReturnType(): void
+    {
+        self::assertEquals('/** @return string */', $this->createUpdater()->setReturnType(
+            '/** @return Foobar */',
+            TypeFactory::string()
+        ));
+    }
+
+    public function testUpdateReturnTypeWithMultipleTags(): void
+    {
+        self::assertEquals(<<<'EOT'
+                /** 
+                 * This is some text
+                 * @param Foobar
+                 * @return string 
+                 * @return string 
+                 */
+                EOT, 
+                $this->createUpdater()->setReturnType(<<<'EOT'
+                /** 
+                 * This is some text
+                 * @param Foobar
+                 * @return Bazboo 
+                 * @return Foobar 
+                 */
+                EOT,
+                TypeFactory::string()
+        ));
+    }
+
+    public function testAddIfNotExisting(): void
+    {
+        self::assertEquals('/** @return string */', $this->createUpdater()->setReturnType(
+            '/** */',
+            TypeFactory::string()
+        ));
+    }
+
+    private function createUpdater(): ParserDocblockUpdater
+    {
+        return (new ParserDocblockUpdater(DocblockParser::create()));
+    }
+}

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Transformer/UpdateDocblockTransformerTest.php
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Transformer/UpdateDocblockTransformerTest.php
@@ -520,7 +520,9 @@ class UpdateDocblockTransformerTest extends WorseTestCase
                     /**
                      * @return Baz[]
                      */
-                    public function baz(): array {}
+                    public function baz(): array {
+                        return [];
+                    }
                 }
 
                 class Foobar extends Foobag {
@@ -538,7 +540,9 @@ class UpdateDocblockTransformerTest extends WorseTestCase
                     /**
                      * @return Baz[]
                      */
-                    public function baz(): array {}
+                    public function baz(): array {
+                        return [];
+                    }
                 }
 
                 class Foobar extends Foobag {

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Transformer/UpdateDocblockTransformerTest.php
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Transformer/UpdateDocblockTransformerTest.php
@@ -4,10 +4,12 @@ namespace Phpactor\CodeTransform\Tests\Adapter\WorseReflection\Transformer;
 
 use Generator;
 use Phpactor\CodeBuilder\Util\TextFormat;
+use Phpactor\CodeTransform\Adapter\DocblockParser\ParserDocblockUpdater;
 use Phpactor\CodeTransform\Adapter\WorseReflection\Transformer\UpdateDocblockTransformer;
 use Phpactor\CodeTransform\Domain\Diagnostic;
 use Phpactor\CodeTransform\Domain\SourceCode;
 use Phpactor\CodeTransform\Tests\Adapter\WorseReflection\WorseTestCase;
+use Phpactor\DocblockParser\DocblockParser;
 use Phpactor\WorseReflection\Reflector;
 
 class UpdateDocblockTransformerTest extends WorseTestCase
@@ -640,6 +642,7 @@ class UpdateDocblockTransformerTest extends WorseTestCase
 
                 trait Foobar {
                     /**
+                     *
                      */
                     public function baz(): array
                     {
@@ -661,6 +664,52 @@ class UpdateDocblockTransformerTest extends WorseTestCase
 
                 trait Foobar {
                     /**
+                     *
+                     * @return Generator<array{string,Closure(Bar): string}>
+                     */
+                    public function baz(): array
+                    {
+                        yield [
+                            'foobar',
+                            function (Bar $b): string {
+                            }
+                        ];
+                    }
+                }
+                EOT
+        ];
+
+        yield 'updates existing docblock with other tags' => [
+            <<<'EOT'
+                <?php
+
+                namespace Foo;
+
+                trait Foobar {
+                    /**
+                     * @author Daniel Leech
+                     */
+                    public function baz(): array
+                    {
+                        yield [
+                            'foobar',
+                            function (Bar $b): string {
+                            }
+                        ];
+                    }
+                }
+                EOT
+            ,
+            <<<'EOT'
+                <?php
+
+                namespace Foo;
+
+                use Generator;
+
+                trait Foobar {
+                    /**
+                     * @author Daniel Leech
                      * @return Generator<array{string,Closure(Bar): string}>
                      */
                     public function baz(): array
@@ -767,7 +816,8 @@ class UpdateDocblockTransformerTest extends WorseTestCase
             $reflector,
             $this->updater(),
             $this->builderFactory($reflector),
-            new TextFormat()
+            new TextFormat(),
+            new ParserDocblockUpdater(DocblockParser::create())
         );
     }
 }

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Transformer/UpdateDocblockTransformerTest.php
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Transformer/UpdateDocblockTransformerTest.php
@@ -631,6 +631,49 @@ class UpdateDocblockTransformerTest extends WorseTestCase
                 }
                 EOT
         ];
+
+        yield 'updates existing docblock' => [
+            <<<'EOT'
+                <?php
+
+                namespace Foo;
+
+                trait Foobar {
+                    /**
+                     */
+                    public function baz(): array
+                    {
+                        yield [
+                            'foobar',
+                            function (Bar $b): string {
+                            }
+                        ];
+                    }
+                }
+                EOT
+            ,
+            <<<'EOT'
+                <?php
+
+                namespace Foo;
+
+                use Generator;
+
+                trait Foobar {
+                    /**
+                     * @return Generator<array{string,Closure(Bar): string}>
+                     */
+                    public function baz(): array
+                    {
+                        yield [
+                            'foobar',
+                            function (Bar $b): string {
+                            }
+                        ];
+                    }
+                }
+                EOT
+        ];
     }
 
     /**

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/WorseTestCase.php
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/WorseTestCase.php
@@ -5,7 +5,7 @@ namespace Phpactor\CodeTransform\Tests\Adapter\WorseReflection;
 use Phpactor\CodeTransform\Tests\Adapter\AdapterTestCase;
 use Phpactor\WorseReflection\Bridge\Phpactor\MemberProvider\DocblockMemberProvider;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\AssignmentToMissingPropertyProvider;
-use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\MissingDocblockProvider;
+use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\MissingDocblockReturnTypeProvider;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\MissingMethodProvider;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\MissingReturnTypeProvider;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\UnusedImportProvider;
@@ -23,7 +23,7 @@ class WorseTestCase extends AdapterTestCase
         $builder = ReflectorBuilder::create();
         $builder->addMemberProvider(new DocblockMemberProvider());
         $builder->addDiagnosticProvider(new MissingMethodProvider());
-        $builder->addDiagnosticProvider(new MissingDocblockProvider());
+        $builder->addDiagnosticProvider(new MissingDocblockReturnTypeProvider());
         $builder->addDiagnosticProvider(new AssignmentToMissingPropertyProvider());
         $builder->addDiagnosticProvider(new MissingReturnTypeProvider());
         $builder->addDiagnosticProvider(new UnusedImportProvider());

--- a/lib/Completion/Tests/Integration/Bridge/TolerantParser/Qualifier/ClassMemberQualifierTest.php
+++ b/lib/Completion/Tests/Integration/Bridge/TolerantParser/Qualifier/ClassMemberQualifierTest.php
@@ -9,6 +9,10 @@ use Phpactor\Completion\Bridge\TolerantParser\TolerantQualifier;
 
 class ClassMemberQualifierTest extends TolerantQualifierTestCase
 {
+
+    /**
+     * @return Generator<string,array{string,Closure(<missing>): void}>
+     */
     public function provideCouldComplete(): Generator
     {
         yield 'non member access' => [

--- a/lib/Completion/Tests/Integration/Bridge/TolerantParser/Qualifier/ClassMemberQualifierTest.php
+++ b/lib/Completion/Tests/Integration/Bridge/TolerantParser/Qualifier/ClassMemberQualifierTest.php
@@ -3,28 +3,28 @@
 namespace Phpactor\Completion\Tests\Integration\Bridge\TolerantParser\Qualifier;
 
 use Generator;
+use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\Expression\ScopedPropertyAccessExpression;
 use Phpactor\Completion\Bridge\TolerantParser\Qualifier\ClassMemberQualifier;
 use Phpactor\Completion\Bridge\TolerantParser\TolerantQualifier;
 
 class ClassMemberQualifierTest extends TolerantQualifierTestCase
 {
-
     /**
-     * @return Generator<string,array{string,Closure(<missing>): void}>
+     * @return Generator<string,array{string,(\Closure(Node|null): void)}>
      */
     public function provideCouldComplete(): Generator
     {
         yield 'non member access' => [
             '<?php $hello<>',
-            function ($node): void {
+            function (?Node $node): void {
                 $this->assertNull($node);
             }
         ];
 
         yield 'variable with previous accessor' => [
             '<?php $foobar->hello; $hello<>',
-            function ($node): void {
+            function (?Node $node): void {
                 $this->assertNull($node);
             }
 
@@ -32,28 +32,28 @@ class ClassMemberQualifierTest extends TolerantQualifierTestCase
 
         yield 'statement with previous member access' => [
             '<?php if ($foobar && $this->foobar) { echo<>',
-            function ($node): void {
+            function (?Node $node): void {
                 $this->assertNull($node);
             }
         ];
 
         yield 'variable with previous static member access' => [
             '<?php Hello::hello(); $foo<>',
-            function ($node): void {
+            function (?Node $node): void {
                 $this->assertNull($node);
             }
         ];
 
         yield 'returns the scoped property access expression' => [
             '<?php Hello::<>',
-            function ($node): void {
+            function (?Node $node): void {
                 self::assertInstanceOf(ScopedPropertyAccessExpression::class, $node);
             }
         ];
 
         yield 'returns the scoped property access expression parent' => [
             '<?php Hello::FO<>',
-            function ($node): void {
+            function (?Node $node): void {
                 $this->assertInstanceOf(ScopedPropertyAccessExpression::class, $node);
             }
         ];

--- a/lib/DocblockParser/Ast/Docblock.php
+++ b/lib/DocblockParser/Ast/Docblock.php
@@ -56,6 +56,16 @@ class Docblock extends Node
         }
     }
 
+    public function phpDocOpen(): ?Token {
+        foreach ($this->tokens() as $token) {
+            if ($token->type === Token::T_PHPDOC_OPEN) {
+                return $token;
+            }
+        }
+
+        return null;
+    }
+
     public function prose(): string
     {
         return trim(implode('', array_map(function (Element $token): string {

--- a/lib/DocblockParser/Ast/Docblock.php
+++ b/lib/DocblockParser/Ast/Docblock.php
@@ -109,6 +109,9 @@ class Docblock extends Node
             if ($child->type === Token::T_ASTERISK) {
                 return $previous->length();
             }
+            if ($child->type === Token::T_PHPDOC_CLOSE) {
+                return $previous->length();
+            }
             $previous = $child;
         }
 

--- a/lib/DocblockParser/Ast/Docblock.php
+++ b/lib/DocblockParser/Ast/Docblock.php
@@ -82,4 +82,37 @@ class Docblock extends Node
             return '';
         }, iterator_to_array($this->children, false))));
     }
+
+    public function lastMultilineContentToken(): ?Token
+    {
+        $hasLeading = false;
+        foreach ($this->tokens() as $child) {
+            if ($child->type === Token::T_ASTERISK) {
+                $hasLeading = true;
+            }
+            if ($child->type === Token::T_PHPDOC_CLOSE && $hasLeading) {
+                return $lastToken;
+            }
+            $lastToken = $child;
+        }
+
+        return null;
+    }
+
+    public function indentationLevel(): int
+    {
+        $previous = null;
+        foreach ($this->children->elements as $child) {
+            if (!$child instanceof Token) {
+                continue;
+            }
+            if ($child->type === Token::T_ASTERISK) {
+                return $previous->length();
+            }
+            $previous = $child;
+        }
+
+        return 0;
+
+    }
 }

--- a/lib/DocblockParser/Ast/Docblock.php
+++ b/lib/DocblockParser/Ast/Docblock.php
@@ -56,7 +56,8 @@ class Docblock extends Node
         }
     }
 
-    public function phpDocOpen(): ?Token {
+    public function phpDocOpen(): ?Token
+    {
         foreach ($this->tokens() as $token) {
             if ($token->type === Token::T_PHPDOC_OPEN) {
                 return $token;
@@ -86,6 +87,7 @@ class Docblock extends Node
     public function lastMultilineContentToken(): ?Token
     {
         $hasLeading = false;
+        $lastToken = null;
         foreach ($this->tokens() as $child) {
             if ($child->type === Token::T_ASTERISK) {
                 $hasLeading = true;
@@ -116,6 +118,5 @@ class Docblock extends Node
         }
 
         return 0;
-
     }
 }

--- a/lib/DocblockParser/Ast/Node.php
+++ b/lib/DocblockParser/Ast/Node.php
@@ -48,7 +48,9 @@ abstract class Node implements Element
     }
 
     /**
-     * @return Generator<Element>
+     * @template T
+     * @param class-string<T> $elementFqn
+     * @return Generator<T>
      */
     public function descendantElements(?string $elementFqn = null): Generator
     {
@@ -190,7 +192,7 @@ abstract class Node implements Element
         return 0;
     }
 
-    private function length(): int
+    public function length(): int
     {
         return $this->end() - $this->start();
     }

--- a/lib/DocblockParser/Ast/Node.php
+++ b/lib/DocblockParser/Ast/Node.php
@@ -48,9 +48,9 @@ abstract class Node implements Element
     }
 
     /**
-     * @template T
+     * @template T of Element
      * @param class-string<T> $elementFqn
-     * @return Generator<T>
+     * @return ($elementFqn is null ? Generator<Element> : Generator<T>)
      */
     public function descendantElements(?string $elementFqn = null): Generator
     {
@@ -66,6 +66,10 @@ abstract class Node implements Element
         }
     }
 
+    /**
+     * @template T of Element
+     * @param class-string<T> $elementFqn
+     */
     public function hasDescendant(string $elementFqn): bool
     {
         foreach ($this->descendantElements($elementFqn) as $element) {
@@ -142,6 +146,11 @@ abstract class Node implements Element
         return false;
     }
 
+    public function length(): int
+    {
+        return $this->end() - $this->start();
+    }
+
     /**
      * @param iterable<Element|array<Element>> $nodes
      *
@@ -190,11 +199,6 @@ abstract class Node implements Element
         }
 
         return 0;
-    }
-
-    public function length(): int
-    {
-        return $this->end() - $this->start();
     }
 
     /**

--- a/lib/DocblockParser/Tests/Unit/Ast/NodeTest.php
+++ b/lib/DocblockParser/Tests/Unit/Ast/NodeTest.php
@@ -13,7 +13,6 @@ use Phpactor\DocblockParser\Ast\Type\GenericNode;
 use Phpactor\DocblockParser\Ast\Type\ListBracketsNode;
 use Phpactor\DocblockParser\Ast\Type\ScalarNode;
 use Phpactor\DocblockParser\Ast\Type\UnionNode;
-use Prophecy\Doubler\Generator\Node\MethodNode;
 
 class NodeTest extends NodeTestCase
 {
@@ -41,7 +40,8 @@ class NodeTest extends NodeTestCase
                 self::assertCount(7, iterator_to_array($methodNode->children()));
                 self::assertCount(1, iterator_to_array($methodNode->children(ClassNode::class)));
                 self::assertTrue($methodNode->hasDescendant(ScalarNode::class));
-                self::assertFalse($methodNode->hasDescendant(MethodNode::class));
+                /** @phpstan-ignore-next-line */
+                self::assertFalse($methodNode->hasDescendant('NotExisting'));
                 self::assertCount(2, iterator_to_array($methodNode->descendantElements(ScalarNode::class)));
                 self::assertInstanceOf(ScalarNode::class, $methodNode->firstDescendant(ScalarNode::class));
             }

--- a/lib/Extension/CodeTransform/CodeTransformExtension.php
+++ b/lib/Extension/CodeTransform/CodeTransformExtension.php
@@ -16,6 +16,7 @@ use Phpactor\CodeBuilder\Adapter\Twig\TwigRenderer;
 use Phpactor\CodeBuilder\Domain\TemplatePathResolver\PhpVersionPathResolver;
 use Phpactor\CodeBuilder\Adapter\WorseReflection\WorseBuilderFactory;
 use Phpactor\CodeBuilder\Adapter\TolerantParser\TolerantUpdater;
+use Phpactor\CodeTransform\Adapter\DocblockParser\ParserDocblockUpdater;
 use Phpactor\CodeTransform\Adapter\Native\GenerateNew\ClassGenerator;
 use Phpactor\CodeTransform\Adapter\TolerantParser\ClassToFile\Transformer\ClassNameFixerTransformer;
 use Phpactor\CodeTransform\Adapter\TolerantParser\Refactor\TolerantChangeVisiblity;
@@ -42,6 +43,7 @@ use Phpactor\CodeTransform\Adapter\WorseReflection\Transformer\RemoveUnusedImpor
 use Phpactor\CodeTransform\Adapter\WorseReflection\Transformer\UpdateDocblockTransformer;
 use Phpactor\CodeTransform\Adapter\WorseReflection\Transformer\UpdateReturnTypeTransformer;
 use Phpactor\CodeTransform\CodeTransform;
+use Phpactor\CodeTransform\Domain\DocBlockUpdater;
 use Phpactor\CodeTransform\Domain\Generators;
 use Phpactor\CodeTransform\Domain\Helper\InterestingOffsetFinder;
 use Phpactor\CodeTransform\Domain\Helper\MissingMethodFinder;
@@ -57,6 +59,7 @@ use Phpactor\CodeTransform\Domain\Refactor\OverrideMethod;
 use Phpactor\CodeTransform\Domain\Refactor\RenameVariable;
 use Phpactor\CodeTransform\Domain\Refactor\GenerateMethod;
 use Phpactor\CodeTransform\Domain\Refactor\ReplaceQualifierWithImport;
+use Phpactor\DocblockParser\DocblockParser;
 use Phpactor\Extension\CodeTransform\Rpc\TransformHandler;
 use Phpactor\Extension\CodeTransform\Rpc\ClassNewHandler;
 use Phpactor\Extension\ClassToFile\ClassToFileExtension;
@@ -480,8 +483,13 @@ class CodeTransformExtension implements Extension
                 $container->get(Updater::class),
                 $container->get(BuilderFactory::class),
                 $container->get(TextFormat::class),
+                $container->get(DocBlockUpdater::class),
             );
         }, [ 'code_transform.transformer' => [ 'name' => 'add_missing_docblocks' ]]);
+
+        $container->register(DocBlockUpdater::class, function (Container $container) {
+            return new ParserDocblockUpdater(DocblockParser::create());
+        });
 
         $container->register(UpdateReturnTypeTransformer::class, function (Container $container) {
             return new UpdateReturnTypeTransformer(

--- a/lib/Extension/WorseReflection/WorseReflectionExtension.php
+++ b/lib/Extension/WorseReflection/WorseReflectionExtension.php
@@ -7,7 +7,7 @@ use Phpactor\Extension\ClassToFile\ClassToFileExtension;
 use Phpactor\Extension\FilePathResolver\FilePathResolverExtension;
 use Phpactor\WorseReflection\Bridge\Phpactor\MemberProvider\DocblockMemberProvider;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\AssignmentToMissingPropertyProvider;
-use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\MissingDocblockProvider;
+use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\MissingDocblockReturnTypeProvider;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\MissingMethodProvider;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\MissingReturnTypeProvider;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\UnresolvableNameProvider;
@@ -165,8 +165,8 @@ class WorseReflectionExtension implements Extension
         $container->register(MissingMethodProvider::class, function (Container $container) {
             return new MissingMethodProvider();
         }, [ self::TAG_DIAGNOSTIC_PROVIDER => []]);
-        $container->register(MissingDocblockProvider::class, function (Container $container) {
-            return new MissingDocblockProvider();
+        $container->register(MissingDocblockReturnTypeProvider::class, function (Container $container) {
+            return new MissingDocblockReturnTypeProvider();
         }, [ self::TAG_DIAGNOSTIC_PROVIDER => []]);
         $container->register(AssignmentToMissingPropertyProvider::class, function (Container $container) {
             return new AssignmentToMissingPropertyProvider();

--- a/lib/WorseReflection/Bridge/Phpactor/DocblockParser/DocblockParserFactory.php
+++ b/lib/WorseReflection/Bridge/Phpactor/DocblockParser/DocblockParserFactory.php
@@ -76,7 +76,8 @@ class DocblockParserFactory implements DocBlockFactory
         assert($node instanceof ParserDocblock);
         return new ParsedDocblock(
             $node,
-            new TypeConverter($this->reflector, $scope)
+            new TypeConverter($this->reflector, $scope),
+            $docblock
         );
     }
 }

--- a/lib/WorseReflection/Bridge/Phpactor/DocblockParser/DocblockParserFactory.php
+++ b/lib/WorseReflection/Bridge/Phpactor/DocblockParser/DocblockParserFactory.php
@@ -76,8 +76,7 @@ class DocblockParserFactory implements DocBlockFactory
         assert($node instanceof ParserDocblock);
         return new ParsedDocblock(
             $node,
-            new TypeConverter($this->reflector, $scope),
-            $docblock
+            new TypeConverter($this->reflector, $scope)
         );
     }
 }

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/MissingDocblockReturnTypeDiagnostic.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/MissingDocblockReturnTypeDiagnostic.php
@@ -6,7 +6,7 @@ use Phpactor\TextDocument\ByteOffsetRange;
 use Phpactor\WorseReflection\Core\Diagnostic;
 use Phpactor\WorseReflection\Core\DiagnosticSeverity;
 
-class MissingDocblockDiagnostic implements Diagnostic
+class MissingDocblockReturnTypeDiagnostic implements Diagnostic
 {
     public function __construct(
         private ByteOffsetRange $range,

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/MissingDocblockReturnTypeProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/MissingDocblockReturnTypeProvider.php
@@ -43,6 +43,12 @@ class MissingDocblockReturnTypeProvider implements DiagnosticProvider
         $claimedReturnType = $method->inferredType();
         $phpReturnType = $method->type();
 
+        // if there is already a return type, ignore. phpactor's guess
+        // will currently likely be wrong often.
+        if ($method->docblock()->returnType()->isDefined()) {
+            return;
+        }
+
         // do not try it for overriden methods
         if ($method->original()->declaringClass()->name() != $class->name()) {
             return;

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/MissingDocblockReturnTypeProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/MissingDocblockReturnTypeProvider.php
@@ -12,7 +12,7 @@ use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
 use Phpactor\WorseReflection\Core\Type\GenericClassType;
 use Phpactor\WorseReflection\Core\Util\NodeUtil;
 
-class MissingDocblockProvider implements DiagnosticProvider
+class MissingDocblockReturnTypeProvider implements DiagnosticProvider
 {
     public function exit(NodeContextResolver $resolver, Frame $frame, Node $node): iterable
     {
@@ -69,7 +69,7 @@ class MissingDocblockProvider implements DiagnosticProvider
         }
 
         if ($actualReturnType->isClosure()) {
-            yield new MissingDocblockDiagnostic(
+            yield new MissingDocblockReturnTypeDiagnostic(
                 $method->nameRange(),
                 sprintf(
                     'Method "%s" is missing docblock return type: %s',
@@ -98,7 +98,7 @@ class MissingDocblockProvider implements DiagnosticProvider
             return;
         }
 
-        yield new MissingDocblockDiagnostic(
+        yield new MissingDocblockReturnTypeDiagnostic(
             $method->nameRange(),
             sprintf(
                 'Method "%s" is missing docblock return type: %s',

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/MissingDocblockReturnTypeProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/MissingDocblockReturnTypeProvider.php
@@ -43,11 +43,6 @@ class MissingDocblockReturnTypeProvider implements DiagnosticProvider
         $claimedReturnType = $method->inferredType();
         $phpReturnType = $method->type();
 
-        // if there is already a docblock, ignore
-        if ($method->docblock()->isDefined()) {
-            return;
-        }
-
         // do not try it for overriden methods
         if ($method->original()->declaringClass()->name() != $class->name()) {
             return;

--- a/lib/WorseReflection/Core/DocBlock/PlainDocblock.php
+++ b/lib/WorseReflection/Core/DocBlock/PlainDocblock.php
@@ -20,7 +20,7 @@ class PlainDocblock implements DocBlock
 
     public function __construct(string $raw = '')
     {
-        $this->raw = trim($raw);
+        $this->raw = $raw;
     }
 
     public function methodType(string $methodName): Type

--- a/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Diagonstics/MissingDocblockProviderTest.php
+++ b/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Diagonstics/MissingDocblockProviderTest.php
@@ -2,7 +2,7 @@
 
 namespace Phpactor\WorseReflection\Tests\Integration\Bridge\TolerantParser\Diagonstics;
 
-use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\MissingDocblockProvider;
+use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\MissingDocblockReturnTypeProvider;
 use Phpactor\WorseReflection\Core\DiagnosticProvider;
 use Phpactor\WorseReflection\Core\Diagnostics;
 
@@ -14,6 +14,6 @@ class MissingDocblockProviderTest extends DiagnosticsTestCase
     }
     protected function provider(): DiagnosticProvider
     {
-        return new MissingDocblockProvider();
+        return new MissingDocblockReturnTypeProvider();
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,16 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Method Phpactor\\\\Application\\:\\:handleException\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: lib/Application.php
-
-		-
-			message: "#^Method Phpactor\\\\Application\\:\\:serializeException\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: lib/Application.php
-
-		-
 			message: "#^Parameter \\#1 \\$e of method Phpactor\\\\Application\\:\\:serializeException\\(\\) expects Exception, Throwable given\\.$#"
 			count: 1
 			path: lib/Application.php
@@ -3226,11 +3216,6 @@ parameters:
 			path: lib/Extension/Core/Console/Prompt/Prompt.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\Core\\\\Rpc\\\\CacheClearHandler\\:\\:handle\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: lib/Extension/Core/Rpc/CacheClearHandler.php
-
-		-
 			message: "#^Method Phpactor\\\\Extension\\\\Core\\\\Rpc\\\\CacheClearHandler\\:\\:handle\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: lib/Extension/Core/Rpc/CacheClearHandler.php
@@ -4191,47 +4176,12 @@ parameters:
 			path: lib/Filesystem/Domain/FallbackFilesystemRegistry.php
 
 		-
-			message: "#^Method Phpactor\\\\Filesystem\\\\Domain\\\\FilePath\\:\\:asSplFileInfo\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: lib/Filesystem/Domain/FilePath.php
-
-		-
-			message: "#^Method Phpactor\\\\Filesystem\\\\Domain\\\\FilePath\\:\\:concatPath\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: lib/Filesystem/Domain/FilePath.php
-
-		-
 			message: "#^Method Phpactor\\\\Filesystem\\\\Domain\\\\FilePath\\:\\:fromParts\\(\\) has parameter \\$parts with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: lib/Filesystem/Domain/FilePath.php
 
 		-
 			message: "#^Method Phpactor\\\\Filesystem\\\\Domain\\\\FilePath\\:\\:fromUnknown\\(\\) has parameter \\$path with no type specified\\.$#"
-			count: 1
-			path: lib/Filesystem/Domain/FilePath.php
-
-		-
-			message: "#^Method Phpactor\\\\Filesystem\\\\Domain\\\\FilePath\\:\\:isDirectory\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: lib/Filesystem/Domain/FilePath.php
-
-		-
-			message: "#^Method Phpactor\\\\Filesystem\\\\Domain\\\\FilePath\\:\\:isWithin\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: lib/Filesystem/Domain/FilePath.php
-
-		-
-			message: "#^Method Phpactor\\\\Filesystem\\\\Domain\\\\FilePath\\:\\:isWithinOrSame\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: lib/Filesystem/Domain/FilePath.php
-
-		-
-			message: "#^Method Phpactor\\\\Filesystem\\\\Domain\\\\FilePath\\:\\:makeAbsoluteFromString\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: lib/Filesystem/Domain/FilePath.php
-
-		-
-			message: "#^Method Phpactor\\\\Filesystem\\\\Domain\\\\FilePath\\:\\:path\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: lib/Filesystem/Domain/FilePath.php
 
@@ -4541,11 +4491,6 @@ parameters:
 			path: lib/PathFinder/Tests/Unit/PathFinderTest.php
 
 		-
-			message: "#^Method Phpactor\\\\Phpactor\\:\\:isFile\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: lib/Phpactor.php
-
-		-
 			message: "#^Parameter \\#1 \\$string of function strlen expects string, string\\|false given\\.$#"
 			count: 1
 			path: lib/Phpactor.php
@@ -4607,11 +4552,6 @@ parameters:
 
 		-
 			message: "#^Method Phpactor\\\\WorseReferenceFinder\\\\WorsePlainTextClassDefinitionLocator\\:\\:resolveImportTable\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/WorseReferenceFinder/WorsePlainTextClassDefinitionLocator.php
-
-		-
-			message: "#^Method Phpactor\\\\WorseReferenceFinder\\\\WorsePlainTextClassDefinitionLocator\\:\\:resolveNamespace\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: lib/WorseReferenceFinder/WorsePlainTextClassDefinitionLocator.php
 
@@ -4826,16 +4766,6 @@ parameters:
 			path: lib/WorseReflection/Core/Inference/PropertyAssignments.php
 
 		-
-			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Name\\:\\:__construct\\(\\) has parameter \\$parts with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/WorseReflection/Core/Name.php
-
-		-
-			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Name\\:\\:fromParts\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: lib/WorseReflection/Core/Name.php
-
-		-
 			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Name\\:\\:fromParts\\(\\) has parameter \\$parts with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: lib/WorseReflection/Core/Name.php
@@ -4847,11 +4777,6 @@ parameters:
 
 		-
 			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Name\\:\\:prepend\\(\\) should return static\\(Phpactor\\\\WorseReflection\\\\Core\\\\Name\\) but returns Phpactor\\\\WorseReflection\\\\Core\\\\Name\\.$#"
-			count: 1
-			path: lib/WorseReflection/Core/Name.php
-
-		-
-			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Name\\:\\:substitute\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: lib/WorseReflection/Core/Name.php
 
@@ -5009,11 +4934,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$source of static method Phpactor\\\\WorseReflection\\\\Core\\\\SourceCode\\:\\:fromPathAndString\\(\\) expects string, string\\|false given\\.$#"
 			count: 1
 			path: lib/WorseReflection/Core/SourceCodeLocator/NativeReflectionFunctionSourceLocator.php
-
-		-
-			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Util\\\\OriginalMethodResolver\\:\\:resolveInterface\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: lib/WorseReflection/Core/Util/OriginalMethodResolver.php
 
 		-
 			message: "#^Property Phpactor\\\\WorseReflection\\\\Core\\\\Virtual\\\\VirtualReflectionMethod\\:\\:\\$type is unused\\.$#"


### PR DESCRIPTION
This PR improves the docblock "updating" by actually updating missing docblocks (previously it would only create new ones).

Note currently:

- We only update `@return` tags
- We will not update existing `@return` tags because Phpactor's type inference is not _that_ good, but it's a useful starting point.
![recorded](https://user-images.githubusercontent.com/530801/209447187-98d11c39-8d7b-4e95-98a0-62cc2e45579f.gif)

Next up.... adding `@param` tags