### PR TITLE
Fixing sphinx-autobuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,11 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?= -W
-SPHINXBUILD   ?= sphinx-build
-SOURCEDIR     = doc
-BUILDDIR      = build
+SPHINXOPTS       ?= -W
+SPHINXBUILD      ?= sphinx-build
+SPHINXAUTOBUILD  ?= sphinx-autobuild
+SOURCEDIR         = doc
+BUILDDIR          = build
 
 .PHONY: help sphinx
 
@@ -35,7 +36,7 @@ help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 sphinxwatch:
-	@config/bin/watchdocs.sh
+	@$(SPHINXAUTOBUILD) "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 sphinx:
 	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 docutils==0.18.1
 sphinx==5.0.0
 sphinx-tabs==3.4.1
+sphinx-autobuild==2021.3.14


### PR DESCRIPTION
Adding sphinx-autobuild to the requirements and using that in the make file. It spins up a liveserver for the site, it's not ideal but sounds easier than the solution with a complicated `inotify` command to rerun the normal build command.

Closes #2169 