### PR TITLE
Code action profiling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "phpactor/amp-fswatch": "^0.2.0",
         "thecodingmachine/safe": "^1.0",
         "phpactor/phly-event-dispatcher": "^2.0.0",
-        "phpactor/language-server": "^4.0.3",
+        "phpactor/language-server": "^5.0.0",
         "phpactor/language-server-protocol": "^3.17.3",
         "dantleech/object-renderer": "^0.1.1",
         "monolog/monolog": "^1.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "16713dc9aa554bba1a6c64ae10ea5467",
+    "content-hash": "4ec52ce962fff20e1f23df708033399d",
     "packages": [
         {
             "name": "amphp/amp",
@@ -1216,12 +1216,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/JetBrains/phpstorm-stubs.git",
-                "reference": "412835dca173b2ca9297977552971ddea6aaaec9"
+                "reference": "ddf4f5261160e0660cc4b686beda04093c0193da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/412835dca173b2ca9297977552971ddea6aaaec9",
-                "reference": "412835dca173b2ca9297977552971ddea6aaaec9",
+                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/ddf4f5261160e0660cc4b686beda04093c0193da",
+                "reference": "ddf4f5261160e0660cc4b686beda04093c0193da",
                 "shasum": ""
             },
             "require-dev": {
@@ -1257,7 +1257,7 @@
             "support": {
                 "source": "https://github.com/JetBrains/phpstorm-stubs/tree/master"
             },
-            "time": "2023-03-15T16:14:31+00:00"
+            "time": "2023-04-02T14:22:59+00:00"
         },
         {
             "name": "kelunik/certificate",
@@ -1642,16 +1642,16 @@
         },
         {
             "name": "phpactor/language-server",
-            "version": "4.0.3",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/language-server.git",
-                "reference": "4a0de9fd8315323e93b06fbb33921dca9e5cfea6"
+                "reference": "a42c3331f1f67b6a541d50fb14556debca7813e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/language-server/zipball/4a0de9fd8315323e93b06fbb33921dca9e5cfea6",
-                "reference": "4a0de9fd8315323e93b06fbb33921dca9e5cfea6",
+                "url": "https://api.github.com/repos/phpactor/language-server/zipball/a42c3331f1f67b6a541d50fb14556debca7813e2",
+                "reference": "a42c3331f1f67b6a541d50fb14556debca7813e2",
                 "shasum": ""
             },
             "require": {
@@ -1702,9 +1702,9 @@
             "description": "Generic Language Server Platform",
             "support": {
                 "issues": "https://github.com/phpactor/language-server/issues",
-                "source": "https://github.com/phpactor/language-server/tree/4.0.3"
+                "source": "https://github.com/phpactor/language-server/tree/5.0.0"
             },
-            "time": "2023-03-12T11:49:11+00:00"
+            "time": "2023-04-09T10:18:29+00:00"
         },
         {
             "name": "phpactor/language-server-protocol",
@@ -2319,16 +2319,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.21",
+            "version": "v5.4.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "c77433ddc6cdc689caf48065d9ea22ca0853fbd9"
+                "reference": "3cd51fd2e6c461ca678f84d419461281bd87a0a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/c77433ddc6cdc689caf48065d9ea22ca0853fbd9",
-                "reference": "c77433ddc6cdc689caf48065d9ea22ca0853fbd9",
+                "url": "https://api.github.com/repos/symfony/console/zipball/3cd51fd2e6c461ca678f84d419461281bd87a0a8",
+                "reference": "3cd51fd2e6c461ca678f84d419461281bd87a0a8",
                 "shasum": ""
             },
             "require": {
@@ -2393,12 +2393,12 @@
             "homepage": "https://symfony.com",
             "keywords": [
                 "cli",
-                "command line",
+                "command-line",
                 "console",
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.21"
+                "source": "https://github.com/symfony/console/tree/v5.4.22"
             },
             "funding": [
                 {
@@ -2414,7 +2414,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-25T16:59:41+00:00"
+            "time": "2023-03-25T09:27:28+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -3196,16 +3196,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v5.4.21",
+            "version": "v5.4.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "d4ce417ebcb0b7d090b4c178ed6d3accc518e8bd"
+                "reference": "4b850da0cc3a2a9181c1ed407adbca4733dc839b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/d4ce417ebcb0b7d090b4c178ed6d3accc518e8bd",
-                "reference": "d4ce417ebcb0b7d090b4c178ed6d3accc518e8bd",
+                "url": "https://api.github.com/repos/symfony/process/zipball/4b850da0cc3a2a9181c1ed407adbca4733dc839b",
+                "reference": "4b850da0cc3a2a9181c1ed407adbca4733dc839b",
                 "shasum": ""
             },
             "require": {
@@ -3238,7 +3238,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v5.4.21"
+                "source": "https://github.com/symfony/process/tree/v5.4.22"
             },
             "funding": [
                 {
@@ -3254,7 +3254,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-21T19:46:44+00:00"
+            "time": "2023-03-06T21:29:33+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -3341,16 +3341,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v5.4.21",
+            "version": "v5.4.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "edac10d167b78b1d90f46a80320d632de0bd9f2f"
+                "reference": "8036a4c76c0dd29e60b6a7cafcacc50cf088ea62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/edac10d167b78b1d90f46a80320d632de0bd9f2f",
-                "reference": "edac10d167b78b1d90f46a80320d632de0bd9f2f",
+                "url": "https://api.github.com/repos/symfony/string/zipball/8036a4c76c0dd29e60b6a7cafcacc50cf088ea62",
+                "reference": "8036a4c76c0dd29e60b6a7cafcacc50cf088ea62",
                 "shasum": ""
             },
             "require": {
@@ -3407,7 +3407,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.4.21"
+                "source": "https://github.com/symfony/string/tree/v5.4.22"
             },
             "funding": [
                 {
@@ -3423,7 +3423,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-22T08:00:55+00:00"
+            "time": "2023-03-14T06:11:53+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -3881,16 +3881,16 @@
     "packages-dev": [
         {
             "name": "blackfire/php-sdk",
-            "version": "v1.33.0",
+            "version": "v1.35.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/blackfireio/php-sdk.git",
-                "reference": "aa8f03aca0395d1724988a6c8f4ca95c2b01ecf8"
+                "reference": "2c5950ff2ad29c2af96c69810eb304f0f350177d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/blackfireio/php-sdk/zipball/aa8f03aca0395d1724988a6c8f4ca95c2b01ecf8",
-                "reference": "aa8f03aca0395d1724988a6c8f4ca95c2b01ecf8",
+                "url": "https://api.github.com/repos/blackfireio/php-sdk/zipball/2c5950ff2ad29c2af96c69810eb304f0f350177d",
+                "reference": "2c5950ff2ad29c2af96c69810eb304f0f350177d",
                 "shasum": ""
             },
             "require": {
@@ -3923,7 +3923,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.34-dev"
+                    "dev-master": "1.36-dev"
                 }
             },
             "autoload": {
@@ -3953,9 +3953,9 @@
             ],
             "support": {
                 "issues": "https://github.com/blackfireio/php-sdk/issues",
-                "source": "https://github.com/blackfireio/php-sdk/tree/v1.33.0"
+                "source": "https://github.com/blackfireio/php-sdk/tree/v1.35.0"
             },
-            "time": "2023-01-26T07:42:49+00:00"
+            "time": "2023-04-06T09:37:28+00:00"
         },
         {
             "name": "composer/ca-bundle",
@@ -4179,12 +4179,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/rdohms/phpunit-arraysubset-asserts.git",
-                "reference": "676fe6dbb3508c9336ba52c86091ef2116bf9ccc"
+                "reference": "2a0e7744402d5d5466e7534735bedc4d760ff422"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rdohms/phpunit-arraysubset-asserts/zipball/676fe6dbb3508c9336ba52c86091ef2116bf9ccc",
-                "reference": "676fe6dbb3508c9336ba52c86091ef2116bf9ccc",
+                "url": "https://api.github.com/repos/rdohms/phpunit-arraysubset-asserts/zipball/2a0e7744402d5d5466e7534735bedc4d760ff422",
+                "reference": "2a0e7744402d5d5466e7534735bedc4d760ff422",
                 "shasum": ""
             },
             "require": {
@@ -4192,8 +4192,7 @@
                 "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "require-dev": {
-                "dms/coding-standard": "^9",
-                "squizlabs/php_codesniffer": "^3.4"
+                "dms/coding-standard": "^9"
             },
             "default-branch": true,
             "type": "library",
@@ -4217,7 +4216,7 @@
                 "issues": "https://github.com/rdohms/phpunit-arraysubset-asserts/issues",
                 "source": "https://github.com/rdohms/phpunit-arraysubset-asserts/tree/master"
             },
-            "time": "2023-02-02T10:23:51+00:00"
+            "time": "2023-03-20T10:05:20+00:00"
         },
         {
             "name": "doctrine/annotations",
@@ -4589,16 +4588,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.15.1",
+            "version": "v3.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "d48755372a113bddb99f749e34805d83f3acfe04"
+                "reference": "d40f9436e1c448d309fa995ab9c14c5c7a96f2dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/d48755372a113bddb99f749e34805d83f3acfe04",
-                "reference": "d48755372a113bddb99f749e34805d83f3acfe04",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/d40f9436e1c448d309fa995ab9c14c5c7a96f2dc",
+                "reference": "d40f9436e1c448d309fa995ab9c14c5c7a96f2dc",
                 "shasum": ""
             },
             "require": {
@@ -4673,7 +4672,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.15.1"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.16.0"
             },
             "funding": [
                 {
@@ -4681,7 +4680,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-03-13T23:26:30+00:00"
+            "time": "2023-04-02T19:30:06+00:00"
         },
         {
             "name": "jangregor/phpstan-prophecy",
@@ -5236,16 +5235,16 @@
         },
         {
             "name": "phpbench/phpbench",
-            "version": "1.2.9",
+            "version": "1.2.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpbench/phpbench.git",
-                "reference": "7aaea137809603b1c4f46d1790ba0f009be15797"
+                "reference": "95206f92479674599a75e02b74b9933e2d9883aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpbench/phpbench/zipball/7aaea137809603b1c4f46d1790ba0f009be15797",
-                "reference": "7aaea137809603b1c4f46d1790ba0f009be15797",
+                "url": "https://api.github.com/repos/phpbench/phpbench/zipball/95206f92479674599a75e02b74b9933e2d9883aa",
+                "reference": "95206f92479674599a75e02b74b9933e2d9883aa",
                 "shasum": ""
             },
             "require": {
@@ -5314,7 +5313,7 @@
             "description": "PHP Benchmarking Framework",
             "support": {
                 "issues": "https://github.com/phpbench/phpbench/issues",
-                "source": "https://github.com/phpbench/phpbench/tree/1.2.9"
+                "source": "https://github.com/phpbench/phpbench/tree/1.2.10"
             },
             "funding": [
                 {
@@ -5322,7 +5321,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-03-08T08:56:01+00:00"
+            "time": "2023-03-24T08:52:55+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -5436,16 +5435,16 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.7.0",
+            "version": "1.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "1534aea9bde19a5c85c5d1e1f834ab63f4c5dcf5"
+                "reference": "dfc078e8af9c99210337325ff5aa152872c98714"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/1534aea9bde19a5c85c5d1e1f834ab63f4c5dcf5",
-                "reference": "1534aea9bde19a5c85c5d1e1f834ab63f4c5dcf5",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/dfc078e8af9c99210337325ff5aa152872c98714",
+                "reference": "dfc078e8af9c99210337325ff5aa152872c98714",
                 "shasum": ""
             },
             "require": {
@@ -5488,9 +5487,9 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.7.0"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.7.1"
             },
-            "time": "2023-03-12T10:13:29+00:00"
+            "time": "2023-03-27T19:02:04+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -5658,16 +5657,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.16.1",
+            "version": "1.18.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "e27e92d939e2e3636f0a1f0afaba59692c0bf571"
+                "reference": "22dcdfd725ddf99583bfe398fc624ad6c5004a0f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/e27e92d939e2e3636f0a1f0afaba59692c0bf571",
-                "reference": "e27e92d939e2e3636f0a1f0afaba59692c0bf571",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/22dcdfd725ddf99583bfe398fc624ad6c5004a0f",
+                "reference": "22dcdfd725ddf99583bfe398fc624ad6c5004a0f",
                 "shasum": ""
             },
             "require": {
@@ -5697,22 +5696,22 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.16.1"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.18.1"
             },
-            "time": "2023-02-07T18:11:17+00:00"
+            "time": "2023-04-07T11:51:11+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.7",
+            "version": "1.10.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "b10ceb526d9607903c5b2673f1fc8775dbe48975"
+                "reference": "8aa62e6ea8b58ffb650e02940e55a788cbc3fe21"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b10ceb526d9607903c5b2673f1fc8775dbe48975",
-                "reference": "b10ceb526d9607903c5b2673f1fc8775dbe48975",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8aa62e6ea8b58ffb650e02940e55a788cbc3fe21",
+                "reference": "8aa62e6ea8b58ffb650e02940e55a788cbc3fe21",
                 "shasum": ""
             },
             "require": {
@@ -5761,20 +5760,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-16T15:24:20+00:00"
+            "time": "2023-04-04T19:17:42+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
-            "version": "1.3.10",
+            "version": "1.3.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-phpunit.git",
-                "reference": "4cc5c6cc38e56bce7ea47c4091814e516d172dc3"
+                "reference": "9e1b9de6d260461f6e99b6a8f2dbb0bbb98b579c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/4cc5c6cc38e56bce7ea47c4091814e516d172dc3",
-                "reference": "4cc5c6cc38e56bce7ea47c4091814e516d172dc3",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/9e1b9de6d260461f6e99b6a8f2dbb0bbb98b579c",
+                "reference": "9e1b9de6d260461f6e99b6a8f2dbb0bbb98b579c",
                 "shasum": ""
             },
             "require": {
@@ -5811,9 +5810,9 @@
             "description": "PHPUnit extensions and rules for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-phpunit/issues",
-                "source": "https://github.com/phpstan/phpstan-phpunit/tree/1.3.10"
+                "source": "https://github.com/phpstan/phpstan-phpunit/tree/1.3.11"
             },
-            "time": "2023-03-02T10:25:13+00:00"
+            "time": "2023-03-25T19:42:13+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -6135,16 +6134,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.5",
+            "version": "9.6.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "86e761949019ae83f49240b2f2123fb5ab3b2fc5"
+                "reference": "b65d59a059d3004a040c16a82e07bbdf6cfdd115"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/86e761949019ae83f49240b2f2123fb5ab3b2fc5",
-                "reference": "86e761949019ae83f49240b2f2123fb5ab3b2fc5",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b65d59a059d3004a040c16a82e07bbdf6cfdd115",
+                "reference": "b65d59a059d3004a040c16a82e07bbdf6cfdd115",
                 "shasum": ""
             },
             "require": {
@@ -6217,7 +6216,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.5"
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.6"
             },
             "funding": [
                 {
@@ -6233,7 +6233,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-09T06:34:10+00:00"
+            "time": "2023-03-27T11:43:46+00:00"
         },
         {
             "name": "psr/cache",
@@ -7248,16 +7248,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v5.4.21",
+            "version": "v5.4.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "f0ae1383a8285dfc6752b8d8602790953118ff5a"
+                "reference": "1df20e45d56da29a4b1d8259dd6e950acbf1b13f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/f0ae1383a8285dfc6752b8d8602790953118ff5a",
-                "reference": "f0ae1383a8285dfc6752b8d8602790953118ff5a",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/1df20e45d56da29a4b1d8259dd6e950acbf1b13f",
+                "reference": "1df20e45d56da29a4b1d8259dd6e950acbf1b13f",
                 "shasum": ""
             },
             "require": {
@@ -7313,7 +7313,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v5.4.21"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v5.4.22"
             },
             "funding": [
                 {
@@ -7329,7 +7329,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-14T08:03:56+00:00"
+            "time": "2023-03-17T11:31:58+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -7606,16 +7606,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v5.4.21",
+            "version": "v5.4.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "6c5ac3a1be8b849d59a1a77877ee110e1b55eb74"
+                "reference": "e2edac9ce47e6df07e38143c7cfa6bdbc1a6dcc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/6c5ac3a1be8b849d59a1a77877ee110e1b55eb74",
-                "reference": "6c5ac3a1be8b849d59a1a77877ee110e1b55eb74",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/e2edac9ce47e6df07e38143c7cfa6bdbc1a6dcc4",
+                "reference": "e2edac9ce47e6df07e38143c7cfa6bdbc1a6dcc4",
                 "shasum": ""
             },
             "require": {
@@ -7675,7 +7675,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v5.4.21"
+                "source": "https://github.com/symfony/var-dumper/tree/v5.4.22"
             },
             "funding": [
                 {
@@ -7691,7 +7691,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-23T10:00:28+00:00"
+            "time": "2023-03-25T09:27:28+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/lib/DocblockParser/Parser.php
+++ b/lib/DocblockParser/Parser.php
@@ -67,6 +67,7 @@ final class Parser
         $this->tokens = $tokens;
 
         while ($tokens->hasCurrent()) {
+            /** @phpstan-ignore-next-line Above ensures it is not null */
             if ($tokens->current->type === Token::T_TAG) {
                 $children[] = $this->parseTag();
                 continue;
@@ -81,6 +82,7 @@ final class Parser
             }
         }
 
+        /** @phpstan-ignore-next-line */
         return new Docblock($children);
     }
 

--- a/lib/Extension/LanguageServer/CodeAction/ProfilingCodeActionProvider.php
+++ b/lib/Extension/LanguageServer/CodeAction/ProfilingCodeActionProvider.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServer\CodeAction;
+
+use Amp\CancellationToken;
+use Amp\Promise;
+use Phpactor\LanguageServerProtocol\Range;
+use Phpactor\LanguageServerProtocol\TextDocumentItem;
+use Phpactor\LanguageServer\Core\CodeAction\CodeActionProvider;
+use Psr\Log\LoggerInterface;
+use Throwable;
+use function Amp\call;
+
+class ProfilingCodeActionProvider implements CodeActionProvider
+{
+    public function __construct(private CodeActionProvider $innerProvider, private LoggerInterface $logger)
+    {
+    }
+
+    public function provideActionsFor(TextDocumentItem $textDocument, Range $range, CancellationToken $cancel): Promise
+    {
+        return call(function () use ($textDocument, $range, $cancel) {
+            $start = microtime(true);
+            $this->logger->info(sprintf('PROF        >> code-action [%s]', $this->innerProvider::class));
+            try {
+                $result = yield $this->innerProvider->provideActionsFor($textDocument, $range, $cancel);
+                $elapsed = microtime(true) - $start;
+            } catch (Throwable $e) {
+                $elapsed = microtime(true) - $start;
+                $this->logger->info(sprintf('PROF %-6s << code-action [%s] ERR: [%s] %s', number_format($elapsed, 4), $this->innerProvider::class, $e::class, $e->getMessage()));
+                throw $e;
+            }
+            $this->logger->info(sprintf('PROF %-6s << code-action [%s]', number_format($elapsed, 4), $this->innerProvider::class));
+            return $result;
+        });
+    }
+
+    public function kinds(): array
+    {
+        return $this->innerProvider->kinds();
+    }
+}

--- a/lib/Extension/LanguageServer/LanguageServerExtension.php
+++ b/lib/Extension/LanguageServer/LanguageServerExtension.php
@@ -433,7 +433,7 @@ class LanguageServerExtension implements Extension
         }, [ self::TAG_METHOD_HANDLER => []]);
 
         $container->register(CodeActionHandler::class, function (Container $container) {
-            $services = $this->taggedServices($container, self::TAG_CODE_ACTION_PROVIDER);
+            $services = $this->taggedServices($container, self::TAG_CODE_ACTION_PROVIDER, CodeActionProvider::class);
             if ($container->parameter(self::PARAM_PROFILE)->bool()) {
                 $services = array_map(
                     fn (CodeActionProvider $provider) => new ProfilingCodeActionProvider(
@@ -524,7 +524,7 @@ class LanguageServerExtension implements Extension
 
         $container->register(CodeActionDiagnosticsProvider::class, function (Container $container) {
             return new CodeActionDiagnosticsProvider(
-                ...$this->taggedServices($container, self::TAG_CODE_ACTION_DIAGNOSTICS_PROVIDER)
+                ...$this->taggedServices($container, self::TAG_CODE_ACTION_DIAGNOSTICS_PROVIDER, CodeActionProvider::class)
             );
         }, [
             self::TAG_DIAGNOSTICS_PROVIDER => DiagnosticProviderTag::create('code-action', outsource: true),
@@ -549,9 +549,11 @@ class LanguageServerExtension implements Extension
     }
 
     /**
-     * @return array<int,mixed>
+     * @template TType
+     * @param null|class-string<TType> $fqn
+     * @return ($fqn is class-string<TType> ? list<TType> : list<mixed>)
      */
-    private function taggedServices(Container $container, string $tag): array
+    private function taggedServices(Container $container, string $tag, ?string $fqn = null): array
     {
         $providers = [];
         foreach (array_keys($container->getServiceIdsForTag($tag)) as $serviceId) {

--- a/lib/Extension/LanguageServer/Tests/Example/TestExtension.php
+++ b/lib/Extension/LanguageServer/Tests/Example/TestExtension.php
@@ -83,6 +83,10 @@ class TestExtension implements Extension
 
         $container->register('test.code_action_provider', function (Container $container) {
             return new class implements CodeActionProvider {
+                public function describe(): string
+                {
+                    return 'foobar';
+                }
                 public function provideActionsFor(TextDocumentItem $textDocument, Range $range, CancellationToken $cancel): Promise
                 {
                     return new Success([

--- a/lib/Extension/LanguageServerCodeTransform/CodeAction/CreateClassProvider.php
+++ b/lib/Extension/LanguageServerCodeTransform/CodeAction/CreateClassProvider.php
@@ -77,6 +77,11 @@ class CreateClassProvider implements DiagnosticsProvider, CodeActionProvider
         return 'create-class';
     }
 
+    public function describe(): string
+    {
+        return 'create class in empty file';
+    }
+
     /**
      * @return array<Diagnostic>
      */
@@ -99,10 +104,5 @@ class CreateClassProvider implements DiagnosticsProvider, CodeActionProvider
                 source: 'phpactor'
             )
         ];
-    }
-
-    public function describe(): string
-    {
-        return 'create class in empty file';
     }
 }

--- a/lib/Extension/LanguageServerCodeTransform/CodeAction/CreateClassProvider.php
+++ b/lib/Extension/LanguageServerCodeTransform/CodeAction/CreateClassProvider.php
@@ -100,4 +100,9 @@ class CreateClassProvider implements DiagnosticsProvider, CodeActionProvider
             )
         ];
     }
+
+    public function describe(): string
+    {
+        return 'create class in empty file';
+    }
 }

--- a/lib/Extension/LanguageServerCodeTransform/CodeAction/CreateUnresolvableClassProvider.php
+++ b/lib/Extension/LanguageServerCodeTransform/CodeAction/CreateUnresolvableClassProvider.php
@@ -82,4 +82,9 @@ class CreateUnresolvableClassProvider implements CodeActionProvider
             self::KIND
         ];
     }
+
+    public function describe(): string
+    {
+        return 'create class for any class which cannot be found';
+    }
 }

--- a/lib/Extension/LanguageServerCodeTransform/CodeAction/ExtractConstantProvider.php
+++ b/lib/Extension/LanguageServerCodeTransform/CodeAction/ExtractConstantProvider.php
@@ -59,4 +59,8 @@ class ExtractConstantProvider implements CodeActionProvider
             ];
         });
     }
+    public function describe(): string
+    {
+        return 'extract constant';
+    }
 }

--- a/lib/Extension/LanguageServerCodeTransform/CodeAction/ExtractExpressionProvider.php
+++ b/lib/Extension/LanguageServerCodeTransform/CodeAction/ExtractExpressionProvider.php
@@ -61,4 +61,8 @@ class ExtractExpressionProvider implements CodeActionProvider
             ];
         });
     }
