### PR TITLE
Show reference to new object when invoking on __construct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ Changelog
 
 Features:
 
-  - Experimental support for inlay hints #2138
+  - Show references to new objects when finding references to `__construct` method #2194
+  - Support for inlay hints #2138
   - Deprecation diagnostics #2120
   - Auto configuration - automatically suggest and apply configuration #2114
   - Transform to "promote" unassigned consturctor properties #2106

--- a/lib/Indexer/Adapter/ReferenceFinder/IndexedReferenceFinder.php
+++ b/lib/Indexer/Adapter/ReferenceFinder/IndexedReferenceFinder.php
@@ -101,10 +101,12 @@ class IndexedReferenceFinder implements ReferenceFinder
                 return;
             }
 
+
+
             // note that we check the all implementations: this will multiply
             // the number of NOT and MAYBE matches
             foreach ($this->implementationsOf($containerType) as $containerType) {
-                yield from $this->query->member()->referencesTo(
+                yield from $this->memberReferencesTo(
                     $this->symbolTypeToReferenceType($nodeContext),
                     $nodeContext->symbol()->name(),
                     $containerType
@@ -186,5 +188,14 @@ class IndexedReferenceFinder implements ReferenceFinder
             'Could not convert symbol type "%s" to reference type',
             $symbolType
         ));
+    }
+
+    /**
+     * @param "method"|"constant"|"property" $referenceType
+     * @return Generator<LocationConfidence>
+     */
+    private function memberReferencesTo(string $referenceType, string $memberName, string $containerType): Generator
+    {
+        yield from $this->query->member()->referencesTo($referenceType, $memberName, $containerType);
     }
 }

--- a/lib/Indexer/Adapter/ReferenceFinder/IndexedReferenceFinder.php
+++ b/lib/Indexer/Adapter/ReferenceFinder/IndexedReferenceFinder.php
@@ -7,12 +7,15 @@ use Phpactor\Indexer\Adapter\ReferenceFinder\Util\ContainerTypeResolver;
 use Phpactor\Indexer\Model\QueryClient;
 use Phpactor\Indexer\Model\LocationConfidence;
 use Phpactor\Indexer\Model\Query\Criteria;
+use Phpactor\Indexer\Model\RecordReference;
 use Phpactor\Indexer\Model\Record\MemberRecord;
 use Phpactor\Indexer\Model\SearchClient;
 use Phpactor\ReferenceFinder\PotentialLocation;
 use Phpactor\ReferenceFinder\ReferenceFinder;
 use Phpactor\TextDocument\ByteOffset;
+use Phpactor\TextDocument\Location;
 use Phpactor\TextDocument\TextDocument;
+use Phpactor\TextDocument\TextDocumentUri;
 use Phpactor\WorseReflection\Core\Exception\NotFound;
 use Phpactor\WorseReflection\Core\Inference\Symbol;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
@@ -201,7 +204,19 @@ class IndexedReferenceFinder implements ReferenceFinder
         if ($memberName === '__construct' && $referenceType === 'method') {
             $class = $this->query->class()->get($containerType);
             foreach ($class->references() as $reference) {
-                dump($this->query->file()->get($reference));
+                $file = $this->query->file()->get($reference);
+                foreach ($file->references() as $fileReference) {
+                    if (
+                        $fileReference->type() === 'class' && $fileReference->hasFlag(RecordReference::FLAG_NEW_OBJECT)
+                    ) {
+                        yield LocationConfidence::surely(
+                            new Location(
+                                TextDocumentUri::fromString($file->filePath()),
+                                ByteOffset::fromInt($fileReference->offset())
+                            )
+                        );
+                    }
+                }
             }
             return;
         }

--- a/lib/Indexer/Adapter/ReferenceFinder/IndexedReferenceFinder.php
+++ b/lib/Indexer/Adapter/ReferenceFinder/IndexedReferenceFinder.php
@@ -6,7 +6,9 @@ use Generator;
 use Phpactor\Indexer\Adapter\ReferenceFinder\Util\ContainerTypeResolver;
 use Phpactor\Indexer\Model\QueryClient;
 use Phpactor\Indexer\Model\LocationConfidence;
+use Phpactor\Indexer\Model\Query\Criteria;
 use Phpactor\Indexer\Model\Record\MemberRecord;
+use Phpactor\Indexer\Model\SearchClient;
 use Phpactor\ReferenceFinder\PotentialLocation;
 use Phpactor\ReferenceFinder\ReferenceFinder;
 use Phpactor\TextDocument\ByteOffset;
