### PR TITLE
perf(psalm): improve psalm diagnostics performances

### DIFF
--- a/lib/Extension/LanguageServerPsalm/LanguageServerPsalmExtension.php
+++ b/lib/Extension/LanguageServerPsalm/LanguageServerPsalmExtension.php
@@ -19,6 +19,7 @@ class LanguageServerPsalmExtension implements OptionalExtension
 {
     public const PARAM_PSALM_BIN = 'language_server_psalm.bin';
     public const PARAM_PSALM_SHOW_INFO = 'language_server_psalm.show_info';
+    public const PARAM_PSALM_USE_CACHE = 'language_server_psalm.use_cache';
 
     public function load(ContainerBuilder $container): void
     {
@@ -38,10 +39,11 @@ class LanguageServerPsalmExtension implements OptionalExtension
             $binPath = $container->get(FilePathResolverExtension::SERVICE_FILE_PATH_RESOLVER)->resolve($container->getParameter(self::PARAM_PSALM_BIN));
             $root = $container->get(FilePathResolverExtension::SERVICE_FILE_PATH_RESOLVER)->resolve('%project_root%');
             $shouldShowInfo = $container->getParameter(self::PARAM_PSALM_SHOW_INFO);
+            $useCache = $container->getParameter(self::PARAM_PSALM_USE_CACHE);
 
             return new PsalmProcess(
                 $root,
-                new PsalmConfig($binPath, $shouldShowInfo),
+                new PsalmConfig($binPath, $shouldShowInfo, $useCache),
                 LoggingExtension::channelLogger($container, 'PSALM')
             );
         });
@@ -53,10 +55,12 @@ class LanguageServerPsalmExtension implements OptionalExtension
         $schema->setDefaults([
             self::PARAM_PSALM_BIN => '%project_root%/vendor/bin/psalm',
             self::PARAM_PSALM_SHOW_INFO => true,
+            self::PARAM_PSALM_USE_CACHE => true,
         ]);
         $schema->setDescriptions([
             self::PARAM_PSALM_BIN => 'Path to pslam if different from vendor/bin/psalm',
             self::PARAM_PSALM_SHOW_INFO => 'If infos from psalm should be displayed',
+            self::PARAM_PSALM_USE_CACHE => 'Does psalm should use cache (see `--no-cache` option)',
         ]);
     }
 

--- a/lib/Extension/LanguageServerPsalm/Model/PsalmConfig.php
+++ b/lib/Extension/LanguageServerPsalm/Model/PsalmConfig.php
@@ -4,8 +4,11 @@ namespace Phpactor\Extension\LanguageServerPsalm\Model;
 
 final class PsalmConfig
 {
-    public function __construct(private string $phpstanBin, private bool $shouldShowInfo)
-    {
+    public function __construct(
+        private string $phpstanBin,
+        private bool $shouldShowInfo,
+        private bool $useCache,
+    ) {
     }
 
     public function psalmBin(): string
@@ -16,5 +19,10 @@ final class PsalmConfig
     public function shouldShowInfo(): bool
     {
         return $this->shouldShowInfo;
+    }
+
+    public function useCache(): bool
+    {
+        return $this->useCache;
     }
 }

--- a/lib/Extension/LanguageServerPsalm/Model/PsalmProcess.php
+++ b/lib/Extension/LanguageServerPsalm/Model/PsalmProcess.php
@@ -27,15 +27,21 @@ class PsalmProcess
     public function analyse(string $filename): Promise
     {
         return \Amp\call(function () use ($filename) {
-            $process = new Process([
+            $command = [
                 $this->config->psalmBin(),
-                '--no-cache',
                 sprintf(
                     '--show-info=%s',
                     $this->config->shouldShowInfo() ? 'true' : 'false',
                 ),
                 '--output-format=json',
-            ], $this->cwd);
+            ];
+
+            if (!$this->config->useCache()) {
+                $command[] = '--no-cache';
+            }
+            $command[] = $filename;
+
+            $process = new Process($command, $this->cwd);
 
             $start = microtime(true);
             $pid = yield $process->start();

--- a/lib/Extension/LanguageServerPsalm/Tests/Model/PsalmProcessTest.php
+++ b/lib/Extension/LanguageServerPsalm/Tests/Model/PsalmProcessTest.php
@@ -55,7 +55,7 @@ class PsalmProcessTest extends IntegrationTestCase
         $this->workspace()->put('src/test.php', $source);
         $linter = new PsalmProcess(
             $this->workspace()->path(),
-            new PsalmConfig($psalmBin, $shouldShowInfo),
+            new PsalmConfig($psalmBin, $shouldShowInfo, false),
             new NullLogger()
         );
 


### PR DESCRIPTION
I've lately moved from [null-ls](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/b287e9d124037a7ea5de8e3368a3b75274cec8b4/lua/null-ls/builtins/diagnostics/psalm.lua) to phpactor for psalm diagnostics and I found it slower...

After investigating, I've found that the `PsalmProcess` class doesn't pass the filename to the command, then, psalm always parse all the project instead of just the file it should analyse.

In my case, It reduces the execution time from 5 to 1.8 seconds.

Then, I've also noticed that `--no-cache` directive is passed to the command, and it's not present in the  [null-ls](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/b287e9d124037a7ea5de8e3368a3b75274cec8b4/lua/null-ls/builtins/diagnostics/psalm.lua) command. I've removed it and it reduces the execution time from 1.8 to 0.9 seconds.