### PR TITLE
Refactor fail

### DIFF
--- a/lib/Extension/PHPUnit/FrameWalker/AssertInstanceOfWalker.php
+++ b/lib/Extension/PHPUnit/FrameWalker/AssertInstanceOfWalker.php
@@ -47,7 +47,7 @@ class AssertInstanceOfWalker implements Walker
 
         $args = FunctionArguments::fromList(
             $resolver->resolver(),
-            $frameStack->current(),
+            $frameStack,
             $callExpression->argumentExpressionList
         );
 

--- a/lib/Extension/PHPUnit/FrameWalker/AssertInstanceOfWalker.php
+++ b/lib/Extension/PHPUnit/FrameWalker/AssertInstanceOfWalker.php
@@ -10,6 +10,7 @@ use Microsoft\PhpParser\Node\QualifiedName;
 use Microsoft\PhpParser\Token;
 use Phpactor\WorseReflection\Core\Inference\Frame;
 use Phpactor\WorseReflection\Core\Inference\FrameResolver;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\FunctionArguments;
 use Phpactor\WorseReflection\Core\Inference\Variable;
 use Phpactor\WorseReflection\Core\Inference\Walker;
@@ -28,30 +29,30 @@ class AssertInstanceOfWalker implements Walker
         ];
     }
 
-    public function enter(FrameResolver $resolver, Frame $frame, Node $node): Frame
+    public function enter(FrameResolver $resolver, FrameStack $frameStack, Node $node): void
     {
-        return $frame;
+        return;
     }
 
-    public function exit(FrameResolver $resolver, Frame $frame, Node $node): Frame
+    public function exit(FrameResolver $resolver, FrameStack $frameStack, Node $node): void
     {
         if (!$this->canWalk($node)) {
-            return $frame;
+            return;
         }
 
         $callExpression = $node->parent;
         if (!$callExpression instanceof CallExpression) {
-            return $frame;
+            return;
         }
 
         $args = FunctionArguments::fromList(
             $resolver->resolver(),
-            $frame,
+            $frameStack->current(),
             $callExpression->argumentExpressionList
         );
 
         if (count($args) < 2) {
-            return $frame;
+            return;
         }
 
         $type = $args->at(0)->type();
@@ -65,14 +66,14 @@ class AssertInstanceOfWalker implements Walker
         }
 
         if (!$type instanceof ClassType) {
-            return $frame;
+            return;
         }
 
         $var = $args->at(1);
 
         $frame->locals()->set(Variable::fromSymbolContext($var->withType($type)));
 
-        return $frame;
+        return;
     }
 
     private function canWalk(Node $node): bool

--- a/lib/Extension/WorseReflection/Tests/Unit/TestExtension.php
+++ b/lib/Extension/WorseReflection/Tests/Unit/TestExtension.php
@@ -33,7 +33,7 @@ class TestExtension implements Extension
 
 class TestFrameWalker implements Walker
 {
-    public function enter(FrameResolver $builder, Frame $frame, Node $node): Frame
+    public function enter(FrameResolver $builder, Frame $frame, Node $node): void
     {
         if ($frame->locals()->byName('test_variable')->count()) {
             return $frame;
@@ -47,7 +47,7 @@ class TestFrameWalker implements Walker
         return $frame;
     }
 
-    public function exit(FrameResolver $builder, Frame $frame, Node $node): Frame
+    public function exit(FrameResolver $builder, Frame $frame, Node $node): void
     {
         return $frame;
     }

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/AssignmentToMissingPropertyProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/AssignmentToMissingPropertyProvider.php
@@ -14,6 +14,7 @@ use Phpactor\TextDocument\ByteOffsetRange;
 use Phpactor\WorseReflection\Core\DiagnosticProvider;
 use Phpactor\WorseReflection\Core\Exception\NotFound;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionClass;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionTrait;
@@ -96,7 +97,7 @@ class AssignmentToMissingPropertyProvider implements DiagnosticProvider
             ),
             $class->name()->__toString(),
             $memberName,
-            $this->resolvePropertyType($resolver, $frame, $rightOperand, $accessExpression),
+            $this->resolvePropertyType($resolver, $frameStack, $rightOperand, $accessExpression),
             $accessExpression ? true : false,
         );
     }
@@ -108,18 +109,18 @@ class AssignmentToMissingPropertyProvider implements DiagnosticProvider
 
     private function resolvePropertyType(
         NodeContextResolver $resolver,
-        Frame $frame,
+        FrameStack $frameStack,
         Expression $rightOperand,
         Node|MissingToken|null $accessExpression
     ): Type {
-        $type = $resolver->resolveNode($frame, $rightOperand)->type();
+        $type = $resolver->resolveNode($frameStack, $rightOperand)->type();
 
         if (!$accessExpression instanceof Node) {
             return $type;
         }
 
         return new ArrayType(
-            $accessExpression instanceof SubscriptExpression ? null : $resolver->resolveNode($frame, $accessExpression)->type(),
+            $accessExpression instanceof SubscriptExpression ? null : $resolver->resolveNode($frameStack, $accessExpression)->type(),
             $type
         );
     }

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionConstant.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionConstant.php
@@ -5,6 +5,7 @@ namespace Phpactor\WorseReflection\Bridge\TolerantParser\Reflection;
 use Microsoft\PhpParser\Node\ConstElement;
 use Microsoft\PhpParser\Node;
 use Phpactor\TextDocument\ByteOffsetRange;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionMember;
 use Phpactor\WorseReflection\Core\Type;
 use Phpactor\WorseReflection\Core\ServiceLocator;
@@ -40,7 +41,7 @@ class ReflectionConstant extends AbstractReflectionClassMember implements CoreRe
 
     public function type(): Type
     {
-        $value = $this->serviceLocator->nodeContextResolver()->resolveNode(new Frame(), $this->node->assignment);
+        $value = $this->serviceLocator->nodeContextResolver()->resolveNode(FrameStack::new(), $this->node->assignment);
         return $value->type();
     }
 

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionDeclaredConstant.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionDeclaredConstant.php
@@ -8,6 +8,7 @@ use Microsoft\PhpParser\Node\Expression\CallExpression;
 use Microsoft\PhpParser\Node\StringLiteral;
 use Phpactor\WorseReflection\Core\DocBlock\DocBlock;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Name;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionDeclaredConstant as PhpactorReflectionDeclaredConstant;
 use Phpactor\WorseReflection\Core\SourceCode;
@@ -35,7 +36,7 @@ class ReflectionDeclaredConstant extends AbstractReflectedNode implements Phpact
 
     public function type(): Type
     {
-        return $this->serviceLocator->nodeContextResolver()->resolveNode(new Frame(), $this->value)->type();
+        return $this->serviceLocator->nodeContextResolver()->resolveNode(FrameStack::new(), $this->value)->type();
     }
 
     public function sourceCode(): SourceCode

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionEnumCase.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionEnumCase.php
@@ -7,6 +7,7 @@ use Microsoft\PhpParser\Node\EnumCaseDeclaration;
 use Microsoft\PhpParser\Node\QualifiedName;
 use Microsoft\PhpParser\Token;
 use Phpactor\TextDocument\ByteOffsetRange;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionClassLike;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionMember;
 use Phpactor\WorseReflection\Core\Type;
@@ -86,7 +87,7 @@ class ReflectionEnumCase extends AbstractReflectionClassMember implements CoreRe
         return $this->serviceLocator()
                     ->nodeContextResolver()
                     ->resolveNode(
-                        new Frame(),
+                        FrameStack::new(),
                         $this->node->assignment
                     )->type();
     }

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionParameter.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionParameter.php
@@ -2,6 +2,7 @@
 
 namespace Phpactor\WorseReflection\Bridge\TolerantParser\Reflection;
 
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionFunctionLike;
 use Phpactor\WorseReflection\Core\ServiceLocator;
 use Microsoft\PhpParser\Node\Parameter;
@@ -69,7 +70,7 @@ class ReflectionParameter extends AbstractReflectedNode implements CoreReflectio
         if (null === $this->parameter->default) {
             return DefaultValue::undefined();
         }
-        $value = $this->serviceLocator->nodeContextResolver()->resolveNode(new Frame(), $this->parameter->default)->type();
+        $value = $this->serviceLocator->nodeContextResolver()->resolveNode(FrameStack::new(), $this->parameter->default)->type();
 
         return DefaultValue::fromValue(TypeUtil::valueOrNull($value));
     }

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflector/TolerantSourceCodeReflector.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflector/TolerantSourceCodeReflector.php
@@ -58,9 +58,9 @@ class TolerantSourceCodeReflector implements SourceCodeReflector
         $node = $rootNode->getDescendantNodeAtPosition($offset->toInt());
 
         $resolver = $this->serviceLocator->nodeContextResolver();
-        $frame = $this->serviceLocator->frameBuilder()->build($node);
+        $frameStack = $this->serviceLocator->frameBuilder()->build($node);
 
