### PR TITLE
Gh 2345: Support single line comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ Changelog
 
 Improvements:
 
-  - Do not promote parameters that are used in parent constructor #2119
+  - Do not promote parameters that are used in parent constructor #2119 @mamazu
+  - Improve detection of Xdebug @bart-jaskulsi #2347
+  - Improve plain docblock parsing #2345
+  - Generate `@param` tag for iterables #2343 @mamazu
+
+## 2023.08.06-1
 
 Bug fixes:
 

--- a/lib/WorseReflection/Core/DocBlock/PlainDocblock.php
+++ b/lib/WorseReflection/Core/DocBlock/PlainDocblock.php
@@ -12,7 +12,6 @@ use Phpactor\WorseReflection\Core\Type;
 use Phpactor\WorseReflection\Core\TypeFactory;
 use Phpactor\WorseReflection\Core\Deprecation;
 use Phpactor\WorseReflection\Core\TypeResolver;
-use function Safe\preg_replace;
 
 class PlainDocblock implements DocBlock
 {
@@ -22,7 +21,6 @@ class PlainDocblock implements DocBlock
     const START = 0;
     const WHITESPACE = 4;
     const WS_OR_TERMINATE = 5;
-
 
     private string $raw;
 
@@ -70,52 +68,52 @@ class PlainDocblock implements DocBlock
             $buffer .= $char;
 
             switch ($mode) {
-            case self::START:
-                if ($buffer === '/*') {
-                    $mode = self::EXTRA_ASTERIX;
-                    $buffer = '';
-                }
-                break;
-            case self::EXTRA_ASTERIX:
-                if ($buffer === '*') {
-                    $buffer = '';
-                }
-                $mode = self::TEXT;
-                break;
-            case self::TEXT:
-                if ($char === "\n") {
-                    $text .= "\n";
-                    $mode = self::LEADING;
+                case self::START:
+                    if ($buffer === '/*') {
+                        $mode = self::EXTRA_ASTERIX;
+                        $buffer = '';
+                    }
                     break;
-                }
-                if ($char === '*') {
-                    $mode = self::WS_OR_TERMINATE;
-                    break;
-                }
-                $text .= $char;
-                break;
-            case self::LEADING:
-                if ($char === '*') {
-                    $mode = self::WS_OR_TERMINATE;
-                }
-                break;
-            case self::WHITESPACE:
-                if ($char !== ' ') {
+                case self::EXTRA_ASTERIX:
+                    if ($buffer === '*') {
+                        $buffer = '';
+                    }
                     $mode = self::TEXT;
+                    break;
+                case self::TEXT:
+                    if ($char === "\n") {
+                        $text .= "\n";
+                        $mode = self::LEADING;
+                        break;
+                    }
+                    if ($char === '*') {
+                        $mode = self::WS_OR_TERMINATE;
+                        break;
+                    }
                     $text .= $char;
-                }
-                break;
-            case self::WS_OR_TERMINATE:
-                if ($char === '/') {
-                    return trim($text);
-                }
-
-                if ($char !== ' ') {
-                    $text = trim($text, ' ') . $char;
-                    $mode = self::TEXT;
                     break;
-                }
-                break;
+                case self::LEADING:
+                    if ($char === '*') {
+                        $mode = self::WS_OR_TERMINATE;
+                    }
+                    break;
+                case self::WHITESPACE:
+                    if ($char !== ' ') {
+                        $mode = self::TEXT;
+                        $text .= $char;
+                    }
+                    break;
+                case self::WS_OR_TERMINATE:
+                    if ($char === '/') {
+                        return trim($text);
+                    }
+
+                    if ($char !== ' ') {
+                        $text = trim($text, ' ') . $char;
+                        $mode = self::TEXT;
+                        break;
+                    }
+                    break;
             }
         }
 

--- a/lib/WorseReflection/Core/DocBlock/PlainDocblock.php
+++ b/lib/WorseReflection/Core/DocBlock/PlainDocblock.php
@@ -15,12 +15,12 @@ use Phpactor\WorseReflection\Core\TypeResolver;
 
 class PlainDocblock implements DocBlock
 {
-    const LEADING = 3;
-    const TEXT = 2;
-    const EXTRA_ASTERIX = 1;
-    const START = 0;
-    const WHITESPACE = 4;
-    const WS_OR_TERMINATE = 5;
+    private const LEADING = 3;
+    private const TEXT = 2;
+    private const EXTRA_ASTERIX = 1;
+    private const START = 0;
+    private const WHITESPACE = 4;
+    private const WS_OR_TERMINATE = 5;
 
     private string $raw;
 

--- a/lib/WorseReflection/Tests/Unit/Core/DocBlock/PlainDocblockTest.php
+++ b/lib/WorseReflection/Tests/Unit/Core/DocBlock/PlainDocblockTest.php
@@ -35,7 +35,7 @@ class PlainDocblockTest extends TestCase
 
     public function testSingle(): void
     {
-        self::assertEquals("hello world", $this->createDocblock(
+        self::assertEquals('hello world', $this->createDocblock(
             '/** hello world */'
         )->formatted());
     }

--- a/lib/WorseReflection/Tests/Unit/Core/DocBlock/PlainDocblockTest.php
+++ b/lib/WorseReflection/Tests/Unit/Core/DocBlock/PlainDocblockTest.php
@@ -33,6 +33,13 @@ class PlainDocblockTest extends TestCase
         )->formatted());
     }
 
+    public function testSingle(): void
+    {
+        self::assertEquals("hello world", $this->createDocblock(
+            '/** hello world */'
+        )->formatted());
+    }
+
     private function createDocblock(string $string): DocBlock
     {
         return new PlainDocblock($string);


### PR DESCRIPTION
Use a simple parser in the plain docblock class, fixes #2345 