@@ -196,6 +198,13 @@ class IndexedReferenceFinder implements ReferenceFinder
      */
     private function memberReferencesTo(string $referenceType, string $memberName, string $containerType): Generator
     {
+        if ($memberName === '__construct' && $referenceType === 'method') {
+            $class = $this->query->class()->get($containerType);
+            foreach ($class->references() as $reference) {
+                dump($this->query->file()->get($reference));
+            }
+            return;
+        }
         yield from $this->query->member()->referencesTo($referenceType, $memberName, $containerType);
     }
 }

--- a/lib/Indexer/Adapter/Tolerant/Indexer/ClassLikeReferenceIndexer.php
+++ b/lib/Indexer/Adapter/Tolerant/Indexer/ClassLikeReferenceIndexer.php
@@ -4,6 +4,7 @@ namespace Phpactor\Indexer\Adapter\Tolerant\Indexer;
 
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\Expression\CallExpression;
+use Microsoft\PhpParser\Node\Expression\ObjectCreationExpression;
 use Microsoft\PhpParser\Node\QualifiedName;
 use Microsoft\PhpParser\Node\TraitUseClause;
 use Phpactor\Indexer\Model\Index;
@@ -73,7 +74,11 @@ class ClassLikeReferenceIndexer extends AbstractClassLikeIndexer
         $fileRecord = $index->get(FileRecord::fromPath($document->uri()->path()));
         assert($fileRecord instanceof FileRecord);
         $reference = new RecordReference(ClassRecord::RECORD_TYPE, $targetRecord->identifier(), $node->getStartPosition());
-        $reference->addFlag(RecordReference::FLAG_NEW_OBJECT);
+
+        if ($node->parent instanceof ObjectCreationExpression) {
+            $reference->addFlag(RecordReference::FLAG_NEW_OBJECT);
+        }
+
         $fileRecord->addReference($reference);
         $index->write($fileRecord);
     }

--- a/lib/Indexer/Adapter/Tolerant/Indexer/ClassLikeReferenceIndexer.php
+++ b/lib/Indexer/Adapter/Tolerant/Indexer/ClassLikeReferenceIndexer.php
@@ -52,7 +52,7 @@ class ClassLikeReferenceIndexer extends AbstractClassLikeIndexer
         assert($node instanceof QualifiedName);
 
         $name =
-            $node->parent->parent instanceof TraitUseClause ?
+            $node->parent?->parent instanceof TraitUseClause ?
                 TolerantQualifiedNameResolver::getResolvedName($node) :
                 $node->getResolvedName();
 

--- a/lib/Indexer/Adapter/Tolerant/Indexer/ClassLikeReferenceIndexer.php
+++ b/lib/Indexer/Adapter/Tolerant/Indexer/ClassLikeReferenceIndexer.php
@@ -72,7 +72,9 @@ class ClassLikeReferenceIndexer extends AbstractClassLikeIndexer
 
         $fileRecord = $index->get(FileRecord::fromPath($document->uri()->path()));
         assert($fileRecord instanceof FileRecord);
-        $fileRecord->addReference(new RecordReference(ClassRecord::RECORD_TYPE, $targetRecord->identifier(), $node->getStartPosition()));
+        $reference = new RecordReference(ClassRecord::RECORD_TYPE, $targetRecord->identifier(), $node->getStartPosition());
+        $reference->addFlag(RecordReference::FLAG_NEW_OBJECT);
+        $fileRecord->addReference($reference);
         $index->write($fileRecord);
     }
 }

--- a/lib/Indexer/Model/Record/ClassRecord.php
+++ b/lib/Indexer/Model/Record/ClassRecord.php
@@ -11,7 +11,6 @@ final class ClassRecord implements Record, HasFileReferences, HasFlags, HasPath,
     use HasFileReferencesTrait;
     use HasPathTrait;
     use HasFlagsTrait;
-
     public const RECORD_TYPE = 'class';
     public const TYPE_CLASS = 'class';
     public const TYPE_INTERFACE = 'interface';

--- a/lib/Indexer/Model/Record/ClassRecord.php
+++ b/lib/Indexer/Model/Record/ClassRecord.php
@@ -10,6 +10,8 @@ final class ClassRecord implements Record, HasFileReferences, HasFlags, HasPath,
     use FullyQualifiedReferenceTrait;
     use HasFileReferencesTrait;
     use HasPathTrait;
+    use HasFlagsTrait;
+
     public const RECORD_TYPE = 'class';
     public const TYPE_CLASS = 'class';
     public const TYPE_INTERFACE = 'interface';
@@ -31,8 +33,6 @@ final class ClassRecord implements Record, HasFileReferences, HasFlags, HasPath,
      * Type of "class": class, interface or trait, etc
      */
     private ?string $type = null;
