### PR TITLE
Diagnostics outsource default

### DIFF
--- a/lib/Extension/LanguageServer/LanguageServerExtension.php
+++ b/lib/Extension/LanguageServer/LanguageServerExtension.php
@@ -492,7 +492,7 @@ class LanguageServerExtension implements Extension
         $container->register(AggregateDiagnosticsProvider::class, function (Container $container) {
             $providers = $this->collectDiagnosticProviders(
                 $container,
-                outsourced: $container->parameter(self::PARAM_DIAGNOSTIC_OUTSOURCE)->bool() ? true : null,
+                outsourced: $container->parameter(self::PARAM_DIAGNOSTIC_OUTSOURCE)->bool() ? false : null,
             );
 
             return new AggregateDiagnosticsProvider(

--- a/lib/Extension/LanguageServer/LanguageServerExtension.php
+++ b/lib/Extension/LanguageServer/LanguageServerExtension.php
@@ -118,7 +118,7 @@ class LanguageServerExtension implements Extension
             self::PARAM_DIAGNOSTIC_ON_SAVE => true,
             self::PARAM_DIAGNOSTIC_ON_OPEN => true,
             self::PARAM_DIAGNOSTIC_PROVIDERS => null,
-            self::PARAM_DIAGNOSTIC_OUTSOURCE => false,
+            self::PARAM_DIAGNOSTIC_OUTSOURCE => true,
             self::PARAM_FILE_EVENTS => true,
             self::PARAM_FILE_EVENT_GLOBS => ['**/*.php'],
             self::PARAM_PROFILE => false,
@@ -492,7 +492,7 @@ class LanguageServerExtension implements Extension
         $container->register(AggregateDiagnosticsProvider::class, function (Container $container) {
             $providers = $this->collectDiagnosticProviders(
                 $container,
-                outsourced: $container->parameter(self::PARAM_DIAGNOSTIC_OUTSOURCE)->bool() ? false : null,
+                outsourced: $container->parameter(self::PARAM_DIAGNOSTIC_OUTSOURCE)->bool() ? true : null,
             );
 
             return new AggregateDiagnosticsProvider(

--- a/lib/WorseReflection/Tests/Benchmarks/AnalyserBench.php
+++ b/lib/WorseReflection/Tests/Benchmarks/AnalyserBench.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Phpactor\WorseReflection\Tests\Benchmarks;
+
+use Phpactor\TextDocument\TextDocumentBuilder;
+
+class AnalyserBench extends BaseBenchCase
+{
+    public function benchAnalyse(): void
+    {
+        $this->getReflector()->reflectOffset(TextDocumentBuilder::fromUri(__DIR__ . '/../../../../vendor/phpactor/tolerant-php-parser/src/Parser.php')->build(), 183744);
+    }
+}
+

--- a/lib/WorseReflection/Tests/Benchmarks/AnalyserBench.php
+++ b/lib/WorseReflection/Tests/Benchmarks/AnalyserBench.php
@@ -11,4 +11,3 @@ class AnalyserBench extends BaseBenchCase
         $this->getReflector()->reflectOffset(TextDocumentBuilder::fromUri(__DIR__ . '/../../../../vendor/phpactor/tolerant-php-parser/src/Parser.php')->build(), 183744);
     }
 }
-


### PR DESCRIPTION
Outsource the diagnostics to a separate process by default - it seems to work fine and also they seem to leak memory quite horrendously when run in the same process repeatedly.