### PR TITLE
Gh 2302: Do not report super globals as undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Changelog
 
 Bug fixes:
 
-  - Do not report globals as undefined #2302
+  - Do not report globals or super globals as undefined #2302
 
 ## 2023.06.17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## 2023.06.18
+
+Bug fixes:
+
+  - Do not report globals as undefined #2302
+
 ## 2023.06.17
 
 Features:

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UndefinedVariableProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UndefinedVariableProvider.php
@@ -277,6 +277,26 @@ class UndefinedVariableProvider implements DiagnosticProvider
                 Assert::assertCount(0, $diagnostics);
             }
         );
+        yield new DiagnosticExample(
+            title: 'super globals',
+            source: <<<'PHP'
+                <?php
+                $GLOBALS['foo'];
+                $_SERVER['foo'];
+                $_GET['foo'];
+                $_POST['foo'];
+                $_FILES['foo'];
+                $_COOKIE['foo'];
+                $_SESSION['foo'];
+                $_REQUEST['foo'];
+                $_ENV['foo'];
+
+                PHP,
+            valid: true,
+            assertion: function (Diagnostics $diagnostics): void {
+                Assert::assertCount(0, $diagnostics);
+            }
+        );
     }
 
     public function enter(NodeContextResolver $resolver, Frame $frame, Node $node): iterable

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UndefinedVariableProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UndefinedVariableProvider.php
@@ -304,7 +304,7 @@ class UndefinedVariableProvider implements DiagnosticProvider
                 <?php
                 function foo(): void
                 {
-                    globals $foo, $bar;
+                    global $foo, $bar;
 
                     echo $foo;
                     echo $bar;

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UndefinedVariableProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UndefinedVariableProvider.php
@@ -16,6 +16,7 @@ use Phpactor\WorseReflection\Core\Diagnostics;
 use Phpactor\WorseReflection\Core\Inference\Context\FunctionCallContext;
 use Phpactor\WorseReflection\Core\Inference\Frame;
 use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
+use Phpactor\WorseReflection\Core\Inference\SuperGlobals;
 use Phpactor\WorseReflection\Core\Inference\Variable as PhpactorVariable;
 use Phpactor\WorseReflection\Core\Util\NodeUtil;
 
@@ -312,6 +313,12 @@ class UndefinedVariableProvider implements DiagnosticProvider
         }
 
         if (!$name = $node->getName()) {
+            return [];
+        }
+
+        $global = SuperGlobals::list()[$name] ?? null;
+
+        if ($global) {
             return [];
         }
 

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UndefinedVariableProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UndefinedVariableProvider.php
@@ -298,6 +298,24 @@ class UndefinedVariableProvider implements DiagnosticProvider
                 Assert::assertCount(0, $diagnostics);
             }
         );
+        yield new DiagnosticExample(
+            title: 'local globals',
+            source: <<<'PHP'
+                <?php
+                function foo(): void
+                {
+                    globals $foo, $bar;
+
+                    echo $foo;
+                    echo $bar;
+                }
+
+                PHP,
+            valid: true,
+            assertion: function (Diagnostics $diagnostics): void {
+                Assert::assertCount(0, $diagnostics);
+            }
+        );
     }
 
     public function enter(NodeContextResolver $resolver, Frame $frame, Node $node): iterable

--- a/lib/WorseReflection/Core/DefaultResolverFactory.php
+++ b/lib/WorseReflection/Core/DefaultResolverFactory.php
@@ -37,6 +37,7 @@ use Microsoft\PhpParser\Node\Statement\EnumDeclaration;
 use Microsoft\PhpParser\Node\Statement\ExpressionStatement;
 use Microsoft\PhpParser\Node\Statement\ForeachStatement;
 use Microsoft\PhpParser\Node\Statement\FunctionDeclaration;
+use Microsoft\PhpParser\Node\Statement\GlobalDeclaration;
 use Microsoft\PhpParser\Node\Statement\IfStatementNode;
 use Microsoft\PhpParser\Node\Statement\InterfaceDeclaration;
 use Microsoft\PhpParser\Node\Statement\ReturnStatement;
@@ -72,6 +73,7 @@ use Phpactor\WorseReflection\Core\Inference\Resolver\ConstElementResolver;
 use Phpactor\WorseReflection\Core\Inference\Resolver\EnumCaseDeclarationResolver;
 use Phpactor\WorseReflection\Core\Inference\Resolver\ExpressionStatementResolver;
 use Phpactor\WorseReflection\Core\Inference\Resolver\ForeachStatementResolver;
+use Phpactor\WorseReflection\Core\Inference\Resolver\GlobalDeclarationResolver;
 use Phpactor\WorseReflection\Core\Inference\Resolver\IfStatementResolver;
 use Phpactor\WorseReflection\Core\Inference\Resolver\MemberAccessExpressionResolver;
 use Phpactor\WorseReflection\Core\Inference\Resolver\MemberAccess\NodeContextFromMemberAccess;
