### PR TITLE
Improve diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,7 @@ jobs:
 
             -
                 name: "Composer install"
-                uses: "ramsey/composer-install@v1"
+                uses: "ramsey/composer-install@v2"
                 with:
                     composer-options: "--no-scripts"
                     ignore-cache: "yes"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,6 +248,7 @@ jobs:
                 uses: "ramsey/composer-install@v1"
                 with:
                     composer-options: "--no-scripts"
+                    ignore-cache: "yes"
             -
                 name: "Run PHPBench"
                 run: "vendor/bin/phpbench run --progress=plain --iterations=1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Changelog
 
 ## master
 
+Improvements:
+
+  - Improve Diagnostics: Run linters in parallel #2327
+
 Bug fixes:
 
   - Fix generic extends with templated argument #2295

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "phpactor/amp-fswatch": "^0.2.0",
         "thecodingmachine/safe": "^1.0",
         "phpactor/phly-event-dispatcher": "^2.0.0",
-        "phpactor/language-server": "^5.1.0",
+        "phpactor/language-server": "^6.0.0",
         "phpactor/language-server-protocol": "^3.17.3",
         "dantleech/object-renderer": "^0.1.1",
         "monolog/monolog": "^1.23",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "phpactor/amp-fswatch": "^0.2.0",
         "thecodingmachine/safe": "^1.0",
         "phpactor/phly-event-dispatcher": "^2.0.0",
-        "phpactor/language-server": "^6.0.0",
+        "phpactor/language-server": "^6.0.1",
         "phpactor/language-server-protocol": "^3.17.3",
         "dantleech/object-renderer": "^0.1.1",
         "monolog/monolog": "^1.23",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "phpactor/amp-fswatch": "^0.2.0",
         "thecodingmachine/safe": "^1.0",
         "phpactor/phly-event-dispatcher": "^2.0.0",
-        "phpactor/language-server": "^6.0.1",
+        "phpactor/language-server": "^6.0.2",
         "phpactor/language-server-protocol": "^3.17.3",
         "dantleech/object-renderer": "^0.1.1",
         "monolog/monolog": "^1.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a223f6d51d033ede9de94c082acaab44",
