### PR TITLE
Add command to dump and profile parsing

### DIFF
--- a/lib/Extension/WorseReflection/Command/DumpAstCommand.php
+++ b/lib/Extension/WorseReflection/Command/DumpAstCommand.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Phpactor\Extension\WorseReflection\Command;
+
+use Microsoft\PhpParser\Node;
+use Microsoft\PhpParser\Node\SourceFileNode;
+use Microsoft\PhpParser\Parser;
+use Microsoft\PhpParser\Token;
+use Phpactor\Extension\Debug\Model\DocumentorRegistry;
+use RuntimeException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class DumpAstCommand extends Command
+{
+    const ARG_PATH = 'path';
+
+    public function __construct(private Parser $parser)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription('Dump and profile the ast for a given file');
+        $this->addArgument(self::ARG_PATH, InputArgument::REQUIRED);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        /** @var string $path */
+        $path = $input->getArgument(self::ARG_PATH);
+        $contents = file_get_contents($path);
+        if (false === $contents) {
+            throw new RuntimeException(sprintf(
+                'Could not read file %s',
+                $path
+            ));
+        }
+        $parseStart = microtime(true);
+        $rootNode = $this->parser->parseSourceFile($contents);
+        $parseEnd = microtime(true);
+
+        $traveralStart = microtime(true);
+        $out = '';
+        $this->dump($output, $rootNode, $out);
+        $traversalEnd = microtime(true);
+
+        $output->writeln($out);
+        $output->writeln('');
+        $output->writeln(sprintf('Parsing time: %ss', number_format($parseEnd - $parseStart, 4)));
+        $output->writeln(sprintf('Traversal time: %ss', number_format($traversalEnd - $traveralStart, 4)));
+
+        return 0;
+    }
+
+    private function dump(OutputInterface $output, Node $node, string &$out): void
+    {
+        foreach ($node->getChildNodesAndTokens() as $child) {
+            if ($child instanceof Node) {
+                $out .= sprintf('<info><%s></>', $child->getNodeKindName());
+                $this->dump($output, $child, $out);
+            }
+            if ($child instanceof Token) {
+                $out .= $child->getFullText($node->getFileContents());
+            }
+        }
+    }
+}

--- a/lib/Extension/WorseReflection/Command/DumpAstCommand.php
+++ b/lib/Extension/WorseReflection/Command/DumpAstCommand.php
@@ -3,10 +3,8 @@
 namespace Phpactor\Extension\WorseReflection\Command;
 
 use Microsoft\PhpParser\Node;
-use Microsoft\PhpParser\Node\SourceFileNode;
 use Microsoft\PhpParser\Parser;
 use Microsoft\PhpParser\Token;
-use Phpactor\Extension\Debug\Model\DocumentorRegistry;
 use RuntimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;

--- a/lib/Extension/WorseReflection/Tests/Command/DumpAstCommandTest.php
+++ b/lib/Extension/WorseReflection/Tests/Command/DumpAstCommandTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Phpactor\Extension\WorseReflection\Tests\Command;
+
+use Microsoft\PhpParser\Parser;
+use Phpactor\Extension\WorseReflection\Command\DumpAstCommand;
+use Phpactor\TestUtils\PHPUnit\TestCase;
+use Phpactor\TestUtils\Workspace;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class DumpAstCommandTest extends TestCase
+{
+    public function testDumpAstCommand(): void
+    {
+        $output = new BufferedOutput();
+        $workspace = new Workspace(__DIR__ . '/../Workspace');
+        $workspace->reset();
+        $workspace->put('test.php', '<?php echo "hello";');
+        $exitCode = (new DumpAstCommand(new Parser()))->run(new ArrayInput([
+            'path' => $workspace->path('test.php')
+        ]), $output);
+        self::assertEquals(0, $exitCode);
+        self::assertStringContainsString('Parsing time', $output->fetch());
+
+    }
+}

--- a/lib/Extension/WorseReflection/Tests/Command/DumpAstCommandTest.php
+++ b/lib/Extension/WorseReflection/Tests/Command/DumpAstCommandTest.php
@@ -22,6 +22,5 @@ class DumpAstCommandTest extends TestCase
         ]), $output);
         self::assertEquals(0, $exitCode);
         self::assertStringContainsString('Parsing time', $output->fetch());
-
     }
 }

--- a/lib/Extension/WorseReflection/WorseReflectionExtension.php
+++ b/lib/Extension/WorseReflection/WorseReflectionExtension.php
@@ -2,9 +2,12 @@
 
 namespace Phpactor\Extension\WorseReflection;
 
+use Microsoft\PhpParser\Parser;
+use Phpactor\Extension\Console\ConsoleExtension;
 use Phpactor\Extension\Logger\LoggingExtension;
 use Phpactor\Extension\ClassToFile\ClassToFileExtension;
 use Phpactor\Extension\FilePathResolver\FilePathResolverExtension;
+use Phpactor\Extension\WorseReflection\Command\DumpAstCommand;
 use Phpactor\WorseReflection\Bridge\Phpactor\MemberProvider\DocblockMemberProvider;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\AssignmentToMissingPropertyProvider;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\DeprecatedUsageDiagnosticProvider;
@@ -70,6 +73,7 @@ class WorseReflectionExtension implements Extension
 
     public function load(ContainerBuilder $container): void
     {
+        $this->registerCommands($container);
         $this->registerReflection($container);
         $this->registerSourceLocators($container);
         $this->registerMemberProviders($container);
@@ -188,5 +192,16 @@ class WorseReflectionExtension implements Extension
         $container->register(DeprecatedUsageDiagnosticProvider::class, function (Container $container) {
             return new DeprecatedUsageDiagnosticProvider();
         }, [ self::TAG_DIAGNOSTIC_PROVIDER => []]);
+    }
+
+    private function registerCommands(ContainerBuilder $container): void
+    {
+        $container->register(DumpAstCommand::class, function (Container $container) {
+            return new DumpAstCommand($container->expect(self::SERVICE_PARSER, Parser::class));
+        }, [
+            ConsoleExtension::TAG_COMMAND => [
+                'name' => 'worse:dump-ast',
+            ]
+        ]);
     }
 }


### PR DESCRIPTION
Introduces `worse:dump-ast path/to/phpfile.php` to debug and profile the AST parsing.