### PR TITLE
Fixing constant indexer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Features:
 
 Bug fixes:
 
+  - Fix constant declaration indexing with `define` #2249 @mamazu
   - Fix use of class-string<Foo> variable as static scope resolution qualifier #2238
   - URL decode root URI - fixes issues with special chars in path #2228
   - Do not deduplicate suggestions of different types (e.g. prop/method with same name) #2214

--- a/lib/Indexer/Adapter/Tolerant/Indexer/ConstantDeclarationIndexer.php
+++ b/lib/Indexer/Adapter/Tolerant/Indexer/ConstantDeclarationIndexer.php
@@ -81,26 +81,23 @@ class ConstantDeclarationIndexer implements TolerantIndexer
             return;
         }
 
-        // In this case we only care about the name of the constant which is the first argument
-        $firstArgument = null;
         foreach ($node->argumentExpressionList->getChildNodes() as $expression) {
             if (!$expression instanceof ArgumentExpression) {
                 return;
             }
+            $string = $expression->expression;
+            if (!$string instanceof StringLiteral) {
+                return;
+            }
 
-            $firstArgument = $expression;
-            break;
-        }
+            $record = $index->get(ConstantRecord::fromName($string->getStringContentsText()));
+            assert($record instanceof ConstantRecord);
+            $record->setStart(ByteOffset::fromInt($node->getStartPosition()));
+            $record->setFilePath($document->uri()->path());
+            $index->write($record);
 
-        $string = $firstArgument?->expression;
-        if (!$string instanceof StringLiteral) {
+            // Return after the first argument, because we only need the name of the constant.
             return;
         }
-
-        $record = $index->get(ConstantRecord::fromName($string->getStringContentsText()));
-        assert($record instanceof ConstantRecord);
-        $record->setStart(ByteOffset::fromInt($node->getStartPosition()));
-        $record->setFilePath($document->uri()->path());
-        $index->write($record);
     }
 }

--- a/lib/Indexer/Adapter/Tolerant/Indexer/ConstantDeclarationIndexer.php
+++ b/lib/Indexer/Adapter/Tolerant/Indexer/ConstantDeclarationIndexer.php
@@ -82,6 +82,7 @@ class ConstantDeclarationIndexer implements TolerantIndexer
         }
 
         // In this case we only care about the name of the constant which is the first argument
+        $firstArgument = null;
         foreach ($node->argumentExpressionList->getChildNodes() as $expression) {
             if (!$expression instanceof ArgumentExpression) {
                 return;
@@ -91,7 +92,7 @@ class ConstantDeclarationIndexer implements TolerantIndexer
             break;
         }
 
-        $string = $expression->expression;
+        $string = $firstArgument?->expression;
         if (!$string instanceof StringLiteral) {
             return;
         }

--- a/lib/Indexer/Adapter/Tolerant/Indexer/ConstantDeclarationIndexer.php
+++ b/lib/Indexer/Adapter/Tolerant/Indexer/ConstantDeclarationIndexer.php
@@ -81,20 +81,25 @@ class ConstantDeclarationIndexer implements TolerantIndexer
             return;
         }
 
+        // In this case we only care about the name of the constant which is the first argument
         foreach ($node->argumentExpressionList->getChildNodes() as $expression) {
             if (!$expression instanceof ArgumentExpression) {
                 return;
             }
-            $string = $expression->expression;
-            if (!$string instanceof StringLiteral) {
-                return;
-            }
 
-            $record = $index->get(ConstantRecord::fromName($string->getStringContentsText()));
-            assert($record instanceof ConstantRecord);
-            $record->setStart(ByteOffset::fromInt($node->getStartPosition()));
-            $record->setFilePath($document->uri()->path());
-            $index->write($record);
+            $firstArgument = $expression;
+            break;
         }
+
+        $string = $expression->expression;
+        if (!$string instanceof StringLiteral) {
+            return;
+        }
+
+        $record = $index->get(ConstantRecord::fromName($string->getStringContentsText()));
+        assert($record instanceof ConstantRecord);
+        $record->setStart(ByteOffset::fromInt($node->getStartPosition()));
+        $record->setFilePath($document->uri()->path());
+        $index->write($record);
     }
 }

--- a/lib/Indexer/Tests/Adapter/Tolerant/Indexer/ConstantDeclarationIndexerTest.php
+++ b/lib/Indexer/Tests/Adapter/Tolerant/Indexer/ConstantDeclarationIndexerTest.php
@@ -82,9 +82,10 @@ class ConstantDeclarationIndexerTest extends TolerantIndexerTestCase
                 ));
             }
         ];
+
         yield 'a define creates only one constant'  => [
             "// File: src/file1.php\n<?php define('FOOBAR', 'FOOBAR123');",
-            function(IndexAgent $agent): void {
+            function (IndexAgent $agent): void {
                 self::assertInstanceOf(
                     ConstantRecord::class,
                     $agent->query()->constant()->get('FOOBAR')

--- a/lib/Indexer/Tests/Adapter/Tolerant/Indexer/ConstantDeclarationIndexerTest.php
+++ b/lib/Indexer/Tests/Adapter/Tolerant/Indexer/ConstantDeclarationIndexerTest.php
@@ -82,6 +82,25 @@ class ConstantDeclarationIndexerTest extends TolerantIndexerTestCase
                 ));
             }
         ];
+        yield 'a define creates only one constant'  => [
+            "// File: src/file1.php\n<?php define('FOOBAR', 'FOOBAR123');",
+            function(IndexAgent $agent): void {
+                self::assertInstanceOf(
+                    ConstantRecord::class,
+                    $agent->query()->constant()->get('FOOBAR')
+                );
+
+                self::assertCount(1, iterator_to_array(
+                    $agent->search()->search(
+                        Criteria::and(
+                            Criteria::isConstant(),
+                            Criteria::fqnBeginsWith('FOOBAR')
+                        )
+                    )
+                ));
+            }
+        ];
+
         yield 'namespaced define' => [
             "// File: src/file1.php\n<?php namespace Foo; define('Barfoo\FOOBAR', 1)",
             function (IndexAgent $agent): void {

--- a/lib/Indexer/Tests/Adapter/Tolerant/Indexer/ConstantDeclarationIndexerTest.php
+++ b/lib/Indexer/Tests/Adapter/Tolerant/Indexer/ConstantDeclarationIndexerTest.php
@@ -17,6 +17,8 @@ class ConstantDeclarationIndexerTest extends TolerantIndexerTestCase
 
     /**
      * @dataProvider provideDeclaration
+     *
+     * @param Closure(IndexAgent):void $assertion
      */
     public function testDeclaration(string $manifest, Closure $assertion): void
     {
@@ -34,7 +36,7 @@ class ConstantDeclarationIndexerTest extends TolerantIndexerTestCase
     }
 
     /**
-     * @return Generator<mixed>
+     * @return Generator<array{string, Closure(IndexAgent):void}>
      */
     public function provideDeclaration(): Generator
     {


### PR DESCRIPTION
Closes #2168

## What was the problem?
The problem was that in the old code phpactor created a constant for every (string literal) argument in a define call. This isn't correct since the first argument in the call is the name and the second argument is the value of the constant. The multilineness of the value was what tricked the cache. But this isn't a problem since the second argument shouldn't be a constant in the first place.