-        return TolerantReflectionOffset::fromFrameAndSymbolContext($frame, $resolver->resolveNode($frame, $node));
+        return TolerantReflectionOffset::fromFrameAndSymbolContext($frame, $resolver->resolveNode($frameStack, $node));
     }
 
     /**

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflector/TolerantSourceCodeReflector.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflector/TolerantSourceCodeReflector.php
@@ -60,7 +60,7 @@ class TolerantSourceCodeReflector implements SourceCodeReflector
         $resolver = $this->serviceLocator->nodeContextResolver();
         $frameStack = $this->serviceLocator->frameBuilder()->build($node);
 
-        return TolerantReflectionOffset::fromFrameAndSymbolContext($frame, $resolver->resolveNode($frameStack, $node));
+        return TolerantReflectionOffset::fromFrameAndSymbolContext($frameStack->current(), $resolver->resolveNode($frameStack, $node));
     }
 
     /**

--- a/lib/WorseReflection/Core/Inference/FrameResolver.php
+++ b/lib/WorseReflection/Core/Inference/FrameResolver.php
@@ -76,12 +76,12 @@ final class FrameResolver
     /**
      * @param Node|Token|MissingToken $node
      */
-    public function resolveNode(Frame $frame, $node): NodeContext
+    public function resolveNode(FrameStack $frameStack, $node): NodeContext
     {
-        $info = $this->nodeContextResolver->resolveNode($frame, $node);
+        $info = $this->nodeContextResolver->resolveNode($frameStack, $node);
 
         if ($info->issues()) {
-            $frame->problems()->add($info);
+            $frameStack->current()->problems()->add($info);
         }
 
         return $info;

--- a/lib/WorseReflection/Core/Inference/FrameStack.php
+++ b/lib/WorseReflection/Core/Inference/FrameStack.php
@@ -32,7 +32,7 @@ final class FrameStack
     public function newFrame(): self
     {
         $this->frames[] = $this->current;
-        $this->current = new Frame();
+        $this->current = new Frame(null, null, null, $this->current);
 
         return $this;
     }

--- a/lib/WorseReflection/Core/Inference/FrameStack.php
+++ b/lib/WorseReflection/Core/Inference/FrameStack.php
@@ -2,6 +2,49 @@
 
 namespace Phpactor\WorseReflection\Core\Inference;
 
+use RuntimeException;
+
 final class FrameStack
 {
+    private Frame $current;
+
+    /**
+     * @var Frame[]
+     */
+    private array $frames;
+
+    private function __construct(Frame $initial)
+    {
+        $this->current = $initial;
+        $this->frames = [];
+    }
+
+    public static function new(): self
+    {
+        return new self(new Frame());
+    }
+
+    public function current(): Frame
+    {
+        return $this->current;
+    }
+
+    public function newFrame(): self
+    {
+        $this->frames[] = $this->current;
+        $this->current = new Frame();
+
+        return $this;
+    }
+
+    public function popFrame(): void
+    {
+        $current = array_pop($this->frames);
+        if (null === $current) {
+            throw new RuntimeException(
+                'Cannot pop frame because there are no frames to pop from'
+            );
+        }
+        $this->current = $current;
+    }
 }

--- a/lib/WorseReflection/Core/Inference/FunctionArguments.php
+++ b/lib/WorseReflection/Core/Inference/FunctionArguments.php
@@ -16,7 +16,7 @@ class FunctionArguments implements IteratorAggregate, Countable
     /**
      * @param ArgumentExpression[] $arguments
      */
-    public function __construct(private NodeContextResolver $resolver, private Frame $frame, private array $arguments)
+    public function __construct(private NodeContextResolver $resolver, private FrameStack $frame, private array $arguments)
     {
     }
 
@@ -27,12 +27,12 @@ class FunctionArguments implements IteratorAggregate, Countable
         }, iterator_to_array($this->getIterator())));
     }
 
