### PR TITLE
Relative name completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Changelog
 
 ## master
 
+Features:
+
+  - Hierarchical namespace segment completion #2070
+
 Bug fixes:
 
   - `new class-string<Foo>` now resolves to `new Foo` #2065

--- a/lib/Completion/Bridge/TolerantParser/ReferenceFinder/AttributeCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/ReferenceFinder/AttributeCompletor.php
@@ -4,41 +4,28 @@ namespace Phpactor\Completion\Bridge\TolerantParser\ReferenceFinder;
 
 use Generator;
 use Microsoft\PhpParser\Node;
+use Microsoft\PhpParser\Node\QualifiedName;
 use Phpactor\Completion\Bridge\TolerantParser\CompletionContext;
 use Phpactor\Completion\Bridge\TolerantParser\TolerantCompletor;
-use Phpactor\Completion\Core\DocumentPrioritizer\DocumentPrioritizer;
-use Phpactor\Completion\Core\Suggestion;
-use Phpactor\ReferenceFinder\NameSearcher;
-use Phpactor\ReferenceFinder\NameSearcherType;
+use Phpactor\Completion\Core\Completor\NameSearcherCompletor;
+use Phpactor\Name\NameUtil;
 use Phpactor\TextDocument\ByteOffset;
 use Phpactor\TextDocument\TextDocument;
 
