### PR TITLE
Update Drupal 8+ docs.

### DIFF
--- a/doc/integrations/drupal8.rst
+++ b/doc/integrations/drupal8.rst
@@ -1,15 +1,19 @@
-Drupal 8
-========
+Drupal 8+
+=========
 
-Inc Files
-^^^^^^^^^
+Inc and module files
+^^^^^^^^^^^^^^^^^^^^
 
-By default Phpactor will not index `.inc` files.
+By default Phpactor will not index `.inc` nor `.module` files.
 
-Run the following on your project to enable the indexing of `.inc` files.
+Run the following on your project to enable the indexing of `.inc` and `.module` files.
 
 ```
-phpactor config:set indexer.supported_extensions '["php", "inc"]'
+phpactor config:set indexer.supported_extensions '["php", "inc", "module"]'
+```
+
+```
+phpactor config:set indexer.include_patterns '["/**/*.php", "/**/*.inc", "/**/*.module"]'
 ```
 
 Bootstrapping


### PR DESCRIPTION
As I promised in https://github.com/phpactor/phpactor/issues/2296 I tried the new release but it didn't work 100% because the include patterns also need to be tweaked. I don't know why it worked for @dantleech 

It seems like something is not quite right when two config items need to be configured in a very similar fashion to include a new file extension but I can't think of a way right now of only using `indexer.include_patterns`.

There is a plan in Drupal to have all php files with the php extension but being such a big project I think it is a long way there.
https://www.drupal.org/project/drupal/issues/7269
There is also `.install`, `.theme`, `.profile` and `.engine` but I think those can be ignored.
