### PR TITLE
Implement indexing classes with type attributes

### DIFF
--- a/lib/Indexer/Adapter/Tolerant/Indexer/ClassDeclarationIndexer.php
+++ b/lib/Indexer/Adapter/Tolerant/Indexer/ClassDeclarationIndexer.php
@@ -52,7 +52,8 @@ class ClassDeclarationIndexer extends AbstractClassLikeIndexer
             foreach ($attributeGroup->attributes->children as $attribute) {
                 /** @var Attribute $attribute */
                 if ($attribute->name->getText() === 'Attribute') {
-                    $record->setType(ClassRecord::TYPE_ATTRIBUTE);
+                    $record->addFlag(ClassRecord::FLAG_ATTRIBUTE);
+                    return;
                 }
             }
         }

--- a/lib/Indexer/Adapter/Tolerant/Indexer/ClassDeclarationIndexer.php
+++ b/lib/Indexer/Adapter/Tolerant/Indexer/ClassDeclarationIndexer.php
@@ -4,12 +4,13 @@ namespace Phpactor\Indexer\Adapter\Tolerant\Indexer;
 
 use Microsoft\PhpParser\MissingToken;
 use Microsoft\PhpParser\Node;
+use Microsoft\PhpParser\Node\Attribute;
+use Microsoft\PhpParser\Node\Statement\ClassDeclaration;
 use Phpactor\Indexer\Model\Exception\CannotIndexNode;
+use Phpactor\Indexer\Model\Index;
 use Phpactor\Indexer\Model\Name\FullyQualifiedName;
 use Phpactor\Indexer\Model\Record\ClassRecord;
-use Microsoft\PhpParser\Node\Statement\ClassDeclaration;
 use Phpactor\TextDocument\TextDocument;
-use Phpactor\Indexer\Model\Index;
 
 class ClassDeclarationIndexer extends AbstractClassLikeIndexer
 {
@@ -35,7 +36,26 @@ class ClassDeclarationIndexer extends AbstractClassLikeIndexer
         $this->indexClassInterfaces($index, $record, $node);
         $this->indexBaseClass($index, $record, $node);
 
+        $this->indexAttributes($record, $node);
+
         $index->write($record);
+    }
+
+    public function indexAttributes(ClassRecord $record, ClassDeclaration $node): void
+    {
+        $attributes = $node->attributes ?? [];
+        if (count($attributes) === 0) {
+            return;
+        }
+
+        foreach ($attributes as $attributeGroup) {
+            foreach ($attributeGroup->attributes->children as $attribute) {
+                /** @var Attribute $attribute */
+                if ($attribute->name->getText() === 'Attribute') {
+                    $record->setType(ClassRecord::TYPE_ATTRIBUTE);
+                }
+            }
+        }
     }
 
     private function indexClassInterfaces(Index $index, ClassRecord $classRecord, ClassDeclaration $node): void

--- a/lib/Indexer/Model/Query/Criteria.php
+++ b/lib/Indexer/Model/Query/Criteria.php
@@ -66,6 +66,11 @@ abstract class Criteria
         return new IsClassType(ClassRecord::TYPE_TRAIT);
     }
 
+    public static function isClassAttribute(): IsClassType
+    {
+        return new IsClassType(ClassRecord::TYPE_ATTRIBUTE);
+    }
+
     public static function isClassTypeUndefined(): IsClassType
     {
         return new IsClassType(null);

--- a/lib/Indexer/Model/Query/Criteria.php
+++ b/lib/Indexer/Model/Query/Criteria.php
@@ -66,11 +66,6 @@ abstract class Criteria
         return new IsClassType(ClassRecord::TYPE_TRAIT);
     }
 
