### PR TITLE
Outsourcing Diagnostics to external process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Features:
 
   - Hierarchical namespace segment completion #2070
   - Completion for promoted property visiblity #2087
+  - Option `language_server.diagnostic_outsource` to outsource diagnostics in separate process #2105
 
 Bug fixes:
 

--- a/doc/reference/configuration.rst
+++ b/doc/reference/configuration.rst
@@ -1237,7 +1237,7 @@ Specify which diagnostic providers should be active (default to all)
 If applicable diagnostics should be "outsourced" to a different process
 
 
-**Default**: ``true``
+**Default**: ``false``
 
 
 .. _param_language_server,file_events:

--- a/doc/reference/configuration.rst
+++ b/doc/reference/configuration.rst
@@ -1227,6 +1227,19 @@ Specify which diagnostic providers should be active (default to all)
 **Default**: ``null``
 
 
+.. _param_language_server.diagnostic_outsource:
+
+
+``language_server.diagnostic_outsource``
+""""""""""""""""""""""""""""""""""""""""
+
+
+If applicable diagnostics should be "outsourced" to a different process
+
+
+**Default**: ``true``
+
+
 .. _param_language_server,file_events:
 
 

--- a/lib/CodeTransform/Domain/SourceCode.php
+++ b/lib/CodeTransform/Domain/SourceCode.php
@@ -92,6 +92,11 @@ final class SourceCode implements TextDocument
      */
     public static function fromTextDocument(TextDocument $textDocument): self
     {
+        if (null === $textDocument->uri()) {
+            throw new RuntimeException(
+                'Cannot create source code from text document with no URI'
+            );
+        }
         return new self($textDocument->__toString(), $textDocument->uri());
     }
 }

--- a/lib/CodeTransform/Domain/SourceCode.php
+++ b/lib/CodeTransform/Domain/SourceCode.php
@@ -9,7 +9,7 @@ use RuntimeException;
 
 final class SourceCode implements TextDocument
 {
-    private function __construct(private string $code, private TextDocumentUri $path)
+    private function __construct(private string $code, private TextDocumentUri $uri)
     {
     }
 
@@ -30,7 +30,7 @@ final class SourceCode implements TextDocument
 
     public function withSource(string $code): SourceCode
     {
-        return new self($code, $this->path);
+        return new self($code, $this->uri);
     }
 
     public function withPath(string $path): SourceCode
@@ -40,7 +40,7 @@ final class SourceCode implements TextDocument
 
     public function path(): string
     {
-        return $this->path->path();
+        return $this->uri->path();
     }
 
     public function extractSelection(int $offsetStart, int $offsetEnd): string
@@ -77,7 +77,7 @@ final class SourceCode implements TextDocument
 
     public function uri(): TextDocumentUri
     {
-        return $this->path;
+        return $this->uri;
     }
 
     public function language(): TextDocumentLanguage

--- a/lib/Extension/LanguageServer/Command/DiagnosticsCommand.php
+++ b/lib/Extension/LanguageServer/Command/DiagnosticsCommand.php
@@ -6,6 +6,7 @@ use Amp\CancellationTokenSource;
 use Phpactor\LanguageServer\Core\Diagnostics\DiagnosticsProvider;
 use Phpactor\LanguageServer\Test\ProtocolFactory;
 use Phpactor\TextDocument\TextDocumentBuilder;
+use RuntimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -31,7 +32,13 @@ class DiagnosticsCommand extends Command
         $diagnostics = wait(
             $this->provider->provideDiagnostics($textDocument, (new CancellationTokenSource())->getToken())
         );
-        $output->write(json_encode($diagnostics));
+        $decoded = json_encode($diagnostics);
+        if (false === $decoded) {
+            throw new RuntimeException(
+                'Could not encode diagnostics',
+            );
+        }
+        $output->write($decoded);
         return 0;
     }
 

--- a/lib/Extension/LanguageServer/Command/DiagnosticsCommand.php
+++ b/lib/Extension/LanguageServer/Command/DiagnosticsCommand.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServer\Command;
+
+use Phpactor\LanguageServer\Core\Diagnostics\DiagnosticsProvider;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class DiagnosticsCommand extends Command
+{
+    public const NAME = 'language-server:diagnostics';
+
+    public function __construct(private DiagnosticsProvider $provider)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription('Internal: resolve diagnostics in JSON for document provided over STDIN');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+    }
+}

--- a/lib/Extension/LanguageServer/Command/DiagnosticsCommand.php
+++ b/lib/Extension/LanguageServer/Command/DiagnosticsCommand.php
@@ -5,7 +5,6 @@ namespace Phpactor\Extension\LanguageServer\Command;
 use Amp\CancellationTokenSource;
 use Phpactor\LanguageServer\Core\Diagnostics\DiagnosticsProvider;
 use Phpactor\LanguageServer\Test\ProtocolFactory;
-use Phpactor\TextDocument\TextDocumentBuilder;
 use RuntimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -32,6 +31,7 @@ class DiagnosticsCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var string $uri */
         $uri = $input->getOption(self::PARAM_URI) ?: 'untitled:///new';
 
         $textDocument = ProtocolFactory::textDocumentItem($uri, $this->stdin());

--- a/lib/Extension/LanguageServer/Command/DiagnosticsCommand.php
+++ b/lib/Extension/LanguageServer/Command/DiagnosticsCommand.php
@@ -2,10 +2,14 @@
 
 namespace Phpactor\Extension\LanguageServer\Command;
 
+use Amp\CancellationTokenSource;
 use Phpactor\LanguageServer\Core\Diagnostics\DiagnosticsProvider;
+use Phpactor\LanguageServer\Test\ProtocolFactory;
+use Phpactor\TextDocument\TextDocumentBuilder;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use function Amp\Promise\wait;
 
 class DiagnosticsCommand extends Command
 {
@@ -23,5 +27,22 @@ class DiagnosticsCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $textDocument = ProtocolFactory::textDocumentItem('undefined:///', $this->stdin());
+        $diagnostics = wait(
+            $this->provider->provideDiagnostics($textDocument, (new CancellationTokenSource())->getToken())
+        );
+        $output->write(json_encode($diagnostics));
+        return 0;
+    }
+
+    private function stdin(): string
+    {
+        $in = '';
+
+        while ($line = fgets(STDIN)) {
+            $in .= $line;
+        }
+
+        return $in;
     }
 }

--- a/lib/Extension/LanguageServer/Container/DiagnosticProviderTag.php
+++ b/lib/Extension/LanguageServer/Container/DiagnosticProviderTag.php
@@ -4,6 +4,9 @@ namespace Phpactor\Extension\LanguageServer\Container;
 
 class DiagnosticProviderTag
 {
+    const NAME = 'name';
+    const OUTSOURCE = 'outsource';
+
     /**
      * @param bool $outsource if this diagnostic provider should be outsourced to different process.
      * @return array{name:string,outsource:bool}

--- a/lib/Extension/LanguageServer/Container/DiagnosticProviderTag.php
+++ b/lib/Extension/LanguageServer/Container/DiagnosticProviderTag.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServer\Container;
+
+class DiagnosticProviderTag
+{
+    /**
+     * @param bool $outsource if this diagnostic provider should be outsourced to different process.
+     * @return array{name:string,outsource:bool}
+     */
+    public static function create(string $name, bool $outsource = false): array
+    {
+        return [
+            'name' => $name,
+            'outsource' => $outsource,
+        ];
+    }
+}

--- a/lib/Extension/LanguageServer/Container/DiagnosticProviderTag.php
+++ b/lib/Extension/LanguageServer/Container/DiagnosticProviderTag.php
@@ -4,8 +4,8 @@ namespace Phpactor\Extension\LanguageServer\Container;
 
 class DiagnosticProviderTag
 {
-    const NAME = 'name';
-    const OUTSOURCE = 'outsource';
+    public const NAME = 'name';
+    public const OUTSOURCE = 'outsource';
 
     /**
      * @param bool $outsource if this diagnostic provider should be outsourced to different process.
@@ -14,8 +14,8 @@ class DiagnosticProviderTag
     public static function create(string $name, bool $outsource = false): array
     {
         return [
-            'name' => $name,
-            'outsource' => $outsource,
+            self::NAME  => $name,
+            self::OUTSOURCE => $outsource,
         ];
     }
 }

--- a/lib/Extension/LanguageServer/DiagnosticProvider/OutsourcedDiagnosticsProvider.php
+++ b/lib/Extension/LanguageServer/DiagnosticProvider/OutsourcedDiagnosticsProvider.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServer\DiagnosticProvider;
+
+use Amp\CancellationToken;
+use Amp\Process\Process;
+use Amp\Promise;
+use Phpactor\LanguageServerProtocol\Diagnostic;
+use Phpactor\LanguageServerProtocol\TextDocumentItem;
+use Phpactor\LanguageServer\Core\Diagnostics\DiagnosticsProvider;
+use RuntimeException;
+use function Amp\ByteStream\buffer;
+use function Amp\call;
+
+class OutsourcedDiagnosticsProvider implements DiagnosticsProvider
+{
+    /**
+     * @param list<string> $command
+     */
+    public function __construct(private array $command)
+    {
+    }
+
+    public function provideDiagnostics(TextDocumentItem $textDocument, CancellationToken $cancel): Promise
+    {
+        return call(function () use ($textDocument) {
+            $process = new Process($this->command);
+            $pid = yield $process->start();
+            $stdin = $process->getStdin();
+
+            yield $stdin->write($textDocument->text);
+            $stdin->close();
+
+            $exitCode = yield $process->join();
+            if ($exitCode !== 0) {
+                throw new RuntimeException(sprintf(
+                    'Phpactor diagnostics process exited with code "%s": %s',
+                    $exitCode,
+                    yield buffer($process->getStderr())
+                ));
+            }
+            $json = yield buffer($process->getStdout());
+            $array = json_decode($json, true);
+            if (!is_array($array)) {
+                throw new RuntimeException(sprintf(
+                    'Could not decode JSON: %s',
+                    $json
+                ));
+            }
+
+            return array_map(fn (array $diagnostic) => Diagnostic::fromArray($diagnostic), $array);
+        });
+    }
+
+    public function name(): string
+    {
+        return 'outsourced';
+    }
+}

--- a/lib/Extension/LanguageServer/DiagnosticProvider/OutsourcedDiagnosticsProvider.php
+++ b/lib/Extension/LanguageServer/DiagnosticProvider/OutsourcedDiagnosticsProvider.php
@@ -23,7 +23,7 @@ class OutsourcedDiagnosticsProvider implements DiagnosticsProvider
 
     public function provideDiagnostics(TextDocumentItem $textDocument, CancellationToken $cancel): Promise
     {
-        return call(function () use ($textDocument, $cancel) {
+        return call(function () use ($textDocument) {
             $process = new Process(array_merge($this->command, [
                 '--uri=' . escapeshellarg($textDocument->uri)
             ]));

--- a/lib/Extension/LanguageServer/DiagnosticProvider/OutsourcedDiagnosticsProvider.php
+++ b/lib/Extension/LanguageServer/DiagnosticProvider/OutsourcedDiagnosticsProvider.php
@@ -17,7 +17,7 @@ class OutsourcedDiagnosticsProvider implements DiagnosticsProvider
     /**
      * @param list<string> $command
      */
-    public function __construct(private array $command)
+    public function __construct(private array $command, private string $cwd)
     {
     }
 
@@ -25,8 +25,8 @@ class OutsourcedDiagnosticsProvider implements DiagnosticsProvider
     {
         return call(function () use ($textDocument) {
             $process = new Process(array_merge($this->command, [
-                '--uri=' . escapeshellarg($textDocument->uri)
-            ]));
+                '--uri=' . $textDocument->uri
+            ]), $this->cwd);
             $pid = yield $process->start();
 
             $stdin = $process->getStdin();

--- a/lib/Extension/LanguageServer/LanguageServerExtension.php
+++ b/lib/Extension/LanguageServer/LanguageServerExtension.php
@@ -193,7 +193,7 @@ class LanguageServerExtension implements Extension
 
         $container->register(DiagnosticsCommand::class, function (Container $container) {
             /** @var AggregateDiagnosticsProvider $provider */
-            $provider = $container->get(AggregateDiagnosticsProvider::class . '.all');
+            $provider = $container->get(AggregateDiagnosticsProvider::class . '.outsourced');
             return new DiagnosticsCommand($provider);
         }, [ ConsoleExtension::TAG_COMMAND => [ 'name' => DiagnosticsCommand::NAME ]]);
     }
@@ -489,7 +489,7 @@ class LanguageServerExtension implements Extension
             );
         });
 
-        $container->register(AggregateDiagnosticsProvider::class.'.all', function (Container $container) {
+        $container->register(AggregateDiagnosticsProvider::class.'.outsourced', function (Container $container) {
             $providers = $this->collectDiagnosticProviders($container, true);
 
             return new AggregateDiagnosticsProvider(
@@ -552,15 +552,16 @@ class LanguageServerExtension implements Extension
     /**
      * @return DiagnosticsProvider[]
      */
-    private function collectDiagnosticProviders(Container $container, bool $withOutsourced): array
+    private function collectDiagnosticProviders(Container $container, bool $outsourced): array
     {
         $providers = [];
         foreach ($container->getServiceIdsForTag(self::TAG_DIAGNOSTICS_PROVIDER) as $serviceId => $attrs) {
             Assert::isArray($attrs, 'Attributes must be an array, got "%s"');
 
             if (
-                $withOutsourced &&
                 ($attrs[DiagnosticProviderTag::OUTSOURCE] ?? false)
+                !==
+                $outsourced
             ) {
                 continue;
             }

--- a/lib/Extension/LanguageServer/LanguageServerExtension.php
+++ b/lib/Extension/LanguageServer/LanguageServerExtension.php
@@ -477,7 +477,10 @@ class LanguageServerExtension implements Extension
             foreach ($container->getServiceIdsForTag(self::TAG_DIAGNOSTICS_PROVIDER) as $serviceId => $attrs) {
                 Assert::isArray($attrs, 'Attributes must be an array, got "%s"');
 
-                if ($attrs[DiagnosticProviderTag::OUTSOURCE] ?? false) {
+                if (
+                    $container->getParameter(self::PARAM_DIAGNOSTIC_OUTSOURCE) &&
+                    ($attrs[DiagnosticProviderTag::OUTSOURCE] ?? false)
+                ) {
                     continue;
                 }
 
@@ -487,7 +490,7 @@ class LanguageServerExtension implements Extension
                     continue;
                 }
 
-                $providers[$attrs[DiagnosticProviderTag::OUTSOURCE] ?? $serviceId] = $provider;
+                $providers[$attrs[DiagnosticProviderTag::NAME] ?? $serviceId] = $provider;
             }
 
             $enabled = $container->getParameter(self::PARAM_DIAGNOSTIC_PROVIDERS);

--- a/lib/Extension/LanguageServer/LanguageServerExtension.php
+++ b/lib/Extension/LanguageServer/LanguageServerExtension.php
@@ -7,6 +7,7 @@ use Phly\EventDispatcher\EventDispatcher;
 use Phpactor\Container\Container;
 use Phpactor\Container\ContainerBuilder;
 use Phpactor\Container\Extension;
+use Phpactor\Extension\FilePathResolver\FilePathResolverExtension;
 use Phpactor\Extension\LanguageServer\Command\DiagnosticsCommand;
 use Phpactor\Extension\LanguageServer\DiagnosticProvider\OutsourcedDiagnosticsProvider;
 use Phpactor\Extension\LanguageServer\Dispatcher\PhpactorDispatcherFactory;
@@ -511,6 +512,7 @@ class LanguageServerExtension implements Extension
         ]);
 
         $container->register(OutsourcedDiagnosticsProvider::class, function (Container $container) {
+            $projectPath = $container->get(FilePathResolverExtension::SERVICE_FILE_PATH_RESOLVER)->resolve('%project_root%');
             // only register this if we should call out to an external process for diagnostics
             if (!$container->getParameter(self::PARAM_DIAGNOSTIC_OUTSOURCE)) {
                 return null;
@@ -519,7 +521,7 @@ class LanguageServerExtension implements Extension
             return new OutsourcedDiagnosticsProvider([
                 __DIR__ . '/../../../bin/phpactor',
                 'language-server:diagnostics'
-            ]);
+            ], $projectPath);
         }, [
             self::TAG_DIAGNOSTICS_PROVIDER => DiagnosticProviderTag::create('outsourced'),
         ]);

--- a/lib/Extension/LanguageServer/LanguageServerExtension.php
+++ b/lib/Extension/LanguageServer/LanguageServerExtension.php
@@ -22,6 +22,7 @@ use Phpactor\Extension\LanguageServer\Container\DiagnosticProviderTag;
 use Phpactor\Extension\Logger\LoggingExtension;
 use Phpactor\Extension\Console\ConsoleExtension;
 use Phpactor\Extension\LanguageServer\Command\StartCommand;
+use Phpactor\FilePathResolver\PathResolver;
 use Phpactor\LanguageServerProtocol\ClientCapabilities;
 use Phpactor\LanguageServer\Core\CodeAction\AggregateCodeActionProvider;
 use Phpactor\LanguageServer\Core\Command\CommandDispatcher;
@@ -512,7 +513,9 @@ class LanguageServerExtension implements Extension
         ]);
 
         $container->register(OutsourcedDiagnosticsProvider::class, function (Container $container) {
-            $projectPath = $container->get(FilePathResolverExtension::SERVICE_FILE_PATH_RESOLVER)->resolve('%project_root%');
+            /** @var PathResolver $resolver */
+            $resolver = $container->get(FilePathResolverExtension::SERVICE_FILE_PATH_RESOLVER);
+            $projectPath = $resolver->resolve('%project_root%');
             // only register this if we should call out to an external process for diagnostics
             if (!$container->getParameter(self::PARAM_DIAGNOSTIC_OUTSOURCE)) {
                 return null;

--- a/lib/Extension/LanguageServer/LanguageServerExtension.php
+++ b/lib/Extension/LanguageServer/LanguageServerExtension.php
@@ -117,7 +117,7 @@ class LanguageServerExtension implements Extension
             self::PARAM_DIAGNOSTIC_ON_SAVE => true,
             self::PARAM_DIAGNOSTIC_ON_OPEN => true,
             self::PARAM_DIAGNOSTIC_PROVIDERS => null,
-            self::PARAM_DIAGNOSTIC_OUTSOURCE => true,
+            self::PARAM_DIAGNOSTIC_OUTSOURCE => false,
             self::PARAM_FILE_EVENTS => true,
             self::PARAM_FILE_EVENT_GLOBS => ['**/*.php'],
             self::PARAM_PROFILE => false,

--- a/lib/Extension/LanguageServer/LanguageServerExtension.php
+++ b/lib/Extension/LanguageServer/LanguageServerExtension.php
@@ -508,6 +508,7 @@ class LanguageServerExtension implements Extension
         }, [
             self::TAG_DIAGNOSTICS_PROVIDER => [
                 'name' => 'code-action'
+                'channel' => 'phpactor',
             ],
         ]);
     }

--- a/lib/Extension/LanguageServer/LanguageServerExtension.php
+++ b/lib/Extension/LanguageServer/LanguageServerExtension.php
@@ -90,6 +90,7 @@ class LanguageServerExtension implements Extension
     public const PARAM_DIAGNOSTIC_ON_SAVE = 'language_server.diagnostics_on_save';
     public const PARAM_DIAGNOSTIC_ON_OPEN = 'language_server.diagnostics_on_open';
     public const PARAM_DIAGNOSTIC_PROVIDERS = 'language_server.diagnostic_providers';
+    public const PARAM_DIAGNOSTIC_CHANNELS = 'language_server.diagnostic_channels';
     public const PARAM_FILE_EVENTS = 'language_server,file_events';
     public const PARAM_FILE_EVENT_GLOBS = 'language_server.file_event_globs';
     public const PARAM_PROFILE = 'language_server.profile';
@@ -110,6 +111,7 @@ class LanguageServerExtension implements Extension
             self::PARAM_DIAGNOSTIC_ON_SAVE => true,
             self::PARAM_DIAGNOSTIC_ON_OPEN => true,
             self::PARAM_DIAGNOSTIC_PROVIDERS => null,
+            self::PARAM_DIAGNOSTIC_CHANNELS => ['phpactor'],
             self::PARAM_FILE_EVENTS => true,
             self::PARAM_FILE_EVENT_GLOBS => ['**/*.php'],
             self::PARAM_PROFILE => false,
@@ -131,6 +133,7 @@ class LanguageServerExtension implements Extension
             self::PARAM_DIAGNOSTIC_ON_SAVE => 'Perform diagnostics when the text document is saved',
             self::PARAM_DIAGNOSTIC_ON_OPEN => 'Perform diagnostics when opening a text document',
             self::PARAM_DIAGNOSTIC_PROVIDERS => 'Specify which diagnostic providers should be active (default to all)',
+            self::PARAM_DIAGNOSTIC_CHANNELS => 'Determine which diagnostic channels will run in this process',
             self::PARAM_FILE_EVENTS => 'Register to recieve file events',
             self::PARAM_SHUTDOWN_GRACE_PERIOD => 'Amount of time to wait before responding to a shutdown notification',
             self::PARAM_SELF_DESTRUCT_TIMEOUT => 'Wait this amount of time after a shutdown request before self-destructing',
@@ -506,10 +509,7 @@ class LanguageServerExtension implements Extension
                 ...$this->taggedServices($container, self::TAG_CODE_ACTION_DIAGNOSTICS_PROVIDER)
             );
         }, [
-            self::TAG_DIAGNOSTICS_PROVIDER => [
-                'name' => 'code-action'
-                'channel' => 'phpactor',
-            ],
+            self::TAG_DIAGNOSTICS_PROVIDER => DiagnosticProviderTag::create('code-action', outsource: true),
         ]);
     }
 

--- a/lib/Extension/LanguageServer/Tests/Unit/Command/DiagnosticsCommandTest.php
+++ b/lib/Extension/LanguageServer/Tests/Unit/Command/DiagnosticsCommandTest.php
@@ -3,6 +3,8 @@
 namespace Phpactor\Extension\LanguageServer\Tests\Unit\Command;
 
 use Phpactor\Extension\LanguageServer\Tests\Unit\LanguageServerTestCase;
+use Phpactor\LanguageServerProtocol\Diagnostic;
+use RuntimeException;
 use Symfony\Component\Process\Process;
 
 class DiagnosticsCommandTest extends LanguageServerTestCase
@@ -14,17 +16,29 @@ class DiagnosticsCommandTest extends LanguageServerTestCase
 
     public function testDiagnostics(): void
     {
-        $diagnostics = $this->diagnosticsFor('<?php ');
-        dump($diagnostics);
+        $diagnostics = $this->diagnosticsFor('<?php Barfoo::class; // class not found');
+        self::assertCount(1, $diagnostics);
+        self::assertEquals('Class "Barfoo" not found', $diagnostics[0]->message);
     }
 
-    private function diagnosticsFor(string $sourceCode): string
+    /**
+     * @return Diagnostic[]
+     */
+    private function diagnosticsFor(string $sourceCode): array
     {
         $process = new Process([
             __DIR__ . '/../../../../../../bin/phpactor',
             'language-server:diagnostics',
         ], $this->workspace()->path(), [], $sourceCode);
         $process->mustRun();
-        return $process->getOutput();
+
+        $diagnostics = array_map(function (mixed $diagnostic): Diagnostic {
+            if (!is_array($diagnostic)) {
+                throw new RuntimeException('nope');
+            }
+            return Diagnostic::fromArray($diagnostic);
+        }, (array)json_decode($process->getOutput(), true));
+
+        return $diagnostics;
     }
 }

--- a/lib/Extension/LanguageServer/Tests/Unit/Command/DiagnosticsCommandTest.php
+++ b/lib/Extension/LanguageServer/Tests/Unit/Command/DiagnosticsCommandTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServer\Tests\Unit\Command;
+
+use Phpactor\Extension\LanguageServer\Tests\Unit\LanguageServerTestCase;
+use Symfony\Component\Process\Process;
+
+class DiagnosticsCommandTest extends LanguageServerTestCase
+{
+    protected function setUp(): void
+    {
+        $this->workspace()->reset();
+    }
+
+    public function testDiagnostics(): void
+    {
+        $diagnostics = $this->diagnosticsFor('<?php ');
+        dump($diagnostics);
+    }
+
+    private function diagnosticsFor(string $sourceCode): string
+    {
+        $process = new Process([
+            __DIR__ . '/../../../../../../bin/phpactor',
+            'language-server:diagnostics',
+        ], $this->workspace()->path(), [], $sourceCode);
+        $process->mustRun();
+        return $process->getOutput();
+    }
+}

--- a/lib/Extension/LanguageServer/Tests/Unit/DiagnosticsProvider/OutsourcedDiagnosticsProvierTest.php
+++ b/lib/Extension/LanguageServer/Tests/Unit/DiagnosticsProvider/OutsourcedDiagnosticsProvierTest.php
@@ -15,7 +15,7 @@ class OutsourcedDiagnosticsProvierTest extends LanguageServerTestCase
         $provider = new OutsourcedDiagnosticsProvider([
             __DIR__ . '/../../../../../../bin/phpactor',
             'language-server:diagnostics',
-        ]);
+        ], $this->workspace()->path());
         $diagnostics = wait($provider->provideDiagnostics(
             ProtocolFactory::textDocumentItem('file:///foo', '<?php echo Hello::class'),
             (new CancellationTokenSource())->getToken()

--- a/lib/Extension/LanguageServer/Tests/Unit/DiagnosticsProvider/OutsourcedDiagnosticsProvierTest.php
+++ b/lib/Extension/LanguageServer/Tests/Unit/DiagnosticsProvider/OutsourcedDiagnosticsProvierTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServer\Tests\Unit\DiagnosticsProvider;
+
+use Amp\CancellationTokenSource;
+use Phpactor\Extension\LanguageServer\DiagnosticProvider\OutsourcedDiagnosticsProvider;
+use Phpactor\Extension\LanguageServer\Tests\Unit\LanguageServerTestCase;
+use Phpactor\LanguageServer\Test\ProtocolFactory;
+use function Amp\Promise\wait;
+
+class OutsourcedDiagnosticsProvierTest extends LanguageServerTestCase
+{
+    public function testDiagnostics(): void
+    {
+        $provider = new OutsourcedDiagnosticsProvider([
+            __DIR__ . '/../../../../../../bin/phpactor',
+            'language-server:diagnostics',
+        ]);
+        $diagnostics = wait($provider->provideDiagnostics(
+            ProtocolFactory::textDocumentItem('file:///foo', '<?php echo Hello::class'),
+            (new CancellationTokenSource())->getToken()
+        ));
+        self::assertCount(1, $diagnostics);
+        self::assertEquals('Class "Hello" not found', $diagnostics[0]->message);
+    }
+}

--- a/lib/Extension/LanguageServer/Tests/Unit/LanguageServerTestCase.php
+++ b/lib/Extension/LanguageServer/Tests/Unit/LanguageServerTestCase.php
@@ -44,7 +44,9 @@ class LanguageServerTestCase extends TestCase
      */
     protected function createTester(?InitializeParams $params = null, array $config = []): LanguageServerTester
     {
-        $builder = $this->createContainer($config)->get(
+        $builder = $this->createContainer(array_merge($config, [
+            LanguageServerExtension::PARAM_DIAGNOSTIC_OUTSOURCE => false,
+        ]))->get(
             LanguageServerBuilder::class
         );
 

--- a/lib/Extension/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
+++ b/lib/Extension/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
@@ -321,7 +321,7 @@ class LanguageServerCodeTransformExtension implements Extension
                 'Fix PSR namespace and class name'
             );
         }, [
-            LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => DiagnosticProviderTag::create('transformer', false),
+            LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => DiagnosticProviderTag::create('transformer', true),
             LanguageServerExtension::TAG_CODE_ACTION_PROVIDER => []
         ]);
 

--- a/lib/Extension/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
+++ b/lib/Extension/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
@@ -44,6 +44,7 @@ use Phpactor\Extension\LanguageServerCodeTransform\LspCommand\ImportNameCommand;
 use Phpactor\Extension\LanguageServerCodeTransform\LspCommand\TransformCommand;
 use Phpactor\Extension\LanguageServerCodeTransform\Model\NameImport\CandidateFinder;
 use Phpactor\Extension\LanguageServerCodeTransform\Model\NameImport\NameImporter;
+use Phpactor\Extension\LanguageServer\Container\DiagnosticProviderTag;
 use Phpactor\Extension\LanguageServer\LanguageServerExtension;
 use Phpactor\Extension\WorseReflection\WorseReflectionExtension;
 use Phpactor\Indexer\Model\SearchClient;
@@ -278,9 +279,7 @@ class LanguageServerCodeTransformExtension implements Extension
                 $container->get('worse_reflection.tolerant_parser')
             );
         }, [
-            LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => [
-                'channel' => 'phpactor',
-            ],
+            LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => DiagnosticProviderTag::create('create-class', outsource: true),
             LanguageServerExtension::TAG_CODE_ACTION_PROVIDER => []
         ]);
 
@@ -311,9 +310,7 @@ class LanguageServerCodeTransformExtension implements Extension
                 'Implement contracts'
             );
         }, [
-            LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => [
-                'channel' => 'phpactor',
-            ],
+            LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => DiagnosticProviderTag::create('implement-contracts', outsource: true),
             LanguageServerExtension::TAG_CODE_ACTION_PROVIDER => []
         ]);
 

--- a/lib/Extension/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
+++ b/lib/Extension/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
@@ -321,9 +321,7 @@ class LanguageServerCodeTransformExtension implements Extension
                 'Fix PSR namespace and class name'
             );
         }, [
-            LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => [
-                'channel' => 'phpactor',
-            ],
+            LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => DiagnosticProviderTag::create('transformer', false),
             LanguageServerExtension::TAG_CODE_ACTION_PROVIDER => []
         ]);
 

--- a/lib/Extension/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
+++ b/lib/Extension/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
@@ -278,7 +278,9 @@ class LanguageServerCodeTransformExtension implements Extension
                 $container->get('worse_reflection.tolerant_parser')
             );
         }, [
-            LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => [],
+            LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => [
+                'channel' => 'phpactor',
+            ],
             LanguageServerExtension::TAG_CODE_ACTION_PROVIDER => []
         ]);
 
@@ -309,7 +311,9 @@ class LanguageServerCodeTransformExtension implements Extension
                 'Implement contracts'
             );
         }, [
-            LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => [],
+            LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => [
+                'channel' => 'phpactor',
+            ],
             LanguageServerExtension::TAG_CODE_ACTION_PROVIDER => []
         ]);
 
@@ -320,7 +324,9 @@ class LanguageServerCodeTransformExtension implements Extension
                 'Fix PSR namespace and class name'
             );
         }, [
-            LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => [],
+            LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => [
+                'channel' => 'phpactor',
+            ],
             LanguageServerExtension::TAG_CODE_ACTION_PROVIDER => []
         ]);
 

--- a/lib/Extension/LanguageServerCodeTransform/Tests/IntegrationTestCase.php
+++ b/lib/Extension/LanguageServerCodeTransform/Tests/IntegrationTestCase.php
@@ -41,6 +41,7 @@ class IntegrationTestCase extends TestCase
             LanguageServerBridgeExtension::class,
             TestLanguageServerSessionExtension::class,
         ], array_merge([
+            LanguageServerExtension::PARAM_DIAGNOSTIC_OUTSOURCE => false,
             FilePathResolverExtension::PARAM_APPLICATION_ROOT => __DIR__ .'/../../',
             WorseReflectionExtension::PARAM_STUB_DIR => __DIR__. '/Empty',
             WorseReflectionExtension::PARAM_STUB_CACHE_DIR => __DIR__ . '/Workspace/wr-cache',

--- a/lib/Extension/LanguageServerDiagnostics/LanguageServerDiagnosticsExtension.php
+++ b/lib/Extension/LanguageServerDiagnostics/LanguageServerDiagnosticsExtension.php
@@ -7,6 +7,7 @@ use Phpactor\Container\ContainerBuilder;
 use Phpactor\Container\Extension;
 use Phpactor\Extension\LanguageServerDiagnostics\Model\PhpLinter;
 use Phpactor\Extension\LanguageServerDiagnostics\Provider\PhpLintDiagnosticProvider;
+use Phpactor\Extension\LanguageServer\Container\DiagnosticProviderTag;
 use Phpactor\Extension\LanguageServer\LanguageServerExtension;
 use Phpactor\MapResolver\Resolver;
 use Phpactor\TextDocument\TextDocumentLocator;
@@ -21,10 +22,7 @@ class LanguageServerDiagnosticsExtension implements Extension
                 $container->get(TextDocumentLocator::class)
             );
         }, [
-            LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => [
-                'name' => 'php',
-                'channel' => 'phpactor',
-            ]
+            LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => DiagnosticProviderTag::create('php')
         ]);
     }
 

--- a/lib/Extension/LanguageServerDiagnostics/LanguageServerDiagnosticsExtension.php
+++ b/lib/Extension/LanguageServerDiagnostics/LanguageServerDiagnosticsExtension.php
@@ -22,7 +22,8 @@ class LanguageServerDiagnosticsExtension implements Extension
             );
         }, [
             LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => [
-                'name' => 'php'
+                'name' => 'php',
+                'channel' => 'phpactor',
             ]
         ]);
     }

--- a/lib/Extension/LanguageServerPhpCsFixer/LanguageServerPhpCsFixerExtension.php
+++ b/lib/Extension/LanguageServerPhpCsFixer/LanguageServerPhpCsFixerExtension.php
@@ -10,6 +10,7 @@ use Phpactor\Extension\LanguageServerPhpCsFixer\Formatter\PhpCsFixerFormatter;
 use Phpactor\Extension\LanguageServerPhpCsFixer\LspCommand\FormatCommand;
 use Phpactor\Extension\LanguageServerPhpCsFixer\Model\PhpCsFixerProcess;
 use Phpactor\Extension\LanguageServerPhpCsFixer\Provider\PhpCsFixerDiagnosticsProvider;
+use Phpactor\Extension\LanguageServer\Container\DiagnosticProviderTag;
 use Phpactor\Extension\LanguageServer\LanguageServerExtension;
 use Phpactor\Extension\Logger\LoggingExtension;
 use Phpactor\LanguageServer\Core\Server\ClientApi;
@@ -49,10 +50,7 @@ class LanguageServerPhpCsFixerExtension implements OptionalExtension
                 LoggingExtension::channelLogger($container, 'php-cs-fixer'),
             );
         }, [
-            LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => [
-                'name' => 'php-cs-fixer',
-                'channel' => 'phpactor',
-            ],
+            LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => DiagnosticProviderTag::create('php-cs-fixer'),
             LanguageServerExtension::TAG_CODE_ACTION_PROVIDER => []
         ]);
 

--- a/lib/Extension/LanguageServerPhpCsFixer/LanguageServerPhpCsFixerExtension.php
+++ b/lib/Extension/LanguageServerPhpCsFixer/LanguageServerPhpCsFixerExtension.php
@@ -50,7 +50,8 @@ class LanguageServerPhpCsFixerExtension implements OptionalExtension
             );
         }, [
             LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => [
-                'name' => 'php-cs-fixer'
+                'name' => 'php-cs-fixer',
+                'channel' => 'phpactor',
             ],
             LanguageServerExtension::TAG_CODE_ACTION_PROVIDER => []
         ]);

--- a/lib/Extension/LanguageServerPhpstan/LanguageServerPhpstanExtension.php
+++ b/lib/Extension/LanguageServerPhpstan/LanguageServerPhpstanExtension.php
@@ -10,6 +10,7 @@ use Phpactor\Extension\LanguageServerPhpstan\Model\Linter\PhpstanLinter;
 use Phpactor\Extension\LanguageServerPhpstan\Model\PhpstanConfig;
 use Phpactor\Extension\LanguageServerPhpstan\Model\PhpstanProcess;
 use Phpactor\Extension\LanguageServerPhpstan\Provider\PhpstanDiagnosticProvider;
+use Phpactor\Extension\LanguageServer\Container\DiagnosticProviderTag;
 use Phpactor\Extension\LanguageServer\LanguageServerExtension;
 use Phpactor\Extension\Logger\LoggingExtension;
 use Phpactor\Extension\FilePathResolver\FilePathResolverExtension;
@@ -28,9 +29,7 @@ class LanguageServerPhpstanExtension implements OptionalExtension
                 $container->get(Linter::class)
             );
         }, [
-            LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER=> [
-                'name' => 'phpstan',
-            ],
+            LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER=> DiagnosticProviderTag::create('phpstan'),
         ]);
 
         $container->register(Linter::class, function (Container $container) {

--- a/lib/Extension/LanguageServerPhpstan/LanguageServerPhpstanExtension.php
+++ b/lib/Extension/LanguageServerPhpstan/LanguageServerPhpstanExtension.php
@@ -29,7 +29,7 @@ class LanguageServerPhpstanExtension implements OptionalExtension
             );
         }, [
             LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER=> [
-                'name' => 'phpstan'
+                'name' => 'phpstan',
             ],
         ]);
 

--- a/lib/Extension/LanguageServerPsalm/LanguageServerPsalmExtension.php
+++ b/lib/Extension/LanguageServerPsalm/LanguageServerPsalmExtension.php
@@ -10,6 +10,7 @@ use Phpactor\Extension\LanguageServerPsalm\Model\Linter;
 use Phpactor\Extension\LanguageServerPsalm\Model\Linter\PsalmLinter;
 use Phpactor\Extension\LanguageServerPsalm\Model\PsalmConfig;
 use Phpactor\Extension\LanguageServerPsalm\Model\PsalmProcess;
+use Phpactor\Extension\LanguageServer\Container\DiagnosticProviderTag;
 use Phpactor\Extension\LanguageServer\LanguageServerExtension;
 use Phpactor\Extension\Logger\LoggingExtension;
 use Phpactor\Extension\FilePathResolver\FilePathResolverExtension;

--- a/lib/Extension/LanguageServerPsalm/LanguageServerPsalmExtension.php
+++ b/lib/Extension/LanguageServerPsalm/LanguageServerPsalmExtension.php
@@ -28,7 +28,8 @@ class LanguageServerPsalmExtension implements OptionalExtension
                 $container->get(Linter::class)
             );
         }, [
-            LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => [],
+            LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => [
+            ],
         ]);
 
         $container->register(Linter::class, function (Container $container) {

--- a/lib/Extension/LanguageServerPsalm/LanguageServerPsalmExtension.php
+++ b/lib/Extension/LanguageServerPsalm/LanguageServerPsalmExtension.php
@@ -28,8 +28,7 @@ class LanguageServerPsalmExtension implements OptionalExtension
                 $container->get(Linter::class)
             );
         }, [
-            LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => [
-            ],
+            LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => DiagnosticProviderTag::create('psalm'),
         ]);
 
         $container->register(Linter::class, function (Container $container) {

--- a/lib/Extension/LanguageServerWorseReflection/LanguageServerWorseReflectionExtension.php
+++ b/lib/Extension/LanguageServerWorseReflection/LanguageServerWorseReflectionExtension.php
@@ -59,6 +59,8 @@ class LanguageServerWorseReflectionExtension implements Extension
 
         $container->register(WorseDiagnosticProvier::class, function (Container $container) {
             return new WorseDiagnosticProvider($container->get(WorseReflectionExtension::SERVICE_REFLECTOR));
-        }, [ LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => [] ]);
+        }, [ LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => [
+                'channel' => 'phpactor',
+        ] ]);
     }
 }

--- a/lib/Extension/LanguageServerWorseReflection/LanguageServerWorseReflectionExtension.php
+++ b/lib/Extension/LanguageServerWorseReflection/LanguageServerWorseReflectionExtension.php
@@ -60,6 +60,6 @@ class LanguageServerWorseReflectionExtension implements Extension
 
         $container->register(WorseDiagnosticProvier::class, function (Container $container) {
             return new WorseDiagnosticProvider($container->get(WorseReflectionExtension::SERVICE_REFLECTOR));
-        }, [ LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => DiagnosticProviderTag::create('code-action') ]);
+        }, [ LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => DiagnosticProviderTag::create('code-action', true) ]);
     }
 }

--- a/lib/Extension/LanguageServerWorseReflection/LanguageServerWorseReflectionExtension.php
+++ b/lib/Extension/LanguageServerWorseReflection/LanguageServerWorseReflectionExtension.php
@@ -9,6 +9,7 @@ use Phpactor\Extension\LanguageServerWorseReflection\DiagnosticProvider\WorseDia
 use Phpactor\Extension\LanguageServerWorseReflection\SourceLocator\WorkspaceSourceLocator;
 use Phpactor\Extension\LanguageServerWorseReflection\Workspace\WorkspaceIndex;
 use Phpactor\Extension\LanguageServerWorseReflection\Workspace\WorkspaceIndexListener;
+use Phpactor\Extension\LanguageServer\Container\DiagnosticProviderTag;
 use Phpactor\Extension\LanguageServer\LanguageServerExtension;
 use Phpactor\Extension\WorseReflection\WorseReflectionExtension;
 use Phpactor\MapResolver\Resolver;
@@ -59,8 +60,6 @@ class LanguageServerWorseReflectionExtension implements Extension
 
         $container->register(WorseDiagnosticProvier::class, function (Container $container) {
             return new WorseDiagnosticProvider($container->get(WorseReflectionExtension::SERVICE_REFLECTOR));
-        }, [ LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => [
-                'channel' => 'phpactor',
-        ] ]);
+        }, [ LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => DiagnosticProviderTag::create('code-action') ]);
     }
 }

--- a/lib/TextDocument/Tests/Unit/TextDocumentBuilderTest.php
+++ b/lib/TextDocument/Tests/Unit/TextDocumentBuilderTest.php
@@ -36,6 +36,7 @@ class TextDocumentBuilderTest extends TestCase
 
         $this->assertEquals('foobar', $doc->__toString());
         $this->assertEquals('file:///foobar/asd', $doc->uri()->__toString());
+        $this->assertEquals('/foobar/asd', $doc->uri()->path());
         $this->assertEquals('foo', $doc->language()->__toString());
     }
 

--- a/lib/TextDocument/Tests/Unit/TextDocumentBuilderTest.php
+++ b/lib/TextDocument/Tests/Unit/TextDocumentBuilderTest.php
@@ -36,7 +36,7 @@ class TextDocumentBuilderTest extends TestCase
 
         $this->assertEquals('foobar', $doc->__toString());
         $this->assertEquals('file:///foobar/asd', $doc->uri()->__toString());
-        $this->assertEquals('/foobar/asd', $doc->uri()->path());
+        $this->assertEquals('/foobar/asd', $doc->uri()?->path());
         $this->assertEquals('foo', $doc->language()->__toString());
     }
 

--- a/lib/WorseReflection/Core/Type/IntType.php
+++ b/lib/WorseReflection/Core/Type/IntType.php
@@ -29,14 +29,14 @@ class IntType extends NumericType implements BitwiseOperable, HasEmptyType
         return new BooleanType();
     }
 
-    public function bitwiseXor(Type $right): Type
-    {
-        if ($right instanceof IntType && $right instanceof Literal && $this instanceof Literal) {
-            return $this->withValue($this->value() ^ $right->value());
-        }
-
-        return new BooleanType();
+public function bitwiseXor(Type $right): Type
+{
+    if ($right instanceof IntType && $right instanceof Literal && $this instanceof Literal) {
+        return $this->withValue($this->value() ^ $right->value());
     }
+
+    return new BooleanType();
+}
 
     public function bitwiseOr(Type $right): Type
     {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1351,11 +1351,6 @@ parameters:
 			path: lib/CodeTransform/Domain/SourceCode.php
 
 		-
-			message: "#^Parameter \\#2 \\$path of class Phpactor\\\\CodeTransform\\\\Domain\\\\SourceCode constructor expects Phpactor\\\\TextDocument\\\\TextDocumentUri, Phpactor\\\\TextDocument\\\\TextDocumentUri\\|null given\\.$#"
-			count: 1
-			path: lib/CodeTransform/Domain/SourceCode.php
-
-		-
 			message: "#^Method Phpactor\\\\CodeTransform\\\\Domain\\\\Transformers\\:\\:in\\(\\) has parameter \\$transformerNames with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: lib/CodeTransform/Domain/Transformers.php
@@ -4902,11 +4897,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$workspace of class Phpactor\\\\LanguageServer\\\\Handler\\\\TextDocument\\\\CodeActionHandler constructor expects Phpactor\\\\LanguageServer\\\\Core\\\\Workspace\\\\Workspace, mixed given\\.$#"
-			count: 1
-			path: lib/Extension/LanguageServer/LanguageServerExtension.php
-
-		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$providers of class Phpactor\\\\LanguageServer\\\\Core\\\\Diagnostics\\\\AggregateDiagnosticsProvider constructor expects Phpactor\\\\LanguageServer\\\\Core\\\\Diagnostics\\\\DiagnosticsProvider, mixed given\\.$#"
 			count: 1
 			path: lib/Extension/LanguageServer/LanguageServerExtension.php
 


### PR DESCRIPTION
This PR experiments with creating a new process to resolve diagnostics.

This has a big effect on peformance in large files (e.g. the toelrant-php-parser `Parser.php`) as diagnostics have been blocking all other LS functionality:

- `"PROF 7.2593 << request #52 [textDocument/completion]"` <- BEFORE
- `"PROF 0.8991 << request #30 [textDocument/completion]"` <- AFTER

The only real disadvantage is that unsaved files (other than the one being edited) will not be taken into account during the analysis - but this is a reasonable trade off I think.

(I originally envisioned worker "language server(s)" running in the background and syncing files to them, but meh, this delivers most of the value and doesn't suffer from stale caches or having to manage long-running processes)

TODO:

- [x] Configuration flag needs to enable / disable calling out to the worker process.
- [x] Code action providers not showing diagnostics, why?
- [ ] 
---

Additionally, I wonder if the command could be generalized to allow outsourcing things like `documentHighlight`, `codeActions` etc.