### PR TITLE
Small bugfix for null exception on empty var

### DIFF
--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UndefinedVariableProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UndefinedVariableProvider.php
@@ -25,13 +25,19 @@ class UndefinedVariableProvider implements DiagnosticProvider
         if ($node->parent?->parent instanceof PropertyDeclaration) {
             return [];
         }
-        foreach ($frame->locals()->byName($node->getName()) as $variable) {
-            if ($variable->wasDefinition()) {
-                return [];
-            }
-        }
 
         $name = $node->getName();
+
+        if ($name) {
+            foreach ($frame->locals()->byName($name) as $variable) {
+                if ($variable->wasDefinition()) {
+                    return [];
+                }
+            }
+        } else {
+            $name = 'UNDEFINED';
+        }
+
         yield new UndefinedVariableDiagnostic(
             NodeUtil::byteOffsetRangeForNode($node),
             $name,

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UndefinedVariableProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UndefinedVariableProvider.php
@@ -26,16 +26,14 @@ class UndefinedVariableProvider implements DiagnosticProvider
             return [];
         }
 
-        $name = $node->getName();
+        if (!$name = $node->getName()) {
+            return [];
+        }
 
-        if ($name) {
-            foreach ($frame->locals()->byName($name) as $variable) {
-                if ($variable->wasDefinition()) {
-                    return [];
-                }
+        foreach ($frame->locals()->byName($name) as $variable) {
+            if ($variable->wasDefinition()) {
+                return [];
             }
-        } else {
-            $name = 'UNDEFINED';
         }
 
         yield new UndefinedVariableDiagnostic(

--- a/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Diagonstics/UndefinedVariableProvider/VariableIsIncomplete.test
+++ b/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Diagonstics/UndefinedVariableProvider/VariableIsIncomplete.test
@@ -1,0 +1,5 @@
+<?php
+
+class foo {
+    public string $
+}

--- a/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Diagonstics/UndefinedVariableProviderTest.php
+++ b/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Diagonstics/UndefinedVariableProviderTest.php
@@ -90,7 +90,18 @@ class UndefinedVariableProviderTest extends DiagnosticsTestCase
         self::assertCount(0, $diagnostics);
     }
 
+    /**
+     * @param Diagnostics<Diagnostic> $diagnostics
+     */
     public function checkVariableListAssignment(Diagnostics $diagnostics): void
+    {
+        self::assertCount(0, $diagnostics);
+    }
+
+    /**
+     * @param Diagnostics<Diagnostic> $diagnostics
+     */
+    public function checkVariableIsIncomplete(Diagnostics $diagnostics): void
     {
         self::assertCount(0, $diagnostics);
     }


### PR DESCRIPTION
In the logs the the following would constantly throw errors:

```php
class demo {
  public string $<CUR>
}
```

This is because the variable has no name yet.