+    public function describe(): string
+    {
+        return 'extract expression';
+    }
 }

--- a/lib/Extension/LanguageServerCodeTransform/CodeAction/ExtractMethodProvider.php
+++ b/lib/Extension/LanguageServerCodeTransform/CodeAction/ExtractMethodProvider.php
@@ -60,4 +60,8 @@ class ExtractMethodProvider implements CodeActionProvider
             ];
         });
     }
+    public function describe(): string
+    {
+        return 'extract method';
+    }
 }

--- a/lib/Extension/LanguageServerCodeTransform/CodeAction/FillObjectProvider.php
+++ b/lib/Extension/LanguageServerCodeTransform/CodeAction/FillObjectProvider.php
@@ -51,4 +51,8 @@ class FillObjectProvider implements CodeActionProvider
     {
         return [self::KIND];
     }
+    public function describe(): string
+    {
+        return 'fill new object construct with named parameters';
+    }
 }

--- a/lib/Extension/LanguageServerCodeTransform/CodeAction/GenerateConstructorProvider.php
+++ b/lib/Extension/LanguageServerCodeTransform/CodeAction/GenerateConstructorProvider.php
@@ -51,4 +51,9 @@ class GenerateConstructorProvider implements CodeActionProvider
     {
         return [self::KIND];
     }
