### PR TITLE
Added missing port in docs lsp/running

### DIFF
--- a/doc/lsp/running.rst
+++ b/doc/lsp/running.rst
@@ -24,7 +24,7 @@ The TCP server is useful for debugging:
 
 .. code:: bash
 
-   $ phpactor language-server --address=127.0.0.1 -vvv
+   $ phpactor language-server --address=127.0.0.1:8888 -vvv
 
 You should see something like:
 


### PR DESCRIPTION
https://phpactor.readthedocs.io/en/master/lsp/running.html#run-with-tcp-server

I tried to run the command on this page and it failed:

```
➜ $ phpactor language-server --address=127.0.0.1 -vvv     
Starting language server, use -vvv for verbose output

In Server.php line 58:
                                                                                            
  [Amp\Socket\SocketException]                                                              
  Could not create server tcp://127.0.0.1: [Error: #0] Failed to parse address "127.0.0.1"  
```

Realized it was missing the port when looking through the code so added it to the docs