-class AttributeCompletor implements TolerantCompletor
+class AttributeCompletor extends NameSearcherCompletor implements TolerantCompletor
 {
-    public function __construct(
-        private NameSearcher $nameSearcher,
-        private DocumentPrioritizer $prioritizer
-    ) {
-    }
-
     public function complete(Node $node, TextDocument $source, ByteOffset $offset): Generator
     {
         if (!CompletionContext::attribute($node)) {
             return true;
         }
 
-        $search = $node->getText();
-        $type = NameSearcherType::CLASS_;
-
-        foreach ($this->nameSearcher->search($search, $type) as $result) {
-            yield Suggestion::createWithOptions($result->name()->head(), [
-                'type' => Suggestion::TYPE_CLASS,
-                'priority' => $this->prioritizer->priority($result->uri(), $source->uri()),
-                'short_description' => sprintf('%s %s', $type, $result->name()->__toString()),
-                'class_import' => $result->name()->__toString(),
-                'name_import' => $result->name()->__toString(),
-            ]);
+        $name = $node->__toString();
+        if ($node instanceof QualifiedName && NameUtil::isQualified($name)) {
+            $name = NameUtil::toFullyQualfiied((string)$node->getResolvedName());
         }
+
+        yield from $this->completeName($name, $source->uri(), $node);
 
         return true;
     }

--- a/lib/Completion/Bridge/TolerantParser/ReferenceFinder/ExpressionNameCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/ReferenceFinder/ExpressionNameCompletor.php
@@ -40,7 +40,7 @@ class ExpressionNameCompletor extends CoreNameSearcherCompletor implements Toler
 
         $name = $node->__toString();
         if ($node instanceof QualifiedName && str_contains($name, '\\')) {
-            $name = $node->getResolvedName()->__toString();
+            $name = '\\' . $node->getResolvedName()->__toString();
         }
 
         $suggestions = $this->completeName($name, $source->uri(), $node);

--- a/lib/Completion/Bridge/TolerantParser/ReferenceFinder/ExpressionNameCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/ReferenceFinder/ExpressionNameCompletor.php
@@ -11,6 +11,7 @@ use Phpactor\Completion\Bridge\TolerantParser\TolerantCompletor;
 use Phpactor\Completion\Core\Completor\NameSearcherCompletor as CoreNameSearcherCompletor;
 use Phpactor\Completion\Core\DocumentPrioritizer\DocumentPrioritizer;
 use Phpactor\Completion\Core\Formatter\ObjectFormatter;
+use Phpactor\Name\NameUtil;
 use Phpactor\ReferenceFinder\NameSearcher;
 use Phpactor\ReferenceFinder\Search\NameSearchResult;
 use Phpactor\TextDocument\ByteOffset;
@@ -39,7 +40,7 @@ class ExpressionNameCompletor extends CoreNameSearcherCompletor implements Toler
         }
 
         $name = $node->__toString();
-        if ($node instanceof QualifiedName && str_contains($name, '\\')) {
+        if ($node instanceof QualifiedName && NameUtil::isQualified($name)) {
             $name = '\\' . $node->getResolvedName()->__toString();
         }
 

--- a/lib/Completion/Bridge/TolerantParser/ReferenceFinder/ExpressionNameCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/ReferenceFinder/ExpressionNameCompletor.php
@@ -28,7 +28,6 @@ class ExpressionNameCompletor extends CoreNameSearcherCompletor implements Toler
         parent::__construct($nameSearcher, $prioritizer);
     }
 
-
     // 1. If no namespace separator  - search by short name
     // 2. If namespace separator - resolve namespace, search by FQN
     public function complete(Node $node, TextDocument $source, ByteOffset $offset): Generator
@@ -41,7 +40,7 @@ class ExpressionNameCompletor extends CoreNameSearcherCompletor implements Toler
 
         $name = $node->__toString();
         if ($node instanceof QualifiedName && NameUtil::isQualified($name)) {
-            $name = '\\' . $node->getResolvedName()->__toString();
+            $name = NameUtil::toFullyQualfiied((string)$node->getResolvedName());
         }
 
         $suggestions = $this->completeName($name, $source->uri(), $node);

--- a/lib/Completion/Bridge/TolerantParser/ReferenceFinder/UseNameCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/ReferenceFinder/UseNameCompletor.php
@@ -6,21 +6,13 @@ use Generator;
 use Microsoft\PhpParser\Node;
 use Phpactor\Completion\Bridge\TolerantParser\CompletionContext;
 use Phpactor\Completion\Bridge\TolerantParser\TolerantCompletor;
-use Phpactor\Completion\Core\DocumentPrioritizer\DocumentPrioritizer;
-use Phpactor\Completion\Core\Suggestion;
-use Phpactor\ReferenceFinder\NameSearcher;
+use Phpactor\Completion\Core\Completor\NameSearcherCompletor;
+use Phpactor\Name\NameUtil;
 use Phpactor\TextDocument\ByteOffset;
 use Phpactor\TextDocument\TextDocument;
 
-class UseNameCompletor implements TolerantCompletor
+class UseNameCompletor extends NameSearcherCompletor implements TolerantCompletor
 {
-    public function __construct(
-        private NameSearcher $nameSearcher,
-        private DocumentPrioritizer $prioritizer
-    ) {
-    }
-
-
     public function complete(Node $node, TextDocument $source, ByteOffset $offset): Generator
     {
         $parent = $node->parent;
@@ -30,16 +22,8 @@ class UseNameCompletor implements TolerantCompletor
         }
 
         $search = $node->getText();
-        foreach ($this->nameSearcher->search($search) as $result) {
-            if (!$result->type()->isClass()) {
-                continue;
-            }
-
-            yield Suggestion::createWithOptions($result->name()->__toString(), [
-                'type' => Suggestion::TYPE_CLASS,
-                'priority' => $this->prioritizer->priority($result->uri(), $source->uri())
-            ]);
-        }
+        $search = NameUtil::toFullyQualfiied($search);
+        yield from $this->completeName($search, $source->uri(), $node);
 
         return true;
     }

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/DoctrineAnnotationCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/DoctrineAnnotationCompletor.php
@@ -17,6 +17,7 @@ use Phpactor\TextDocument\ByteOffset;
 use Phpactor\TextDocument\TextDocument;
 use Phpactor\TextDocument\TextDocumentUri;
 use Phpactor\WorseReflection\Core\Exception\NotFound;
+use Phpactor\WorseReflection\Core\Util\NodeUtil;
 use Phpactor\WorseReflection\Reflector;
 
 class DoctrineAnnotationCompletor extends NameSearcherCompletor implements Completor
@@ -53,7 +54,7 @@ class DoctrineAnnotationCompletor extends NameSearcherCompletor implements Compl
             return true;
         }
 
-        $namespace = $node->getNamespaceDefinition()?->name->__toString();
+        $namespace = NodeUtil::namespace($node);
         if (NameUtil::isQualified($annotation) && $namespace) {
             $annotation = '\\' . NameUtil::join($namespace, $annotation);
         }

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/DoctrineAnnotationCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/DoctrineAnnotationCompletor.php
@@ -10,6 +10,7 @@ use Phpactor\Completion\Core\Completor;
 use Phpactor\Completion\Core\Completor\NameSearcherCompletor;
 use Phpactor\Completion\Core\Suggestion;
 use Phpactor\Completion\Core\Util\OffsetHelper;
+use Phpactor\Name\NameUtil;
 use Phpactor\ReferenceFinder\NameSearcher;
 use Phpactor\ReferenceFinder\Search\NameSearchResult;
 use Phpactor\TextDocument\ByteOffset;
