### PR TITLE
Inlay hint performance improvement

### DIFF
--- a/lib/Extension/LanguageServerWorseReflection/Tests/InlayHint/InlayHintProviderTest.php
+++ b/lib/Extension/LanguageServerWorseReflection/Tests/InlayHint/InlayHintProviderTest.php
@@ -33,7 +33,7 @@ class InlayHintProviderTest extends IntegrationTestCase
             ByteOffsetRange::fromInts(
                 0,
                 strlen($source)
-            )
+            ),
         ));
         $assertion($hints);
     }


### PR DESCRIPTION
Ensure we only have one inlayhint co-routine running at once (or at least cancel running ones on new requests).