+
+    public function describe(): string
+    {
+        return 'generate constructor for new object instantiation';
+    }
 }

--- a/lib/Extension/LanguageServerCodeTransform/CodeAction/GenerateDecoratorProvider.php
+++ b/lib/Extension/LanguageServerCodeTransform/CodeAction/GenerateDecoratorProvider.php
@@ -78,4 +78,9 @@ class GenerateDecoratorProvider implements CodeActionProvider
             ];
         });
     }
+
+    public function describe(): string
+    {
+        return 'convert an empty class that implements an interface into a decorator';
+    }
 }

--- a/lib/Extension/LanguageServerCodeTransform/CodeAction/GenerateMethodProvider.php
+++ b/lib/Extension/LanguageServerCodeTransform/CodeAction/GenerateMethodProvider.php
@@ -75,6 +75,11 @@ class GenerateMethodProvider implements DiagnosticsProvider, CodeActionProvider
         return 'generate-method';
     }
 
+    public function describe(): string
+    {
+        return 'generate non-existing method';
+    }
+
     /**
      * @return Promise<array<Diagnostic>>
      */
@@ -117,10 +122,5 @@ class GenerateMethodProvider implements DiagnosticsProvider, CodeActionProvider
 
             return $diagnostics;
         });
-    }
-
-    public function describe(): string
-    {
-        return 'generate non-existing method';
     }
 }