@@ -50,6 +51,11 @@ class DoctrineAnnotationCompletor extends NameSearcherCompletor implements Compl
         if (!$annotation = $this->extractAnnotation($truncatedSource)) {
             // Ignore if not an annotation
             return true;
+        }
+
+        $namespace = $node->getNamespaceDefinition()?->name->__toString();
+        if (NameUtil::isQualified($annotation) && $namespace) {
+            $annotation = '\\' . NameUtil::join($namespace, $annotation);
         }
 
         $suggestions = $this->completeName($annotation, $source->uri());

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/ImportedNameCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/ImportedNameCompletor.php
@@ -4,6 +4,7 @@ namespace Phpactor\Completion\Bridge\TolerantParser\WorseReflection;
 
 use Generator;
 use Microsoft\PhpParser\Node;
+use Microsoft\PhpParser\Node\QualifiedName;
 use Microsoft\PhpParser\ResolvedName;
 use Phpactor\Completion\Bridge\TolerantParser\CompletionContext;
 use Phpactor\Completion\Bridge\TolerantParser\Qualifier\ClassQualifier;
@@ -11,6 +12,7 @@ use Phpactor\Completion\Bridge\TolerantParser\TolerantCompletor;
 use Phpactor\Completion\Bridge\TolerantParser\TolerantQualifiable;
 use Phpactor\Completion\Bridge\TolerantParser\TolerantQualifier;
 use Phpactor\Completion\Core\Suggestion;
+use Phpactor\Name\NameUtil;
 use Phpactor\TextDocument\ByteOffset;
 use Phpactor\TextDocument\TextDocument;
 
@@ -28,6 +30,10 @@ class ImportedNameCompletor implements TolerantCompletor, TolerantQualifiable
         if (
             !CompletionContext::expression($node)
         ) {
+            return true;
+        }
+
+        if ($node instanceof QualifiedName && NameUtil::isQualified($node)) {
             return true;
         }
 

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/KeywordCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/KeywordCompletor.php
@@ -32,6 +32,10 @@ class KeywordCompletor implements TolerantCompletor
             return true;
         }
 