+    "content-hash": "e8a1cf081de93297b7556199b5a8272a",
     "packages": [
         {
             "name": "amphp/amp",
@@ -1641,16 +1641,16 @@
         },
         {
             "name": "phpactor/language-server",
-            "version": "6.0.1",
+            "version": "6.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/language-server.git",
-                "reference": "71e2f710db6d49c64822b140e38c3dd88f2e452e"
+                "reference": "78a27025521ef203b230dabc37f16d308ad73820"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/language-server/zipball/71e2f710db6d49c64822b140e38c3dd88f2e452e",
-                "reference": "71e2f710db6d49c64822b140e38c3dd88f2e452e",
+                "url": "https://api.github.com/repos/phpactor/language-server/zipball/78a27025521ef203b230dabc37f16d308ad73820",
+                "reference": "78a27025521ef203b230dabc37f16d308ad73820",
                 "shasum": ""
             },
             "require": {
@@ -1701,9 +1701,9 @@
             "description": "Generic Language Server Platform",
             "support": {
                 "issues": "https://github.com/phpactor/language-server/issues",
-                "source": "https://github.com/phpactor/language-server/tree/6.0.1"
+                "source": "https://github.com/phpactor/language-server/tree/6.0.2"
             },
-            "time": "2023-07-29T18:22:38+00:00"
+            "time": "2023-07-29T19:46:20+00:00"
         },
         {
             "name": "phpactor/language-server-protocol",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6a560d23d4ccb0dcc45f6d8d8f088946",
+    "content-hash": "a223f6d51d033ede9de94c082acaab44",
     "packages": [
         {
             "name": "amphp/amp",
@@ -1641,16 +1641,16 @@
         },
         {
             "name": "phpactor/language-server",
-            "version": "6.0.0",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/language-server.git",
-                "reference": "dd2c52f6568dacfab23aa0fd4a566f432f9052d3"
+                "reference": "71e2f710db6d49c64822b140e38c3dd88f2e452e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/language-server/zipball/dd2c52f6568dacfab23aa0fd4a566f432f9052d3",
-                "reference": "dd2c52f6568dacfab23aa0fd4a566f432f9052d3",
+                "url": "https://api.github.com/repos/phpactor/language-server/zipball/71e2f710db6d49c64822b140e38c3dd88f2e452e",
+                "reference": "71e2f710db6d49c64822b140e38c3dd88f2e452e",
                 "shasum": ""
             },
             "require": {
@@ -1701,9 +1701,9 @@
             "description": "Generic Language Server Platform",
             "support": {
                 "issues": "https://github.com/phpactor/language-server/issues",
-                "source": "https://github.com/phpactor/language-server/tree/6.0.0"
+                "source": "https://github.com/phpactor/language-server/tree/6.0.1"
             },
-            "time": "2023-07-29T17:25:40+00:00"
+            "time": "2023-07-29T18:22:38+00:00"
         },
         {
             "name": "phpactor/language-server-protocol",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b1c8fa69a7a200374f301f5cc8e4c5c7",
+    "content-hash": "6a560d23d4ccb0dcc45f6d8d8f088946",
     "packages": [
         {
             "name": "amphp/amp",
@@ -1215,12 +1215,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/JetBrains/phpstorm-stubs.git",
-                "reference": "077d371b23d38d7f6f039994bfb03732d7965fbc"
+                "reference": "0b9854c8ba932966f3cb1469a2d18ab9249272b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/077d371b23d38d7f6f039994bfb03732d7965fbc",
-                "reference": "077d371b23d38d7f6f039994bfb03732d7965fbc",
+                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/0b9854c8ba932966f3cb1469a2d18ab9249272b9",
+                "reference": "0b9854c8ba932966f3cb1469a2d18ab9249272b9",
                 "shasum": ""
             },
             "require-dev": {
@@ -1256,7 +1256,7 @@
             "support": {
                 "source": "https://github.com/JetBrains/phpstorm-stubs/tree/master"
             },
-            "time": "2023-04-18T09:13:06+00:00"
+            "time": "2023-07-20T19:40:08+00:00"
         },
         {
             "name": "kelunik/certificate",
@@ -1641,16 +1641,16 @@
         },
         {
             "name": "phpactor/language-server",
-            "version": "5.1.3",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/language-server.git",
-                "reference": "1fee1300ed76f35e3980cbd6b78a97c279af1c06"
+                "reference": "dd2c52f6568dacfab23aa0fd4a566f432f9052d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/language-server/zipball/1fee1300ed76f35e3980cbd6b78a97c279af1c06",
-                "reference": "1fee1300ed76f35e3980cbd6b78a97c279af1c06",
+                "url": "https://api.github.com/repos/phpactor/language-server/zipball/dd2c52f6568dacfab23aa0fd4a566f432f9052d3",
+                "reference": "dd2c52f6568dacfab23aa0fd4a566f432f9052d3",
                 "shasum": ""
             },
             "require": {
@@ -1701,9 +1701,9 @@
             "description": "Generic Language Server Platform",
             "support": {
                 "issues": "https://github.com/phpactor/language-server/issues",
-                "source": "https://github.com/phpactor/language-server/tree/5.1.3"
+                "source": "https://github.com/phpactor/language-server/tree/6.0.0"
             },
-            "time": "2023-06-04T09:44:27+00:00"
+            "time": "2023-07-29T17:25:40+00:00"
         },
         {
             "name": "phpactor/language-server-protocol",
@@ -2252,16 +2252,16 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.4",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
                 "shasum": ""
             },
             "require": {
@@ -2306,7 +2306,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.5"
             },
             "funding": [
                 {
@@ -2314,20 +2314,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:10:38+00:00"
+            "time": "2023-05-07T05:35:17+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.22",
+            "version": "v5.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "3cd51fd2e6c461ca678f84d419461281bd87a0a8"
+                "reference": "b504a3d266ad2bb632f196c0936ef2af5ff6e273"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/3cd51fd2e6c461ca678f84d419461281bd87a0a8",
-                "reference": "3cd51fd2e6c461ca678f84d419461281bd87a0a8",
+                "url": "https://api.github.com/repos/symfony/console/zipball/b504a3d266ad2bb632f196c0936ef2af5ff6e273",
+                "reference": "b504a3d266ad2bb632f196c0936ef2af5ff6e273",
                 "shasum": ""
             },
             "require": {
@@ -2397,7 +2397,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.22"
+                "source": "https://github.com/symfony/console/tree/v5.4.26"
             },
             "funding": [
                 {
@@ -2413,7 +2413,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-25T09:27:28+00:00"
+            "time": "2023-07-19T20:11:33+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -2484,16 +2484,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.4.21",
+            "version": "v5.4.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "e75960b1bbfd2b8c9e483e0d74811d555ca3de9f"
+                "reference": "0ce3a62c9579a53358d3a7eb6b3dfb79789a6364"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/e75960b1bbfd2b8c9e483e0d74811d555ca3de9f",
-                "reference": "e75960b1bbfd2b8c9e483e0d74811d555ca3de9f",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/0ce3a62c9579a53358d3a7eb6b3dfb79789a6364",
+                "reference": "0ce3a62c9579a53358d3a7eb6b3dfb79789a6364",
                 "shasum": ""
             },
             "require": {
@@ -2528,7 +2528,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.4.21"
+                "source": "https://github.com/symfony/filesystem/tree/v5.4.25"
             },
             "funding": [
                 {
@@ -2544,7 +2544,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-14T08:03:56+00:00"
+            "time": "2023-05-31T13:04:02+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -3195,16 +3195,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v5.4.22",
+            "version": "v5.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "4b850da0cc3a2a9181c1ed407adbca4733dc839b"
+                "reference": "1a44dc377ec86a50fab40d066cd061e28a6b482f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/4b850da0cc3a2a9181c1ed407adbca4733dc839b",
-                "reference": "4b850da0cc3a2a9181c1ed407adbca4733dc839b",
+                "url": "https://api.github.com/repos/symfony/process/zipball/1a44dc377ec86a50fab40d066cd061e28a6b482f",
+                "reference": "1a44dc377ec86a50fab40d066cd061e28a6b482f",
                 "shasum": ""
             },
             "require": {
@@ -3237,7 +3237,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v5.4.22"
+                "source": "https://github.com/symfony/process/tree/v5.4.26"
             },
             "funding": [
                 {
@@ -3253,7 +3253,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-06T21:29:33+00:00"
+            "time": "2023-07-12T15:44:31+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -3340,16 +3340,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v5.4.22",
+            "version": "v5.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "8036a4c76c0dd29e60b6a7cafcacc50cf088ea62"
+                "reference": "1181fe9270e373537475e826873b5867b863883c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/8036a4c76c0dd29e60b6a7cafcacc50cf088ea62",
-                "reference": "8036a4c76c0dd29e60b6a7cafcacc50cf088ea62",
+                "url": "https://api.github.com/repos/symfony/string/zipball/1181fe9270e373537475e826873b5867b863883c",
+                "reference": "1181fe9270e373537475e826873b5867b863883c",
                 "shasum": ""
             },
             "require": {
@@ -3406,7 +3406,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.4.22"
+                "source": "https://github.com/symfony/string/tree/v5.4.26"
             },
             "funding": [
                 {
@@ -3422,20 +3422,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-14T06:11:53+00:00"
+            "time": "2023-06-28T12:46:07+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v5.4.21",
+            "version": "v5.4.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "3713e20d93e46e681e51605d213027e48dab3469"
+                "reference": "4cd2e3ea301aadd76a4172756296fe552fb45b0b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/3713e20d93e46e681e51605d213027e48dab3469",
-                "reference": "3713e20d93e46e681e51605d213027e48dab3469",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/4cd2e3ea301aadd76a4172756296fe552fb45b0b",
+                "reference": "4cd2e3ea301aadd76a4172756296fe552fb45b0b",
                 "shasum": ""
             },
             "require": {
@@ -3481,7 +3481,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v5.4.21"
+                "source": "https://github.com/symfony/yaml/tree/v5.4.23"
             },
             "funding": [
                 {
@@ -3497,7 +3497,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-21T19:46:44+00:00"
+            "time": "2023-04-23T19:33:36+00:00"
         },
         {
             "name": "thecodingmachine/safe",
@@ -3640,16 +3640,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v2.15.4",
+            "version": "v2.15.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "3e059001d6d597dd50ea7c74dd2464b4adea48d3"
+                "reference": "fc02a6af3eeb97c4bf5650debc76c2eda85ac22e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/3e059001d6d597dd50ea7c74dd2464b4adea48d3",
-                "reference": "3e059001d6d597dd50ea7c74dd2464b4adea48d3",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/fc02a6af3eeb97c4bf5650debc76c2eda85ac22e",
+                "reference": "fc02a6af3eeb97c4bf5650debc76c2eda85ac22e",
                 "shasum": ""
             },
             "require": {
@@ -3704,7 +3704,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v2.15.4"
+                "source": "https://github.com/twigphp/Twig/tree/v2.15.5"
             },
             "funding": [
                 {
@@ -3716,7 +3716,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-27T12:26:20+00:00"
+            "time": "2023-05-03T17:49:41+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -3958,16 +3958,16 @@
         },
         {
             "name": "composer/ca-bundle",
-            "version": "1.3.5",
+            "version": "1.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "74780ccf8c19d6acb8d65c5f39cd72110e132bbd"
+                "reference": "90d087e988ff194065333d16bc5cf649872d9cdb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/74780ccf8c19d6acb8d65c5f39cd72110e132bbd",
-                "reference": "74780ccf8c19d6acb8d65c5f39cd72110e132bbd",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/90d087e988ff194065333d16bc5cf649872d9cdb",
+                "reference": "90d087e988ff194065333d16bc5cf649872d9cdb",
                 "shasum": ""
             },
             "require": {
@@ -4014,7 +4014,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/ca-bundle/issues",
-                "source": "https://github.com/composer/ca-bundle/tree/1.3.5"
+                "source": "https://github.com/composer/ca-bundle/tree/1.3.6"
             },
             "funding": [
                 {
@@ -4030,7 +4030,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-11T08:27:00+00:00"
+            "time": "2023-06-06T12:02:59+00:00"
         },
         {
             "name": "composer/semver",
@@ -4178,17 +4178,17 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/rdohms/phpunit-arraysubset-asserts.git",
-                "reference": "2a0e7744402d5d5466e7534735bedc4d760ff422"
+                "reference": "aa6b9e858414e91cca361cac3b2035ee57d212e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rdohms/phpunit-arraysubset-asserts/zipball/2a0e7744402d5d5466e7534735bedc4d760ff422",
-                "reference": "2a0e7744402d5d5466e7534735bedc4d760ff422",
+                "url": "https://api.github.com/repos/rdohms/phpunit-arraysubset-asserts/zipball/aa6b9e858414e91cca361cac3b2035ee57d212e0",
+                "reference": "aa6b9e858414e91cca361cac3b2035ee57d212e0",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.4 || ^7.0 || ^8.0",
-                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0"
             },
             "require-dev": {
                 "dms/coding-standard": "^9"
@@ -4213,9 +4213,9 @@
             "description": "This package provides ArraySubset and related asserts once deprecated in PHPUnit 8",
             "support": {
                 "issues": "https://github.com/rdohms/phpunit-arraysubset-asserts/issues",
-                "source": "https://github.com/rdohms/phpunit-arraysubset-asserts/tree/master"
+                "source": "https://github.com/rdohms/phpunit-arraysubset-asserts/tree/v0.5.0"
             },
-            "time": "2023-03-20T10:05:20+00:00"
+            "time": "2023-06-02T17:33:53+00:00"
         },
         {
             "name": "doctrine/annotations",
@@ -4295,25 +4295,29 @@
         },
         {
             "name": "doctrine/deprecations",
-            "version": "v1.0.0",
+            "version": "v1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de"
+                "reference": "612a3ee5ab0d5dd97b7cf3874a6efe24325efac3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de",
-                "reference": "0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/612a3ee5ab0d5dd97b7cf3874a6efe24325efac3",
+                "reference": "612a3ee5ab0d5dd97b7cf3874a6efe24325efac3",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1|^8.0"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
                 "doctrine/coding-standard": "^9",
-                "phpunit/phpunit": "^7.5|^8.5|^9.5",
-                "psr/log": "^1|^2|^3"
+                "phpstan/phpstan": "1.4.10 || 1.10.15",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "psalm/plugin-phpunit": "0.18.4",
+                "psr/log": "^1 || ^2 || ^3",
+                "vimeo/psalm": "4.30.0 || 5.12.0"
             },
             "suggest": {
                 "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
@@ -4332,9 +4336,9 @@
             "homepage": "https://www.doctrine-project.org/",
             "support": {
                 "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/v1.0.0"
+                "source": "https://github.com/doctrine/deprecations/tree/v1.1.1"
             },
-            "time": "2022-05-02T15:47:09+00:00"
+            "time": "2023-06-03T09:27:29+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -4587,16 +4591,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.16.0",
+            "version": "v3.22.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "d40f9436e1c448d309fa995ab9c14c5c7a96f2dc"
+                "reference": "92b019f6c8d79aa26349d0db7671d37440dc0ff3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/d40f9436e1c448d309fa995ab9c14c5c7a96f2dc",
-                "reference": "d40f9436e1c448d309fa995ab9c14c5c7a96f2dc",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/92b019f6c8d79aa26349d0db7671d37440dc0ff3",
+                "reference": "92b019f6c8d79aa26349d0db7671d37440dc0ff3",
                 "shasum": ""
             },
             "require": {
@@ -4620,6 +4624,7 @@
                 "symfony/stopwatch": "^5.4 || ^6.0"
             },
             "require-dev": {
+                "facile-it/paraunit": "^1.3 || ^2.0",
                 "justinrainbow/json-schema": "^5.2",
                 "keradus/cli-executor": "^2.0",
                 "mikey179/vfsstream": "^1.6.11",
@@ -4671,7 +4676,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.16.0"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.22.0"
             },
             "funding": [
                 {
@@ -4679,7 +4684,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-04-02T19:30:06+00:00"
+            "time": "2023-07-16T23:08:06+00:00"
         },
         {
             "name": "jangregor/phpstan-prophecy",
@@ -4858,16 +4863,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.15.4",
+            "version": "v4.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290"
+                "reference": "19526a33fb561ef417e822e85f08a00db4059c17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
-                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/19526a33fb561ef417e822e85f08a00db4059c17",
+                "reference": "19526a33fb561ef417e822e85f08a00db4059c17",
                 "shasum": ""
             },
             "require": {
@@ -4908,9 +4913,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.4"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.16.0"
             },
-            "time": "2023-03-05T19:49:14+00:00"
+            "time": "2023-06-25T14:52:30+00:00"
         },
         {
             "name": "openlss/lib-array2xml",
@@ -5234,16 +5239,16 @@
         },
         {
             "name": "phpbench/phpbench",
-            "version": "1.2.10",
+            "version": "1.2.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpbench/phpbench.git",
-                "reference": "95206f92479674599a75e02b74b9933e2d9883aa"
+                "reference": "edbd1b7ecf704eb01f7a2bcd1b8aa8c189f9fa4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpbench/phpbench/zipball/95206f92479674599a75e02b74b9933e2d9883aa",
-                "reference": "95206f92479674599a75e02b74b9933e2d9883aa",
+                "url": "https://api.github.com/repos/phpbench/phpbench/zipball/edbd1b7ecf704eb01f7a2bcd1b8aa8c189f9fa4e",
+                "reference": "edbd1b7ecf704eb01f7a2bcd1b8aa8c189f9fa4e",
                 "shasum": ""
             },
             "require": {
@@ -5312,7 +5317,7 @@
             "description": "PHP Benchmarking Framework",
             "support": {
                 "issues": "https://github.com/phpbench/phpbench/issues",
-                "source": "https://github.com/phpbench/phpbench/tree/1.2.10"
+                "source": "https://github.com/phpbench/phpbench/tree/1.2.14"
             },
             "funding": [
                 {
@@ -5320,7 +5325,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-03-24T08:52:55+00:00"
+            "time": "2023-07-09T09:16:08+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -5434,16 +5439,16 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.7.1",
+            "version": "1.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "dfc078e8af9c99210337325ff5aa152872c98714"
+                "reference": "b2fe4d22a5426f38e014855322200b97b5362c0d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/dfc078e8af9c99210337325ff5aa152872c98714",
-                "reference": "dfc078e8af9c99210337325ff5aa152872c98714",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/b2fe4d22a5426f38e014855322200b97b5362c0d",
+                "reference": "b2fe4d22a5426f38e014855322200b97b5362c0d",
                 "shasum": ""
             },
             "require": {
@@ -5486,9 +5491,9 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.7.1"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.7.2"
             },
-            "time": "2023-03-27T19:02:04+00:00"
+            "time": "2023-05-30T18:13:47+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -5612,22 +5617,22 @@
         },
         {
             "name": "phpstan/extension-installer",
-            "version": "1.3.0",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/extension-installer.git",
-                "reference": "f5e02d40f277d28513001976f444d9ff1dc15e9a"
+                "reference": "f45734bfb9984c6c56c4486b71230355f066a58a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/f5e02d40f277d28513001976f444d9ff1dc15e9a",
-                "reference": "f5e02d40f277d28513001976f444d9ff1dc15e9a",
+                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/f45734bfb9984c6c56c4486b71230355f066a58a",
+                "reference": "f45734bfb9984c6c56c4486b71230355f066a58a",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^2.0",
                 "php": "^7.2 || ^8.0",
-                "phpstan/phpstan": "^1.8.0"
+                "phpstan/phpstan": "^1.9.0"
             },
             "require-dev": {
                 "composer/composer": "^2.0",
@@ -5636,12 +5641,7 @@
             },
             "type": "composer-plugin",
             "extra": {
-                "class": "PHPStan\\ExtensionInstaller\\Plugin",
-                "phpstan/extension-installer": {
-                    "ignore": [
-                        "phpstan/phpstan-phpunit"
-                    ]
-                }
+                "class": "PHPStan\\ExtensionInstaller\\Plugin"
             },
             "autoload": {
                 "psr-4": {
@@ -5655,28 +5655,30 @@
             "description": "Composer plugin for automatic installation of PHPStan extensions",
             "support": {
                 "issues": "https://github.com/phpstan/extension-installer/issues",
-                "source": "https://github.com/phpstan/extension-installer/tree/1.3.0"
+                "source": "https://github.com/phpstan/extension-installer/tree/1.3.1"
             },
-            "time": "2023-04-18T13:08:02+00:00"
+            "time": "2023-05-24T08:59:17+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.20.0",
+            "version": "1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "10553ab3f0337ff1a71433c3417d7eb2a3eec1fd"
+                "reference": "a2b24135c35852b348894320d47b3902a94bc494"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/10553ab3f0337ff1a71433c3417d7eb2a3eec1fd",
-                "reference": "10553ab3f0337ff1a71433c3417d7eb2a3eec1fd",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a2b24135c35852b348894320d47b3902a94bc494",
+                "reference": "a2b24135c35852b348894320d47b3902a94bc494",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2 || ^8.0"
             },
             "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^4.15",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/extension-installer": "^1.0",
                 "phpstan/phpstan": "^1.5",
@@ -5700,22 +5702,22 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.20.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.23.0"
             },
-            "time": "2023-04-20T11:18:07+00:00"
+            "time": "2023-07-23T22:17:56+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.14",
+            "version": "1.10.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "d232901b09e67538e5c86a724be841bea5768a7c"
+                "reference": "5d660cbb7e1b89253a47147ae44044f49832351f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d232901b09e67538e5c86a724be841bea5768a7c",
-                "reference": "d232901b09e67538e5c86a724be841bea5768a7c",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/5d660cbb7e1b89253a47147ae44044f49832351f",
+                "reference": "5d660cbb7e1b89253a47147ae44044f49832351f",
                 "shasum": ""
             },
             "require": {
@@ -5764,20 +5766,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-19T13:47:27+00:00"
+            "time": "2023-07-19T12:44:37+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
-            "version": "1.3.11",
+            "version": "1.3.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-phpunit.git",
-                "reference": "9e1b9de6d260461f6e99b6a8f2dbb0bbb98b579c"
+                "reference": "d8bdab0218c5eb0964338d24a8511b65e9c94fa5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/9e1b9de6d260461f6e99b6a8f2dbb0bbb98b579c",
-                "reference": "9e1b9de6d260461f6e99b6a8f2dbb0bbb98b579c",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/d8bdab0218c5eb0964338d24a8511b65e9c94fa5",
+                "reference": "d8bdab0218c5eb0964338d24a8511b65e9c94fa5",
                 "shasum": ""
             },
             "require": {
@@ -5814,22 +5816,22 @@
             "description": "PHPUnit extensions and rules for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-phpunit/issues",
-                "source": "https://github.com/phpstan/phpstan-phpunit/tree/1.3.11"
+                "source": "https://github.com/phpstan/phpstan-phpunit/tree/1.3.13"
             },
-            "time": "2023-03-25T19:42:13+00:00"
+            "time": "2023-05-26T11:05:59+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.26",
+            "version": "9.2.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1"
+                "reference": "b0a88255cb70d52653d80c890bd7f38740ea50d1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
-                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/b0a88255cb70d52653d80c890bd7f38740ea50d1",
+                "reference": "b0a88255cb70d52653d80c890bd7f38740ea50d1",
                 "shasum": ""
             },
             "require": {
@@ -5885,7 +5887,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.26"
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.27"
             },
             "funding": [
                 {
@@ -5893,7 +5896,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-03-06T12:58:08+00:00"
+            "time": "2023-07-26T13:44:30+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -6138,16 +6141,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.7",
+            "version": "9.6.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c993f0d3b0489ffc42ee2fe0bd645af1538a63b2"
+                "reference": "a6d351645c3fe5a30f5e86be6577d946af65a328"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c993f0d3b0489ffc42ee2fe0bd645af1538a63b2",
-                "reference": "c993f0d3b0489ffc42ee2fe0bd645af1538a63b2",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a6d351645c3fe5a30f5e86be6577d946af65a328",
+                "reference": "a6d351645c3fe5a30f5e86be6577d946af65a328",
                 "shasum": ""
             },
             "require": {
@@ -6221,7 +6224,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.7"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.10"
             },
             "funding": [
                 {
@@ -6237,7 +6240,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-14T08:58:40+00:00"
+            "time": "2023-07-10T04:04:23+00:00"
         },
         {
             "name": "psr/cache",
@@ -7188,16 +7191,16 @@
         },
         {
             "name": "seld/jsonlint",
-            "version": "1.9.0",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/jsonlint.git",
-                "reference": "4211420d25eba80712bff236a98960ef68b866b7"
+                "reference": "594fd6462aad8ecee0b45ca5045acea4776667f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/4211420d25eba80712bff236a98960ef68b866b7",
-                "reference": "4211420d25eba80712bff236a98960ef68b866b7",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/594fd6462aad8ecee0b45ca5045acea4776667f1",
+                "reference": "594fd6462aad8ecee0b45ca5045acea4776667f1",
                 "shasum": ""
             },
             "require": {
@@ -7236,7 +7239,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/jsonlint/issues",
-                "source": "https://github.com/Seldaek/jsonlint/tree/1.9.0"
+                "source": "https://github.com/Seldaek/jsonlint/tree/1.10.0"
             },
             "funding": [
                 {
@@ -7248,20 +7251,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-01T13:37:23+00:00"
+            "time": "2023-05-11T13:16:46+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v5.4.22",
+            "version": "v5.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "1df20e45d56da29a4b1d8259dd6e950acbf1b13f"
+                "reference": "5dcc00e03413f05c1e7900090927bb7247cb0aac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/1df20e45d56da29a4b1d8259dd6e950acbf1b13f",
-                "reference": "1df20e45d56da29a4b1d8259dd6e950acbf1b13f",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/5dcc00e03413f05c1e7900090927bb7247cb0aac",
+                "reference": "5dcc00e03413f05c1e7900090927bb7247cb0aac",
                 "shasum": ""
             },
             "require": {
@@ -7317,7 +7320,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v5.4.22"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v5.4.26"
             },
             "funding": [
                 {
@@ -7333,7 +7336,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-17T11:31:58+00:00"
+            "time": "2023-07-06T06:34:20+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -7416,16 +7419,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v5.4.21",
+            "version": "v5.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "078e9a5e1871fcfe6a5ce421b539344c21afef19"
+                "reference": "01ef6b2391a59bb4c5d3c59e2ef9b99c7d335d17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/078e9a5e1871fcfe6a5ce421b539344c21afef19",
-                "reference": "078e9a5e1871fcfe6a5ce421b539344c21afef19",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/01ef6b2391a59bb4c5d3c59e2ef9b99c7d335d17",
+                "reference": "01ef6b2391a59bb4c5d3c59e2ef9b99c7d335d17",
                 "shasum": ""
             },
             "require": {
@@ -7459,7 +7462,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.4.21"
+                "source": "https://github.com/symfony/finder/tree/v5.4.26"
             },
             "funding": [
                 {
@@ -7475,7 +7478,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-16T09:33:00+00:00"
+            "time": "2023-07-09T13:55:15+00:00"
         },
         {
             "name": "symfony/options-resolver",
@@ -7610,16 +7613,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v5.4.22",
+            "version": "v5.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "e2edac9ce47e6df07e38143c7cfa6bdbc1a6dcc4"
+                "reference": "e706c99b4a6f4d9383b52b80dd8c74880501e314"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/e2edac9ce47e6df07e38143c7cfa6bdbc1a6dcc4",
-                "reference": "e2edac9ce47e6df07e38143c7cfa6bdbc1a6dcc4",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/e706c99b4a6f4d9383b52b80dd8c74880501e314",
+                "reference": "e706c99b4a6f4d9383b52b80dd8c74880501e314",
                 "shasum": ""
             },
             "require": {
@@ -7628,12 +7631,12 @@
                 "symfony/polyfill-php80": "^1.16"
             },
             "conflict": {
-                "phpunit/phpunit": "<5.4.3",
                 "symfony/console": "<4.4"
             },
             "require-dev": {
                 "ext-iconv": "*",
                 "symfony/console": "^4.4|^5.0|^6.0",
+                "symfony/http-kernel": "^4.4|^5.0|^6.0",
                 "symfony/process": "^4.4|^5.0|^6.0",
                 "symfony/uid": "^5.1|^6.0",
                 "twig/twig": "^2.13|^3.0.4"
@@ -7679,7 +7682,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v5.4.22"
+                "source": "https://github.com/symfony/var-dumper/tree/v5.4.26"
             },
             "funding": [
                 {
@@ -7695,7 +7698,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-25T09:27:28+00:00"
+            "time": "2023-07-13T07:32:46+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/doc/development/documentation.rst
+++ b/doc/development/documentation.rst
@@ -54,5 +54,3 @@ Use the following command to both install vimdoc and build the documentation:
 .. code:: sh
 
     make vimdoc
-
-.. _developing_blackfire_profiling:

--- a/doc/integrations/psalm.rst
+++ b/doc/integrations/psalm.rst
@@ -5,6 +5,10 @@ Psalm
 
 Phpactor can integrate with Psalm to provide diagnostics in your IDE.
 
+.. note::
+
+   Currently this extension will only analyse saved files.
+
 To do so you set :ref:`param_language_server_psalm.enabled`:
 
 .. code-block:: bash

--- a/doc/reference/configuration.rst
+++ b/doc/reference/configuration.rst
@@ -1,4 +1,4 @@
-.. _configuration:
+.. _ref_configuration:
 
 Configuration
 =============
@@ -1897,6 +1897,22 @@ Override level at which Psalm should report errors (lower => more errors)
 
 
 **Default**: ``null``
+
+
+.. _param_language_server_psalm.timeout:
+
+
+``language_server_psalm.timeout``
+"""""""""""""""""""""""""""""""""
+
+
+Type: integer
+
+
+Kill the psalm process after this number of seconds
+
+
+**Default**: ``15``
 
 
 .. _LanguageServerPhpCsFixerExtension:

--- a/doc/reference/configuration.rst
+++ b/doc/reference/configuration.rst
@@ -1474,6 +1474,19 @@ Show inlay hints for parameters
 **Default**: ``true``
 
 
+.. _param_language_server_worse_reflection.diagnostics.enable:
+
+
+``language_server_worse_reflection.diagnostics.enable``
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+
+Enable diagnostics
+
+
+**Default**: ``true``
+
+
 .. _LanguageServerIndexerExtension:
 
 

--- a/lib/Amp/Process/ProcessUtil.php
+++ b/lib/Amp/Process/ProcessUtil.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Phpactor\Amp\Process;
+
+use Amp\Process\Process;
+use Amp\Process\StatusError;
+use Psr\Log\LoggerInterface;
+use function Amp\asyncCall;
+use function Amp\delay;
+
+class ProcessUtil
+{
+    public static function killAfter(LoggerInterface $logger, Process $process, int $timeout): void
+    {
+        $start = time();
+        asyncCall(function () use ($logger, $process, $start, $timeout) {
+            while ($process->isRunning()) {
+                yield delay(500);
+                // phpstan doesn't expect that $process->isRunning() output can change
+                // @phpstan-ignore-next-line
+                if (time() >= $start + $timeout && $process->isRunning()) {
+                    try {
+                        $process->kill();
+                        $logger->warning(sprintf('Killed process "%s" because it lived longer than %ds', $process->getPid(), $timeout));
+                    } catch (StatusError $e) {
+                    }
+                    break;
+                }
+            }
+        });
+    }
+}

--- a/lib/Completion/Tests/Integration/Bridge/TolerantParser/Qualifier/ClassMemberQualifierTest.php
+++ b/lib/Completion/Tests/Integration/Bridge/TolerantParser/Qualifier/ClassMemberQualifierTest.php
@@ -7,11 +7,12 @@ use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\Expression\ScopedPropertyAccessExpression;
 use Phpactor\Completion\Bridge\TolerantParser\Qualifier\ClassMemberQualifier;
 use Phpactor\Completion\Bridge\TolerantParser\TolerantQualifier;
+use Closure;
 
 class ClassMemberQualifierTest extends TolerantQualifierTestCase
 {
     /**
-     * @return Generator<string,array{string,(\Closure(Node|null): void)}>
+     * @return Generator<string,array{string,(Closure(Node|null): void)}>
      */
     public function provideCouldComplete(): Generator
     {

--- a/lib/DocblockParser/Ast/Tokens.php
+++ b/lib/DocblockParser/Ast/Tokens.php
@@ -14,7 +14,7 @@ final class Tokens implements IteratorAggregate
     /**
      * @var ?Token
      */
-    public $current;
+    public ?Token $current;
 
     private int $position = 0;
 

--- a/lib/DocblockParser/Parser.php
+++ b/lib/DocblockParser/Parser.php
@@ -268,7 +268,8 @@ final class Parser
 
         $type = $this->tokens->chomp();
 
-        if (null === $this->tokens->current) {
+        /** @phpstan-ignore-next-line It can be null*/
+        if (null === $this->tokens->current && $type) {
             return $this->createTypeFromToken($type);
         }
 

--- a/lib/Extension/Behat/Adapter/Symfony/SymfonyDiContextClassResolver.php
+++ b/lib/Extension/Behat/Adapter/Symfony/SymfonyDiContextClassResolver.php
@@ -3,6 +3,7 @@
 namespace Phpactor\Extension\Behat\Adapter\Symfony;
 
 use DOMDocument;
+use DOMElement;
 use DOMXPath;
 use Phpactor\Extension\Behat\Behat\ContextClassResolver;
 use Phpactor\Extension\Behat\Behat\Exception\CouldNotResolverContextClass;
@@ -51,6 +52,9 @@ class SymfonyDiContextClassResolver implements ContextClassResolver
         $query->registerNamespace('s', 'http://symfony.com/schema/dic/services');
         /** @phpstan-ignore-next-line */
         foreach ($query->query('//s:service') as $serviceEl) {
+            if (!$serviceEl instanceof DOMElement) {
+                continue;
+            }
             $this->index[(string)$serviceEl->getAttribute('id')] = (string)$serviceEl->getAttribute('class');
         }
     }

--- a/lib/Extension/Completion/CompletionExtension.php
+++ b/lib/Extension/Completion/CompletionExtension.php
@@ -5,6 +5,7 @@ namespace Phpactor\Extension\Completion;
 use InvalidArgumentException;
 use Phpactor\Completion\Core\ChainCompletor;
 use Phpactor\Completion\Core\ChainSignatureHelper;
+use Phpactor\Completion\Core\Completor;
 use Phpactor\Completion\Core\Completor\DedupeCompletor;
 use Phpactor\Completion\Core\Completor\DocumentingCompletor;
 use Phpactor\Completion\Core\Completor\LabelFormattingCompletor;
@@ -84,6 +85,7 @@ class CompletionExtension implements Extension
             }
 
             $mapped = [];
+            /** @var Completor[] $completors */
             foreach ($completors as $type => $completors) {
                 $completors = new ChainCompletor($completors);
                 if ($container->parameter(self::PARAM_DEDUPE)->bool()) {

--- a/lib/Extension/LanguageServer/DiagnosticProvider/OutsourcedDiagnosticsProvider.php
+++ b/lib/Extension/LanguageServer/DiagnosticProvider/OutsourcedDiagnosticsProvider.php
@@ -5,7 +5,6 @@ namespace Phpactor\Extension\LanguageServer\DiagnosticProvider;
 use Amp\CancellationToken;
 use Amp\Process\Process;
 use Amp\Process\ProcessException;
-use Amp\Process\StatusError;
 use Amp\Promise;
 use Phpactor\Amp\Process\ProcessUtil;
 use Phpactor\LanguageServerProtocol\Diagnostic;
@@ -14,9 +13,7 @@ use Phpactor\LanguageServer\Core\Diagnostics\DiagnosticsProvider;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use function Amp\ByteStream\buffer;
-use function Amp\asyncCall;
 use function Amp\call;
-use function Amp\delay;
 
 class OutsourcedDiagnosticsProvider implements DiagnosticsProvider
 {

--- a/lib/Extension/LanguageServer/LanguageServerExtension.php
+++ b/lib/Extension/LanguageServer/LanguageServerExtension.php
@@ -500,9 +500,13 @@ class LanguageServerExtension implements Extension
     private function registerDiagnostics(ContainerBuilder $container): void
     {
         $container->register(DiagnosticsEngine::class, function (Container $container) {
+            $providers = $this->collectDiagnosticProviders(
+                $container,
+                outsourced: $container->parameter(self::PARAM_DIAGNOSTIC_OUTSOURCE)->bool() ? false : null,
+            );
             return new DiagnosticsEngine(
                 $container->get(ClientApi::class),
-                $container->get(AggregateDiagnosticsProvider::class),
+                $providers,
                 $container->parameter(self::PARAM_DIAGNOSTIC_SLEEP_TIME)->int()
             );
         });

--- a/lib/Extension/LanguageServerCodeTransform/Tests/Unit/CodeAction/ImportNameProviderTest.php
+++ b/lib/Extension/LanguageServerCodeTransform/Tests/Unit/CodeAction/ImportNameProviderTest.php
@@ -58,8 +58,9 @@ class ImportNameProviderTest extends IntegrationTestCase
         self::assertNotNull($result);
         $tester->assertSuccess($result);
 
-        $diagnostics = $tester->transmitter()->filterByMethod('textDocument/publishDiagnostics')->shiftNotification();
-        self::assertNotNull($diagnostics);
+
+        $transmitter = $tester->transmitter()->filterByMethod('textDocument/publishDiagnostics');
+        $diagnostics = $transmitter->shiftNotification();
         $diagnostics = $diagnostics->params['diagnostics'] ?? [];
         $assertion($result->result, $diagnostics);
     }

--- a/lib/Extension/LanguageServerCodeTransform/Tests/Unit/CodeAction/ImportNameProviderTest.php
+++ b/lib/Extension/LanguageServerCodeTransform/Tests/Unit/CodeAction/ImportNameProviderTest.php
@@ -58,7 +58,6 @@ class ImportNameProviderTest extends IntegrationTestCase
         self::assertNotNull($result);
         $tester->assertSuccess($result);
 
-
         $transmitter = $tester->transmitter()->filterByMethod('textDocument/publishDiagnostics');
         $diagnostics = $transmitter->shiftNotification();
         $diagnostics = $diagnostics->params['diagnostics'] ?? [];

--- a/lib/Extension/LanguageServerCompletion/LanguageServerCompletionExtension.php
+++ b/lib/Extension/LanguageServerCompletion/LanguageServerCompletionExtension.php
@@ -2,6 +2,8 @@
 
 namespace Phpactor\Extension\LanguageServerCompletion;
 
+use Phpactor\Completion\Core\SignatureHelper;
+use Phpactor\Completion\Core\TypedCompletorRegistry;
 use Phpactor\Container\Container;
 use Phpactor\Container\ContainerBuilder;
 use Phpactor\Container\Extension;
@@ -12,6 +14,7 @@ use Phpactor\Extension\LanguageServerCompletion\Util\SuggestionNameFormatter;
 use Phpactor\Extension\LanguageServer\LanguageServerExtension;
 use Phpactor\Extension\LanguageServerCompletion\Handler\CompletionHandler;
 use Phpactor\LanguageServerProtocol\ClientCapabilities;
+use Phpactor\LanguageServer\Core\Workspace\Workspace;
 use Phpactor\MapResolver\Resolver;
 
 class LanguageServerCompletionExtension implements Extension
@@ -39,8 +42,8 @@ class LanguageServerCompletionExtension implements Extension
     {
         $container->register('language_server_completion.handler.completion', function (Container $container) {
             return new CompletionHandler(
-                $container->get(LanguageServerExtension::SERVICE_SESSION_WORKSPACE),
-                $container->get(CompletionExtension::SERVICE_REGISTRY),
+                $container->expect(LanguageServerExtension::SERVICE_SESSION_WORKSPACE, Workspace::class),
+                $container->expect(CompletionExtension::SERVICE_REGISTRY, TypedCompletorRegistry::class),
                 $container->get(SuggestionNameFormatter::class),
                 $container->get(NameImporter::class),
                 $this->clientCapabilities($container)->textDocument->completion->completionItem['snippetSupport'] ?? false
@@ -52,13 +55,13 @@ class LanguageServerCompletionExtension implements Extension
         ]]);
 
         $container->register(SuggestionNameFormatter::class, function (Container $container) {
-            return new SuggestionNameFormatter($container->getParameter(self::PARAM_TRIM_LEADING_DOLLAR));
+            return new SuggestionNameFormatter($container->parameter(self::PARAM_TRIM_LEADING_DOLLAR)->bool());
         });
 
         $container->register('language_server_completion.handler.signature_help', function (Container $container) {
             return new SignatureHelpHandler(
-                $container->get(LanguageServerExtension::SERVICE_SESSION_WORKSPACE),
-                $container->get(CompletionExtension::SERVICE_SIGNATURE_HELPER)
+                $container->expect(LanguageServerExtension::SERVICE_SESSION_WORKSPACE, Workspace::class),
+                $container->expect(CompletionExtension::SERVICE_SIGNATURE_HELPER, SignatureHelper::class)
             );
         }, [ LanguageServerExtension::TAG_METHOD_HANDLER => [] ]);
     }

--- a/lib/Extension/LanguageServerCompletion/Tests/IntegrationTestCase.php
+++ b/lib/Extension/LanguageServerCompletion/Tests/IntegrationTestCase.php
@@ -38,6 +38,7 @@ class IntegrationTestCase extends TestCase
 
     protected function createTester(): LanguageServerTester
     {
+        $this->workspace()->reset();
         $container = PhpactorContainer::fromExtensions([
             LoggingExtension::class,
             CompletionExtension::class,

--- a/lib/Extension/LanguageServerCompletion/Tests/IntegrationTestCase.php
+++ b/lib/Extension/LanguageServerCompletion/Tests/IntegrationTestCase.php
@@ -65,6 +65,7 @@ class IntegrationTestCase extends TestCase
             FilePathResolverExtension::PARAM_APPLICATION_ROOT => __DIR__ .'/../../../../',
             ObjectRendererExtension::PARAM_TEMPLATE_PATHS => [],
             IndexerExtension::PARAM_ENABLED_WATCHERS => [],
+            LanguageServerExtension::PARAM_DIAGNOSTIC_OUTSOURCE => false,
         ]);
 
         $builder = $container->get(LanguageServerBuilder::class);

--- a/lib/Extension/LanguageServerPsalm/LanguageServerPsalmExtension.php
+++ b/lib/Extension/LanguageServerPsalm/LanguageServerPsalmExtension.php
@@ -69,7 +69,7 @@ class LanguageServerPsalmExtension implements OptionalExtension
             self::PARAM_PSALM_SHOW_INFO => true,
             self::PARAM_PSALM_USE_CACHE => true,
             self::PARAM_PSALM_ERROR_LEVEL => null,
-            self::PARAM_TIMEOUT => 10,
+            self::PARAM_TIMEOUT => 15,
         ]);
         $schema->setTypes([
             self::PARAM_PSALM_BIN => 'string',

--- a/lib/Extension/LanguageServerPsalm/LanguageServerPsalmExtension.php
+++ b/lib/Extension/LanguageServerPsalm/LanguageServerPsalmExtension.php
@@ -24,6 +24,7 @@ class LanguageServerPsalmExtension implements OptionalExtension
     public const PARAM_PSALM_USE_CACHE = 'language_server_psalm.use_cache';
     public const PARAM_ENABLED = 'language_server_psalm.enabled';
     public const PARAM_PSALM_ERROR_LEVEL = 'language_server_psalm.error_level';
+    public const PARAM_TIMEOUT = 'language_server_psalm.timeout';
 
     public function load(ContainerBuilder $container): void
     {
@@ -53,7 +54,9 @@ class LanguageServerPsalmExtension implements OptionalExtension
             return new PsalmProcess(
                 $root,
                 new PsalmConfig($binPath, $shouldShowInfo, $useCache, $errorLevel ? (int)$errorLevel : null),
-                LoggingExtension::channelLogger($container, 'PSALM')
+                LoggingExtension::channelLogger($container, 'PSALM'),
+                null,
+                $container->parameter(self::PARAM_TIMEOUT)->int(),
             );
         });
     }
@@ -66,17 +69,20 @@ class LanguageServerPsalmExtension implements OptionalExtension
             self::PARAM_PSALM_SHOW_INFO => true,
             self::PARAM_PSALM_USE_CACHE => true,
             self::PARAM_PSALM_ERROR_LEVEL => null,
+            self::PARAM_TIMEOUT => 10,
         ]);
         $schema->setTypes([
             self::PARAM_PSALM_BIN => 'string',
             self::PARAM_PSALM_SHOW_INFO => 'boolean',
             self::PARAM_PSALM_USE_CACHE => 'boolean',
+            self::PARAM_TIMEOUT => 'integer',
         ]);
         $schema->setDescriptions([
             self::PARAM_PSALM_BIN => 'Path to psalm if different from vendor/bin/psalm',
             self::PARAM_PSALM_SHOW_INFO => 'If infos from psalm should be displayed',
             self::PARAM_PSALM_USE_CACHE => 'If the Psalm cache should be used (see the `--no-cache` option)',
             self::PARAM_PSALM_ERROR_LEVEL => 'Override level at which Psalm should report errors (lower => more errors)',
+            self::PARAM_TIMEOUT => 'Kill the psalm process after this number of seconds',
         ]);
     }
 

--- a/lib/Extension/LanguageServerPsalm/Tests/DiagnosticProvider/PsalmDiagnosticProviderTest.php
+++ b/lib/Extension/LanguageServerPsalm/Tests/DiagnosticProvider/PsalmDiagnosticProviderTest.php
@@ -38,7 +38,7 @@ class PsalmDiagnosticProviderTest extends TestCase
 
         wait(delay(10));
 
-        self::assertEquals(2, $this->tester->transmitter()->count());
+        self::assertEquals(1, $this->tester->transmitter()->count());
     }
 
     private function createTestLinter(): TestLinter

--- a/lib/Extension/LanguageServerPsalm/Tests/DiagnosticProvider/PsalmDiagnosticProviderTest.php
+++ b/lib/Extension/LanguageServerPsalm/Tests/DiagnosticProvider/PsalmDiagnosticProviderTest.php
@@ -38,7 +38,7 @@ class PsalmDiagnosticProviderTest extends TestCase
 
         wait(delay(10));
 
-        self::assertEquals(1, $this->tester->transmitter()->count());
+        self::assertEquals(2, $this->tester->transmitter()->count());
     }
 
     private function createTestLinter(): TestLinter

--- a/lib/Extension/LanguageServerWorseReflection/DiagnosticProvider/WorseDiagnosticProvider.php
+++ b/lib/Extension/LanguageServerWorseReflection/DiagnosticProvider/WorseDiagnosticProvider.php
@@ -32,6 +32,7 @@ class WorseDiagnosticProvider implements DiagnosticsProvider
                 );
                 $lspDiagnostic = ProtocolFactory::diagnostic($range, $diagnostic->message());
                 $lspDiagnostic->severity = self::toLspSeverity($diagnostic->severity());
+                $lspDiagnostic->source = 'phpactor';
                 $lspDiagnostics[] = $lspDiagnostic;
 
                 if ($cancel->isRequested()) {

--- a/lib/Extension/LanguageServerWorseReflection/Tests/IntegrationTestCase.php
+++ b/lib/Extension/LanguageServerWorseReflection/Tests/IntegrationTestCase.php
@@ -2,6 +2,7 @@
 
 namespace Phpactor\Extension\LanguageServerWorseReflection\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Phpactor\Extension\LanguageServerWorseReflection\LanguageServerWorseReflectionExtension;
 use Phpactor\Extension\LanguageServer\LanguageServerExtension;
 use Phpactor\Extension\ComposerAutoloader\ComposerAutoloaderExtension;
@@ -13,7 +14,6 @@ use Phpactor\Extension\FilePathResolver\FilePathResolverExtension;
 use Phpactor\Extension\Console\ConsoleExtension;
 use Phpactor\Container\PhpactorContainer;
 use Phpactor\Container\Container;
-use Phpactor\TestUtils\PHPUnit\TestCase;
 use Phpactor\TestUtils\Workspace;
 
 class IntegrationTestCase extends TestCase

--- a/lib/Extension/Php/Model/ComposerPhpVersionResolver.php
+++ b/lib/Extension/Php/Model/ComposerPhpVersionResolver.php
@@ -37,6 +37,7 @@ class ComposerPhpVersionResolver implements PhpVersionResolver
 
     private function resolveLowestVersion(string $versionString): ?string
     {
+        /** @phpstan-ignore-next-line */
         $versions = array_map(function (string $versionString) {
             return preg_replace('/[^0-9.]/', '', trim($versionString));
         }, (array)preg_split('{\|\|?}', $versionString));

--- a/lib/Indexer/Adapter/Php/FileSearchIndex.php
+++ b/lib/Indexer/Adapter/Php/FileSearchIndex.php
@@ -26,7 +26,7 @@ class FileSearchIndex implements SearchIndex
     /**
      * @var array<array{string,string,string|null}>
      */
-    private $subjects = [];
+    private array $subjects = [];
 
     private int $counter = 0;
 

--- a/lib/Indexer/Adapter/Php/InMemory/InMemorySearchIndex.php
+++ b/lib/Indexer/Adapter/Php/InMemory/InMemorySearchIndex.php
@@ -14,7 +14,7 @@ class InMemorySearchIndex implements SearchIndex
     /**
      * @var array<string,array{string,string}>
      */
-    private $buffer = [];
+    private array $buffer = [];
 
     /**
      * @return Generator<Record>

--- a/lib/Indexer/Model/Record/FileRecord.php
+++ b/lib/Indexer/Model/Record/FileRecord.php
@@ -16,7 +16,7 @@ class FileRecord implements HasPath, Record
     /**
      * @var array<array{string,string,int}>
      */
-    private $references = [];
+    private array $references = [];
 
     public function __construct(string $filePath)
     {

--- a/lib/WorseReflection/Core/Inference/Resolver/IfStatementResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/IfStatementResolver.php
@@ -162,9 +162,11 @@ class IfStatementResolver implements Resolver
     {
         /** @phpstan-ignore-next-line lies */
         foreach ($node->statements as $list) {
+            /** @phpstan-ignore-next-line lies */
             if (null === $list) {
                 continue;
             }
+            /** @phpstan-ignore-next-line lies */
             foreach ($list as $statement) {
                 if (!is_object($statement)) {
                     continue;

--- a/lib/WorseReflection/Core/Type/IntType.php
+++ b/lib/WorseReflection/Core/Type/IntType.php
@@ -29,14 +29,14 @@ class IntType extends NumericType implements BitwiseOperable, HasEmptyType
         return new BooleanType();
     }
 
-public function bitwiseXor(Type $right): Type
-{
-    if ($right instanceof IntType && $right instanceof Literal && $this instanceof Literal) {
-        return $this->withValue($this->value() ^ $right->value());
-    }
+    public function bitwiseXor(Type $right): Type
+    {
+        if ($right instanceof IntType && $right instanceof Literal && $this instanceof Literal) {
+            return $this->withValue($this->value() ^ $right->value());
+        }
 
-    return new BooleanType();
-}
+        return new BooleanType();
+    }
 
     public function bitwiseOr(Type $right): Type
     {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1277,7 +1277,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$type of method Phpactor\\\\DocblockParser\\\\Parser\\:\\:createTypeFromToken\\(\\) expects Phpactor\\\\DocblockParser\\\\Ast\\\\Token, Phpactor\\\\DocblockParser\\\\Ast\\\\Token\\|null given\\.$#"
-			count: 3
+			count: 2
 			path: lib/DocblockParser/Parser.php
 
 		-
@@ -1516,42 +1516,12 @@ parameters:
 			path: lib/Extension/ClassMover/Application/ClassMover.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMover\\:\\:expandRelatedPaths\\(\\) has parameter \\$dest with no type specified\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Application/ClassMover.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMover\\:\\:expandRelatedPaths\\(\\) has parameter \\$src with no type specified\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Application/ClassMover.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMover\\:\\:expandRelatedPaths\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Application/ClassMover.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMover\\:\\:getRelatedFiles\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Application/ClassMover.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMover\\:\\:moveClass\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Application/ClassMover.php
-
-		-
 			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMover\\:\\:replaceThoseReferences\\(\\) has parameter \\$files with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: lib/Extension/ClassMover/Application/ClassMover.php
 
 		-
 			message: "#^Parameter \\#2 \\$code of class RuntimeException constructor expects int, null given\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Application/ClassMover.php
-
-		-
-			message: "#^Result of method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\ClassMover\\:\\:moveFile\\(\\) \\(void\\) is used\\.$#"
 			count: 1
 			path: lib/Extension/ClassMover/Application/ClassMover.php
 
@@ -2396,21 +2366,6 @@ parameters:
 			path: lib/Extension/CodeTransformExtra/Application/ClassInflect.php
 
 		-
-			message: "#^Parameter \\#1 \\$filename of function is_file expects string, mixed given\\.$#"
-			count: 1
-			path: lib/Extension/CodeTransformExtra/Application/ClassInflect.php
-
-		-
-			message: "#^Parameter \\#1 \\$src of method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Application\\\\ClassInflect\\:\\:doGenerateFromExisting\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: lib/Extension/CodeTransformExtra/Application/ClassInflect.php
-
-		-
-			message: "#^Parameter \\#2 \\$dest of method Phpactor\\\\Extension\\\\CodeTransformExtra\\\\Application\\\\ClassInflect\\:\\:doGenerateFromExisting\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: lib/Extension/CodeTransformExtra/Application/ClassInflect.php
-
-		-
 			message: "#^Call to an undefined method Phpactor\\\\CodeTransform\\\\Domain\\\\Generator\\:\\:generateNew\\(\\)\\.$#"
 			count: 1
 			path: lib/Extension/CodeTransformExtra/Application/ClassNew.php
@@ -2787,16 +2742,6 @@ parameters:
 
 		-
 			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: lib/Extension/Completion/CompletionExtension.php
-
-		-
-			message: "#^Parameter \\#2 \\$limit of class Phpactor\\\\Completion\\\\Core\\\\Completor\\\\LimitingCompletor constructor expects int, mixed given\\.$#"
-			count: 1
-			path: lib/Extension/Completion/CompletionExtension.php
-
-		-
-			message: "#^Parameter \\#2 \\$matchNameImport of class Phpactor\\\\Completion\\\\Core\\\\Completor\\\\DedupeCompletor constructor expects bool, mixed given\\.$#"
 			count: 1
 			path: lib/Extension/Completion/CompletionExtension.php
 
@@ -4076,31 +4021,6 @@ parameters:
 			path: lib/Extension/LanguageServerCompletion/Handler/SignatureHelpHandler.php
 
 		-
-			message: "#^Parameter \\#1 \\$trimLeadingDollar of class Phpactor\\\\Extension\\\\LanguageServerCompletion\\\\Util\\\\SuggestionNameFormatter constructor expects bool, mixed given\\.$#"
-			count: 1
-			path: lib/Extension/LanguageServerCompletion/LanguageServerCompletionExtension.php
-
-		-
-			message: "#^Parameter \\#1 \\$workspace of class Phpactor\\\\Extension\\\\LanguageServerCompletion\\\\Handler\\\\CompletionHandler constructor expects Phpactor\\\\LanguageServer\\\\Core\\\\Workspace\\\\Workspace, mixed given\\.$#"
-			count: 1
-			path: lib/Extension/LanguageServerCompletion/LanguageServerCompletionExtension.php
-
-		-
-			message: "#^Parameter \\#1 \\$workspace of class Phpactor\\\\Extension\\\\LanguageServerCompletion\\\\Handler\\\\SignatureHelpHandler constructor expects Phpactor\\\\LanguageServer\\\\Core\\\\Workspace\\\\Workspace, mixed given\\.$#"
-			count: 1
-			path: lib/Extension/LanguageServerCompletion/LanguageServerCompletionExtension.php
-
-		-
-			message: "#^Parameter \\#2 \\$helper of class Phpactor\\\\Extension\\\\LanguageServerCompletion\\\\Handler\\\\SignatureHelpHandler constructor expects Phpactor\\\\Completion\\\\Core\\\\SignatureHelper, mixed given\\.$#"
-			count: 1
-			path: lib/Extension/LanguageServerCompletion/LanguageServerCompletionExtension.php
-
-		-
-			message: "#^Parameter \\#2 \\$registry of class Phpactor\\\\Extension\\\\LanguageServerCompletion\\\\Handler\\\\CompletionHandler constructor expects Phpactor\\\\Completion\\\\Core\\\\TypedCompletorRegistry, mixed given\\.$#"
-			count: 1
-			path: lib/Extension/LanguageServerCompletion/LanguageServerCompletionExtension.php
-
-		-
 			message: "#^Call to an undefined method Phpactor\\\\WorseReflection\\\\Core\\\\Reflection\\\\ReflectionClassLike\\:\\:cases\\(\\)\\.$#"
 			count: 2
 			path: lib/Extension/LanguageServerCompletion/Tests/Integration/MarkdownObjectRendererTest.php
@@ -4989,11 +4909,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$className of static method Phpactor\\\\WorseReflection\\\\Core\\\\TypeFactory\\:\\:reflectedClass\\(\\) expects Phpactor\\\\WorseReflection\\\\Core\\\\ClassName\\|string, string\\|null given\\.$#"
 			count: 1
 			path: lib/Extension/PHPUnit/FrameWalker/AssertInstanceOfWalker.php
-
-		-
-			message: "#^Parameter \\#1 \\$callback of function array_map expects \\(callable\\(string\\|false\\)\\: mixed\\)\\|null, Closure\\(string\\)\\: string\\|null given\\.$#"
-			count: 1
-			path: lib/Extension/Php/Model/ComposerPhpVersionResolver.php
 
 		-
 			message: "#^Cannot call method resolve\\(\\) on mixed\\.$#"
@@ -6177,22 +6092,12 @@ parameters:
 
 		-
 			message: "#^Cannot call method resolve\\(\\) on mixed\\.$#"
-			count: 3
+			count: 2
 			path: lib/Indexer/Extension/IndexerExtension.php
 
 		-
 			message: "#^Parameter \\#1 \\$callback of function array_map expects \\(callable\\(mixed\\)\\: mixed\\)\\|null, Closure\\(string\\)\\: string given\\.$#"
 			count: 2
-			path: lib/Indexer/Extension/IndexerExtension.php
-
-		-
-			message: "#^Parameter \\#1 \\$excludePatterns of method Phpactor\\\\Indexer\\\\IndexAgentBuilder\\:\\:setExcludePatterns\\(\\) expects array\\<string\\>, mixed given\\.$#"
-			count: 1
-			path: lib/Indexer/Extension/IndexerExtension.php
-
-		-
-			message: "#^Parameter \\#1 \\$includePatterns of method Phpactor\\\\Indexer\\\\IndexAgentBuilder\\:\\:setIncludePatterns\\(\\) expects array\\<string\\>, mixed given\\.$#"
-			count: 1
 			path: lib/Indexer/Extension/IndexerExtension.php
 
 		-
@@ -6482,11 +6387,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$minimumMemoryLimit of static method Phpactor\\\\Phpactor\\:\\:updateMinMemory\\(\\) expects int, mixed given\\.$#"
-			count: 1
-			path: lib/Phpactor.php
-
-		-
-			message: "#^Parameter \\#1 \\$string of function strlen expects string, string\\|false given\\.$#"
 			count: 1
 			path: lib/Phpactor.php
 


### PR DESCRIPTION
Linting is now much "faster" and linters such as the PHP and Phpator linters are not blocked by slow/external linters such as PHPStan/Psalm.
 
- Linters run in parallel
- Linter concurrency limited to 1
- Clear diagnostics on document update
- If text document has changed since linter started, do not publush diagnostics