@@ -123,6 +125,7 @@ final class DefaultResolverFactory
             EnumCaseDeclaration::class => new EnumCaseDeclarationResolver(),
             Parameter::class => new ParameterResolver(),
             UseVariableName::class => new UseVariableNameResolver(),
+            GlobalDeclaration::class => new GlobalDeclarationResolver(),
             Variable::class => new VariableResolver(),
             MemberAccessExpression::class => new MemberAccessExpressionResolver($this->nodeContextFromMemberAccess),
             ScopedPropertyAccessExpression::class => new ScopedPropertyAccessResolver($this->nodeContextFromMemberAccess),

--- a/lib/WorseReflection/Core/Inference/Resolver/GlobalDeclarationResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/GlobalDeclarationResolver.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Phpactor\WorseReflection\Core\Inference\Resolver;
+
+use Microsoft\PhpParser\Node;
+use Microsoft\PhpParser\Node\Expression\Variable;
+use Microsoft\PhpParser\Node\Statement\GlobalDeclaration;
+use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Inference\NodeContext;
+use Phpactor\WorseReflection\Core\Inference\NodeContextFactory;
+use Phpactor\WorseReflection\Core\Inference\Resolver;
+use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
+use Phpactor\WorseReflection\Core\Inference\Symbol;
+use Phpactor\WorseReflection\Core\Inference\Variable as PhpactorVariable;
+use Phpactor\WorseReflection\Core\TypeFactory;
+
+class GlobalDeclarationResolver implements Resolver
+{
+    public function resolve(NodeContextResolver $resolver, Frame $frame, Node $node): NodeContext
+    {
+        assert($node instanceof GlobalDeclaration);
+        foreach ($node->variableNameList->getChildNodes() as $child) {
+            if (!$child instanceof Variable) {
+                continue;
+            }
+            $name = $child->getName();
+            if (!$name) {
+                continue;
+            }
+
+            $context = NodeContextFactory::create(
+                $name,
+                $node->getStartPosition(),
+                $node->getEndPosition(),
+                [
+                    'symbol_type' => Symbol::VARIABLE,
+                    'type' => TypeFactory::mixed(),
+                ]
+            );
+            $frame->locals()->set(PhpactorVariable::fromSymbolContext($context)->asAssignment());
+        }
+
+        return NodeContextFactory::forNode($node);
+    }
+}

--- a/lib/WorseReflection/Core/Inference/SuperGlobals.php
+++ b/lib/WorseReflection/Core/Inference/SuperGlobals.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Phpactor\WorseReflection\Core\Inference;
+
+use Phpactor\WorseReflection\Core\Type;
+use Phpactor\WorseReflection\Core\TypeFactory;
+
+final class SuperGlobals
+{
+    /**
+     * @return array<string,Type>
+     */
+    public static function list(): array
+    {
+        return [
+            'GLOBALS' => TypeFactory::array(),
+            '_SERVER' => TypeFactory::array(),
+            '_GET' => TypeFactory::array(),
+            '_POST' => TypeFactory::array(),
+            '_FILES' => TypeFactory::array(),
+            '_COOKIE' => TypeFactory::array(),
+            '_SESSION' => TypeFactory::array(),
+            '_REQUEST' => TypeFactory::array(),
+            '_ENV' => TypeFactory::array(),
+        ];
+    }
+}

--- a/lib/WorseReflection/Core/Inference/Walker/PassThroughWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/PassThroughWalker.php
@@ -9,6 +9,7 @@ use Microsoft\PhpParser\Node\Expression\CallExpression;
 use Microsoft\PhpParser\Node\Expression\Variable;
 use Microsoft\PhpParser\Node\Expression\YieldExpression;
 use Microsoft\PhpParser\Node\Statement\ForeachStatement;
+use Microsoft\PhpParser\Node\Statement\GlobalDeclaration;
 use Microsoft\PhpParser\Node\Statement\IfStatementNode;
 use Microsoft\PhpParser\Node\Statement\ReturnStatement;
 use Phpactor\WorseReflection\Core\Inference\Frame;
@@ -28,6 +29,7 @@ class PassThroughWalker implements Walker
             YieldExpression::class,
             ReturnStatement::class,
             IfStatementNode::class,
+            GlobalDeclaration::class,
             ForeachStatement::class,
             CatchClause::class,
             BinaryExpression::class,

--- a/lib/WorseReflection/Tests/Inference/global/global_keyword.test
+++ b/lib/WorseReflection/Tests/Inference/global/global_keyword.test
@@ -1,0 +1,8 @@
+                <?php
+                function foo(): void
+                {
+                    global $foo, $bar;
+
+                    echo $foo;
+                    echo $bar;
+                }


### PR DESCRIPTION
Do not report globals or super globals as undefined.

Note that we should refactor this to integrate better support for globals / super globals in general - i.e. bringing them into the frame scope so that they work as expected and we can get f.e. auto-completion for `$_SERVER` keys