+        if (CompletionContext::attribute($node)) {
+            return true;
+        }
+
         if (
             CompletionContext::classMembersBody($node->parent)
         ) {

--- a/lib/Completion/Core/Completor/NameSearcherCompletion.php
+++ b/lib/Completion/Core/Completor/NameSearcherCompletion.php
@@ -13,7 +13,7 @@ use Phpactor\ReferenceFinder\NameSearcher;
 use Phpactor\ReferenceFinder\Search\NameSearchResult;
 use Phpactor\TextDocument\TextDocumentUri;
 
-abstract class NameSearcherCompletor
+final class NameSearcherCompletion
 {
     private DocumentPrioritizer $prioritizer;
 
@@ -75,6 +75,7 @@ abstract class NameSearcherCompletor
             'priority' => $this->prioritizer->priority($result->uri(), $sourceUri)
         ];
 
+        // needed?
         if (!$wasFullyQualified && ($node === null || !($node->getParent() instanceof NamespaceUseClause))) {
             $options['class_import'] = $this->classImport($result);
             $options['name_import'] = $result->name()->__toString();

--- a/lib/Completion/Core/Completor/NameSearcherCompletor.php
+++ b/lib/Completion/Core/Completor/NameSearcherCompletor.php
@@ -24,6 +24,7 @@ abstract class NameSearcherCompletor
 
     protected function completeName(string $name, ?TextDocumentUri $sourceUri = null, ?Node $node = null): Generator
     {
+        dump($name);
         $wasQualified = NameUtil::isQualified($name);
         $visitedChildSegments = [];
         foreach ($this->nameSearcher->search($name) as $result) {

--- a/lib/Completion/Core/Completor/NameSearcherCompletor.php
+++ b/lib/Completion/Core/Completor/NameSearcherCompletor.php
@@ -24,7 +24,6 @@ abstract class NameSearcherCompletor
 
     protected function completeName(string $name, ?TextDocumentUri $sourceUri = null, ?Node $node = null): Generator
     {
-        dump($name);
         $wasQualified = NameUtil::isQualified($name);
         $visitedChildSegments = [];
         foreach ($this->nameSearcher->search($name) as $result) {

--- a/lib/Completion/Core/Completor/NameSearcherCompletor.php
+++ b/lib/Completion/Core/Completor/NameSearcherCompletor.php
@@ -12,7 +12,6 @@ use Phpactor\Name\NameUtil;
 use Phpactor\ReferenceFinder\NameSearcher;
 use Phpactor\ReferenceFinder\Search\NameSearchResult;
 use Phpactor\TextDocument\TextDocumentUri;
-use PhpBench\Remote as Bench;
 
 abstract class NameSearcherCompletor
 {
@@ -26,7 +25,7 @@ abstract class NameSearcherCompletor
     protected function completeName(string $name, ?TextDocumentUri $sourceUri = null, ?Node $node = null): Generator
     {
         foreach ($this->nameSearcher->search($name) as $result) {
-            $wasQualified = str_contains($name, '\\');
+            $wasQualified = NameUtil::isQualified($name);
             $options = $this->createSuggestionOptions($result, $sourceUri, $node, $wasQualified);
             yield $this->createSuggestion(
                 $name,

--- a/lib/Completion/Tests/Integration/Bridge/TolerantParser/DoctrineAnnotationCompletorTest.php
+++ b/lib/Completion/Tests/Integration/Bridge/TolerantParser/DoctrineAnnotationCompletorTest.php
@@ -59,19 +59,19 @@ class DoctrineAnnotationCompletorTest extends CompletorTestCase
             <<<'EOT'
                 <?php
 
-                namespace App\Annotation;
+                namespace App\Annotation {
+                    /**
+                     * @Annotation
+                     */
+                    class Entity {}
+                }
 
-                /**
-                 * @Annotation
-                 */
-                class Entity {}
-
-                namespace App;
-
-                /**
-                 * @Ent<>
-                 */
-                class Foo {}
+                namespace App {
+                    /**
+                     * @Ent<>
+                     */
+                    class Foo {}
+                }
                 EOT
         , [
             [

--- a/lib/Completion/Tests/Integration/Bridge/TolerantParser/ReferenceFinder/AttributeCompletorTest.php
+++ b/lib/Completion/Tests/Integration/Bridge/TolerantParser/ReferenceFinder/AttributeCompletorTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Phpactor\Completion\Tests\Integration\Bridge\TolerantParser\ReferenceFinder;
+
+use Generator;
+use Phpactor\Completion\Bridge\TolerantParser\ReferenceFinder\AttributeCompletor;
+use Phpactor\Completion\Bridge\TolerantParser\ReferenceFinder\ExpressionNameCompletor;
+use Phpactor\Completion\Bridge\TolerantParser\TolerantCompletor;
+use Phpactor\Completion\Core\DocumentPrioritizer\DefaultResultPrioritizer;
+use Phpactor\Completion\Core\DocumentPrioritizer\DocumentPrioritizer;
+use Phpactor\Completion\Core\Suggestion;
+use Phpactor\Completion\Tests\Integration\Bridge\TolerantParser\TolerantCompletorTestCase;
+use Phpactor\ReferenceFinder\NameSearcher;
+use Phpactor\ReferenceFinder\Search\NameSearchResult;
+use Phpactor\TextDocument\TextDocument;
+use Phpactor\WorseReflection\ReflectorBuilder;
+
+class AttributeCompletorTest extends TolerantCompletorTestCase
+{
+    /**
+     * @dataProvider provideComplete
+     *
+     * @param array{string,array<int,array<string,string>>} $expected
+     */
+    public function testComplete(string $source, array $expected): void
+    {
+        $this->assertComplete($source, $expected);
+    }
+
+    /**
+     * @return Generator<string,array{string,array<int,array<string,string>>}>
+     */
+    public function provideComplete(): Generator
+    {
+        yield 'new class instance' => [
+            '<?php namespace Foo { #[Foo<>]class Bar{}',
+ [
+                [
+                    'type'              => Suggestion::TYPE_CLASS,
+                    'name'              => 'Foobar',
+                    'short_description' => 'Foobar',
+                ]
+            ]
+        ];
+
+        yield 'only show children for qualified names' => [
+            '<?php namespace Foo { #[Relative\<>]class Bar{}', [
+                [
+                    'type'              => Suggestion::TYPE_MODULE,
+                    'name'              => 'One',
+                    'short_description' => 'Foo\Relative\One',
+                ],
+                [
+                    'type'              => Suggestion::TYPE_CLASS,
+                    'name'              => 'Two',
+                    'short_description' => 'Foo\Relative\Two',
+                ],
+                [
+                    'type'              => Suggestion::TYPE_MODULE,
+                    'name'              => 'Two',
+                    'short_description' => 'Foo\Relative\Two',
+                ],
+            ],
+        ];
+    }
+
+    protected function createTolerantCompletor(TextDocument $source): TolerantCompletor
+    {
+        $searcher = $this->prophesize(NameSearcher::class);
+        $searcher->search('Foo')->willYield([
+            NameSearchResult::create('class', 'Foobar'),
+        ]);
+        $searcher->search('\\Foo\\Relative')->willYield([
+            NameSearchResult::create('class', 'Foo\Relative\One\Blah\Boo'),
+            NameSearchResult::create('class', 'Foo\Relative\One\Glorm\Bar'),
+            NameSearchResult::create('class', 'Foo\Relative\One\Blah'),
+            NameSearchResult::create('class', 'Foo\Relative\Two'),
+            NameSearchResult::create('class', 'Foo\Relative\Two\Glorm\Bar'),
+        ]);
+
+        $reflector = ReflectorBuilder::create()->addSource($source)->build();
+
+        return new AttributeCompletor(
+            $searcher->reveal(),
+            new DefaultResultPrioritizer(),
+        );
+    }
+}

--- a/lib/Completion/Tests/Integration/Bridge/TolerantParser/ReferenceFinder/ExpressionNameCompletorTest.php
+++ b/lib/Completion/Tests/Integration/Bridge/TolerantParser/ReferenceFinder/ExpressionNameCompletorTest.php
@@ -175,7 +175,7 @@ class ExpressionNameCompletorTest extends TolerantCompletorTestCase
                 [
                     'type'              => Suggestion::TYPE_CLASS,
                     'name'              => 'Foobar',
-                    'short_description' => 'Foobar',
+                    'short_description' => 'Foobar\Foo\Foobar',
                 ]
             ],
         ];
@@ -208,11 +208,11 @@ class ExpressionNameCompletorTest extends TolerantCompletorTestCase
         $searcher->search('b')->willYield([
             NameSearchResult::create('class', 'Foo\\Bar'),
         ]);
-        $searcher->search('NS1\Foo\Fo')->willYield([
+        $searcher->search('\NS1\Foo\Fo')->willYield([
             NameSearchResult::create('class', 'Foobar')
         ]);
-        $searcher->search('Foobar\Foo\Fo')->willYield([
-            NameSearchResult::create('class', 'Foobar')
+        $searcher->search('\Foobar\Foo\Fo')->willYield([
+            NameSearchResult::create('class', 'Foobar\Foo\Foobar')
         ]);
 
         $reflector = ReflectorBuilder::create()->addSource($source)->build();

--- a/lib/Completion/Tests/Integration/Bridge/TolerantParser/ReferenceFinder/ExpressionNameCompletorTest.php
+++ b/lib/Completion/Tests/Integration/Bridge/TolerantParser/ReferenceFinder/ExpressionNameCompletorTest.php
@@ -183,14 +183,19 @@ class ExpressionNameCompletorTest extends TolerantCompletorTestCase
         yield 'only show children for qualified names' => [
             '<?php namespace NS1{ use Foobar\Foo; class Foobar {} match (true) { 1 => Relative\<> }', [
                 [
-                    'type'              => Suggestion::TYPE_CLASS,
+                    'type'              => Suggestion::TYPE_MODULE,
                     'name'              => 'One',
-                    'short_description' => 'Relative\One',
+                    'short_description' => 'NS1\Relative\One',
                 ],
                 [
                     'type'              => Suggestion::TYPE_CLASS,
-                    'name'              => 'One',
-                    'short_description' => 'Relative\Two',
+                    'name'              => 'Two',
+                    'short_description' => 'NS1\Relative\Two',
+                ],
+                [
+                    'type'              => Suggestion::TYPE_MODULE,
+                    'name'              => 'Two',
+                    'short_description' => 'NS1\Relative\Two',
                 ],
             ],
         ];

--- a/lib/Completion/Tests/Integration/Bridge/TolerantParser/ReferenceFinder/ExpressionNameCompletorTest.php
+++ b/lib/Completion/Tests/Integration/Bridge/TolerantParser/ReferenceFinder/ExpressionNameCompletorTest.php
@@ -179,6 +179,21 @@ class ExpressionNameCompletorTest extends TolerantCompletorTestCase
                 ]
             ],
         ];
+
+        yield 'only show children for qualified names' => [
+            '<?php namespace NS1{ use Foobar\Foo; class Foobar {} match (true) { 1 => Relative\<> }', [
+                [
+                    'type'              => Suggestion::TYPE_CLASS,
+                    'name'              => 'One',
+                    'short_description' => 'Relative\One',
+                ],
+                [
+                    'type'              => Suggestion::TYPE_CLASS,
+                    'name'              => 'One',
+                    'short_description' => 'Relative\Two',
+                ],
+            ],
+        ];
     }
 
     protected function createTolerantCompletor(TextDocument $source): TolerantCompletor
@@ -213,6 +228,13 @@ class ExpressionNameCompletorTest extends TolerantCompletorTestCase
         ]);
         $searcher->search('\Foobar\Foo\Fo')->willYield([
             NameSearchResult::create('class', 'Foobar\Foo\Foobar')
+        ]);
+        $searcher->search('\\NS1\\Relative')->willYield([
+            NameSearchResult::create('class', 'NS1\Relative\One\Blah\Boo'),
+            NameSearchResult::create('class', 'NS1\Relative\One\Glorm\Bar'),
+            NameSearchResult::create('class', 'NS1\Relative\One\Blah'),
+            NameSearchResult::create('class', 'NS1\Relative\Two'),
+            NameSearchResult::create('class', 'NS1\Relative\Two\Glorm\Bar'),
         ]);
 
         $reflector = ReflectorBuilder::create()->addSource($source)->build();

--- a/lib/Completion/Tests/Integration/CompletorTestCase.php
+++ b/lib/Completion/Tests/Integration/CompletorTestCase.php
@@ -37,7 +37,7 @@ abstract class CompletorTestCase extends IntegrationTestCase
             TextDocumentBuilder::create($source)->language('php')->uri('file:///tmp/test')->build(),
             ByteOffset::fromInt((int)$offset)
         );
-        $suggestions = iterator_to_array($suggestionGenerator);
+        $suggestions = iterator_to_array($suggestionGenerator, false);
         usort($suggestions, function (Suggestion $suggestion1, Suggestion $suggestion2) {
             return $suggestion1->name() <=> $suggestion2->name();
         });

--- a/lib/Completion/Tests/Unit/Bridge/TolerantParser/CompletionContextTest.php
+++ b/lib/Completion/Tests/Unit/Bridge/TolerantParser/CompletionContextTest.php
@@ -138,6 +138,10 @@ class CompletionContextTest extends TestCase
             '<?php class Foo { public const X = [sel<> }',
             false,
         ];
+        yield 'attribute' => [
+            '<?php class Foo { public function baz(){} #[Foo\<>]public function bar(){}}',
+            false,
+        ];
     }
 
     /**

--- a/lib/Extension/LanguageServerCompletion/Handler/CompletionHandler.php
+++ b/lib/Extension/LanguageServerCompletion/Handler/CompletionHandler.php
@@ -150,7 +150,8 @@ class CompletionHandler implements Handler, CanRegisterCapabilities
             '@',
             '(',
             '\'',
-            '"'
+            '"',
+            '\\'
         ]);
         $capabilities->signatureHelpProvider = new SignatureHelpOptions(['(', ',']);
         $capabilities->completionProvider->resolveProvider = true;

--- a/lib/Indexer/Adapter/ReferenceFinder/IndexedNameSearcher.php
+++ b/lib/Indexer/Adapter/ReferenceFinder/IndexedNameSearcher.php
@@ -29,7 +29,6 @@ class IndexedNameSearcher implements NameSearcher
         }
 
         $fullyQualified = str_starts_with($name, '\\');
-
         if ($fullyQualified) {
             $criteria = Criteria::fqnBeginsWith(substr($name, 1));
         } else {

--- a/lib/Name/NameUtil.php
+++ b/lib/Name/NameUtil.php
@@ -71,4 +71,12 @@ final class NameUtil
         // trim?
         return ltrim($name, '\\');
     }
+
+    public static function toFullyQualfiied(string $name): string
+    {
+        if (substr($name, 0, 1) == '\\') {
+            return $name;
+        }
+        return '\\' . $name;
+    }
 }

--- a/lib/Name/NameUtil.php
+++ b/lib/Name/NameUtil.php
@@ -4,7 +4,15 @@ namespace Phpactor\Name;
 
 final class NameUtil
 {
-    public static function relativeTo(string $search, string $fqn): string
+    /**
+     * Return the FQN relative to the search.
+     *
+     * @param string $search - an absolute (but probably incomplete) qualified name
+     * @param string $fqn - a fully qualfiied name
+     *
+     * @return string the name relative to the last namespace of the search.
+     */
+    public static function relativeToSearch(string $search, string $fqn): string
     {
         $fqn = explode('\\', $fqn);
         $search = explode('\\', $search);

--- a/lib/Name/NameUtil.php
+++ b/lib/Name/NameUtil.php
@@ -26,6 +26,11 @@ final class NameUtil
 
             $rel[] = $segment;
         }
-        return implode($rel);
+        return implode('\\', $rel);
+    }
+
+    public static function isQualified(string $name): bool
+    {
+        return str_contains($name, '\\');
     }
 }

--- a/lib/Name/NameUtil.php
+++ b/lib/Name/NameUtil.php
@@ -63,13 +63,7 @@ final class NameUtil
 
     public static function join(string ...$segments): string
     {
-        return implode('\\', array_map(fn(string $s) => self::normalize($s), $segments));
-    }
-
-    private static function normalize(string $name): string
-    {
-        // trim?
-        return ltrim($name, '\\');
+        return implode('\\', array_map(fn (string $s) => self::normalize($s), $segments));
     }
 
     public static function toFullyQualfiied(string $name): string
@@ -78,5 +72,11 @@ final class NameUtil
             return $name;
         }
         return '\\' . $name;
+    }
+
+    private static function normalize(string $name): string
+    {
+        // trim?
+        return ltrim($name, '\\');
     }
 }

