### PR TITLE
Ensure errors bubble up and are caught in diangostic engine

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "phpactor/amp-fswatch": "^0.3.0",
         "thecodingmachine/safe": "^1.0",
         "phpactor/phly-event-dispatcher": "^2.0.0",
-        "phpactor/language-server": "^6.0.2",
+        "phpactor/language-server": "^6.1.0",
         "phpactor/language-server-protocol": "^3.17.3",
         "dantleech/object-renderer": "^0.1.1",
         "monolog/monolog": "^1.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5cf84950e396ca5382656828a64d150d",
+    "content-hash": "40048cb1f1e6ce517915db0b0de52d81",
     "packages": [
         {
             "name": "amphp/amp",
@@ -1643,16 +1643,16 @@
         },
         {
             "name": "phpactor/language-server",
-            "version": "6.0.2",
+            "version": "6.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/language-server.git",
-                "reference": "78a27025521ef203b230dabc37f16d308ad73820"
+                "reference": "b12211da450104566aa36aa3127abefe0cdf8bbf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/language-server/zipball/78a27025521ef203b230dabc37f16d308ad73820",
-                "reference": "78a27025521ef203b230dabc37f16d308ad73820",
+                "url": "https://api.github.com/repos/phpactor/language-server/zipball/b12211da450104566aa36aa3127abefe0cdf8bbf",
+                "reference": "b12211da450104566aa36aa3127abefe0cdf8bbf",
                 "shasum": ""
             },
             "require": {
@@ -1703,9 +1703,9 @@
             "description": "Generic Language Server Platform",
             "support": {
                 "issues": "https://github.com/phpactor/language-server/issues",
-                "source": "https://github.com/phpactor/language-server/tree/6.0.2"
+                "source": "https://github.com/phpactor/language-server/tree/6.1.0"
             },
-            "time": "2023-07-29T19:46:20+00:00"
+            "time": "2023-09-10T11:29:43+00:00"
         },
         {
             "name": "phpactor/language-server-protocol",

--- a/doc/integrations/phpcs.rst
+++ b/doc/integrations/phpcs.rst
@@ -13,7 +13,7 @@ Phpactor can use PHP_CodeSniffer to:
 - format your code via the LSP ``textDocument/formatting`` action,
 - provide diagnostics for potential fixes,
 
-To do so you set :ref:`_param_php_code_sniffer.enabled`:
+To do so you set :ref:`param_php_code_sniffer.enabled`:
 
 .. code-block:: bash
 

--- a/lib/Extension/LanguageServer/LanguageServerExtension.php
+++ b/lib/Extension/LanguageServer/LanguageServerExtension.php
@@ -506,6 +506,7 @@ class LanguageServerExtension implements Extension
             );
             return new DiagnosticsEngine(
                 $container->get(ClientApi::class),
+                $this->logger($container, 'LSPDIAG'),
                 $providers,
                 $container->parameter(self::PARAM_DIAGNOSTIC_SLEEP_TIME)->int()
             );

--- a/lib/Extension/LanguageServerPsalm/Model/PsalmProcess.php
+++ b/lib/Extension/LanguageServerPsalm/Model/PsalmProcess.php
@@ -7,6 +7,7 @@ use Amp\Process\ProcessException;
 use Amp\Promise;
 use Phpactor\Amp\Process\ProcessUtil;
 use Phpactor\LanguageServerProtocol\Diagnostic;
+use RuntimeException;
 use function Amp\ByteStream\buffer;
 use Psr\Log\LoggerInterface;
 
@@ -74,13 +75,11 @@ class PsalmProcess
             }
 
             if ($exitCode !== 0 && $exitCode !== 2) {
-                $this->logger->error(sprintf(
+                throw new RuntimeException(
                     'Psalm exited with code "%s": %s',
                     $exitCode,
                     yield buffer($process->getStderr())
-                ));
-
-                return [];
+                );
             }
 
             $stdout = yield buffer($process->getStdout());

--- a/lib/Extension/PhpCodeSniffer/Model/PhpCodeSnifferProcess.php
+++ b/lib/Extension/PhpCodeSniffer/Model/PhpCodeSnifferProcess.php
@@ -8,6 +8,7 @@ use Phpactor\Amp\Process\ProcessBuilder;
 use Phpactor\LanguageServerProtocol\TextDocumentItem;
 use Phpactor\TextDocument\TextDocumentUri;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 use Safe\Exceptions\FilesystemException;
 use Throwable;
 use function Amp\ByteStream\buffer;
@@ -138,7 +139,7 @@ class PhpCodeSnifferProcess
                 && $exitCode !== self::EXIT_FOUND_NON_FIXABLE_ERRORS
                 && $exitCode !== self::EXIT_FILES_NEEDS_FIXING
             ) {
-                $this->logger->error(
+                throw new RuntimeException(
                     sprintf(
                         "phpcs exited with code '%s'; cmd: %s; stderr: '%s'; stdout: '%s'",
                         $exitCode,

--- a/lib/Extension/PhpCodeSniffer/Model/PhpCodeSnifferProcess.php
+++ b/lib/Extension/PhpCodeSniffer/Model/PhpCodeSnifferProcess.php
@@ -148,7 +148,6 @@ class PhpCodeSnifferProcess
                         $stdout
                     )
                 );
-                return '[]';
             }
 
             return $stdout;


### PR DESCRIPTION
This PR fixes the error-handling regression introduced by the new (parallel) diagnostic engine and will also ensure that the user is notified if a linter/diagnostic provider crashes.

Fixes #2364 