--- a/lib/Extension/LanguageServerCodeTransform/CodeAction/GenerateMethodProvider.php
+++ b/lib/Extension/LanguageServerCodeTransform/CodeAction/GenerateMethodProvider.php
@@ -118,4 +118,9 @@ class GenerateMethodProvider implements DiagnosticsProvider, CodeActionProvider
             return $diagnostics;
         });
     }
+
+    public function describe(): string
+    {
+        return 'generate non-existing method';
+    }
 }

--- a/lib/Extension/LanguageServerCodeTransform/CodeAction/ImportNameProvider.php
+++ b/lib/Extension/LanguageServerCodeTransform/CodeAction/ImportNameProvider.php
@@ -176,4 +176,9 @@ class ImportNameProvider implements CodeActionProvider, DiagnosticsProvider
             )
         ]);
     }
+
+    public function describe(): string
+    {
+        return 'import unresolvable class names';
+    }
 }

--- a/lib/Extension/LanguageServerCodeTransform/CodeAction/ImportNameProvider.php
+++ b/lib/Extension/LanguageServerCodeTransform/CodeAction/ImportNameProvider.php
@@ -85,6 +85,11 @@ class ImportNameProvider implements CodeActionProvider, DiagnosticsProvider
         return 'import-name';
     }
 
+    public function describe(): string
+    {
+        return 'import unresolvable class names';
+    }
+
     private function diagnosticsFromUnresolvedName(NameWithByteOffset $unresolvedName, TextDocumentItem $item, ?bool $hasCandidates = null): array
     {
         $range = new Range(
@@ -175,10 +180,5 @@ class ImportNameProvider implements CodeActionProvider, DiagnosticsProvider
                 ]
             )
         ]);