--- a/lib/Name/NameUtil.php
+++ b/lib/Name/NameUtil.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Phpactor\Name;
+
+final class NameUtil
+{
+    public static function relativeTo(string $search, string $fqn): string
+    {
+        $fqn = explode('\\', $fqn);
+        $search = explode('\\', $search);
+        $rel = [];
+
+        foreach ($fqn as $segment) {
+            $seg = array_shift($search);
+            if ($seg === $segment) {
+                continue;
+            }
+
+            $rel[] = $segment;
+        }
+        return implode($rel);
+    }
+}

--- a/lib/Name/NameUtil.php
+++ b/lib/Name/NameUtil.php
@@ -33,4 +33,27 @@ final class NameUtil
     {
         return str_contains($name, '\\');
     }
+
+    /**
+     * Return the child segment name relative to the given search.
+     *
+     * @return array{?string,bool}
+     */
+    public static function childSegmentAtSearch(string $fqn, string $search): array
+    {
+        $fqn = explode('\\', $fqn);
+        $search = explode('\\', $search);
+        $rel = [];
+
+        foreach ($fqn as $index => $segment) {
+            $seg = array_shift($search);
+            if ($segment === $seg) {
+                continue;
+            }
+
+            return [$segment, $index === count($fqn) - 1];
+        }
+
+        return [null, false];
+    }
 }

