### PR TITLE
fix #2202

### DIFF
--- a/lib/Extension/LanguageServerPhpCsFixer/Model/PhpCsFixerProcess.php
+++ b/lib/Extension/LanguageServerPhpCsFixer/Model/PhpCsFixerProcess.php
@@ -93,7 +93,7 @@ class PhpCsFixerProcess
     public function run(string ...$args): Promise
     {
         return call(function () use ($args) {
-            $process = new Process([$this->binPath, ...$args], null, $this->env);
+            $process = new Process([$this->binPath, ...$args], null, $this->env + ['PATH' => getenv('PATH')]);
             yield $process->start();
 
             $process->join()


### PR DESCRIPTION
Fix PATH env lost issue when using php-cs-fixer formatter, see #2202 