### PR TITLE
Fixing the ObjectProphecy type

### DIFF
--- a/lib/Completion/Tests/Unit/CompletorTest.php
+++ b/lib/Completion/Tests/Unit/CompletorTest.php
@@ -17,9 +17,9 @@ class CompletorTest extends TestCase
     const EXAMPLE_OFFSET = 1234;
 
     /**
-     * @var ObjectProphecy|Completor
+     * @var ObjectProphecy<Completor>
      */
-    private $completor1;
+    private ObjectProphecy $completor1;
 
     protected function setUp(): void
     {

--- a/lib/Completion/Tests/Unit/Core/ChainSignatureHelperTest.php
+++ b/lib/Completion/Tests/Unit/Core/ChainSignatureHelperTest.php
@@ -10,28 +10,29 @@ use Phpactor\Completion\Tests\TestCase;
 use Phpactor\TextDocument\ByteOffset;
 use Phpactor\TextDocument\TextDocument;
 use Phpactor\TextDocument\TextDocumentBuilder;
+use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Log\LoggerInterface;
 
 class ChainSignatureHelperTest extends TestCase
 {
     /**
-     * @var ObjectProphecy|LoggerInterface
+     * @var ObjectProphecy<LoggerInterface>
      */
-    private $logger;
+    private ObjectProphecy $logger;
 
     /**
-     * @var SignatureHelper|ObjectProphecy
+     * @var ObjectProphecy<SignatureHelper>
      */
-    private $helper1;
+    private ObjectProphecy $helper1;
 
     private TextDocument $document;
 
     private ByteOffset $offset;
 
     /**
-     * @var SignatureHelper|ObjectProphecy
+     * @var ObjectProphecy<SignatureHelper>
      */
-    private $help;
+    private ObjectProphecy $help;
 
     protected function setUp(): void
     {

--- a/lib/Completion/Tests/Unit/Core/ChainSignatureHelperTest.php
+++ b/lib/Completion/Tests/Unit/Core/ChainSignatureHelperTest.php
@@ -30,7 +30,7 @@ class ChainSignatureHelperTest extends TestCase
     private ByteOffset $offset;
 
     /**
-     * @var ObjectProphecy<SignatureHelper>
+     * @var ObjectProphecy<SignatureHelp>
      */
     private ObjectProphecy $help;
 

--- a/lib/Extension/FilePathResolver/FilePathResolverExtension.php
+++ b/lib/Extension/FilePathResolver/FilePathResolverExtension.php
@@ -21,6 +21,7 @@ use Phpactor\MapResolver\Resolver;
 use Phpactor\TextDocument\TextDocumentUri;
 use Psr\Log\LogLevel;
 use RuntimeException;
+use Phpactor\FilePathResolver\Expander;
 
 class FilePathResolverExtension implements Extension
 {
@@ -116,12 +117,14 @@ class FilePathResolverExtension implements Extension
                 new SuffixExpanderDecorator(new XdgDataExpander('data'), $suffix),
             ];
 
-            if (null !== $applicationRoot = $container->getParameter(self::PARAM_APPLICATION_ROOT)) {
-                $expanders[] = new ValueExpander('application_root', $container->getParameter(self::PARAM_APPLICATION_ROOT));
+            /** @var string|null $applicationRoot */
+            $applicationRoot = $container->getParameter(self::PARAM_APPLICATION_ROOT);
+            if (null !== $applicationRoot) {
+                $expanders[] = new ValueExpander('application_root', $applicationRoot);
             }
 
             foreach (array_keys($container->getServiceIdsForTag(self::TAG_EXPANDER)) as $serviceId) {
-                $expanders[] = $container->get($serviceId);
+                $expanders[] = $container->expect($serviceId, Expander::class);
             }
 
             return new Expanders($expanders);

--- a/lib/Extension/LanguageServerCodeTransform/Tests/Unit/LspCommand/ImportAllUnresolvedNamesCommandTest.php
+++ b/lib/Extension/LanguageServerCodeTransform/Tests/Unit/LspCommand/ImportAllUnresolvedNamesCommandTest.php
@@ -25,8 +25,14 @@ class ImportAllUnresolvedNamesCommandTest extends TestCase
     const EXAMPLE_URI = 'file:///foobar';
     const EXAMPLE_CANDIDATE = 'Foobar';
 
+    /**
+     * @var ObjectProphecy<CandidateFinder> $candidateFinder
+     */
     private ObjectProphecy $candidateFinder;
 
+    /**
+     * @var ObjectProphecy<ImportNameCommand> $importName
+     */
     private ObjectProphecy $importName;
 
     public function setUp(): void

--- a/lib/Extension/LanguageServerReferenceFinder/Tests/Unit/Handler/GotoImplementationHandlerTest.php
+++ b/lib/Extension/LanguageServerReferenceFinder/Tests/Unit/Handler/GotoImplementationHandlerTest.php
@@ -22,9 +22,9 @@ class GotoImplementationHandlerTest extends TestCase
     const EXAMPLE_TEXT = 'hello';
 
     /**
-     * @var ObjectProphecy|ClassImplementationFinder
+     * @var ObjectProphecy<ClassImplementationFinder>
      */
-    private $finder;
+    private ObjectProphecy $finder;
 
     protected function setUp(): void
     {

--- a/lib/FilePathResolver/Expanders.php
+++ b/lib/FilePathResolver/Expanders.php
@@ -14,6 +14,9 @@ class Expanders implements IteratorAggregate
      */
     private array $expanders = [];
 
+    /**
+     * @param Expander[] $expanders
+     */
     public function __construct(array $expanders)
     {
         foreach ($expanders as $expander) {

--- a/lib/FilePathResolver/Tests/Unit/Filter/TokenExpandingFilterTest.php
+++ b/lib/FilePathResolver/Tests/Unit/Filter/TokenExpandingFilterTest.php
@@ -41,6 +41,9 @@ class TokenExpandingFilterTest extends TestCase
         $this->assertEquals('/start/baz/fab/end', $path);
     }
 
+    /**
+     * @param Expander[] $expanders
+     */
     private function create(array $expanders = []): TokenExpandingFilter
     {
         return new TokenExpandingFilter(new Expanders($expanders));

--- a/lib/Filesystem/Tests/Unit/Domain/FallbackFilesystemRegistryTest.php
+++ b/lib/Filesystem/Tests/Unit/Domain/FallbackFilesystemRegistryTest.php
@@ -20,7 +20,9 @@ class FallbackFilesystemRegistryTest extends TestCase
 
     private FallbackFilesystemRegistry $registry;
 
-    /** @var ObjectProphecy<Filesystem> */
+    /**
+     * @var ObjectProphecy<Filesystem>
+     */
     private ObjectProphecy|Filesystem $filesystem1;
 
     public function setUp(): void

--- a/lib/ReferenceFinder/Tests/Unit/ChainDefinitionLocationProviderTest.php
+++ b/lib/ReferenceFinder/Tests/Unit/ChainDefinitionLocationProviderTest.php
@@ -22,14 +22,14 @@ class ChainDefinitionLocationProviderTest extends TestCase
     use ProphecyTrait;
 
     /**
-     * @var ObjectProphecy|DefinitionLocator
+     * @var ObjectProphecy<DefinitionLocator>
      */
-    private $locator1;
+    private ObjectProphecy $locator1;
 
     /**
-     * @var ObjectProphecy|DefinitionLocator
+     * @var ObjectProphecy<DefinitionLocator>
      */
-    private $locator2;
+    private ObjectProphecy $locator2;
 
     private TextDocument $document;
 

--- a/lib/ReferenceFinder/Tests/Unit/ChainImplementationFinderTest.php
+++ b/lib/ReferenceFinder/Tests/Unit/ChainImplementationFinderTest.php
@@ -20,14 +20,14 @@ class ChainImplementationFinderTest extends TestCase
     use ProphecyTrait;
 
     /**
-     * @var ObjectProphecy|ClassImplementationFinder
+     * @var ObjectProphecy<ClassImplementationFinder>
      */
-    private $locator1;
+    private ObjectProphecy $locator1;
 
     /**
-     * @var ObjectProphecy|ClassImplementationFinder
+     * @var ObjectProphecy<ClassImplementationFinder>
      */
-    private $locator2;
+    private ObjectProphecy $locator2;
 
     private TextDocument $document;
 

--- a/lib/ReferenceFinder/Tests/Unit/ChainReferenceFinderTest.php
+++ b/lib/ReferenceFinder/Tests/Unit/ChainReferenceFinderTest.php
@@ -20,14 +20,14 @@ class ChainReferenceFinderTest extends TestCase
     use ProphecyTrait;
 
     /**
-     * @var ObjectProphecy|ClassReferenceFinder
+     * @var ObjectProphecy<ClassReferenceFinder>
      */
-    private $locator1;
+    private ObjectProphecy $locator1;
 
     /**
-     * @var ObjectProphecy|ClassReferenceFinder
+     * @var ObjectProphecy<ClassReferenceFinder>
      */
-    private $locator2;
+    private ObjectProphecy $locator2;
 
     private TextDocument $document;
 

--- a/lib/ReferenceFinder/Tests/Unit/ChainTypeLocatorTest.php
+++ b/lib/ReferenceFinder/Tests/Unit/ChainTypeLocatorTest.php
@@ -23,14 +23,14 @@ class ChainTypeLocatorTest extends TestCase
     use ProphecyTrait;
 
     /**
-     * @var ObjectProphecy|TypeLocator
+     * @var ObjectProphecy<TypeLocator>
      */
-    private $locator1;
+    private ObjectProphecy $locator1;
 
     /**
-     * @var ObjectProphecy|TypeLocator
+     * @var ObjectProphecy<TypeLocator>
      */
-    private $locator2;
+    private ObjectProphecy $locator2;
 
     private TextDocument $document;
 

--- a/lib/WorseReflection/Tests/Unit/Core/Reflection/Collection/HomogeneousReflectionMemberCollectionTest.php
+++ b/lib/WorseReflection/Tests/Unit/Core/Reflection/Collection/HomogeneousReflectionMemberCollectionTest.php
@@ -18,17 +18,17 @@ class HomogeneousReflectionMemberCollectionTest extends TestCase
     use ProphecyTrait;
 
     /**
-     * @var ObjectProphecy|ReflectionMember
+     * @var ObjectProphecy<ReflectionMember>
      */
-    private $member1;
+    private ObjectProphecy $member1;
 
     /**
-     * @var ObjectProphecy|ReflectionMember
+     * @var ObjectProphecy<ReflectionMember>
      */
-    private $member2;
+    private ObjectProphecy $member2;
 
     /**
-     * @var ObjectProphecy|ReflectionMember
+     * @var ObjectProphecy<ReflectionMember>
      */
     private ObjectProphecy $member3;
 

--- a/lib/WorseReflection/Tests/Unit/Core/Reflector/ClassReflector/MemonizedClassReflectorTest.php
+++ b/lib/WorseReflection/Tests/Unit/Core/Reflector/ClassReflector/MemonizedClassReflectorTest.php
@@ -18,9 +18,9 @@ class MemonizedClassReflectorTest extends TestCase
     use ProphecyTrait;
 
     /**
-     * @var ClassReflector|ObjectProphecy
+     * @var ObjectProphecy<ClassReflector>
      */
-    private $innerClassReflector;
+    private ObjectProphecy $innerClassReflector;
 
     /**
      * @var MemonizedClassReflector
@@ -28,9 +28,9 @@ class MemonizedClassReflectorTest extends TestCase
     private MemonizedReflector $reflector;
 
     /**
-     * @var ObjectProphecy|FunctionReflector
+     * @var ObjectProphecy<FunctionReflector>
      */
-    private $innerFunctionReflector;
+    private ObjectProphecy $innerFunctionReflector;
 
     private ClassName $className;
 

--- a/tests/Unit/Extension/Core/Rpc/CacheClearHandlerTest.php
+++ b/tests/Unit/Extension/Core/Rpc/CacheClearHandlerTest.php
@@ -11,9 +11,9 @@ use Prophecy\Prophecy\ObjectProphecy;
 class CacheClearHandlerTest extends HandlerTestCase
 {
     /**
-     * @var CacheClear|ObjectProphecy
+     * @var ObjectProphecy<CacheClear>
      */
-    private $clearCache;
+    private ObjectProphecy $clearCache;
 
     public function setUp(): void
     {

--- a/tests/Unit/Extension/Core/Rpc/StatusHandlerTest.php
+++ b/tests/Unit/Extension/Core/Rpc/StatusHandlerTest.php
@@ -15,9 +15,9 @@ use Phpactor\Extension\Core\Rpc\StatusHandler;
 class StatusHandlerTest extends HandlerTestCase
 {
     /**
-     * @var Status|ObjectProphecy
+     * @var ObjectProphecy<Status>
      */
-    private $status;
+    private ObjectProphecy $status;
 
     private ObjectProphecy $paths;
 


### PR DESCRIPTION
## What's in there

* ObjectProphecy|A => ObjectProphecy<A> which is the correct type
* Now php-cs-fixer also added type hints to the properties

## Why?

For some reason my version of the phpstan analyser returns 220 errors when running it with the same configuration as in the pipeline. Even a fresh install doesn't help. :shrug:  Well some of the issues are valid and have been fixed in this PR.