--- a/lib/Name/NameUtil.php
+++ b/lib/Name/NameUtil.php
@@ -14,6 +14,8 @@ final class NameUtil
      */
     public static function relativeToSearch(string $search, string $fqn): string
     {
+        // $fqn = ltrim($fqn, '\\');
+        // $search = ltrim($search, '\\');
         $fqn = explode('\\', $fqn);
         $search = explode('\\', $search);
         $rel = [];
@@ -41,6 +43,8 @@ final class NameUtil
      */
     public static function childSegmentAtSearch(string $fqn, string $search): array
     {
+        $fqn = self::normalize($fqn);
+        $search = self::normalize($search);
         $fqn = explode('\\', $fqn);
         $search = explode('\\', $search);
         $rel = [];
@@ -55,5 +59,16 @@ final class NameUtil
         }
 
         return [null, false];
+    }
+
+    public static function join(string ...$segments): string
+    {
+        return implode('\\', array_map(fn(string $s) => self::normalize($s), $segments));
+    }
+
+    private static function normalize(string $name): string
+    {
+        // trim?
+        return ltrim($name, '\\');
     }
 }

--- a/lib/Name/Tests/Unit/NameUtilTest.php
+++ b/lib/Name/Tests/Unit/NameUtilTest.php
@@ -46,4 +46,56 @@ class NameUtilTest extends TestCase
             'Bar\Foobar',
         ];
     }
