### PR TITLE
Invalidate diagnositc cache on update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Bug fixes:
 
 Improvements:
 
+  - Invalidate diagnostics cache only when document changes #2191
   - Optimize analysis for scopes with many many assignments #2188
   - Made some heavy blocking operations non-blocking (e.g. diagnostics, code
     actions).

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Helper/WorseMissingMethodFinderTest.php
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Helper/WorseMissingMethodFinderTest.php
@@ -18,7 +18,7 @@ class WorseMissingMethodFinderTest extends WorseTestCase
     {
         [$source, $offset] = ExtractOffset::fromSource($source);
         $reflector = $this->reflectorForWorkspace($source);
-        $document = TextDocumentBuilder::create($source)->build();
+        $document = TextDocumentBuilder::create($source)->uri('file:///test')->build();
 
         $methods = wait((new WorseMissingMethodFinder($reflector))->find($document));
         self::assertCount($expectedCount, $methods);

--- a/lib/Extension/LanguageServerCodeTransform/CodeAction/GenerateMethodProvider.php
+++ b/lib/Extension/LanguageServerCodeTransform/CodeAction/GenerateMethodProvider.php
@@ -7,6 +7,7 @@ use Amp\Promise;
 use Phpactor\CodeTransform\Domain\Helper\MissingMethodFinder;
 use Phpactor\Extension\LanguageServerBridge\Converter\PositionConverter;
 use Phpactor\Extension\LanguageServerBridge\Converter\RangeConverter;
+use Phpactor\Extension\LanguageServerBridge\Converter\TextDocumentConverter;
 use Phpactor\Extension\LanguageServerCodeTransform\LspCommand\GenerateMethodCommand;
 use Phpactor\LanguageServerProtocol\CodeAction;
 use Phpactor\LanguageServerProtocol\Command;
@@ -87,7 +88,7 @@ class GenerateMethodProvider implements DiagnosticsProvider, CodeActionProvider
     {
         return call(function () use ($textDocument) {
             $methods = yield $this->missingMethodFinder->find(
-                TextDocumentBuilder::create($textDocument->text)->build()
+                TextDocumentConverter::fromLspTextItem($textDocument)
             );
             $diagnostics = [];
 

--- a/lib/Extension/LanguageServerCodeTransform/CodeAction/GenerateMethodProvider.php
+++ b/lib/Extension/LanguageServerCodeTransform/CodeAction/GenerateMethodProvider.php
@@ -17,7 +17,6 @@ use Phpactor\LanguageServerProtocol\Range;
 use Phpactor\LanguageServerProtocol\TextDocumentItem;
 use Phpactor\LanguageServer\Core\CodeAction\CodeActionProvider;
 use Phpactor\LanguageServer\Core\Diagnostics\DiagnosticsProvider;
-use Phpactor\TextDocument\TextDocumentBuilder;
 use function Amp\call;
 
 class GenerateMethodProvider implements DiagnosticsProvider, CodeActionProvider

--- a/lib/Extension/LanguageServerWorseReflection/LanguageServerWorseReflectionExtension.php
+++ b/lib/Extension/LanguageServerWorseReflection/LanguageServerWorseReflectionExtension.php
@@ -9,6 +9,7 @@ use Phpactor\Extension\LanguageServerWorseReflection\DiagnosticProvider\WorseDia
 use Phpactor\Extension\LanguageServerWorseReflection\Handler\InlayHintHandler;
 use Phpactor\Extension\LanguageServerWorseReflection\InlayHint\InlayHintOptions;
 use Phpactor\Extension\LanguageServerWorseReflection\InlayHint\InlayHintProvider;
+use Phpactor\Extension\LanguageServerWorseReflection\Listener\InvalidateDocumentCacheListener;
 use Phpactor\Extension\LanguageServerWorseReflection\SourceLocator\WorkspaceSourceLocator;
 use Phpactor\Extension\LanguageServerWorseReflection\Workspace\WorkspaceIndex;
 use Phpactor\Extension\LanguageServerWorseReflection\Workspace\WorkspaceIndexListener;
@@ -17,6 +18,7 @@ use Phpactor\Extension\LanguageServer\LanguageServerExtension;
 use Phpactor\Extension\WorseReflection\WorseReflectionExtension;
 use Phpactor\LanguageServer\Core\Workspace\Workspace;
 use Phpactor\MapResolver\Resolver;
+use Phpactor\WorseReflection\Core\CacheForDocument;
 use Phpactor\WorseReflection\Core\Reflector\SourceCodeReflector;
 use Phpactor\WorseReflection\Reflector;
 use Phpactor\WorseReflection\ReflectorBuilder;
@@ -64,6 +66,10 @@ class LanguageServerWorseReflectionExtension implements Extension
                 $container->get(WorkspaceIndex::class),
             );
         }, [ LanguageServerExtension::TAG_LISTENER_PROVIDER => [] ]);
+
+        $container->register(WorkspaceIndexListener::class, function (Container $container) {
+            return new InvalidateDocumentCacheListener($container->get(CacheForDocument::class));
+        });
 
         $container->register(WorkspaceIndex::class, function (Container $container) {
             return new WorkspaceIndex(

--- a/lib/Extension/LanguageServerWorseReflection/LanguageServerWorseReflectionExtension.php
+++ b/lib/Extension/LanguageServerWorseReflection/LanguageServerWorseReflectionExtension.php
@@ -67,7 +67,7 @@ class LanguageServerWorseReflectionExtension implements Extension
             );
         }, [ LanguageServerExtension::TAG_LISTENER_PROVIDER => [] ]);
 
-        $container->register(WorkspaceIndexListener::class, function (Container $container) {
+        $container->register(InvalidateDocumentCacheListener::class, function (Container $container) {
             return new InvalidateDocumentCacheListener($container->get(CacheForDocument::class));
         });
 

--- a/lib/Extension/LanguageServerWorseReflection/Listener/InvalidateDocumentCacheListener.php
+++ b/lib/Extension/LanguageServerWorseReflection/Listener/InvalidateDocumentCacheListener.php
@@ -10,7 +10,8 @@ use Psr\EventDispatcher\ListenerProviderInterface;
 
 class InvalidateDocumentCacheListener implements ListenerProviderInterface
 {
-    public function __construct(private CacheForDocument $cache) {
+    public function __construct(private CacheForDocument $cache)
+    {
     }
 
     /**
@@ -19,12 +20,12 @@ class InvalidateDocumentCacheListener implements ListenerProviderInterface
     public function getListenersForEvent($event): iterable
     {
         if ($event instanceof TextDocumentUpdated) {
-            yield function () use ($event) {
+            yield function () use ($event): void {
                 $this->cache->purge(TextDocumentUri::fromString($event->identifier()->uri));
             };
         }
         if ($event instanceof TextDocumentClosed) {
-            yield function () use ($event) {
+            yield function () use ($event): void {
                 $this->cache->purge(TextDocumentUri::fromString($event->identifier()->uri));
             };
         }

--- a/lib/Extension/LanguageServerWorseReflection/Listener/InvalidateDocumentCacheListener.php
+++ b/lib/Extension/LanguageServerWorseReflection/Listener/InvalidateDocumentCacheListener.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerWorseReflection\Listener;
+
+use Phpactor\LanguageServer\Event\TextDocumentClosed;
+use Phpactor\LanguageServer\Event\TextDocumentUpdated;
+use Phpactor\TextDocument\TextDocumentUri;
+use Phpactor\WorseReflection\Core\CacheForDocument;
+use Psr\EventDispatcher\ListenerProviderInterface;
+
+class InvalidateDocumentCacheListener implements ListenerProviderInterface
+{
+    public function __construct(private CacheForDocument $cache) {
+    }
+
+    /**
+     * @return iterable<callable>
+     */
+    public function getListenersForEvent($event): iterable
+    {
+        if ($event instanceof TextDocumentUpdated) {
+            yield function () use ($event) {
+                $this->cache->purge(TextDocumentUri::fromString($event->identifier()->uri));
+            };
+        }
+        if ($event instanceof TextDocumentClosed) {
+            yield function () use ($event) {
+                $this->cache->purge(TextDocumentUri::fromString($event->identifier()->uri));
+            };
+        }
+    }
+}

--- a/lib/Extension/WorseReflection/WorseReflectionExtension.php
+++ b/lib/Extension/WorseReflection/WorseReflectionExtension.php
@@ -18,6 +18,8 @@ use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\MissingReturnType
 use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\UnresolvableNameProvider;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Diagnostics\UnusedImportProvider;
 use Phpactor\WorseReflection\Core\Cache;
+use Phpactor\WorseReflection\Core\CacheForDocument;
+use Phpactor\WorseReflection\Core\Cache\StaticCache;
 use Phpactor\WorseReflection\Core\Cache\TtlCache;
 use Phpactor\WorseReflection\Core\SourceCodeLocator\NativeReflectionFunctionSourceLocator;
 use Phpactor\WorseReflection\Core\SourceCodeLocator\StubSourceLocator;
@@ -94,6 +96,7 @@ class WorseReflectionExtension implements Extension
             if ($container->parameter(self::PARAM_ENABLE_CACHE)->bool()) {
                 $builder->enableCache();
                 $builder->withCache($container->get(Cache::class));
+                $builder->withCacheForDocument($container->get(CacheForDocument::class));
             }
 
             foreach ($container->getServiceIdsForTag(self::TAG_SOURCE_LOCATOR) as $serviceId => $attrs) {
@@ -136,6 +139,11 @@ class WorseReflectionExtension implements Extension
 
         $container->register(Cache::class, function (Container $container) {
             return new TtlCache($container->parameter(self::PARAM_CACHE_LIFETIME)->float());
+        });
+        $container->register(CacheForDocument::class, function (Container $container) {
+            return new CacheForDocument(
+                fn () => new StaticCache(),
+            );
         });
     }
 

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflector/TolerantSourceCodeReflector.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflector/TolerantSourceCodeReflector.php
@@ -25,7 +25,6 @@ use Phpactor\WorseReflection\Core\Inference\NodeReflector;
 use Phpactor\WorseReflection\Core\ServiceLocator;
 use Microsoft\PhpParser\Parser;
 use Phpactor\WorseReflection\Core\Reflection\Collection\ReflectionFunctionCollection as TolerantReflectionFunctionCollection;
-use RuntimeException;
 use function Amp\call;
 use function Amp\delay;
 

--- a/lib/WorseReflection/Core/CacheForDocument.php
+++ b/lib/WorseReflection/Core/CacheForDocument.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Phpactor\WorseReflection\Core;
+
+use Closure;
+use Phpactor\TextDocument\TextDocumentUri;
+
+class CacheForDocument
+{
+    /**
+     * @var array<string,Cache>
+     */
+    private array $caches = [];
+
+    /**
+     * @param Closure(): Cache $cacheFactory
+     */
+    public function __construct(private Closure $cacheFactory)
+    {
+    }
+
+    /**
+     * @template T
+     * @param Closure(): T $setter
+     * @return T
+     */
+    public function getOrSet(TextDocumentUri $uri, string $key, Closure $setter)
+    {
+        if (!isset($this->caches[$uri->__toString()])) {
+            $this->caches[$uri->__toString()] = ($this->cacheFactory)();
+        }
+        return $this->caches[$uri->__toString()]->getOrSet($key, $setter);
+    }
+
+    public function purge(TextDocumentUri $uri): void
+    {
+        unset($this->caches[$uri->__toString()]);
+    }
+}

--- a/lib/WorseReflection/Core/ServiceLocator.php
+++ b/lib/WorseReflection/Core/ServiceLocator.php
@@ -6,6 +6,7 @@ use Phpactor\WorseReflection\Bridge\Phpactor\DocblockParser\CachedParserFactory;
 use Phpactor\WorseReflection\Bridge\Phpactor\DocblockParser\DocblockParserFactory;
 use Phpactor\WorseReflection\Core\Cache\NullCache;
 use Phpactor\WorseReflection\Core\Cache\StaticCache;
+use Phpactor\WorseReflection\Core\Cache\TtlCache;
 use Phpactor\WorseReflection\Core\Inference\GenericMapResolver;
 use Phpactor\WorseReflection\Core\Inference\Resolver\MemberAccess\MemberContextResolver;
 use Phpactor\WorseReflection\Core\Inference\Resolver\MemberAccess\NodeContextFromMemberAccess;
@@ -44,6 +45,8 @@ class ServiceLocator
     private Cache $cache;
 
     private NodeToTypeConverter $nameResolver;
+
+    private CacheForDocument $cacheForDocument;
 
     /**
      * @param Walker[] $frameWalkers
@@ -95,6 +98,7 @@ class ServiceLocator
 
         $this->nameResolver = new NodeToTypeConverter($this->reflector, $this->logger);
         $this->cache = $cache;
+        $this->cacheForDocument = new CacheForDocument(fn () => new StaticCache());
     }
 
     public function reflector(): Reflector
@@ -160,6 +164,11 @@ class ServiceLocator
     public function cache(): Cache
     {
         return $this->cache;
+    }
+
+    public function cacheForDocument(): CacheForDocument
+    {
+        return $this->cacheForDocument;
     }
 
     public function newDiagnosticsWalker(): DiagnosticsWalker

--- a/lib/WorseReflection/Core/ServiceLocator.php
+++ b/lib/WorseReflection/Core/ServiceLocator.php
@@ -46,8 +46,6 @@ class ServiceLocator
 
     private NodeToTypeConverter $nameResolver;
 
-    private CacheForDocument $cacheForDocument;
-
     /**
      * @param Walker[] $frameWalkers
      * @param ReflectionMemberProvider[] $methodProviders
@@ -63,6 +61,7 @@ class ServiceLocator
         private array $diagnosticProviders,
         private array $memberContextResolvers,
         Cache $cache,
+        private CacheForDocument $cacheForDocument,
         bool $enableContextualLocation = false
     ) {
         $sourceReflector = $reflectorFactory->create($this);
@@ -98,7 +97,6 @@ class ServiceLocator
 
         $this->nameResolver = new NodeToTypeConverter($this->reflector, $this->logger);
         $this->cache = $cache;
-        $this->cacheForDocument = new CacheForDocument(fn () => new StaticCache());
     }
 
     public function reflector(): Reflector

--- a/lib/WorseReflection/Core/ServiceLocator.php
+++ b/lib/WorseReflection/Core/ServiceLocator.php
@@ -6,7 +6,6 @@ use Phpactor\WorseReflection\Bridge\Phpactor\DocblockParser\CachedParserFactory;
 use Phpactor\WorseReflection\Bridge\Phpactor\DocblockParser\DocblockParserFactory;
 use Phpactor\WorseReflection\Core\Cache\NullCache;
 use Phpactor\WorseReflection\Core\Cache\StaticCache;
-use Phpactor\WorseReflection\Core\Cache\TtlCache;
 use Phpactor\WorseReflection\Core\Inference\GenericMapResolver;
 use Phpactor\WorseReflection\Core\Inference\Resolver\MemberAccess\MemberContextResolver;
 use Phpactor\WorseReflection\Core\Inference\Resolver\MemberAccess\NodeContextFromMemberAccess;

--- a/lib/WorseReflection/ReflectorBuilder.php
+++ b/lib/WorseReflection/ReflectorBuilder.php
@@ -5,6 +5,7 @@ namespace Phpactor\WorseReflection;
 use Phpactor\TextDocument\TextDocument;
 use Phpactor\TextDocument\TextDocumentBuilder;
 use Phpactor\WorseReflection\Core\Cache;
+use Phpactor\WorseReflection\Core\CacheForDocument;
 use Phpactor\WorseReflection\Core\Cache\NullCache;
 use Phpactor\WorseReflection\Core\Cache\TtlCache;
 use Phpactor\WorseReflection\Core\DiagnosticProvider;
@@ -65,6 +66,8 @@ final class ReflectorBuilder
      * @var MemberContextResolver[]
      */
     private array $memberContextResolvers = [];
+
+    private CacheForDocument $cacheForDocument;
 
     /**
      * Create a new instance of the builder
@@ -145,6 +148,7 @@ final class ReflectorBuilder
             $this->diagnosticProviders,
             $this->memberContextResolvers,
             $this->buildCache(),
+            $this->cacheForDocument ?? new CacheForDocument(fn () => new NullCache()),
             $this->enableContextualSourceLocation
         ))->reflector();
     }
@@ -182,6 +186,13 @@ final class ReflectorBuilder
     public function withCache(Cache $cache): ReflectorBuilder
     {
         $this->cache = $cache;
+
+        return $this;
+    }
+
+    public function withCacheForDocument(CacheForDocument $cacheForDocument): ReflectorBuilder
+    {
+        $this->cacheForDocument = $cacheForDocument;
 
         return $this;
     }

--- a/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Diagonstics/DiagnosticsTestCase.php
+++ b/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Diagonstics/DiagnosticsTestCase.php
@@ -34,7 +34,7 @@ abstract class DiagnosticsTestCase extends IntegrationTestCase
 
     public function diagnosticsFromSource(string $source): Diagnostics
     {
-        $source = TextDocumentBuilder::fromUnknown($source);
+        $source = TextDocumentBuilder::create($source)->uri('file:///test')->build();
         $reflector = $this->createBuilder($source)->enableCache()->addDiagnosticProvider($this->provider())->build();
         $reflector->reflectOffset($source, mb_strlen($source));
         return wait($reflector->diagnostics($source));
@@ -45,7 +45,7 @@ abstract class DiagnosticsTestCase extends IntegrationTestCase
         $this->workspace()->reset();
         $this->workspace()->loadManifest($manifest);
         $source = $this->workspace()->getContents('test.php');
-        $source = TextDocumentBuilder::fromUnknown($source);
+        $source = TextDocumentBuilder::create($source)->uri('file:///test.php')->build();
 
         $builder = ReflectorBuilder::create()
             ->withLogger($this->logger());

--- a/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Diagonstics/UnresolvableNameProviderTest.php
+++ b/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Diagonstics/UnresolvableNameProviderTest.php
@@ -487,7 +487,7 @@ class UnresolvableNameProviderTest extends DiagnosticsTestCase
         )->build();
 
         $found = wait($reflector->diagnostics(
-            TextDocumentBuilder::create('<?php Foobar::class;')->build()
+            TextDocumentBuilder::create('<?php Foobar::class;')->uri('file:///test')->build()
         ));
         self::assertCount(1, $found);
     }
@@ -499,7 +499,7 @@ class UnresolvableNameProviderTest extends DiagnosticsTestCase
         )->build();
 
         $found = wait($reflector->diagnostics(
-            TextDocumentBuilder::create('<?php barboo();')->build()
+            TextDocumentBuilder::create('<?php barboo();')->uri('file:///test')->build()
         ));
         self::assertCount(1, $found);
     }

--- a/lib/WorseReflection/Tests/Unit/Core/CacheForDocumentTest.php
+++ b/lib/WorseReflection/Tests/Unit/Core/CacheForDocumentTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Phpactor\WorseReflection\Tests\Unit\Core;
+
+use PHPUnit\Framework\TestCase;
+use Phpactor\TextDocument\TextDocumentUri;
+use Phpactor\WorseReflection\Core\CacheForDocument;
+use Phpactor\WorseReflection\Core\Cache\StaticCache;
+
+class CacheForDocumentTest extends TestCase
+{
+    public function testGetSet(): void
+    {
+        $cache = new CacheForDocument(fn () => new StaticCache());
+        $result = $cache->getOrSet(TextDocumentUri::fromString('file:///foo'), 'bar', function () {
+            return 'bar';
+        });
+        self::assertEquals('bar', $result);
+        $result = $cache->getOrSet(TextDocumentUri::fromString('file:///foo'), 'bar', function () {
+            return 'boo';
+        });
+        self::assertEquals('bar', $result);
+        $result = $cache->getOrSet(TextDocumentUri::fromString('file:///baz'), 'bar', function () {
+            return 'boo';
+        });
+        self::assertEquals('boo', $result);
+    }
+}


### PR DESCRIPTION
Adds a caching mechanism for diagnostics based on the text document URI - has _dramatic_ impact on large files where it can take > than the default cache TTL for code actions to be resolved (e.g. on large file it took > 1 minute to resolve code actions, now it takes 7 seconds on first run) 

A further optimisation would be to cache reflection classes - although this might look different as we don't know the text document URI, so would be more like tag invalidation.

