### PR TITLE
Change clone URL to HTTPS instead of SSH

### DIFF
--- a/doc/usage/standalone.rst
+++ b/doc/usage/standalone.rst
@@ -36,7 +36,7 @@ You can checkout the project and then create a symlink.
 .. code:: bash
 
    $ cd ~/home/you/somewhere
-   $ git clone git@github.com:phpactor/phpactor
+   $ git clone https://github.com/phpactor/phpactor.git
    $ cd phpactor
    $ composer install
    $ cd /usr/local/bin


### PR DESCRIPTION
Attempting to clone with SSH will fail due to permission deined, for non-collaborators.