### PR TITLE
feat(psalm): allows to avoid infos to be displayed

### DIFF
--- a/lib/Extension/LanguageServerPsalm/LanguageServerPsalmExtension.php
+++ b/lib/Extension/LanguageServerPsalm/LanguageServerPsalmExtension.php
@@ -18,6 +18,7 @@ use Phpactor\MapResolver\Resolver;
 class LanguageServerPsalmExtension implements OptionalExtension
 {
     public const PARAM_PSALM_BIN = 'language_server_psalm.bin';
+    public const PARAM_PSALM_SHOW_INFO = 'language_server_psalm.show_info';
 
     public function load(ContainerBuilder $container): void
     {
@@ -36,10 +37,11 @@ class LanguageServerPsalmExtension implements OptionalExtension
         $container->register(PsalmProcess::class, function (Container $container) {
             $binPath = $container->get(FilePathResolverExtension::SERVICE_FILE_PATH_RESOLVER)->resolve($container->getParameter(self::PARAM_PSALM_BIN));
             $root = $container->get(FilePathResolverExtension::SERVICE_FILE_PATH_RESOLVER)->resolve('%project_root%');
+            $shouldShowInfo = $container->getParameter(self::PARAM_PSALM_SHOW_INFO);
 
             return new PsalmProcess(
                 $root,
-                new PsalmConfig($binPath),
+                new PsalmConfig($binPath, $shouldShowInfo),
                 LoggingExtension::channelLogger($container, 'PSALM')
             );
         });
@@ -50,9 +52,11 @@ class LanguageServerPsalmExtension implements OptionalExtension
     {
         $schema->setDefaults([
             self::PARAM_PSALM_BIN => '%project_root%/vendor/bin/psalm',
+            self::PARAM_PSALM_SHOW_INFO => true,
         ]);
         $schema->setDescriptions([
             self::PARAM_PSALM_BIN => 'Path to pslam if different from vendor/bin/psalm',
+            self::PARAM_PSALM_SHOW_INFO => 'If infos from psalm should be displayed',
         ]);
     }
 

--- a/lib/Extension/LanguageServerPsalm/Model/PsalmConfig.php
+++ b/lib/Extension/LanguageServerPsalm/Model/PsalmConfig.php
@@ -4,12 +4,17 @@ namespace Phpactor\Extension\LanguageServerPsalm\Model;
 
 final class PsalmConfig
 {
-    public function __construct(private string $phpstanBin)
+    public function __construct(private string $phpstanBin, private bool $shouldShowInfo)
     {
     }
 
     public function psalmBin(): string
     {
         return $this->phpstanBin;
+    }
+
+    public function shouldShowInfo(): bool
+    {
+        return $this->shouldShowInfo;
     }
 }

--- a/lib/Extension/LanguageServerPsalm/Model/PsalmProcess.php
+++ b/lib/Extension/LanguageServerPsalm/Model/PsalmProcess.php
@@ -30,8 +30,11 @@ class PsalmProcess
             $process = new Process([
                 $this->config->psalmBin(),
                 '--no-cache',
-                '--show-info=true',
-                '--output-format=json'
+                sprintf(
+                    '--show-info=%s',
+                    $this->config->shouldShowInfo() ? 'true' : 'false',
+                ),
+                '--output-format=json',
             ], $this->cwd);
 
             $start = microtime(true);


### PR DESCRIPTION
When I use psalm extension, it displays info diagnostics (that are issues from higher analysis levels). It could be annoying (that the case for me).

I propose to add an option to allows to disable it.