-    public static function isClassAttribute(): IsClassType
-    {
-        return new IsClassType(ClassRecord::TYPE_ATTRIBUTE);
-    }
-
     public static function isClassTypeUndefined(): IsClassType
     {
         return new IsClassType(null);

--- a/lib/Indexer/Model/Record/ClassRecord.php
+++ b/lib/Indexer/Model/Record/ClassRecord.php
@@ -15,6 +15,7 @@ final class ClassRecord implements Record, HasFileReferences, HasPath, HasFullyQ
     public const TYPE_INTERFACE = 'interface';
     public const TYPE_TRAIT = 'trait';
     public const TYPE_ENUM = 'enum';
+    public const TYPE_ATTRIBUTE = 'attribute';
 
     /**
      * @var array<string>
@@ -27,7 +28,7 @@ final class ClassRecord implements Record, HasFileReferences, HasPath, HasFullyQ
     private array $implements = [];
 
     /**
-     * Type of "class": class, interface or trait
+     * Type of "class": class, interface or trait, etc
      */
     private ?string $type = null;
 

--- a/lib/Indexer/Model/Record/ClassRecord.php
+++ b/lib/Indexer/Model/Record/ClassRecord.php
@@ -15,7 +15,7 @@ final class ClassRecord implements Record, HasFileReferences, HasPath, HasFullyQ
     public const TYPE_INTERFACE = 'interface';
     public const TYPE_TRAIT = 'trait';
     public const TYPE_ENUM = 'enum';
-    public const TYPE_ATTRIBUTE = 'attribute';
+    public const FLAG_ATTRIBUTE = 1;
 
     /**
      * @var array<string>
@@ -31,6 +31,8 @@ final class ClassRecord implements Record, HasFileReferences, HasPath, HasFullyQ
      * Type of "class": class, interface or trait, etc
      */
     private ?string $type = null;
+
+    private int $flags = 0;
 
     public static function fromName(string $name): self
     {
@@ -110,5 +112,24 @@ final class ClassRecord implements Record, HasFileReferences, HasPath, HasFullyQ
         $clone = clone $this;
         $clone->type = $type;
         return $clone;
+    }
+
+    public function setFlags(int $flags): self
+    {
+        $this->flags = $flags;
+
+        return $this;
+    }
+
+    public function addFlag(int $flag): self
+    {
+        $this->flags = $this->flags | $flag;
+
+        return $this;
+    }
+
+    public function hasFlag(int $flag): bool
+    {
+        return (bool) ($this->flags & $flag);
     }
 }

--- a/lib/Indexer/Tests/Adapter/IndexBuilderTestCase.php
+++ b/lib/Indexer/Tests/Adapter/IndexBuilderTestCase.php
@@ -38,6 +38,24 @@ abstract class IndexBuilderTestCase extends IntegrationTestCase
      */
     public function provideIndexesClassLike(): Generator
     {
+        yield 'attribute' => [
+            <<<DOC
+                    // File: project/attribute.php
+                    <?php
+
+                    #[Attribute]
+                    class IamAnAttribute {}
+                DOC,
+            'IamAnAttribute',
+            function (ClassRecord $record): void {
+                self::assertInstanceOf(ClassRecord::class, $record);
+                self::assertEquals($this->workspace()->path('project/attribute.php'), $record->filePath());
+                self::assertEquals('IamAnAttribute', $record->fqn());
+                self::assertEquals(7, $record->start()->toInt());
+                self::assertEquals(ClassRecord::TYPE_ATTRIBUTE, $record->type());
+            }
+        ];
+
         yield 'class' => [
             "// File: project/test.php\n<?php class ThisClass {}",
             'ThisClass',

--- a/lib/Indexer/Tests/Adapter/IndexBuilderTestCase.php
+++ b/lib/Indexer/Tests/Adapter/IndexBuilderTestCase.php
@@ -34,7 +34,7 @@ abstract class IndexBuilderTestCase extends IntegrationTestCase
     }
 
     /**
-     * @return Generator<string, array>
+     * @return Generator<string, array{string, string, Closure}>
      */
     public function provideIndexesClassLike(): Generator
     {
@@ -51,8 +51,8 @@ abstract class IndexBuilderTestCase extends IntegrationTestCase
                 self::assertInstanceOf(ClassRecord::class, $record);
                 self::assertEquals($this->workspace()->path('project/attribute.php'), $record->filePath());
                 self::assertEquals('IamAnAttribute', $record->fqn());
-                self::assertEquals(7, $record->start()->toInt());
-                self::assertEquals(ClassRecord::TYPE_ATTRIBUTE, $record->type());
+                self::assertEquals(15, $record->start()->toInt());
+                self::assertTrue($record->hasFlag(ClassRecord::FLAG_ATTRIBUTE));
             }
         ];
 


### PR DESCRIPTION
As mentioned here: #2060 for an efficient suggestion when it comes to attributes we need to index which classes are attributes and which aren't. This PR adds a type `TYPE_ATTRIBUTE` which can be used for filtering later.