-    }
-
-    public function describe(): string
-    {
-        return 'import unresolvable class names';
     }
 }

--- a/lib/Extension/LanguageServerCodeTransform/CodeAction/PropertyAccessGeneratorProvider.php
+++ b/lib/Extension/LanguageServerCodeTransform/CodeAction/PropertyAccessGeneratorProvider.php
@@ -92,4 +92,8 @@ class PropertyAccessGeneratorProvider implements CodeActionProvider
             ];
         });
     }
+    public function describe(): string
+    {
+        return 'add properties that are assigned to but not present';
+    }
 }

--- a/lib/Extension/LanguageServerCodeTransform/CodeAction/ReplaceQualifierWithImportProvider.php
+++ b/lib/Extension/LanguageServerCodeTransform/CodeAction/ReplaceQualifierWithImportProvider.php
@@ -57,4 +57,9 @@ class ReplaceQualifierWithImportProvider implements CodeActionProvider
             ];
         });
     }
+
+    public function describe(): string
+    {
+        return 'replace qualifier with importer';
+    }
 }

--- a/lib/Extension/LanguageServerCodeTransform/CodeAction/TransformerCodeActionPovider.php
+++ b/lib/Extension/LanguageServerCodeTransform/CodeAction/TransformerCodeActionPovider.php
@@ -96,4 +96,9 @@ class TransformerCodeActionPovider implements DiagnosticsProvider, CodeActionPro
     {
         return 'quickfix.'.$this->name;
     }
+
+    public function describe(): string
+    {
+        return sprintf('"%s" transformer', $this->name);
+    }
 }

--- a/lib/Extension/LanguageServerCodeTransform/CodeAction/TransformerCodeActionPovider.php
+++ b/lib/Extension/LanguageServerCodeTransform/CodeAction/TransformerCodeActionPovider.php
@@ -72,6 +72,11 @@ class TransformerCodeActionPovider implements DiagnosticsProvider, CodeActionPro
         return $this->name;
     }
 
+    public function describe(): string
+    {
+        return sprintf('"%s" transformer', $this->name);
+    }
+
     /**
      * @return Promise<array<Diagnostic>>
      */
@@ -95,10 +100,5 @@ class TransformerCodeActionPovider implements DiagnosticsProvider, CodeActionPro
     private function kind(): string
     {
         return 'quickfix.'.$this->name;
-    }
-
-    public function describe(): string
-    {
-        return sprintf('"%s" transformer', $this->name);
     }
 }

--- a/lib/Extension/LanguageServerPhpCsFixer/Provider/PhpCsFixerDiagnosticsProvider.php
+++ b/lib/Extension/LanguageServerPhpCsFixer/Provider/PhpCsFixerDiagnosticsProvider.php
@@ -91,6 +91,11 @@ class PhpCsFixerDiagnosticsProvider implements DiagnosticsProvider, CodeActionPr
         return 'php-cs-fixer';
     }
 