-
-    private int $flags = 0;
 
     public static function fromName(string $name): self
     {
@@ -112,29 +112,5 @@ final class ClassRecord implements Record, HasFileReferences, HasFlags, HasPath,
         $clone = clone $this;
         $clone->type = $type;
         return $clone;
-    }
-
-    public function setFlags(int $flags): self
-    {
-        $this->flags = $flags;
-
-        return $this;
-    }
-
-    public function addFlag(int $flag): self
-    {
-        $this->flags = $this->flags | $flag;
-
-        return $this;
-    }
-
-    public function hasFlag(int $flag): bool
-    {
-        return (bool) ($this->flags & $flag);
-    }
-
-    public function flags(): int
-    {
-        return $this->flags;
     }
 }

--- a/lib/Indexer/Model/Record/FileRecord.php
+++ b/lib/Indexer/Model/Record/FileRecord.php
@@ -59,7 +59,8 @@ class FileRecord implements HasPath, Record
             $reference->type(),
             $reference->identifier(),
             $reference->offset(),
-            $reference->contaninerType()
+            $reference->contaninerType(),
+            $reference->flags()
         ];
 
         return $this;

--- a/lib/Indexer/Model/Record/HasFlagsTrait.php
+++ b/lib/Indexer/Model/Record/HasFlagsTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Phpactor\Indexer\Model\Record;
+
+trait HasFlagsTrait
+{
+    private int $flags = 0;
+
+    public function setFlags(int $flags): self
+    {
+        $this->flags = $flags;
+
+        return $this;
+    }
+
+    public function addFlag(int $flag): self
+    {
+        $this->flags = $this->flags | $flag;
+
+        return $this;
+    }
+
+    public function hasFlag(int $flag): bool
+    {
+        return (bool) ($this->flags & $flag);
+    }
+
+    public function flags(): int
+    {
+        return $this->flags;
+    }
+}

--- a/lib/Indexer/Model/RecordReference.php
+++ b/lib/Indexer/Model/RecordReference.php
@@ -8,7 +8,6 @@ use Phpactor\Indexer\Model\Record\HasFlagsTrait;
 class RecordReference implements HasFlags
 {
     use HasFlagsTrait;
-
     const FLAG_NEW_OBJECT = 1;
 
     public function __construct(

--- a/lib/Indexer/Model/RecordReference.php
+++ b/lib/Indexer/Model/RecordReference.php
@@ -2,14 +2,23 @@
 
 namespace Phpactor\Indexer\Model;
 
-class RecordReference
+use Phpactor\Indexer\Model\Record\HasFlags;
+use Phpactor\Indexer\Model\Record\HasFlagsTrait;
+
+class RecordReference implements HasFlags
 {
+    use HasFlagsTrait;
+
+    const FLAG_NEW_OBJECT = 1;
+
     public function __construct(
         private string $type,
         private string $identifier,
         private int $offset,
-        private ?string $contaninerType = null
+        private ?string $contaninerType = null,
+        int $flags = 0
     ) {
+        $this->flags = $flags;
     }
 
     public function offset(): int

--- a/lib/Indexer/Tests/Adapter/ReferenceFinder/IndexedReferenceFinderTest.php
+++ b/lib/Indexer/Tests/Adapter/ReferenceFinder/IndexedReferenceFinderTest.php
@@ -233,6 +233,21 @@ class IndexedReferenceFinderTest extends IntegrationTestCase
         ,
             3
         ];
+
+        yield 'show new object expressions when finding references on __construct' => [
+            <<<'EOT'
+                // File: project/foobar.php
+                <?php Foobar::bar();
+
+                // File: project/subject.php
+                <?php class Foobar { public function __c<>onstruct() {} public static function bar() {} }
+
+                // File: project/class1.php
+                <?php new Foobar();
+                EOT
+        ,
+            1
+        ];
     }
 
     /**

--- a/lib/Indexer/Tests/Adapter/ReferenceFinder/IndexedReferenceFinderTest.php
+++ b/lib/Indexer/Tests/Adapter/ReferenceFinder/IndexedReferenceFinderTest.php
@@ -248,6 +248,21 @@ class IndexedReferenceFinderTest extends IntegrationTestCase
         ,
             1
         ];
+
+        yield 'show new object expressions when finding references on __construct 2' => [
+            <<<'EOT'
+                // File: project/foobar.php
+                <?php Foobar::bar();
+
+                // File: project/subject.php
+                <?php class Foobar { public function __c<>onstruct() {} public static function bar() {} }
+
+                // File: project/class1.php
+                <?php new Foobar(); new Barfoo();
+                EOT
+        ,
+            1
+        ];
     }
 
     /**


### PR DESCRIPTION
When invoking "references" on a `__construct` return all `new` expressions for that object.

Fixes #1563 