### PR TITLE
Do not promote parameters from the parent constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,16 @@
 Changelog
 =========
 
+## master
+
+  - Do not promote parameters that are used in parent constructor #2119
+
 ## 2023.08.06
 
 Improvements:
 
   - Improve Diagnostics: Run linters in parallel #2327
   - Index documents on save #2326
-  - Do not promote parameters that are used in parent constructor #2119
 
 Bug fixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Improvements:
 
   - Improve Diagnostics: Run linters in parallel #2327
   - Index documents on save #2326
+  - Do not promote parameters that are used in parent constructor #2119
 
 Bug fixes:
 

--- a/lib/CodeTransform/Adapter/WorseReflection/Transformer/CompleteConstructor.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Transformer/CompleteConstructor.php
@@ -148,7 +148,7 @@ class CompleteConstructor implements Transformer
     */
     private function getParentClassParamaterNames(ReflectionClass $class): array
     {
-        $ancestor = $class->ancestors()->firstOrNull();
+        $ancestor = $class->parent();
         if ($ancestor === null) {
             return [];
         }

--- a/lib/CodeTransform/Adapter/WorseReflection/Transformer/CompleteConstructor.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Transformer/CompleteConstructor.php
@@ -153,13 +153,12 @@ class CompleteConstructor implements Transformer
             return [];
         }
 
-        $constructMethod = $ancestor->methods()->get('__construct');
-        if ($constructMethod === null) {
+        if (!$ancestor->methods()->has('__construct')) {
             return [];
         }
 
         $parameters = [];
-        foreach($constructMethod->parameters() as $parameter) {
+        foreach($ancestor->methods()->get('__construct')->parameters() as $parameter) {
             $parameters[] = $parameter->name();
         }
 

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Transformer/CompleteConstructorTest.php
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Transformer/CompleteConstructorTest.php
@@ -722,6 +722,30 @@ class CompleteConstructorTest extends WorseTestCase
                 }
                 EOT,
         ];
+
+        yield 'No promotion if there is a parent class constructor somewhere in the hierarchy' => [
+            <<<'EOT'
+                class B {
+                    public function __construct(private string $a) {}
+                }
+                class A extends B {}
+
+                class Foo extends A {
+                    public function __construct(string $a) {parent::__construct($a);}
+                }
+                EOT,
+            <<<'EOT'
+                class B {
+                    public function __construct(private string $a) {}
+                }
+                class A extends B {}
+
+                class Foo extends A {
+                    public function __construct(string $a) {parent::__construct($a);}
+                }
+                EOT,
+            ];
+
     }
 
 }

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Transformer/CompleteConstructorTest.php
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Transformer/CompleteConstructorTest.php
@@ -615,6 +615,7 @@ class CompleteConstructorTest extends WorseTestCase
         $transformed = wait($transformer->transform($source));
         $this->assertEquals((string) $expected, (string) $transformed->apply($source));
     }
+
     /**
      * @return Generator<string,array{string,string}>
      */
@@ -670,4 +671,57 @@ class CompleteConstructorTest extends WorseTestCase
 
         ];
     }
+
+    /**
+     * @dataProvider provideCompleteConstructorWithParentClass
+     */
+    public function testCompleteConstructorWithParentClass(string $example, string $expected): void
+    {
+        $source = SourceCode::fromString($example);
+        $transformer = new CompleteConstructor($this->reflectorForWorkspace($example), $this->updater(), 'private', true);
+        $transformed = wait($transformer->transform($source));
+        $this->assertEquals((string) $expected, (string) $transformed->apply($source));
+    }
+
+    /**
+    * @return Generator<array{string, string}>
+    */
+    public function provideCompleteConstructorWithParentClass(): Generator
+    {
+        yield 'Do not promote constructor arguments if a parent class already has the same argument' => [
+            <<<'EOT'
+                <?php
+                class A
+                {
+                    public function __construct(public string $someString) {}
+                }
+
+
+                class SomeClassTest extends A
+                {
+                    public function __construct(public int $test, string $someString)
+                    {
+                        parent::__construct($someString);
+                    }
+                }
+                EOT,
+            <<<'EOT'
+                <?php
+                class A
+                {
+                    public function __construct(public string $someString) {}
+                }
+
+
+                class SomeClassTest extends A
+                {
+                    public function __construct(public int $test, string $someString)
+                    {
+                        parent::__construct($someString);
+                    }
+                }
+                EOT,
+        ];
+    }
+
 }


### PR DESCRIPTION
This stops the promotion of parameters in the constructor that have the same name as the properties in the parent constructor. This does not work when the names differ.

Refs #2119