+    public function describe(): string
+    {
+        return 'php-cs-fixer';
+    }
+
     /**
      * @return Promise<Diagnostic[]|false> False when there are no diagnostics available for file, array othwerwise
      *                                     Array containing diagnostics to show
@@ -301,10 +306,5 @@ class PhpCsFixerDiagnosticsProvider implements DiagnosticsProvider, CodeActionPr
 
             return $this->ruleDescriptions[$rule];
         });
-    }
-
-    public function describe(): string
-    {
-        return 'php-cs-fixer';
     }
 }

--- a/lib/Extension/LanguageServerPhpCsFixer/Provider/PhpCsFixerDiagnosticsProvider.php
+++ b/lib/Extension/LanguageServerPhpCsFixer/Provider/PhpCsFixerDiagnosticsProvider.php
@@ -302,4 +302,9 @@ class PhpCsFixerDiagnosticsProvider implements DiagnosticsProvider, CodeActionPr
             return $this->ruleDescriptions[$rule];
         });
     }
+
+    public function describe(): string
+    {
+        return 'php-cs-fixer';
+    }
 }

--- a/lib/Extension/LanguageServerPsalm/Tests/IntegrationTestCase.php
+++ b/lib/Extension/LanguageServerPsalm/Tests/IntegrationTestCase.php
@@ -9,7 +9,7 @@ abstract class IntegrationTestCase extends TestCase
 {
     protected function tearDown(): void
     {
-//        $this->workspace()->reset();
+        //        $this->workspace()->reset();
     }
 
     protected static function workspace(): Workspace

--- a/lib/Name/NameUtil.php
+++ b/lib/Name/NameUtil.php
@@ -37,6 +37,18 @@ final class NameUtil
     }
 
     /**
+     * Return short name (i.e. last segment) of a given PHP FQN
+     */
+    public static function shortName(string $fqn): string
+    {
+        $shortNamePos = strrpos($fqn, '\\');
+        if (false === $shortNamePos) {
+            return $fqn;
+        }
+        return substr($fqn, $shortNamePos + 1);
+    }
+
+    /**
      * Return the child segment name relative to the given search.
      *
      * @return array{?string,bool}

--- a/lib/Name/QualifiedName.php
+++ b/lib/Name/QualifiedName.php
@@ -82,7 +82,7 @@ final class QualifiedName implements Name
     {
         $parts = $this->parts;
         array_unshift($parts, ...$name->toArray());
-        return new self($parts);
+        return new self($parts ?? []);
     }
 
     /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -51,7 +51,7 @@ parameters:
 			path: lib/ClassMover/Domain/Name/Namespace_.php
 
 		-
-			message: "#^Parameter \\#1 \\$parts of class Phpactor\\\\ClassMover\\\\Domain\\\\Name\\\\QualifiedName constructor expects non\\-empty\\-array\\<string\\>, array\\<int, non\\-falsy\\-string\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$parts of class Phpactor\\\\ClassMover\\\\Domain\\\\Name\\\\QualifiedName constructor expects non\\-empty\\-array\\<string\\>, array\\<int\\<0, max\\>, non\\-falsy\\-string\\> given\\.$#"
 			count: 1
 			path: lib/ClassMover/Domain/Name/QualifiedName.php
 
@@ -691,21 +691,6 @@ parameters:
 			path: lib/CodeTransform/Adapter/WorseReflection/Transformer/ImplementContracts.php
 
 		-
-			message: "#^Cannot access property \\$children on Microsoft\\\\PhpParser\\\\Node\\\\DelimitedList\\\\NamespaceUseGroupClauseList\\|null\\.$#"
-			count: 1
-			path: lib/CodeTransform/Adapter/WorseReflection/Transformer/RemoveUnusedImportsTransformer.php
-
-		-
-			message: "#^Cannot call method getEndPosition\\(\\) on Microsoft\\\\PhpParser\\\\Node\\|null\\.$#"
-			count: 2
-			path: lib/CodeTransform/Adapter/WorseReflection/Transformer/RemoveUnusedImportsTransformer.php
-
-		-
-			message: "#^Cannot call method getStartPosition\\(\\) on Microsoft\\\\PhpParser\\\\Node\\|null\\.$#"
-			count: 2
-			path: lib/CodeTransform/Adapter/WorseReflection/Transformer/RemoveUnusedImportsTransformer.php
-
-		-
 			message: "#^Method Phpactor\\\\CodeTransform\\\\CodeTransform\\:\\:transform\\(\\) has parameter \\$transformations with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: lib/CodeTransform/CodeTransform.php
@@ -1332,7 +1317,7 @@ parameters:
 
 		-
 			message: "#^Cannot access property \\$type on Phpactor\\\\DocblockParser\\\\Ast\\\\Token\\|null\\.$#"
-			count: 4
+			count: 3
 			path: lib/DocblockParser/Parser.php
 
 		-
@@ -1346,18 +1331,18 @@ parameters:
 			path: lib/DocblockParser/Parser.php
 
 		-
-			message: "#^Parameter \\#1 \\$children of class Phpactor\\\\DocblockParser\\\\Ast\\\\Docblock constructor expects array\\<Phpactor\\\\DocblockParser\\\\Ast\\\\Element\\>, array\\<int, Phpactor\\\\DocblockParser\\\\Ast\\\\TagNode\\|Phpactor\\\\DocblockParser\\\\Ast\\\\Token\\|null\\> given\\.$#"
-			count: 1
-			path: lib/DocblockParser/Parser.php
-
-		-
 			message: "#^Parameter \\#1 \\$list of class Phpactor\\\\DocblockParser\\\\Ast\\\\ParameterList constructor expects array\\<Phpactor\\\\DocblockParser\\\\Ast\\\\Tag\\\\ParameterTag\\|Phpactor\\\\DocblockParser\\\\Ast\\\\Token\\>, array\\<int, Phpactor\\\\DocblockParser\\\\Ast\\\\Tag\\\\ParameterTag\\|Phpactor\\\\DocblockParser\\\\Ast\\\\Token\\|null\\> given\\.$#"
 			count: 1
 			path: lib/DocblockParser/Parser.php
 
 		-
 			message: "#^Parameter \\#1 \\$list of class Phpactor\\\\DocblockParser\\\\Ast\\\\TypeList constructor expects array\\<Phpactor\\\\DocblockParser\\\\Ast\\\\Token\\|Phpactor\\\\DocblockParser\\\\Ast\\\\TypeNode\\>, array\\<int, Phpactor\\\\DocblockParser\\\\Ast\\\\Token\\|Phpactor\\\\DocblockParser\\\\Ast\\\\TypeNode\\|null\\> given\\.$#"
-			count: 2
+			count: 1
+			path: lib/DocblockParser/Parser.php
+
+		-
+			message: "#^Parameter \\#1 \\$list of class Phpactor\\\\DocblockParser\\\\Ast\\\\TypeList constructor expects array\\<Phpactor\\\\DocblockParser\\\\Ast\\\\Token\\|Phpactor\\\\DocblockParser\\\\Ast\\\\TypeNode\\>, array\\<int\\<0, max\\>, Phpactor\\\\DocblockParser\\\\Ast\\\\Token\\|Phpactor\\\\DocblockParser\\\\Ast\\\\TypeNode\\|null\\> given\\.$#"
+			count: 1
 			path: lib/DocblockParser/Parser.php
 
 		-
@@ -1452,7 +1437,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$type of method Phpactor\\\\DocblockParser\\\\Parser\\:\\:createTypeFromToken\\(\\) expects Phpactor\\\\DocblockParser\\\\Ast\\\\Token, Phpactor\\\\DocblockParser\\\\Ast\\\\Token\\|null given\\.$#"
-			count: 4
+			count: 3
 			path: lib/DocblockParser/Parser.php
 
 		-
@@ -1616,7 +1601,7 @@ parameters:
 			path: lib/Extension/Behat/ReferenceFinder/StepDefinitionLocator.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\Behat\\\\ReferenceFinder\\\\StepDefinitionLocator\\:\\:findSteps\\(\\) should return array\\<Phpactor\\\\Extension\\\\Behat\\\\Behat\\\\Step\\> but returns array\\<int, mixed\\>\\.$#"
+			message: "#^Method Phpactor\\\\Extension\\\\Behat\\\\ReferenceFinder\\\\StepDefinitionLocator\\:\\:findSteps\\(\\) should return array\\<Phpactor\\\\Extension\\\\Behat\\\\Behat\\\\Step\\> but returns array\\<int\\<0, max\\>, mixed\\>\\.$#"
 			count: 1
 			path: lib/Extension/Behat/ReferenceFinder/StepDefinitionLocator.php
 
@@ -3836,7 +3821,7 @@ parameters:
 			path: lib/Extension/FilePathResolver/FilePathResolverExtension.php
 
 		-
-			message: "#^Parameter \\#1 \\$filters of class Phpactor\\\\FilePathResolver\\\\FilteringPathResolver constructor expects array\\<Phpactor\\\\FilePathResolver\\\\Filter\\>, array\\<int, mixed\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$filters of class Phpactor\\\\FilePathResolver\\\\FilteringPathResolver constructor expects array\\<Phpactor\\\\FilePathResolver\\\\Filter\\>, array\\<int\\<0, max\\>, mixed\\> given\\.$#"
 			count: 1
 			path: lib/Extension/FilePathResolver/FilePathResolverExtension.php
 
@@ -3896,11 +3881,6 @@ parameters:
 			path: lib/Extension/LanguageServer/LanguageServerExtension.php
 
 		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$providers of class Phpactor\\\\LanguageServer\\\\Diagnostics\\\\CodeActionDiagnosticsProvider constructor expects Phpactor\\\\LanguageServer\\\\Core\\\\CodeAction\\\\CodeActionProvider, mixed given\\.$#"
-			count: 1
-			path: lib/Extension/LanguageServer/LanguageServerExtension.php
-
-		-
 			message: "#^Parameter \\#2 \\$formatter of class Phpactor\\\\LanguageServer\\\\Handler\\\\TextDocument\\\\FormattingHandler constructor expects Phpactor\\\\LanguageServer\\\\Core\\\\Formatting\\\\Formatter, mixed given\\.$#"
 			count: 1
 			path: lib/Extension/LanguageServer/LanguageServerExtension.php
@@ -3916,7 +3896,7 @@ parameters:
 			path: lib/Extension/LanguageServer/LanguageServerExtension.php
 
 		-
-			message: "#^Parameter \\#7 \\$statusProviders of class Phpactor\\\\Extension\\\\LanguageServer\\\\Handler\\\\DebugHandler constructor expects array\\<Phpactor\\\\Extension\\\\LanguageServer\\\\Status\\\\StatusProvider\\>, array\\<int, mixed\\> given\\.$#"
+			message: "#^Parameter \\#7 \\$statusProviders of class Phpactor\\\\Extension\\\\LanguageServer\\\\Handler\\\\DebugHandler constructor expects array\\<Phpactor\\\\Extension\\\\LanguageServer\\\\Status\\\\StatusProvider\\>, array\\<int\\<0, max\\>, mixed\\> given\\.$#"
 			count: 1
 			path: lib/Extension/LanguageServer/LanguageServerExtension.php
 
@@ -3981,16 +3961,6 @@ parameters:
 			path: lib/Extension/LanguageServerCodeTransform/CodeAction/CreateClassProvider.php
 
 		-
-			message: "#^Cannot cast mixed to string\\.$#"
-			count: 1
-			path: lib/Extension/LanguageServerCodeTransform/CodeAction/CreateUnresolvableClassProvider.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\LanguageServerCodeTransform\\\\CodeAction\\\\CreateUnresolvableClassProvider\\:\\:provideActionsFor\\(\\) should return Amp\\\\Promise\\<array\\<Phpactor\\\\LanguageServerProtocol\\\\CodeAction\\>\\> but returns Amp\\\\Promise\\<mixed\\>\\.$#"
-			count: 1
-			path: lib/Extension/LanguageServerCodeTransform/CodeAction/CreateUnresolvableClassProvider.php
-
-		-
 			message: "#^Method Phpactor\\\\Extension\\\\LanguageServerCodeTransform\\\\CodeAction\\\\ExtractConstantProvider\\:\\:provideActionsFor\\(\\) should return Amp\\\\Promise\\<array\\<Phpactor\\\\LanguageServerProtocol\\\\CodeAction\\>\\> but returns Amp\\\\Promise\\<mixed\\>\\.$#"
 			count: 1
 			path: lib/Extension/LanguageServerCodeTransform/CodeAction/ExtractConstantProvider.php
@@ -4011,17 +3981,7 @@ parameters:
 			path: lib/Extension/LanguageServerCodeTransform/CodeAction/GenerateDecoratorProvider.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\LanguageServerCodeTransform\\\\CodeAction\\\\GenerateMethodProvider\\:\\:provideActionsFor\\(\\) should return Amp\\\\Promise\\<array\\<Phpactor\\\\LanguageServerProtocol\\\\CodeAction\\>\\> but returns Amp\\\\Promise\\<mixed\\>\\.$#"
-			count: 1
-			path: lib/Extension/LanguageServerCodeTransform/CodeAction/GenerateMethodProvider.php
-
-		-
 			message: "#^Method Phpactor\\\\Extension\\\\LanguageServerCodeTransform\\\\CodeAction\\\\ImportNameProvider\\:\\:diagnosticsFromUnresolvedName\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Extension/LanguageServerCodeTransform/CodeAction/ImportNameProvider.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\LanguageServerCodeTransform\\\\CodeAction\\\\ImportNameProvider\\:\\:provideDiagnostics\\(\\) should return Amp\\\\Promise\\<array\\<Phpactor\\\\LanguageServerProtocol\\\\Diagnostic\\>\\> but returns Amp\\\\Promise\\<mixed\\>\\.$#"
 			count: 1
 			path: lib/Extension/LanguageServerCodeTransform/CodeAction/ImportNameProvider.php
 
@@ -4034,11 +3994,6 @@ parameters:
 			message: "#^Method Phpactor\\\\Extension\\\\LanguageServerCodeTransform\\\\CodeAction\\\\ReplaceQualifierWithImportProvider\\:\\:provideActionsFor\\(\\) should return Amp\\\\Promise\\<array\\<Phpactor\\\\LanguageServerProtocol\\\\CodeAction\\>\\> but returns Amp\\\\Promise\\<mixed\\>\\.$#"
 			count: 1
 			path: lib/Extension/LanguageServerCodeTransform/CodeAction/ReplaceQualifierWithImportProvider.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\LanguageServerCodeTransform\\\\CodeAction\\\\TransformerCodeActionPovider\\:\\:provideActionsFor\\(\\) should return Amp\\\\Promise\\<array\\<Phpactor\\\\LanguageServerProtocol\\\\CodeAction\\>\\> but returns Amp\\\\Promise\\<mixed\\>\\.$#"
-			count: 1
-			path: lib/Extension/LanguageServerCodeTransform/CodeAction/TransformerCodeActionPovider.php
 
 		-
 			message: "#^Method Phpactor\\\\Extension\\\\LanguageServerCodeTransform\\\\Converter\\\\DiagnosticsConverter\\:\\:toLspDiagnostics\\(\\) return type has no value type specified in iterable type array\\.$#"
@@ -4124,11 +4079,6 @@ parameters:
 			message: "#^Method Phpactor\\\\Extension\\\\LanguageServerCodeTransform\\\\LspCommand\\\\ReplaceQualifierWithImportCommand\\:\\:__invoke\\(\\) should return Amp\\\\Promise\\<Phpactor\\\\Extension\\\\LanguageServerCodeTransform\\\\LspCommand\\\\ApplyWorkspaceEditResult\\|null\\> but returns Amp\\\\Promise\\<Phpactor\\\\LanguageServerProtocol\\\\ApplyWorkspaceEditResult\\>\\.$#"
 			count: 1
 			path: lib/Extension/LanguageServerCodeTransform/LspCommand/ReplaceQualifierWithImportCommand.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\LanguageServerCodeTransform\\\\LspCommand\\\\TransformCommand\\:\\:__invoke\\(\\) return type with generic interface Amp\\\\Promise does not specify its types\\: TValue$#"
-			count: 1
-			path: lib/Extension/LanguageServerCodeTransform/LspCommand/TransformCommand.php
 
 		-
 			message: "#^Method Phpactor\\\\Extension\\\\LanguageServerCodeTransform\\\\Model\\\\NameImport\\\\NameImporterResult\\:\\:__construct\\(\\) has parameter \\$textEdits with no value type specified in iterable type array\\.$#"
@@ -4731,21 +4681,6 @@ parameters:
 			path: lib/Extension/LanguageServerPhpstan/Tests/Provider/PhpstanDiagnosticProviderTest.php
 
 		-
-			message: "#^Cannot call method resolve\\(\\) on mixed\\.$#"
-			count: 2
-			path: lib/Extension/LanguageServerPsalm/LanguageServerPsalmExtension.php
-
-		-
-			message: "#^Parameter \\#2 \\$shouldShowInfo of class Phpactor\\\\Extension\\\\LanguageServerPsalm\\\\Model\\\\PsalmConfig constructor expects bool, mixed given\\.$#"
-			count: 1
-			path: lib/Extension/LanguageServerPsalm/LanguageServerPsalmExtension.php
-
-		-
-			message: "#^Parameter \\#3 \\$useCache of class Phpactor\\\\Extension\\\\LanguageServerPsalm\\\\Model\\\\PsalmConfig constructor expects bool, mixed given\\.$#"
-			count: 1
-			path: lib/Extension/LanguageServerPsalm/LanguageServerPsalmExtension.php
-
-		-
 			message: "#^Cannot access offset 'column_from' on mixed\\.$#"
 			count: 1
 			path: lib/Extension/LanguageServerPsalm/Model/DiagnosticsParser.php
@@ -4794,11 +4729,6 @@ parameters:
 			message: "#^Method Phpactor\\\\Extension\\\\LanguageServerPsalm\\\\Tests\\\\Model\\\\DiagnosticsParserTest\\:\\:provideParse\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: lib/Extension/LanguageServerPsalm/Tests/Model/DiagnosticsParserTest.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\LanguageServerPsalm\\\\Tests\\\\Model\\\\PsalmProcessTest\\:\\:testLint\\(\\) has parameter \\$expectedDiagnostics with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Extension/LanguageServerPsalm/Tests/Model/PsalmProcessTest.php
 
 		-
 			message: "#^Method Phpactor\\\\Extension\\\\LanguageServerReferenceFinder\\\\Handler\\\\GotoImplementationHandler\\:\\:gotoImplementation\\(\\) return type with generic interface Amp\\\\Promise does not specify its types\\: TValue$#"
@@ -5101,12 +5031,12 @@ parameters:
 			path: lib/Extension/LanguageServerRename/Tests/Util/OffsetExtractor.php
 
 		-
-			message: "#^Parameter \\#2 \\$offsets of class Phpactor\\\\Extension\\\\LanguageServerRename\\\\Tests\\\\Util\\\\OffsetExtractorResult constructor expects array\\<string, array\\<Phpactor\\\\TextDocument\\\\ByteOffset\\>\\>, array\\<int\\|string, array\\<int, Phpactor\\\\TextDocument\\\\ByteOffset\\>\\> given\\.$#"
+			message: "#^Parameter \\#2 \\$offsets of class Phpactor\\\\Extension\\\\LanguageServerRename\\\\Tests\\\\Util\\\\OffsetExtractorResult constructor expects array\\<string, array\\<Phpactor\\\\TextDocument\\\\ByteOffset\\>\\>, array\\<int\\|string, array\\<int\\<0, max\\>, Phpactor\\\\TextDocument\\\\ByteOffset\\>\\> given\\.$#"
 			count: 1
 			path: lib/Extension/LanguageServerRename/Tests/Util/OffsetExtractor.php
 
 		-
-			message: "#^Parameter \\#3 \\$ranges of class Phpactor\\\\Extension\\\\LanguageServerRename\\\\Tests\\\\Util\\\\OffsetExtractorResult constructor expects array\\<string, array\\<Phpactor\\\\TextDocument\\\\ByteOffsetRange\\>\\>, array\\<int\\|string, array\\<int, Phpactor\\\\TextDocument\\\\ByteOffsetRange\\>\\> given\\.$#"
+			message: "#^Parameter \\#3 \\$ranges of class Phpactor\\\\Extension\\\\LanguageServerRename\\\\Tests\\\\Util\\\\OffsetExtractorResult constructor expects array\\<string, array\\<Phpactor\\\\TextDocument\\\\ByteOffsetRange\\>\\>, array\\<int\\|string, array\\<int\\<0, max\\>, Phpactor\\\\TextDocument\\\\ByteOffsetRange\\>\\> given\\.$#"
 			count: 1
 			path: lib/Extension/LanguageServerRename/Tests/Util/OffsetExtractor.php
 
@@ -5174,11 +5104,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$workspace of class Phpactor\\\\Extension\\\\LanguageServerSymbolProvider\\\\Handler\\\\DocumentSymbolProviderHandler constructor expects Phpactor\\\\LanguageServer\\\\Core\\\\Workspace\\\\Workspace, mixed given\\.$#"
 			count: 1
 			path: lib/Extension/LanguageServerSymbolProvider/LanguageServerSymbolProviderExtension.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\LanguageServerWorseReflection\\\\DiagnosticProvider\\\\WorseDiagnosticProvider\\:\\:provideDiagnostics\\(\\) should return Amp\\\\Promise\\<array\\<Phpactor\\\\LanguageServerProtocol\\\\Diagnostic\\>\\> but returns Amp\\\\Promise\\<mixed\\>\\.$#"
-			count: 1
-			path: lib/Extension/LanguageServerWorseReflection/DiagnosticProvider/WorseDiagnosticProvider.php
 
 		-
 			message: "#^Method Phpactor\\\\Extension\\\\LanguageServerWorseReflection\\\\Tests\\\\Benchmark\\\\WorkspaceIndexBench\\:\\:benchUpdate\\(\\) has parameter \\$params with no value type specified in iterable type array\\.$#"
@@ -5331,7 +5256,7 @@ parameters:
 			path: lib/Extension/Navigation/NavigationExtension.php
 
 		-
-			message: "#^Parameter \\#1 \\$navigators of class Phpactor\\\\Extension\\\\Navigation\\\\Navigator\\\\ChainNavigator constructor expects array\\<Phpactor\\\\Extension\\\\Navigation\\\\Navigator\\\\Navigator\\>, array\\<int, mixed\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$navigators of class Phpactor\\\\Extension\\\\Navigation\\\\Navigator\\\\ChainNavigator constructor expects array\\<Phpactor\\\\Extension\\\\Navigation\\\\Navigator\\\\Navigator\\>, array\\<int\\<0, max\\>, mixed\\> given\\.$#"
 			count: 1
 			path: lib/Extension/Navigation/NavigationExtension.php
 
@@ -5431,7 +5356,7 @@ parameters:
 			path: lib/Extension/Php/PhpExtension.php
 
 		-
-			message: "#^Parameter \\#1 \\$finders of class Phpactor\\\\ReferenceFinder\\\\ChainImplementationFinder constructor expects array\\<Phpactor\\\\ReferenceFinder\\\\ClassImplementationFinder\\>, array\\<int, mixed\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$finders of class Phpactor\\\\ReferenceFinder\\\\ChainImplementationFinder constructor expects array\\<Phpactor\\\\ReferenceFinder\\\\ClassImplementationFinder\\>, array\\<int\\<0, max\\>, mixed\\> given\\.$#"
 			count: 1
 			path: lib/Extension/ReferenceFinder/ReferenceFinderExtension.php
 
@@ -6671,11 +6596,6 @@ parameters:
 			path: lib/Indexer/Extension/IndexerExtension.php
 
 		-
-			message: "#^Parameter \\#1 \\$reflector of class Phpactor\\\\Indexer\\\\Adapter\\\\Worse\\\\WorseRecordReferenceEnhancer constructor expects Phpactor\\\\WorseReflection\\\\Core\\\\Reflector\\\\SourceCodeReflector, mixed given\\.$#"
-			count: 1
-			path: lib/Indexer/Extension/IndexerExtension.php
-
-		-
 			message: "#^Parameter \\#1 \\$stubPaths of method Phpactor\\\\Indexer\\\\IndexAgentBuilder\\:\\:setStubPaths\\(\\) expects array\\<string\\>, mixed given\\.$#"
 			count: 1
 			path: lib/Indexer/Extension/IndexerExtension.php
@@ -6897,6 +6817,11 @@ parameters:
 
 		-
 			message: "#^Property Phpactor\\\\Name\\\\QualifiedName\\:\\:\\$parts type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Name/QualifiedName.php
+
+		-
+			message: "#^Variable \\$parts on left side of \\?\\? always exists and is not nullable\\.$#"
 			count: 1
 			path: lib/Name/QualifiedName.php
 


### PR DESCRIPTION
Add profile logging for code actions and also require that code actions describe themselves (mainly to identify "transformer" code actions which all use the same class - but also for more self-documentation in the future).

Result of this profiling points to very significant gains from caching diagnostics - and a good precursor to that would be to introduce an "infinite" cache (or maybe at least > 1 minute so we can throw out the garbage) which is invalidated when documents are updated.