-    public static function fromList(NodeContextResolver $resolver, Frame $frame, ?ArgumentExpressionList $list): self
+    public static function fromList(NodeContextResolver $resolver, FrameStack $frameStack, ?ArgumentExpressionList $list): self
     {
         if ($list === null) {
-            return new self($resolver, $frame, []);
+            return new self($resolver, $frameStack, []);
         }
-        return new self($resolver, $frame, array_values(array_filter(
+        return new self($resolver, $frameStack, array_values(array_filter(
             $list->children,
             fn ($nodeOrToken) => $nodeOrToken instanceof ArgumentExpression
         )));

--- a/lib/WorseReflection/Core/Inference/NodeContextResolver.php
+++ b/lib/WorseReflection/Core/Inference/NodeContextResolver.php
@@ -34,10 +34,10 @@ class NodeContextResolver
     /**
      * @param Node|Token|MissingToken $node
      */
-    public function resolveNode(Frame $frame, $node): NodeContext
+    public function resolveNode(FrameStack $frameStack, $node): NodeContext
     {
         try {
-            return $this->doResolveNodeWithCache($frame, $node);
+            return $this->doResolveNodeWithCache($frameStack, $node);
         } catch (CouldNotResolveNode $couldNotResolveNode) {
             return NodeContextFactory::forNode($node)
                 ->withIssue($couldNotResolveNode->getMessage());
@@ -62,16 +62,16 @@ class NodeContextResolver
      *
      * @param Node|Token|MissingToken|array<MissingToken> $node
      */
-    private function doResolveNodeWithCache(Frame $frame, $node): NodeContext
+    private function doResolveNodeWithCache(FrameStack $frameStack, $node): NodeContext
     {
         // somehow we can get an array of missing tokens here instead of an object...
         if (!is_object($node)) {
             return NodeContext::none();
         }
 
-        $key = 'sc:'.spl_object_id($node).':'.$frame->version();
+        $key = 'sc:'.spl_object_id($node).':'.$frameStack->current()->version();
 
-        return $this->cache->getOrSet($key, function () use ($frame, $node) {
+        return $this->cache->getOrSet($key, function () use ($frameStack, $node) {
             if (false === $node instanceof Node) {
                 throw new CouldNotResolveNode(sprintf(
                     'Non-node class passed to resolveNode, got "%s"',
@@ -79,19 +79,19 @@ class NodeContextResolver
                 ));
             }
 
-            $context = $this->doResolveNode($frame, $node);
+            $context = $this->doResolveNode($frameStack, $node);
             $context = $context->withScope(new ReflectionScope($this->reflector, $node));
 
             return $context;
         });
     }
 
-    private function doResolveNode(Frame $frame, Node $node): NodeContext
+    private function doResolveNode(FrameStack $frameStack, Node $node): NodeContext
     {
         $this->logger->debug(sprintf('Resolving: %s', get_class($node)));
 
         if (isset($this->resolverMap[get_class($node)])) {
-            return $this->resolverMap[get_class($node)]->resolve($this, $frame, $node);
+            return $this->resolverMap[get_class($node)]->resolve($this, $frameStack, $node);
         }
 
         throw new CouldNotResolveNode(sprintf(

--- a/lib/WorseReflection/Core/Inference/NodeContextResolver.php
+++ b/lib/WorseReflection/Core/Inference/NodeContextResolver.php
@@ -32,10 +32,13 @@ class NodeContextResolver
     }
 
     /**
-     * @param Node|Token|MissingToken $node
+     * @param Node|Token|MissingToken|null $node
      */
     public function resolveNode(FrameStack $frameStack, $node): NodeContext
     {
+        if ($node === null) {
+            return NodeContext::none();
+        }
         try {
             return $this->doResolveNodeWithCache($frameStack, $node);
         } catch (CouldNotResolveNode $couldNotResolveNode) {

--- a/lib/WorseReflection/Core/Inference/Resolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver.php
@@ -6,5 +6,5 @@ use Microsoft\PhpParser\Node;
 
 interface Resolver
 {
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext;
+    public function resolve(NodeContextResolver $resolver, FrameStack $frame, Node $node): NodeContext;
 }

--- a/lib/WorseReflection/Core/Inference/Resolver/AnonymousFunctionCreationExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/AnonymousFunctionCreationExpressionResolver.php
@@ -6,6 +6,7 @@ use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\Expression\AnonymousFunctionCreationExpression;
 use Microsoft\PhpParser\Node\Parameter;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\NodeContextFactory;
 use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
@@ -15,7 +16,7 @@ use Phpactor\WorseReflection\Core\Util\NodeUtil;
 
 class AnonymousFunctionCreationExpressionResolver implements Resolver
 {
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof AnonymousFunctionCreationExpression);
         $type = NodeUtil::typeFromQualfiedNameLike(
@@ -31,7 +32,7 @@ class AnonymousFunctionCreationExpressionResolver implements Resolver
                 if (!$parameter instanceof Parameter) {
                     continue;
                 }
-                $args[] = $resolver->resolveNode($frame, $parameter)->type();
+                $args[] = $resolver->resolveNode($frameStack, $parameter)->type();
             }
         }
 

--- a/lib/WorseReflection/Core/Inference/Resolver/ArgumentExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/ArgumentExpressionResolver.php
@@ -5,15 +5,16 @@ namespace Phpactor\WorseReflection\Core\Inference\Resolver;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\Expression\ArgumentExpression;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\Resolver;
 use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
 
 class ArgumentExpressionResolver implements Resolver
 {
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof ArgumentExpression);
-        return $resolver->resolveNode($frame, $node->expression);
+        return $resolver->resolveNode($frameStack, $node->expression);
     }
 }

--- a/lib/WorseReflection/Core/Inference/Resolver/ArrayCreationExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/ArrayCreationExpressionResolver.php
@@ -33,9 +33,9 @@ class ArrayCreationExpressionResolver implements Resolver
         }
 
         foreach ($node->arrayElements->getElements() as $element) {
-            $value = $resolver->resolveNode($frame, $element->elementValue)->type();
+            $value = $resolver->resolveNode($frameStackStack, $element->elementValue)->type();
             if ($element->elementKey) {
-                $key = $resolver->resolveNode($frame, $element->elementKey)->type();
+                $key = $resolver->resolveNode($frameStackStack, $element->elementKey)->type();
                 $keyValue = TypeUtil::valueOrNull($key);
                 if (null === $keyValue) {
                     continue;

--- a/lib/WorseReflection/Core/Inference/Resolver/ArrayCreationExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/ArrayCreationExpressionResolver.php
@@ -33,9 +33,9 @@ class ArrayCreationExpressionResolver implements Resolver
         }
 
         foreach ($node->arrayElements->getElements() as $element) {
-            $value = $resolver->resolveNode($frameStackStack, $element->elementValue)->type();
+            $value = $resolver->resolveNode($frameStack, $element->elementValue)->type();
             if ($element->elementKey) {
-                $key = $resolver->resolveNode($frameStackStack, $element->elementKey)->type();
+                $key = $resolver->resolveNode($frameStack, $element->elementKey)->type();
                 $keyValue = TypeUtil::valueOrNull($key);
                 if (null === $keyValue) {
                     continue;

--- a/lib/WorseReflection/Core/Inference/Resolver/ArrayCreationExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/ArrayCreationExpressionResolver.php
@@ -5,6 +5,7 @@ namespace Phpactor\WorseReflection\Core\Inference\Resolver;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\Expression\ArrayCreationExpression;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\NodeContextFactory;
 use Phpactor\WorseReflection\Core\Inference\Resolver;
@@ -14,7 +15,7 @@ use Phpactor\WorseReflection\TypeUtil;
 
 class ArrayCreationExpressionResolver implements Resolver
 {
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof ArrayCreationExpression);
 

--- a/lib/WorseReflection/Core/Inference/Resolver/ArrowFunctionCreationExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/ArrowFunctionCreationExpressionResolver.php
@@ -32,12 +32,12 @@ class ArrowFunctionCreationExpressionResolver implements Resolver
                 if (!$parameter instanceof Parameter) {
                     continue;
                 }
-                $args[] = $resolver->resolveNode($frame, $parameter)->type();
+                $args[] = $resolver->resolveNode($frameStack, $parameter)->type();
             }
         }
 
         if (!$returnType->isDefined()) {
-            $returnType = $resolver->resolveNode($frame, $node->resultExpression)->type()->generalize();
+            $returnType = $resolver->resolveNode($frameStack, $node->resultExpression)->type()->generalize();
         }
 
         return NodeContextFactory::create(

--- a/lib/WorseReflection/Core/Inference/Resolver/ArrowFunctionCreationExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/ArrowFunctionCreationExpressionResolver.php
@@ -6,6 +6,7 @@ use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\Expression\ArrowFunctionCreationExpression;
 use Microsoft\PhpParser\Node\Parameter;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\NodeContextFactory;
 use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
@@ -15,7 +16,7 @@ use Phpactor\WorseReflection\Core\Util\NodeUtil;
 
 class ArrowFunctionCreationExpressionResolver implements Resolver
 {
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof ArrowFunctionCreationExpression);
         $returnType = NodeUtil::typeFromQualfiedNameLike(

--- a/lib/WorseReflection/Core/Inference/Resolver/AssignmentExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/AssignmentExpressionResolver.php
@@ -11,6 +11,7 @@ use Microsoft\PhpParser\Node\Expression\Variable;
 use Microsoft\PhpParser\Node\Expression\ListIntrinsicExpression;
 use Microsoft\PhpParser\Node\Expression\MemberAccessExpression;
 use Microsoft\PhpParser\Node\Expression\SubscriptExpression;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Microsoft\PhpParser\Node\Expression\AssignmentExpression;
 use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
@@ -36,7 +37,7 @@ use Phpactor\WorseReflection\TypeUtil;
 
 class AssignmentExpressionResolver implements Resolver
 {
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         $context = NodeContextFactory::create('assignment', $node->getStartPosition(), $node->getEndPosition());
         assert($node instanceof AssignmentExpression);

--- a/lib/WorseReflection/Core/Inference/Resolver/AssignmentExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/AssignmentExpressionResolver.php
@@ -42,7 +42,8 @@ class AssignmentExpressionResolver implements Resolver
         $context = NodeContextFactory::create('assignment', $node->getStartPosition(), $node->getEndPosition());
         assert($node instanceof AssignmentExpression);
 
-        $rightContext = $resolver->resolveNode($frame, $node->rightOperand);
+        $rightContext = $resolver->resolveNode($frameStack, $node->rightOperand);
+        $frame = $frameStack->current();
 
         if ($this->hasMissingTokens($node)) {
             return $context;

--- a/lib/WorseReflection/Core/Inference/Resolver/BinaryExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/BinaryExpressionResolver.php
@@ -10,6 +10,7 @@ use Microsoft\PhpParser\Node\Expression\Variable;
 use Microsoft\PhpParser\Node\ReservedWord;
 use Microsoft\PhpParser\TokenKind;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\NodeContextFactory;
 use Phpactor\WorseReflection\Core\Inference\Resolver;
@@ -31,7 +32,7 @@ use Phpactor\WorseReflection\TypeUtil;
 
 class BinaryExpressionResolver implements Resolver
 {
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof BinaryExpression);
 

--- a/lib/WorseReflection/Core/Inference/Resolver/BinaryExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/BinaryExpressionResolver.php
@@ -46,8 +46,8 @@ class BinaryExpressionResolver implements Resolver
             ]
         );
 
-        $left = $resolver->resolveNode($frame, $node->leftOperand);
-        $right = $resolver->resolveNode($frame, $node->rightOperand);
+        $left = $resolver->resolveNode($frameStack, $node->leftOperand);
+        $right = $resolver->resolveNode($frameStack, $node->rightOperand);
 
         // merge type assertions from left AND right
         $context = $context->withTypeAssertions(
@@ -68,7 +68,7 @@ class BinaryExpressionResolver implements Resolver
         $leftOperand = $node->leftOperand;
         if ($leftOperand instanceof UnaryExpression) {
             $leftOperand = $leftOperand->operand;
-            $left = $resolver->resolveNode($frame, $leftOperand);
+            $left = $resolver->resolveNode($frameStack, $leftOperand);
         }
 
         if (!$leftOperand instanceof Node) {

--- a/lib/WorseReflection/Core/Inference/Resolver/BinaryExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/BinaryExpressionResolver.php
@@ -101,7 +101,7 @@ class BinaryExpressionResolver implements Resolver
             $operator
         );
 
-        $this->addVariable($operator, $frame, $leftOperand, $context);
+        $this->addVariable($operator, $frameStack->current(), $leftOperand, $context);
 
         return $context;
     }

--- a/lib/WorseReflection/Core/Inference/Resolver/CallExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/CallExpressionResolver.php
@@ -9,6 +9,7 @@ use Microsoft\PhpParser\Node\Expression\Variable;
 use Phpactor\TextDocument\ByteOffsetRange;
 use Phpactor\WorseReflection\Core\Inference\Context\FunctionCallContext;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\FunctionArguments;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\NodeContextFactory;
@@ -23,7 +24,7 @@ use Phpactor\WorseReflection\Core\Util\NodeUtil;
 
 class CallExpressionResolver implements Resolver
 {
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof CallExpression);
         $resolvableNode = $node->callableExpression;

--- a/lib/WorseReflection/Core/Inference/Resolver/CallExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/CallExpressionResolver.php
@@ -8,7 +8,7 @@ use Microsoft\PhpParser\Node\Expression\ParenthesizedExpression;
 use Microsoft\PhpParser\Node\Expression\Variable;
 use Phpactor\TextDocument\ByteOffsetRange;
 use Phpactor\WorseReflection\Core\Inference\Context\FunctionCallContext;
-use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FramStacke;
 use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\FunctionArguments;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
@@ -29,7 +29,7 @@ class CallExpressionResolver implements Resolver
         assert($node instanceof CallExpression);
         $resolvableNode = $node->callableExpression;
 
-        $context = $resolver->resolveNode($frame, $resolvableNode);
+        $context = $resolver->resolveNode($frameStack, $resolvableNode);
         $returnType = $context->type();
         $containerType = $context->containerType();
 
@@ -75,7 +75,7 @@ class CallExpressionResolver implements Resolver
         Type $containerType,
         NodeContext $context,
         NodeContextResolver $resolver,
-        Frame $frame,
+        FrameStack $frameStack,
         CallExpression $node
     ): NodeContext {
         if ($containerType instanceof ReflectedClassType) {

--- a/lib/WorseReflection/Core/Inference/Resolver/CallExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/CallExpressionResolver.php
@@ -34,7 +34,7 @@ class CallExpressionResolver implements Resolver
         $containerType = $context->containerType();
 
         if ($returnType instanceof ConditionalType) {
-            $context = $this->processConditionalType($returnType, $containerType, $context, $resolver, $frame, $node);
+            $context = $this->processConditionalType($returnType, $containerType, $context, $resolver, $frameStack, $node);
         }
 
         if ($resolvableNode instanceof ParenthesizedExpression && $returnType instanceof ReflectedClassType && $returnType->isInvokable()) {

--- a/lib/WorseReflection/Core/Inference/Resolver/CallExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/CallExpressionResolver.php
@@ -86,7 +86,7 @@ class CallExpressionResolver implements Resolver
             $method = $reflection->methods()->get($context->symbol()->name());
             return $context->withType($type->evaluate(
                 $method,
-                FunctionArguments::fromList($resolver, $frame, $node->argumentExpressionList)
+                FunctionArguments::fromList($resolver, $frameStack, $node->argumentExpressionList)
             ));
         }
 
@@ -101,7 +101,7 @@ class CallExpressionResolver implements Resolver
                 $function
             ))->withType($type->evaluate(
                 $function,
-                FunctionArguments::fromList($resolver, $frame, $node->argumentExpressionList)
+                FunctionArguments::fromList($resolver, $frameStack, $node->argumentExpressionList)
             ));
         }
 

--- a/lib/WorseReflection/Core/Inference/Resolver/CastExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/CastExpressionResolver.php
@@ -5,6 +5,7 @@ namespace Phpactor\WorseReflection\Core\Inference\Resolver;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\Expression\CastExpression;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\NodeContextFactory;
 use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
@@ -14,7 +15,7 @@ use Phpactor\WorseReflection\Core\Util\NodeUtil;
 
 class CastExpressionResolver implements Resolver
 {
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof CastExpression);
 

--- a/lib/WorseReflection/Core/Inference/Resolver/CatchClauseResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/CatchClauseResolver.php
@@ -27,7 +27,7 @@ class CatchClauseResolver implements Resolver
         }
 
         /** @phpstan-ignore-next-line Lies */
-        $type = $resolver->resolveNode($frame, $node->qualifiedNameList)->type();
+        $type = $resolver->resolveNode($frameStack, $node->qualifiedNameList)->type();
         $variableName = $node->variableName;
 
         if (null === $variableName) {

--- a/lib/WorseReflection/Core/Inference/Resolver/CatchClauseResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/CatchClauseResolver.php
@@ -5,6 +5,7 @@ namespace Phpactor\WorseReflection\Core\Inference\Resolver;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\DelimitedList\QualifiedNameList;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\NodeContextFactory;
 use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
@@ -15,7 +16,7 @@ use Phpactor\WorseReflection\Core\Inference\Symbol;
 
 class CatchClauseResolver implements Resolver
 {
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         $context = NodeContextFactory::create('catch', $node->getStartPosition(), $node->getEndPosition());
         assert($node instanceof CatchClause);

--- a/lib/WorseReflection/Core/Inference/Resolver/CatchClauseResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/CatchClauseResolver.php
@@ -18,6 +18,7 @@ class CatchClauseResolver implements Resolver
 {
     public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
+        $frame = $frameStack->current();
         $context = NodeContextFactory::create('catch', $node->getStartPosition(), $node->getEndPosition());
         assert($node instanceof CatchClause);
 

--- a/lib/WorseReflection/Core/Inference/Resolver/ClassLikeResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/ClassLikeResolver.php
@@ -8,6 +8,7 @@ use Microsoft\PhpParser\Node\Statement\EnumDeclaration;
 use Microsoft\PhpParser\Node\Statement\InterfaceDeclaration;
 use Microsoft\PhpParser\Node\Statement\TraitDeclaration;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\NodeContextFactory;
 use Phpactor\WorseReflection\Core\Inference\Resolver;
@@ -17,7 +18,7 @@ use Phpactor\WorseReflection\Core\TypeFactory;
 
 class ClassLikeResolver implements Resolver
 {
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert(
             $node instanceof ClassDeclaration ||

--- a/lib/WorseReflection/Core/Inference/Resolver/CloneExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/CloneExpressionResolver.php
@@ -15,6 +15,6 @@ class CloneExpressionResolver implements Resolver
     public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof CloneExpression);
-        return $resolver->resolveNode($frame, $node->expression);
+        return $resolver->resolveNode($frameStack, $node->expression);
     }
 }

--- a/lib/WorseReflection/Core/Inference/Resolver/CloneExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/CloneExpressionResolver.php
@@ -5,13 +5,14 @@ namespace Phpactor\WorseReflection\Core\Inference\Resolver;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\Expression\CloneExpression;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\Resolver;
 use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
 
 class CloneExpressionResolver implements Resolver
 {
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof CloneExpression);
         return $resolver->resolveNode($frame, $node->expression);

--- a/lib/WorseReflection/Core/Inference/Resolver/CompoundStatementResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/CompoundStatementResolver.php
@@ -17,7 +17,7 @@ class CompoundStatementResolver implements Resolver
     {
         assert($node instanceof CompoundStatementNode);
         foreach ($node->statements as $statement) {
-            $resolver->resolveNode($frame, $statement);
+            $resolver->resolveNode($frameStack, $statement);
         }
 
         return NodeContextFactory::forNode($node);

--- a/lib/WorseReflection/Core/Inference/Resolver/CompoundStatementResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/CompoundStatementResolver.php
@@ -5,6 +5,7 @@ namespace Phpactor\WorseReflection\Core\Inference\Resolver;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\Statement\CompoundStatementNode;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\NodeContextFactory;
 use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
@@ -12,7 +13,7 @@ use Phpactor\WorseReflection\Core\Inference\Resolver;
 
 class CompoundStatementResolver implements Resolver
 {
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof CompoundStatementNode);
         foreach ($node->statements as $statement) {

--- a/lib/WorseReflection/Core/Inference/Resolver/ConstElementResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/ConstElementResolver.php
@@ -5,6 +5,7 @@ namespace Phpactor\WorseReflection\Core\Inference\Resolver;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\ConstElement;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\NodeContextFactory;
 use Phpactor\WorseReflection\Core\Inference\Resolver;
@@ -14,7 +15,7 @@ use Phpactor\WorseReflection\Core\Util\NodeUtil;
 
 class ConstElementResolver implements Resolver
 {
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof ConstElement);
         return NodeContextFactory::create(

--- a/lib/WorseReflection/Core/Inference/Resolver/EnumCaseDeclarationResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/EnumCaseDeclarationResolver.php
@@ -5,6 +5,7 @@ namespace Phpactor\WorseReflection\Core\Inference\Resolver;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\EnumCaseDeclaration;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\NodeContextFactory;
 use Phpactor\WorseReflection\Core\Inference\Resolver;
@@ -14,7 +15,7 @@ use Phpactor\WorseReflection\Core\Util\NodeUtil;
 
 class EnumCaseDeclarationResolver implements Resolver
 {
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof EnumCaseDeclaration);
         return NodeContextFactory::create(

--- a/lib/WorseReflection/Core/Inference/Resolver/ExpressionStatementResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/ExpressionStatementResolver.php
@@ -5,6 +5,7 @@ namespace Phpactor\WorseReflection\Core\Inference\Resolver;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\Statement\ExpressionStatement;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\NodeContextFactory;
 use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
@@ -12,7 +13,7 @@ use Phpactor\WorseReflection\Core\Inference\Resolver;
 
 class ExpressionStatementResolver implements Resolver
 {
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof ExpressionStatement);
         $resolver->resolveNode($frame, $node->expression);

--- a/lib/WorseReflection/Core/Inference/Resolver/ExpressionStatementResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/ExpressionStatementResolver.php
@@ -16,7 +16,7 @@ class ExpressionStatementResolver implements Resolver
     public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof ExpressionStatement);
-        $resolver->resolveNode($frame, $node->expression);
+        $resolver->resolveNode($frameStack, $node->expression);
         return NodeContextFactory::forNode($node);
     }
 }

--- a/lib/WorseReflection/Core/Inference/Resolver/ForeachStatementResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/ForeachStatementResolver.php
@@ -8,6 +8,7 @@ use Microsoft\PhpParser\Node\Expression\ArrayCreationExpression;
 use Microsoft\PhpParser\Node\ForeachKey;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\Statement\CompoundStatementNode;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
 use Phpactor\WorseReflection\Core\Inference\Frame;
 use Microsoft\PhpParser\Node\Statement\ForeachStatement;
@@ -28,7 +29,7 @@ use Phpactor\WorseReflection\Core\Type\UnionType;
 
 class ForeachStatementResolver implements Resolver
 {
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof ForeachStatement);
         $context = NodeContextFactory::forNode($node);

--- a/lib/WorseReflection/Core/Inference/Resolver/FunctionDeclarationResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/FunctionDeclarationResolver.php
@@ -5,6 +5,7 @@ namespace Phpactor\WorseReflection\Core\Inference\Resolver;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\Statement\FunctionDeclaration;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\NodeContextFactory;
 use Phpactor\WorseReflection\Core\Inference\Resolver;
@@ -13,7 +14,7 @@ use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
 
 class FunctionDeclarationResolver implements Resolver
 {
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof FunctionDeclaration);
         return NodeContextFactory::create(

--- a/lib/WorseReflection/Core/Inference/Resolver/IfStatementResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/IfStatementResolver.php
@@ -110,13 +110,13 @@ class IfStatementResolver implements Resolver
         int $end
     ): void {
         $context = $resolver->resolveNode($frameStack, $node->expression);
-        $frameStack->applyTypeAssertions($context->typeAssertions(), $start);
+        $frameStack->current()->applyTypeAssertions($context->typeAssertions(), $start);
 
         foreach ($node->getChildNodes() as $child) {
             $resolver->resolveNode($frameStack, $child);
         }
 
-        $frameStack->applyTypeAssertions(
+        $frameStack->current()->applyTypeAssertions(
             $context->typeAssertions()->negate(),
             $start,
             $end

--- a/lib/WorseReflection/Core/Inference/Resolver/IfStatementResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/IfStatementResolver.php
@@ -60,7 +60,7 @@ class IfStatementResolver implements Resolver
         // evaluate the nodes in the else clause
         if ($node->elseClause) {
             foreach ($node->elseClause->getChildNodes() as $child) {
-                $resolver->resolveNode($frame, $child);
+                $resolver->resolveNode($frameStack, $child);
             }
         }
 
@@ -108,11 +108,11 @@ class IfStatementResolver implements Resolver
         int $start,
         int $end
     ): void {
-        $context = $resolver->resolveNode($frame, $node->expression);
+        $context = $resolver->resolveNode($frameStack, $node->expression);
         $frame->applyTypeAssertions($context->typeAssertions(), $start);
 
         foreach ($node->getChildNodes() as $child) {
-            $resolver->resolveNode($frame, $child);
+            $resolver->resolveNode($frameStack, $child);
         }
 
         $frame->applyTypeAssertions(
@@ -132,7 +132,7 @@ class IfStatementResolver implements Resolver
         int $start,
         int $end
     ): void {
-        $context = $resolver->resolveNode($frame, $node->expression);
+        $context = $resolver->resolveNode($frameStack, $node->expression);
         $terminates = $this->branchTerminates($resolver, $frame, $node);
 
         if ($terminates) {
@@ -180,7 +180,7 @@ class IfStatementResolver implements Resolver
                     }
 
                     if ($callExpression = $statement->getFirstDescendantNode(CallExpression::class)) {
-                        $context = $resolver->resolveNode($frame, $callExpression);
+                        $context = $resolver->resolveNode($frameStack, $callExpression);
 
                         if ($context->type() instanceof NeverType) {
                             return true;

--- a/lib/WorseReflection/Core/Inference/Resolver/IfStatementResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/IfStatementResolver.php
@@ -7,6 +7,7 @@ use Microsoft\PhpParser\Node\Expression\CallExpression;
 use Microsoft\PhpParser\Node\Expression\ExitIntrinsicExpression;
 use Microsoft\PhpParser\Node\Expression\ThrowExpression;
 use Microsoft\PhpParser\Node\Statement\ExpressionStatement;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\NodeContextFactory;
 use Phpactor\WorseReflection\Core\Inference\Resolver;
@@ -22,7 +23,7 @@ use Phpactor\WorseReflection\Core\Type\NeverType;
 
 class IfStatementResolver implements Resolver
 {
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         $context = NodeContextFactory::forNode($node);
         assert($node instanceof IfStatementNode);

--- a/lib/WorseReflection/Core/Inference/Resolver/MemberAccessExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/MemberAccessExpressionResolver.php
@@ -23,6 +23,6 @@ class MemberAccessExpressionResolver implements Resolver
 
         $class = $resolver->resolveNode($frameStack, $node->dereferencableExpression);
 
-        return $this->nodeContextFromMemberAccess->infoFromMemberAccess($resolver, $frame, $class->type(), $node);
+        return $this->nodeContextFromMemberAccess->infoFromMemberAccess($resolver, $frameStack, $class->type(), $node);
     }
 }

--- a/lib/WorseReflection/Core/Inference/Resolver/MemberAccessExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/MemberAccessExpressionResolver.php
@@ -5,6 +5,7 @@ namespace Phpactor\WorseReflection\Core\Inference\Resolver;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\Expression\MemberAccessExpression;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\Resolver;
 use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
@@ -16,7 +17,7 @@ class MemberAccessExpressionResolver implements Resolver
     {
     }
 
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof MemberAccessExpression);
 

--- a/lib/WorseReflection/Core/Inference/Resolver/MemberAccessExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/MemberAccessExpressionResolver.php
@@ -21,7 +21,7 @@ class MemberAccessExpressionResolver implements Resolver
     {
         assert($node instanceof MemberAccessExpression);
 
-        $class = $resolver->resolveNode($frame, $node->dereferencableExpression);
+        $class = $resolver->resolveNode($frameStack, $node->dereferencableExpression);
 
         return $this->nodeContextFromMemberAccess->infoFromMemberAccess($resolver, $frame, $class->type(), $node);
     }

--- a/lib/WorseReflection/Core/Inference/Resolver/MethodDeclarationResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/MethodDeclarationResolver.php
@@ -23,7 +23,7 @@ class MethodDeclarationResolver implements Resolver
 
 
         $classNode = NodeUtil::nodeContainerClassLikeDeclaration($node);
-        $classSymbolContext = $resolver->resolveNode($frame, $classNode);
+        $classSymbolContext = $resolver->resolveNode($frameStack, $classNode);
 
         return new MemberDeclarationContext(
             Symbol::fromTypeNameAndPosition(

--- a/lib/WorseReflection/Core/Inference/Resolver/MethodDeclarationResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/MethodDeclarationResolver.php
@@ -6,6 +6,7 @@ use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\MethodDeclaration;
 use Phpactor\WorseReflection\Core\Inference\Context\MemberDeclarationContext;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\Resolver;
 use Phpactor\WorseReflection\Core\Inference\Symbol;
@@ -16,7 +17,7 @@ use Phpactor\WorseReflection\Core\Util\NodeUtil;
 
 class MethodDeclarationResolver implements Resolver
 {
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof MethodDeclaration);
 

--- a/lib/WorseReflection/Core/Inference/Resolver/NumericLiteralResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/NumericLiteralResolver.php
@@ -5,6 +5,7 @@ namespace Phpactor\WorseReflection\Core\Inference\Resolver;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\NumericLiteral;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\NodeContextFactory;
 use Phpactor\WorseReflection\Core\Inference\Resolver;
@@ -16,7 +17,7 @@ use Phpactor\WorseReflection\Core\Util\NodeUtil;
 
 class NumericLiteralResolver implements Resolver
 {
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof NumericLiteral);
 

--- a/lib/WorseReflection/Core/Inference/Resolver/ObjectCreationExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/ObjectCreationExpressionResolver.php
@@ -7,6 +7,7 @@ use Microsoft\PhpParser\Node\Expression\ObjectCreationExpression;
 use Phpactor\WorseReflection\Core\Exception\CouldNotResolveNode;
 use Phpactor\WorseReflection\Core\Exception\NotFound;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\FunctionArguments;
 use Phpactor\WorseReflection\Core\Inference\GenericMapResolver;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
@@ -24,7 +25,7 @@ class ObjectCreationExpressionResolver implements Resolver
     {
     }
 
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof ObjectCreationExpression);
         if (false === $node->classTypeDesignator instanceof Node) {

--- a/lib/WorseReflection/Core/Inference/Resolver/ObjectCreationExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/ObjectCreationExpressionResolver.php
@@ -33,7 +33,7 @@ class ObjectCreationExpressionResolver implements Resolver
         }
 
 
-        $classContext = $resolver->resolveNode($frame, $node->classTypeDesignator);
+        $classContext = $resolver->resolveNode($frameStack, $node->classTypeDesignator);
         $classType = $classContext->type();
 
         if ($classType instanceof ClassStringType) {

--- a/lib/WorseReflection/Core/Inference/Resolver/ObjectCreationExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/ObjectCreationExpressionResolver.php
@@ -44,14 +44,14 @@ class ObjectCreationExpressionResolver implements Resolver
         }
 
         if ($classType instanceof ClassType) {
-            return $classContext->withType($this->resolveClassType($resolver, $frame, $node, $classType));
+            return $classContext->withType($this->resolveClassType($resolver, $frameStack, $node, $classType));
         }
 
 
         return $classContext;
     }
 
-    private function resolveClassType(NodeContextResolver $resolver, Frame $frame, ObjectCreationExpression $node, ClassType $classType): Type
+    private function resolveClassType(NodeContextResolver $resolver, FrameStack $frameStack, ObjectCreationExpression $node, ClassType $classType): Type
     {
         try {
             $reflection = $resolver->reflector()->reflectClass($classType->name());
@@ -67,7 +67,7 @@ class ObjectCreationExpressionResolver implements Resolver
             return $classType;
         }
 
-        $arguments = FunctionArguments::fromList($resolver, $frame, $node->argumentExpressionList);
+        $arguments = FunctionArguments::fromList($resolver, $frameStack, $node->argumentExpressionList);
         $templateMap = $this->resolver->mergeParameters(
             $templateMap,
             $reflection->methods()->get('__construct')->parameters(),

--- a/lib/WorseReflection/Core/Inference/Resolver/ParameterResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/ParameterResolver.php
@@ -12,6 +12,7 @@ use Phpactor\WorseReflection\Core\Exception\CouldNotResolveNode;
 use Phpactor\WorseReflection\Core\Exception\ItemNotFound;
 use Phpactor\WorseReflection\Core\Exception\NotFound;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\NodeContextFactory;
 use Phpactor\WorseReflection\Core\Inference\Resolver;
@@ -23,7 +24,7 @@ use Phpactor\WorseReflection\Reflector;
 
 class ParameterResolver implements Resolver
 {
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof Parameter);
 

--- a/lib/WorseReflection/Core/Inference/Resolver/ParenthesizedExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/ParenthesizedExpressionResolver.php
@@ -15,6 +15,6 @@ class ParenthesizedExpressionResolver implements Resolver
     public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof ParenthesizedExpression);
-        return $resolver->resolveNode($frame, $node->expression);
+        return $resolver->resolveNode($frameStack, $node->expression);
     }
 }

--- a/lib/WorseReflection/Core/Inference/Resolver/ParenthesizedExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/ParenthesizedExpressionResolver.php
@@ -5,13 +5,14 @@ namespace Phpactor\WorseReflection\Core\Inference\Resolver;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\Expression\ParenthesizedExpression;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\Resolver;
 use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
 
 class ParenthesizedExpressionResolver implements Resolver
 {
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof ParenthesizedExpression);
         return $resolver->resolveNode($frame, $node->expression);

--- a/lib/WorseReflection/Core/Inference/Resolver/PostfixUpdateExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/PostfixUpdateExpressionResolver.php
@@ -6,6 +6,7 @@ use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\Expression\PostfixUpdateExpression;
 use Microsoft\PhpParser\TokenKind;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
 use Phpactor\WorseReflection\Core\Inference\Resolver;
@@ -14,7 +15,7 @@ use Phpactor\WorseReflection\Core\Type\NumericType;
 
 class PostfixUpdateExpressionResolver implements Resolver
 {
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof PostfixUpdateExpression);
         $variable = $resolver->resolveNode($frame, $node->operand);

--- a/lib/WorseReflection/Core/Inference/Resolver/PostfixUpdateExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/PostfixUpdateExpressionResolver.php
@@ -18,7 +18,7 @@ class PostfixUpdateExpressionResolver implements Resolver
     public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof PostfixUpdateExpression);
-        $variable = $resolver->resolveNode($frame, $node->operand);
+        $variable = $resolver->resolveNode($frameStack, $node->operand);
         $type = $variable->type();
         if ($type instanceof NumericType && $type instanceof Literal) {
             $value = $type->value();

--- a/lib/WorseReflection/Core/Inference/Resolver/QualifiedNameListResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/QualifiedNameListResolver.php
@@ -6,6 +6,7 @@ use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\DelimitedList\QualifiedNameList;
 use Microsoft\PhpParser\Node\QualifiedName;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\NodeContextFactory;
 use Phpactor\WorseReflection\Core\Inference\Resolver;
@@ -15,7 +16,7 @@ use Phpactor\WorseReflection\Core\Type\UnionType;
 
 class QualifiedNameListResolver implements Resolver
 {
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof QualifiedNameList);
         $types = [];

--- a/lib/WorseReflection/Core/Inference/Resolver/QualifiedNameListResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/QualifiedNameListResolver.php
@@ -28,7 +28,7 @@ class QualifiedNameListResolver implements Resolver
             if (null === $firstType) {
                 $firstType = $child;
             }
-            $types[] = $resolver->resolveNode($frame, $child)->type();
+            $types[] = $resolver->resolveNode($frameStack, $child)->type();
         }
 
         $type = new UnionType(...$types);

--- a/lib/WorseReflection/Core/Inference/Resolver/QualifiedNameResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/QualifiedNameResolver.php
@@ -41,9 +41,8 @@ class QualifiedNameResolver implements Resolver
 
         $parent = $node->parent;
         if ($parent instanceof CallExpression) {
-            return $this->resolveContextFromCall($resolver, $frame, $parent, $node);
+            return $this->resolveContextFromCall($resolver, $frameStack, $parent, $node);
         }
-
 
         return $this->resolveContext($node);
     }
@@ -113,7 +112,7 @@ class QualifiedNameResolver implements Resolver
 
     private function resolveContextFromCall(
         NodeContextResolver $resolver,
-        Frame $frame,
+        FrameStack $frameStack,
         CallExpression $parent,
         QualifiedName $node
     ): NodeContext {
@@ -143,10 +142,10 @@ class QualifiedNameResolver implements Resolver
         if ($stub) {
             $arguments = FunctionArguments::fromList(
                 $resolver,
-                $frame,
+                $frameStack,
                 $parent->argumentExpressionList
             );
-            return $stub->resolve($frame, $context, $arguments);
+            return $stub->resolve($frameStack->current(), $context, $arguments);
         }
 
         // the function may have been resolved to a global, so create

--- a/lib/WorseReflection/Core/Inference/Resolver/QualifiedNameResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/QualifiedNameResolver.php
@@ -10,6 +10,7 @@ use Phpactor\WorseReflection\Core\Exception\NotFound;
 use Phpactor\WorseReflection\Core\Inference\Context\ClassLikeContext;
 use Phpactor\WorseReflection\Core\Inference\Context\FunctionCallContext;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\FunctionArguments;
 use Phpactor\WorseReflection\Core\Inference\FunctionStubRegistry;
 use Phpactor\WorseReflection\Core\Inference\NodeToTypeConverter;
@@ -34,7 +35,7 @@ class QualifiedNameResolver implements Resolver
     ) {
     }
 
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof QualifiedName);
 

--- a/lib/WorseReflection/Core/Inference/Resolver/ReservedWordResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/ReservedWordResolver.php
@@ -5,6 +5,7 @@ namespace Phpactor\WorseReflection\Core\Inference\Resolver;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\ReservedWord;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\NodeContextFactory;
 use Phpactor\WorseReflection\Core\Inference\Resolver;
@@ -15,7 +16,7 @@ use Phpactor\WorseReflection\Core\Util\NodeUtil;
 
 class ReservedWordResolver implements Resolver
 {
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof ReservedWord);
         $symbolType = $containerType = $type = $value = null;

--- a/lib/WorseReflection/Core/Inference/Resolver/ReturnStatementResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/ReturnStatementResolver.php
@@ -22,7 +22,7 @@ class ReturnStatementResolver implements Resolver
             return $context;
         }
 
-        $type = $resolver->resolveNode($frame, $node->expression)->type();
+        $type = $resolver->resolveNode($frameStack, $node->expression)->type();
         $context = $context->withType($type);
 
         if ($frame->returnType()->isVoid()) {

--- a/lib/WorseReflection/Core/Inference/Resolver/ReturnStatementResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/ReturnStatementResolver.php
@@ -15,6 +15,7 @@ class ReturnStatementResolver implements Resolver
 {
     public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
+        $frame = $frameStack->current();
         $context = NodeContextFactory::forNode($node);
         assert($node instanceof ReturnStatement);
 

--- a/lib/WorseReflection/Core/Inference/Resolver/ReturnStatementResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/ReturnStatementResolver.php
@@ -3,6 +3,7 @@
 namespace Phpactor\WorseReflection\Core\Inference\Resolver;
 
 use Microsoft\PhpParser\Node\Statement\ReturnStatement;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\NodeContextFactory;
 use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
@@ -12,7 +13,7 @@ use Phpactor\WorseReflection\Core\Inference\Frame;
 
 class ReturnStatementResolver implements Resolver
 {
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         $context = NodeContextFactory::forNode($node);
         assert($node instanceof ReturnStatement);

--- a/lib/WorseReflection/Core/Inference/Resolver/ScopedPropertyAccessResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/ScopedPropertyAccessResolver.php
@@ -44,6 +44,6 @@ class ScopedPropertyAccessResolver implements Resolver
 
         $classType = $this->nodeTypeConverter->resolve($node, (string)$name);
 
-        return $this->nodeContextFromMemberAccess->infoFromMemberAccess($resolver, $frame, $classType, $node);
+        return $this->nodeContextFromMemberAccess->infoFromMemberAccess($resolver, $frameStack, $classType, $node);
     }
 }

--- a/lib/WorseReflection/Core/Inference/Resolver/ScopedPropertyAccessResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/ScopedPropertyAccessResolver.php
@@ -6,6 +6,7 @@ use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\Expression\ScopedPropertyAccessExpression;
 use Microsoft\PhpParser\Node\Expression\Variable;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\NodeToTypeConverter;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\Resolver;
@@ -21,7 +22,7 @@ class ScopedPropertyAccessResolver implements Resolver
     ) {
     }
 
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof ScopedPropertyAccessExpression);
 

--- a/lib/WorseReflection/Core/Inference/Resolver/SourceFileNodeResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/SourceFileNodeResolver.php
@@ -4,13 +4,14 @@ namespace Phpactor\WorseReflection\Core\Inference\Resolver;
 
 use Microsoft\PhpParser\Node;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
 use Phpactor\WorseReflection\Core\Inference\Resolver;
 
 class SourceFileNodeResolver implements Resolver
 {
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         return NodeContext::none();
     }

--- a/lib/WorseReflection/Core/Inference/Resolver/StringLiteralResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/StringLiteralResolver.php
@@ -6,6 +6,7 @@ use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\StringLiteral;
 use Microsoft\PhpParser\Token;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\NodeContextFactory;
 use Phpactor\WorseReflection\Core\Inference\Resolver;
@@ -16,7 +17,7 @@ use Phpactor\WorseReflection\Core\Util\NodeUtil;
 
 class StringLiteralResolver implements Resolver
 {
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof StringLiteral);
         // TODO: [TP] tolerant parser method returns the quotes

--- a/lib/WorseReflection/Core/Inference/Resolver/SubscriptExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/SubscriptExpressionResolver.php
@@ -19,7 +19,7 @@ class SubscriptExpressionResolver implements Resolver
     public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof SubscriptExpression);
-        $info = $resolver->resolveNode($frame, $node->postfixExpression);
+        $info = $resolver->resolveNode($frameStack, $node->postfixExpression);
 
         if (null === $node->accessExpression) {
             $info = $info->withIssue(sprintf(
@@ -54,7 +54,7 @@ class SubscriptExpressionResolver implements Resolver
         }
 
         if ($node instanceof StringLiteral) {
-            $string = $resolver->resolveNode($frame, $node);
+            $string = $resolver->resolveNode($frameStack, $node);
 
             $type = $arrayLiteralType->typeAtOffset(TypeUtil::valueOrNull($string->type()));
             if (($type->isDefined())) {

--- a/lib/WorseReflection/Core/Inference/Resolver/SubscriptExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/SubscriptExpressionResolver.php
@@ -6,6 +6,7 @@ use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\Expression\SubscriptExpression;
 use Microsoft\PhpParser\Node\StringLiteral;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\Resolver;
 use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
@@ -15,7 +16,7 @@ use Phpactor\WorseReflection\TypeUtil;
 
 class SubscriptExpressionResolver implements Resolver
 {
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof SubscriptExpression);
         $info = $resolver->resolveNode($frame, $node->postfixExpression);

--- a/lib/WorseReflection/Core/Inference/Resolver/TernaryExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/TernaryExpressionResolver.php
@@ -15,6 +15,7 @@ class TernaryExpressionResolver implements Resolver
 {
     public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
+        $frame = $frameStack->current();
         assert($node instanceof TernaryExpression);
 
         $condition = $resolver->resolveNode($frameStack, $node->condition);

--- a/lib/WorseReflection/Core/Inference/Resolver/TernaryExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/TernaryExpressionResolver.php
@@ -17,7 +17,7 @@ class TernaryExpressionResolver implements Resolver
     {
         assert($node instanceof TernaryExpression);
 
-        $condition = $resolver->resolveNode($frame, $node->condition);
+        $condition = $resolver->resolveNode($frameStack, $node->condition);
         $context = NodeContextFactory::create('trinary', $node->getStartPosition(), $node->getEndPosition());
         $left = NodeContext::none();
         $right = NodeContext::none();
@@ -26,7 +26,7 @@ class TernaryExpressionResolver implements Resolver
         /** @phpstan-ignore-next-line */
         if ($node->ifExpression) {
             $frame->applyTypeAssertions($condition->typeAssertions(), $node->ifExpression->getStartPosition());
-            $left = $resolver->resolveNode($frame, $node->ifExpression);
+            $left = $resolver->resolveNode($frameStack, $node->ifExpression);
         }
 
         /** @phpstan-ignore-next-line */
@@ -37,7 +37,7 @@ class TernaryExpressionResolver implements Resolver
         /** @phpstan-ignore-next-line */
         if ($node->elseExpression) {
             $frame->applyTypeAssertions($condition->typeAssertions()->negate(), $node->elseExpression->getStartPosition());
-            $right = $resolver->resolveNode($frame, $node->elseExpression);
+            $right = $resolver->resolveNode($frameStack, $node->elseExpression);
         }
 
         $empty = $condition->type()->isEmpty();

--- a/lib/WorseReflection/Core/Inference/Resolver/TernaryExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/TernaryExpressionResolver.php
@@ -5,6 +5,7 @@ namespace Phpactor\WorseReflection\Core\Inference\Resolver;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\Expression\TernaryExpression;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\NodeContextFactory;
 use Phpactor\WorseReflection\Core\Inference\Resolver;
@@ -12,7 +13,7 @@ use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
 
 class TernaryExpressionResolver implements Resolver
 {
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof TernaryExpression);
 

--- a/lib/WorseReflection/Core/Inference/Resolver/UnaryOpExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/UnaryOpExpressionResolver.php
@@ -7,6 +7,7 @@ use Microsoft\PhpParser\Node\Expression\BinaryExpression;
 use Microsoft\PhpParser\Node\Expression\UnaryExpression;
 use Microsoft\PhpParser\TokenKind;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\NodeContextFactory;
 use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
@@ -18,7 +19,7 @@ use Phpactor\WorseReflection\TypeUtil;
 
 class UnaryOpExpressionResolver implements Resolver
 {
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof UnaryExpression);
         $operand = $resolver->resolveNode($frame, $node->operand);

--- a/lib/WorseReflection/Core/Inference/Resolver/UnaryOpExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/UnaryOpExpressionResolver.php
@@ -22,7 +22,7 @@ class UnaryOpExpressionResolver implements Resolver
     public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof UnaryExpression);
-        $operand = $resolver->resolveNode($frame, $node->operand);
+        $operand = $resolver->resolveNode($frameStack, $node->operand);
 
         // see sister hack in BinaryExpressionResolver
         // https://github.com/Microsoft/tolerant-php-parser/issues/19

--- a/lib/WorseReflection/Core/Inference/Resolver/UseVariableNameResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/UseVariableNameResolver.php
@@ -5,6 +5,7 @@ namespace Phpactor\WorseReflection\Core\Inference\Resolver;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\UseVariableName;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\NodeContextFactory;
 use Phpactor\WorseReflection\Core\Inference\Resolver;
@@ -12,7 +13,7 @@ use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
 
 class UseVariableNameResolver implements Resolver
 {
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof UseVariableName);
         $name = (string)$node->getName();

--- a/lib/WorseReflection/Core/Inference/Resolver/VariableResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/VariableResolver.php
@@ -54,7 +54,7 @@ class VariableResolver implements Resolver
         }
 
         $variableName = $node->getText();
-        $variables = $frame->locals()->byName($variableName);
+        $variables = $frameStack->current()->locals()->byName($variableName);
 
         // special handling for assignments
         if ($assignment = $node->getFirstAncestor(AssignmentExpression::class)) {
@@ -75,7 +75,7 @@ class VariableResolver implements Resolver
 
 
         $context = NodeContextFactory::forVariableAt(
-            $frame,
+            $frameStack->current(),
             $node->getStartPosition(),
             $node->getEndPosition(),
             $variableName
@@ -88,11 +88,11 @@ class VariableResolver implements Resolver
             fn (Type $type) => TypeCombinator::intersection(TypeFactory::unionEmpty(), $type),
         ))->withType($type);
 
-        $varDocType = $frame->varDocBuffer()->yank($variableName);
+        $varDocType = $frameStack->current()->varDocBuffer()->yank($variableName);
 
         if (null !== $varDocType) {
             $context = $context->withType($varDocType);
-            $this->applyVarDoc($context, $frame, $varDocType);
+            $this->applyVarDoc($context, $frameStack->current(), $varDocType);
         }
 
         return $context;

--- a/lib/WorseReflection/Core/Inference/Resolver/VariableResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/VariableResolver.php
@@ -10,6 +10,7 @@ use Microsoft\PhpParser\Node\Expression\Variable;
 use Microsoft\PhpParser\Node\PropertyDeclaration;
 use Phpactor\WorseReflection\Core\Inference\Context\MemberDeclarationContext;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\MemberTypeResolver;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\NodeContextFactory;
@@ -26,7 +27,7 @@ use Phpactor\WorseReflection\Core\Util\NodeUtil;
 
 class VariableResolver implements Resolver
 {
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof Variable);
 

--- a/lib/WorseReflection/Core/Inference/Resolver/VariableResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/VariableResolver.php
@@ -36,7 +36,7 @@ class VariableResolver implements Resolver
         }
 
         if ($node->name instanceof BracedExpression) {
-            return $resolver->resolveNode($frame, $node->name->expression);
+            return $resolver->resolveNode($frameStack, $node->name->expression);
         }
 
         $parent = $node->parent;
@@ -48,7 +48,7 @@ class VariableResolver implements Resolver
             $parent instanceof ScopedPropertyAccessExpression &&
             $parent->memberName === $node
         ) {
-            $containerType = $resolver->resolveNode($frame, $parent->scopeResolutionQualifier);
+            $containerType = $resolver->resolveNode($frameStack, $parent->scopeResolutionQualifier);
             $access =  $this->resolveStaticPropertyAccess($resolver, $containerType->type(), $node);
             return $access;
         }

--- a/lib/WorseReflection/Core/Inference/Resolver/YieldExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/YieldExpressionResolver.php
@@ -7,6 +7,7 @@ use Microsoft\PhpParser\Node\Expression\YieldExpression;
 use Microsoft\PhpParser\Token;
 use Microsoft\PhpParser\TokenKind;
 use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\NodeContextFactory;
 use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
@@ -18,7 +19,7 @@ use Phpactor\WorseReflection\Core\Type\MissingType;
 
 class YieldExpressionResolver implements Resolver
 {
-    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
         assert($node instanceof YieldExpression);
         $context = NodeContextFactory::forNode($node);

--- a/lib/WorseReflection/Core/Inference/Resolver/YieldExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/YieldExpressionResolver.php
@@ -21,6 +21,7 @@ class YieldExpressionResolver implements Resolver
 {
     public function resolve(NodeContextResolver $resolver, FrameStack $frameStack, Node $node): NodeContext
     {
+        $frame = $frameStack->current();
         assert($node instanceof YieldExpression);
         $context = NodeContextFactory::forNode($node);
 

--- a/lib/WorseReflection/Core/Inference/Resolver/YieldExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/YieldExpressionResolver.php
@@ -36,12 +36,12 @@ class YieldExpressionResolver implements Resolver
 
         $key = new MissingType();
         if ($arrayElement->elementKey) {
-            $key = $resolver->resolveNode($frame, $arrayElement->elementKey)->type();
+            $key = $resolver->resolveNode($frameStack, $arrayElement->elementKey)->type();
         }
         $value = new MissingType();
         /** @phpstan-ignore-next-line No trust */
         if ($arrayElement->elementValue) {
-            $value = $resolver->resolveNode($frame, $arrayElement->elementValue)->type();
+            $value = $resolver->resolveNode($frameStack, $arrayElement->elementValue)->type();
 
             if ($yieldFrom) {
                 $frame->setReturnType($value);

--- a/lib/WorseReflection/Core/Inference/Walker.php
+++ b/lib/WorseReflection/Core/Inference/Walker.php
@@ -19,7 +19,7 @@ interface Walker
      */
     public function nodeFqns(): array;
 
-    public function enter(FrameResolver $resolver, Frame $frame, Node $node): Frame;
+    public function enter(FrameResolver $resolver, FrameStack $frameStack, Node $node): void;
 
-    public function exit(FrameResolver $resolver, Frame $frame, Node $node): Frame;
+    public function exit(FrameResolver $resolver, FrameStack $frameStack, Node $node): void;
 }

--- a/lib/WorseReflection/Core/Inference/Walker/DiagnosticsWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/DiagnosticsWalker.php
@@ -8,6 +8,7 @@ use Phpactor\WorseReflection\Core\DiagnosticProvider;
 use Phpactor\WorseReflection\Core\Diagnostics;
 use Phpactor\WorseReflection\Core\Inference\Frame;
 use Phpactor\WorseReflection\Core\Inference\FrameResolver;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\Walker;
 
 class DiagnosticsWalker implements Walker
@@ -29,16 +30,16 @@ class DiagnosticsWalker implements Walker
         return [];
     }
 
-    public function enter(FrameResolver $resolver, Frame $frame, Node $node): Frame
+    public function enter(FrameResolver $resolver, FrameStack $frameStack, Node $node): void
     {
         $resolver = $resolver->resolver();
         foreach ($this->providers as $provider) {
-            foreach ($provider->enter($resolver, $frame, $node) as $diagnostic) {
+            foreach ($provider->enter($resolver, $frameStack->current(), $node) as $diagnostic) {
                 $this->diagnostics[] = $diagnostic;
             }
         }
 
-        return $frame;
+        return;
     }
 
     /**
@@ -49,15 +50,15 @@ class DiagnosticsWalker implements Walker
         return new Diagnostics($this->diagnostics);
     }
 
-    public function exit(FrameResolver $resolver, Frame $frame, Node $node): Frame
+    public function exit(FrameResolver $resolver, FrameStack $frameStack, Node $node): void
     {
         $resolver = $resolver->resolver();
         foreach ($this->providers as $provider) {
-            foreach ($provider->exit($resolver, $frame, $node) as $diagnostic) {
+            foreach ($provider->exit($resolver, $frameStack->current(), $node) as $diagnostic) {
                 $this->diagnostics[] = $diagnostic;
             }
         }
 
-        return $frame;
+        return;
     }
 }

--- a/lib/WorseReflection/Core/Inference/Walker/IncludeWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/IncludeWalker.php
@@ -71,10 +71,11 @@ class IncludeWalker implements Walker
         $parentNode = $node->parent;
 
         if ($parentNode instanceof AssignmentExpression) {
-            return $this->processAssignment($sourceNode, $resolver, $frame, $parentNode, $node);
+            $this->processAssignment($sourceNode, $resolver, $frameStack, $parentNode, $node);
+            return;
         }
 
-        $frame->locals()->merge($includedFrame->locals());
+        $frameStack->current()->locals()->merge($includedFrame->locals());
 
         return;
     }

--- a/lib/WorseReflection/Core/Inference/Walker/PassThroughWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/PassThroughWalker.php
@@ -14,6 +14,7 @@ use Microsoft\PhpParser\Node\Statement\ReturnStatement;
 use Phpactor\WorseReflection\Core\Inference\Frame;
 use Phpactor\WorseReflection\Core\Inference\FrameResolver;
 use Microsoft\PhpParser\Node\Expression\AssignmentExpression;
+use Phpactor\WorseReflection\Core\Inference\FrameStack;
 use Phpactor\WorseReflection\Core\Inference\Walker;
 
 /**
@@ -37,15 +38,15 @@ class PassThroughWalker implements Walker
         ];
     }
 
-    public function enter(FrameResolver $resolver, Frame $frame, Node $node): Frame
+    public function enter(FrameResolver $resolver, FrameStack $frameStack, Node $node): void
     {
-        $resolver->resolveNode($frame, $node);
+        $resolver->resolveNode($frameStack, $node);
 
-        return $frame;
+        return;
     }
 
-    public function exit(FrameResolver $resolver, Frame $frame, Node $node): Frame
+    public function exit(FrameResolver $resolver, FrameStack $frameStack, Node $node): void
     {
-        return $frame;
+        return;
     }
 }

--- a/lib/WorseReflection/Core/Inference/Walker/TestAssertWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/TestAssertWalker.php
@@ -83,7 +83,7 @@ class TestAssertWalker implements Walker
                 continue;
             }
 
-            $args[] = $resolver->resolveNode($frameStackStack, $expression);
+            $args[] = $resolver->resolveNode($frameStack, $expression);
             $exprs[] = $expression;
         }
 

--- a/lib/WorseReflection/Core/Inference/Walker/TestAssertWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/TestAssertWalker.php
@@ -123,7 +123,7 @@ class TestAssertWalker implements Walker
     private function assertSymbolName(FrameResolver $resolver, FrameStack $frameStack, CallExpression $node): void
     {
         $argList = $node->argumentExpressionList;
-        $args = $this->resolveArgs($argList, $resolver, $frame);
+        $args = $this->resolveArgs($argList, $resolver, $frameStack);
 
         $actual = $args[1]->symbol()->name();
         $expected = $args[0]->type();
@@ -145,8 +145,9 @@ class TestAssertWalker implements Walker
 
     private function assertReturnType(FrameResolver $resolver, FrameStack $frameStack, CallExpression $node): void
     {
+        $frame = $frameStack->current();
         $returnType = $frame->returnType();
-        $args = $this->resolveArgs($node->argumentExpressionList, $resolver, $frame);
+        $args = $this->resolveArgs($node->argumentExpressionList, $resolver, $frameStack);
         if (!isset($args[0])) {
             throw new RuntimeException(
                 'wrAssertReturnType requires an expected type argument'
@@ -163,7 +164,7 @@ class TestAssertWalker implements Walker
 
     private function assertOffset(FrameResolver $resolver, FrameStack $frameStack, CallExpression $node): void
     {
-        $args = $this->resolveArgs($node->argumentExpressionList, $resolver, $frame);
+        $args = $this->resolveArgs($node->argumentExpressionList, $resolver, $frameStack);
         $expectedType = $args[0]->type();
         $type = $args[1]->type();
         if (!$type instanceof IntLiteralType) {
@@ -187,7 +188,7 @@ class TestAssertWalker implements Walker
                 continue;
             }
 
-            $args[] = $resolver->resolveNode($frameStackStack, $expression);
+            $args[] = $resolver->resolveNode($frameStack, $expression);
         }
         return $args;
     }


### PR DESCRIPTION
This is/was an attempt to introduce a mutable "frame stack" to have a mutable reference tot he current frame., enabling "resolvers" to introduce new frames and therefore allow us to remove the "walkers".

This is progressively more difficult, so pausing here, possibly a better way would be to return the current frame in the NodeContext