### PR TITLE
fix: LSP Position is 0 based where LineCol/LineColRange are 1 based.

### DIFF
--- a/lib/Extension/LanguageServerDiagnostics/Model/PhpLinter.php
+++ b/lib/Extension/LanguageServerDiagnostics/Model/PhpLinter.php
@@ -56,8 +56,8 @@ final class PhpLinter
             return [
                 new Diagnostic(
                     range: new Range(
-                        new Position($line, $range->start()->col()),
-                        new Position($line, $range->end()->col())
+                        new Position($line, $range->start()->col() - 1),
+                        new Position($line, $range->end()->col() - 1)
                     ),
                     message: $err,
                     severity: DiagnosticSeverity::ERROR


### PR DESCRIPTION
In PhpLint the reported Diagnostic Range is incorrect as it is 1 based instead of 0.

A good alternative would be to provide mapping classes. `PositionConverter` and `RangeConverter` seem like good candidates to add a `fromLineCol` and `fromLineColRange` methods.