### PR TITLE
Gh 2202 php cs fixer

### DIFF
--- a/lib/Amp/Process/ProcessBuilder.php
+++ b/lib/Amp/Process/ProcessBuilder.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Phpactor\Amp\Process;
+
+use Amp\Process\Process;
+
+final class ProcessBuilder
+{
+    /**
+     * @var array<string,mixed>
+     */
+    private array $env = [];
+
+    private ?string $cwd = null;
+
+    private bool $mergeParentEnv = false;
+
+    /**
+     * @param list<string> $args
+     */
+    private function __construct(private array $args)
+    {
+    }
+
+    /**
+     * @param list<string> $args
+     */
+    public function cmd(array $args): self
+    {
+        $this->args = $args;
+        return $this;
+    }
+
+    public function cwd(string $cwd): self
+    {
+        $this->cwd = $cwd;
+        return $this;
+    }
+    /**
+     * @param array<string,mixed> $env
+     */
+    public function env(array $env): self
+    {
+        $this->env = $env;
+        return $this;
+    }
+
+    public function mergeParentEnv(): self
+    {
+        $this->mergeParentEnv = true;
+        return $this;
+    }
+
+    public function build(): Process
+    {
+        $env = $this->env;
+        if ($this->mergeParentEnv) {
+            $env = array_merge(getenv(), $env);
+        }
+        return new Process($this->args, $this->cwd, $env);
+    }
+
+    /**
+     * @param list<string> $args
+     */
+    public static function create(array $args): self
+    {
+        return new self($args);
+    }
+}

--- a/lib/Amp/Tests/Process/ProcessBuilderTest.php
+++ b/lib/Amp/Tests/Process/ProcessBuilderTest.php
@@ -26,6 +26,7 @@ class ProcessBuilderTest extends TestCase
         $pid = wait($process->start());
         $exitCode = wait($process->join());
         self::assertEquals(0, $exitCode);
+        /** @var string $out @phpstan-ignore-next-line */
         $out = wait(buffer($process->getStdout()));
         self::assertStringContainsString('myenvvar', $out);
         self::assertStringNotContainsString(self::PARENT_PROCESS_ENV_VAR, $out);
@@ -39,6 +40,7 @@ class ProcessBuilderTest extends TestCase
         $pid = wait($process->start());
         $exitCode = wait($process->join());
         self::assertEquals(0, $exitCode);
+        /** @var string $out @phpstan-ignore-next-line */
         $out = wait(buffer($process->getStdout()));
         self::assertStringContainsString('myenvvar', $out);
         self::assertStringContainsString(self::PARENT_PROCESS_ENV_VAR, $out);

--- a/lib/Amp/Tests/Process/ProcessBuilderTest.php
+++ b/lib/Amp/Tests/Process/ProcessBuilderTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Phpactor\Amp\Tests\Process;
+
+use PHPUnit\Framework\TestCase;
+use Phpactor\Amp\Process\ProcessBuilder;
+use function Amp\ByteStream\buffer;
+use function Amp\Promise\wait;
+
+class ProcessBuilderTest extends TestCase
+{
+    const PARENT_PROCESS_ENV_VAR = 'thisistheparentprocess';
+
+    public function testBuildProcess(): void
+    {
+        $process = ProcessBuilder::create(['export'])->build();
+        $pid = wait($process->start());
+        $exitCode = wait($process->join());
+        self::assertEquals(0, $exitCode);
+    }
+
+    public function testDoesNotMergeEnvByDefaultWhenEnvVarsPassed(): void
+    {
+        putenv('FOO='.self::PARENT_PROCESS_ENV_VAR);
+        $process = ProcessBuilder::create(['export'])->env(['ENV'=> 'myenvvar'])->build();
+        $pid = wait($process->start());
+        $exitCode = wait($process->join());
+        self::assertEquals(0, $exitCode);
+        $out = wait(buffer($process->getStdout()));
+        self::assertStringContainsString('myenvvar', $out);
+        self::assertStringNotContainsString(self::PARENT_PROCESS_ENV_VAR, $out);
+        putenv('FOO');
+    }
+
+    public function testInheritsWhenInstructedToWhenEnvVarsPassed(): void
+    {
+        putenv('FOO='.self::PARENT_PROCESS_ENV_VAR);
+        $process = ProcessBuilder::create(['export'])->env(['ENV'=> 'myenvvar'])->mergeParentEnv()->build();
+        $pid = wait($process->start());
+        $exitCode = wait($process->join());
+        self::assertEquals(0, $exitCode);
+        $out = wait(buffer($process->getStdout()));
+        self::assertStringContainsString('myenvvar', $out);
+        self::assertStringContainsString(self::PARENT_PROCESS_ENV_VAR, $out);
+        putenv('FOO');
+    }
+}

--- a/lib/Extension/LanguageServerPhpCsFixer/Model/PhpCsFixerProcess.php
+++ b/lib/Extension/LanguageServerPhpCsFixer/Model/PhpCsFixerProcess.php
@@ -4,6 +4,7 @@ namespace Phpactor\Extension\LanguageServerPhpCsFixer\Model;
 
 use Amp\Process\Process;
 use Amp\Promise;
+use Phpactor\Amp\Process\ProcessBuilder;
 use Phpactor\Extension\LanguageServerPhpCsFixer\Exception\PhpCsFixerError;
 use Psr\Log\LoggerInterface;
 use function Amp\ByteStream\buffer;
@@ -93,7 +94,7 @@ class PhpCsFixerProcess
     public function run(string ...$args): Promise
     {
         return call(function () use ($args) {
-            $process = new Process([$this->binPath, ...$args], null, $this->env);
+            $process = ProcessBuilder::create([$this->binPath, ...$args])->mergeParentEnv()->env($this->env)->build();
             yield $process->start();
 
             $process->join()


### PR DESCRIPTION
ensure we inherit the env for php cs fixer (as we set env vars, and this stops the heritage from the parent process)