+
+    /**
+     * @dataProvider provideSegmentAtSearch
+     * @param array{string,bool} $expected
+     */
+    public function testSegmentAtSearch(string $fqn, string $search, array $expected): void
+    {
+        self::assertEquals($expected, NameUtil::childSegmentAtSearch($fqn, $search));
+    }
+    /**
+     * @return Generator<array{string,string,string}>
+     */
+    public function provideSegmentAtSearch(): Generator
+    {
+        yield [
+            'Foo',
+            'Foo',
+            [null, false],
+        ];
+
+        yield [
+            'Foo\Bar',
+            'Foo',
+            ['Bar', true],
+        ];
+
+        yield [
+            'Foo\Bar',
+            'Foo\Bar',
+            [null, false],
+        ];
+        yield [
+            'Foo\Bar\Foobar',
+            'Foo\Bar\F',
+            ['Foobar', true],
+        ];
+        yield [
+            'Foo\Bar\Foobar\Bar\Baz',
+            'Foo\Bar',
+            ['Foobar', false],
+        ];
+        yield [
+            'Foo\Bar\Foobar\Bar\Baz',
+            'Foo\Bar\\',
+            ['Foobar', false],
+        ];
+        yield [
+            'Foo\Bar\Foobar\Bar\Baz',
+            'Foo',
+            ['Bar', false],
+        ];
+    }
 }

--- a/lib/Name/Tests/Unit/NameUtilTest.php
+++ b/lib/Name/Tests/Unit/NameUtilTest.php
@@ -40,5 +40,10 @@ class NameUtilTest extends TestCase
             'Foo\Bar\Foobar',
             'Foobar',
         ];
+        yield [
+            'Foo',
+            'Foo\Bar\Foobar',
+            'Bar\Foobar',
+        ];
     }
 }

--- a/lib/Name/Tests/Unit/NameUtilTest.php
+++ b/lib/Name/Tests/Unit/NameUtilTest.php
@@ -97,5 +97,15 @@ class NameUtilTest extends TestCase
             'Foo',
             ['Bar', false],
         ];
+        yield [
+            '\Foo\Bar\Foobar\Bar\Baz',
+            'Foo',
+            ['Bar', false],
+        ];
+        yield [
+            'Foo\Bar\Foobar\Bar\Baz',
+            '\Foo\Bar',
+            ['Foobar', false],
+        ];
     }
 }

--- a/lib/Name/Tests/Unit/NameUtilTest.php
+++ b/lib/Name/Tests/Unit/NameUtilTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Phpactor\Name\Tests\Unit;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use Phpactor\Name\NameUtil;
+
+class NameUtilTest extends TestCase
+{
+    /**
+     * @dataProvider provideRelativeTo
+     */
+    public function testRelativeTo(string $search, string $fqn, string $expected): void
+    {
+        self::assertEquals($expected, NameUtil::relativeTo($search, $fqn));
+    }
+    /**
+     * @return Generator<array{string,string,string}>
+     */
+    public function provideRelativeTo(): Generator
+    {
+        yield [
+            'Foo',
+            'Foo',
+            '',
+        ];
+        yield [
+            'Foo',
+            'Foo\Bar',
+            'Bar',
+        ];
+        yield [
+            'Foo\Bar',
+            'Foo\Bar',
+            '',
+        ];
+        yield [
+            'Foo\Bar\F',
+            'Foo\Bar\Foobar',
+            'Foobar',
+        ];
+    }
+}

--- a/lib/Name/Tests/Unit/NameUtilTest.php
+++ b/lib/Name/Tests/Unit/NameUtilTest.php
@@ -56,7 +56,7 @@ class NameUtilTest extends TestCase
         self::assertEquals($expected, NameUtil::childSegmentAtSearch($fqn, $search));
     }
     /**
-     * @return Generator<array{string,string,string}>
+     * @return Generator<array{string,string,array{(null|string),bool}}>
      */
     public function provideSegmentAtSearch(): Generator
     {

--- a/lib/Name/Tests/Unit/NameUtilTest.php
+++ b/lib/Name/Tests/Unit/NameUtilTest.php
@@ -13,7 +13,7 @@ class NameUtilTest extends TestCase
      */
     public function testRelativeTo(string $search, string $fqn, string $expected): void
     {
-        self::assertEquals($expected, NameUtil::relativeTo($search, $fqn));
+        self::assertEquals($expected, NameUtil::relativeToSearch($search, $fqn));
     }
     /**
      * @return Generator<array{string,string,string}>

--- a/lib/WorseReflection/Core/Util/NodeUtil.php
+++ b/lib/WorseReflection/Core/Util/NodeUtil.php
@@ -329,4 +329,19 @@ class NodeUtil
 
         return null;
     }
+
+    public static function namespace(Node $node): ?string
+    {
+        $namespace = $node->getNamespaceDefinition();
+
+        if (null === $namespace) {
+            return null;
+        }
+
+        if (!$namespace->name instanceof QualifiedName) {
+            return null;
+        }
+
+        return $namespace->name->__toString();
+    }
 }


### PR DESCRIPTION
This PR will try and solve the completion of `Relative\Names`, this is especically useful for attributes/annotations such as `@ORM\Foobar()`

![image](https://user-images.githubusercontent.com/530801/216179161-4ca420ed-2ff1-4d47-ac61-17d0d76c74a1.png)

- Makes `\\` a trigger char

TODO:

- [x] Support searching and completion of relative names for expressions.
- [x]  Support namespace completion
- [x] Support only completing the children of the relative name
- [x] Support attributes (why doesn't this just work already?)