### PR TITLE
Generate methods on enum

### DIFF
--- a/lib/CodeBuilder/Adapter/TolerantParser/TolerantUpdater.php
+++ b/lib/CodeBuilder/Adapter/TolerantParser/TolerantUpdater.php
@@ -4,9 +4,11 @@ namespace Phpactor\CodeBuilder\Adapter\TolerantParser;
 use Microsoft\PhpParser\Node\SourceFileNode;
 use Microsoft\PhpParser\Node\Statement\ClassDeclaration;
 use Microsoft\PhpParser\Node\Statement\TraitDeclaration;
+use Microsoft\PhpParser\Node\Statement\EnumDeclaration;
 use Microsoft\PhpParser\Node\Statement\InlineHtml;
 use Microsoft\PhpParser\Node\Statement\NamespaceDefinition;
 use Microsoft\PhpParser\Parser;
+use Phpactor\CodeBuilder\Adapter\TolerantParser\Updater\EnumUpdater;
 use Phpactor\CodeBuilder\Adapter\TolerantParser\Updater\UseStatementUpdater;
 use Phpactor\CodeBuilder\Domain\Code;
 use Phpactor\CodeBuilder\Domain\Prototype\NamespaceName;
@@ -33,6 +35,8 @@ class TolerantUpdater implements Updater
 
     private TraitUpdater $traitUpdater;
 
+    private EnumUpdater $enumUpdater;
+
     private UseStatementUpdater $useStatementUpdater;
 
     public function __construct(
@@ -45,6 +49,7 @@ class TolerantUpdater implements Updater
         $this->classUpdater = new ClassUpdater($renderer);
         $this->interfaceUpdater = new InterfaceUpdater($renderer);
         $this->traitUpdater = new TraitUpdater($renderer);
+        $this->enumUpdater = new EnumUpdater($renderer);
         $this->useStatementUpdater = new UseStatementUpdater();
     }
 
@@ -90,6 +95,7 @@ class TolerantUpdater implements Updater
         $classNodes = [];
         $traitNodes = [];
         $interfaceNodes = [];
+        $enumNodes = [];
         $lastStatement = null;
 
         foreach ($node->statementList as $classNode) {
@@ -109,6 +115,11 @@ class TolerantUpdater implements Updater
                 $name = $classNode->name->getText($node->getFileContents());
                 $traitNodes[$name] = $classNode;
             }
+
+            if ($classNode instanceof EnumDeclaration) {
+                $name = $classNode->name->getText($node->getFileContents());
+                $enumNodes[$name] = $classNode;
+            }
         }
 
         foreach ($prototype->classes()->in(array_keys($classNodes)) as $classPrototype) {
@@ -123,10 +134,15 @@ class TolerantUpdater implements Updater
             $this->traitUpdater->updateTrait($edits, $traitPrototype, $traitNodes[$traitPrototype->name()]);
         }
 
+        foreach ($prototype->enums()->in(array_keys($enumNodes)) as $enumPrototype) {
+            $this->enumUpdater->updateEnum($edits, $enumPrototype, $enumNodes[$enumPrototype->name()]);
+        }
+
         $classes = array_merge(
             iterator_to_array($prototype->classes()->notIn(array_keys($classNodes))),
             iterator_to_array($prototype->interfaces()->notIn(array_keys($interfaceNodes))),
-            iterator_to_array($prototype->traits()->notIn(array_keys($traitNodes)))
+            iterator_to_array($prototype->traits()->notIn(array_keys($traitNodes))),
+            iterator_to_array($prototype->enums()->notIn(array_keys($enumNodes)))
         );
 
         $index = 0;

--- a/lib/CodeBuilder/Adapter/TolerantParser/Updater/AbstractMethodUpdater.php
+++ b/lib/CodeBuilder/Adapter/TolerantParser/Updater/AbstractMethodUpdater.php
@@ -5,6 +5,7 @@ namespace Phpactor\CodeBuilder\Adapter\TolerantParser\Updater;
 use Microsoft\PhpParser\ClassLike;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\DelimitedList\ParameterDeclarationList;
+use Microsoft\PhpParser\Node\EnumCaseDeclaration;
 use Microsoft\PhpParser\Node\MethodDeclaration;
 use Microsoft\PhpParser\Node\Parameter;
 use Microsoft\PhpParser\Node\PropertyDeclaration;
@@ -42,7 +43,7 @@ abstract class AbstractMethodUpdater
         $existingMethodNames = [];
         $existingMethods = [];
         foreach ($this->memberDeclarations($classNode) as $memberNode) {
-            if ($memberNode instanceof PropertyDeclaration) {
+            if ($memberNode instanceof PropertyDeclaration || $memberNode instanceof EnumCaseDeclaration) {
                 $lastMember = $memberNode;
                 $newLine = true;
                 if (!$methodHasBeenEncountered) {

--- a/lib/CodeBuilder/Adapter/TolerantParser/Updater/ClassMethodUpdater.php
+++ b/lib/CodeBuilder/Adapter/TolerantParser/Updater/ClassMethodUpdater.php
@@ -4,7 +4,9 @@ namespace Phpactor\CodeBuilder\Adapter\TolerantParser\Updater;
 
 use Microsoft\PhpParser\Node\ClassMembersNode;
 use Microsoft\PhpParser\ClassLike;
+use Microsoft\PhpParser\Node\EnumMembers;
 use Microsoft\PhpParser\Node\Statement\ClassDeclaration;
+use Microsoft\PhpParser\Node\Statement\EnumDeclaration;
 use Microsoft\PhpParser\Node\Statement\TraitDeclaration;
 use Microsoft\PhpParser\Node\TraitMembers;
 use Phpactor\CodeBuilder\Domain\Renderer;
@@ -18,7 +20,7 @@ use Microsoft\PhpParser\Node;
 class ClassMethodUpdater extends AbstractMethodUpdater
 {
     /**
-    * @return ClassMembersNode|TraitMembers
+    * @return ClassMembersNode|TraitMembers|EnumMembers
     */
     public function memberDeclarationsNode(ClassLike $classNode)
     {
@@ -27,6 +29,9 @@ class ClassMethodUpdater extends AbstractMethodUpdater
         }
         if ($classNode instanceof TraitDeclaration) {
             return $classNode->traitMembers;
+        }
+        if ($classNode instanceof EnumDeclaration) {
+            return $classNode->enumMembers;
         }
 
         throw new RuntimeException(sprintf(
@@ -50,6 +55,9 @@ class ClassMethodUpdater extends AbstractMethodUpdater
         }
         if ($classNode instanceof TraitDeclaration) {
             return $classNode->traitMembers->traitMemberDeclarations;
+        }
+        if ($classNode instanceof EnumDeclaration) {
+            return $classNode->enumMembers->enumMemberDeclarations;
         }
 
         throw new RuntimeException(sprintf(

--- a/lib/CodeBuilder/Adapter/TolerantParser/Updater/EnumUpdater.php
+++ b/lib/CodeBuilder/Adapter/TolerantParser/Updater/EnumUpdater.php
@@ -33,8 +33,9 @@ class EnumUpdater
 
         $nextMember = null;
         $existingCasesNames = [];
+        $memberDeclarations = $enumMembers->enumMemberDeclarations;
 
-        foreach ($enumMembers as $memberNode) {
+        foreach ($memberDeclarations as $memberNode) {
             if (null === $nextMember) {
                 $nextMember = $memberNode;
             }
@@ -48,14 +49,12 @@ class EnumUpdater
         }
 
         foreach ($classPrototype->cases()->notIn($existingCasesNames) as $case) {
-            assert($case instanceof Constant);
-
             $edits->after(
                 $lastConstant,
                 PHP_EOL . $edits->indent($this->renderer->render($case), 1)
             );
 
-            if ($classPrototype->constants()->isLast($case) && (
+            if ($classPrototype->cases()->isLast($case) && (
                 $nextMember instanceof MethodDeclaration ||
                 $nextMember instanceof EnumCaseDeclaration
             )) {

--- a/lib/CodeBuilder/Adapter/TolerantParser/Updater/EnumUpdater.php
+++ b/lib/CodeBuilder/Adapter/TolerantParser/Updater/EnumUpdater.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Phpactor\CodeBuilder\Adapter\TolerantParser\Updater;
+
+use Microsoft\PhpParser\Node\EnumCaseDeclaration;
+use Microsoft\PhpParser\Node\EnumMembers;
+use Microsoft\PhpParser\Node\MethodDeclaration;
+use Microsoft\PhpParser\Node\Statement\EnumDeclaration;
+use Phpactor\CodeBuilder\Domain\Prototype\Constant;
+use Phpactor\CodeBuilder\Domain\Prototype\EnumPrototype;
+use Phpactor\CodeBuilder\Domain\Renderer;
+use Phpactor\CodeBuilder\Adapter\TolerantParser\Edits;
+
+class EnumUpdater
+{
+    private ClassMethodUpdater $methodUpdater;
+
+    public function __construct(private Renderer $renderer)
+    {
+        $this->methodUpdater = new ClassMethodUpdater($renderer);
+    }
+
+    public function updateCases(
+        Edits $edits,
+        EnumPrototype $classPrototype,
+        EnumMembers $enumMembers
+    ): void {
+        if (count($classPrototype->cases()) === 0) {
+            return;
+        }
+
+        $lastConstant = $enumMembers->openBrace;
+
+        $nextMember = null;
+        $existingCasesNames = [];
+
+        foreach ($enumMembers as $memberNode) {
+            if (null === $nextMember) {
+                $nextMember = $memberNode;
+            }
+
+            if ($memberNode instanceof EnumCaseDeclaration) {
+                $existingCasesNames[] = $memberNode->name->getText();
+                $lastConstant = $memberNode;
+                $nextMember = next($memberDeclarations) ?: $nextMember;
+                prev($memberDeclarations);
+            }
+        }
+
+        foreach ($classPrototype->cases()->notIn($existingCasesNames) as $case) {
+            assert($case instanceof Constant);
+
+            $edits->after(
+                $lastConstant,
+                PHP_EOL . $edits->indent($this->renderer->render($case), 1)
+            );
+
+            if ($classPrototype->constants()->isLast($case) && (
+                $nextMember instanceof MethodDeclaration ||
+                $nextMember instanceof EnumCaseDeclaration
+            )) {
+                $edits->after($lastConstant, PHP_EOL);
+            }
+        }
+    }
+
+    public function updateEnum(
+        Edits $edits,
+        EnumPrototype $classPrototype,
+        EnumDeclaration $classNode
+    ): void {
+        $this->updateCases($edits, $classPrototype, $classNode->enumMembers);
+        $this->methodUpdater->updateMethods($edits, $classPrototype, $classNode);
+    }
+}

--- a/lib/CodeBuilder/Adapter/TolerantParser/Updater/EnumUpdater.php
+++ b/lib/CodeBuilder/Adapter/TolerantParser/Updater/EnumUpdater.php
@@ -6,7 +6,6 @@ use Microsoft\PhpParser\Node\EnumCaseDeclaration;
 use Microsoft\PhpParser\Node\EnumMembers;
 use Microsoft\PhpParser\Node\MethodDeclaration;
 use Microsoft\PhpParser\Node\Statement\EnumDeclaration;
-use Phpactor\CodeBuilder\Domain\Prototype\Constant;
 use Phpactor\CodeBuilder\Domain\Prototype\EnumPrototype;
 use Phpactor\CodeBuilder\Domain\Renderer;
 use Phpactor\CodeBuilder\Adapter\TolerantParser\Edits;

--- a/lib/CodeBuilder/Adapter/WorseReflection/WorseBuilderFactory.php
+++ b/lib/CodeBuilder/Adapter/WorseReflection/WorseBuilderFactory.php
@@ -18,6 +18,7 @@ use Phpactor\WorseReflection\Core\Reflection\ReflectionMethod;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionParameter;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionProperty;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionTrait;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionEnum;
 use Phpactor\WorseReflection\Core\Type;
 use Phpactor\WorseReflection\Core\Type\ArrayType;
 use Phpactor\WorseReflection\Reflector;
@@ -53,6 +54,10 @@ class WorseBuilderFactory implements BuilderFactory
             if ($classLike instanceof ReflectionTrait) {
                 $this->build('trait', $builder, $classLike);
                 continue;
+            }
+
+            if ($classLike instanceof ReflectionEnum) {
+                $this->build('enum', $builder, $classLike);
             }
         }
 

--- a/lib/CodeBuilder/Domain/Builder/CaseBuilder.php
+++ b/lib/CodeBuilder/Domain/Builder/CaseBuilder.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpactor\CodeBuilder\Domain\Builder;
+
+use Phpactor\CodeBuilder\Domain\Prototype\UpdatePolicy;
+use Phpactor\CodeBuilder\Domain\Prototype\Case_;
+
+class CaseBuilder extends AbstractBuilder implements NamedBuilder
+{
+    public function __construct(
+        protected EnumBuilder $enumBuilder,
+        protected string $name
+    ) {
+    }
+
+    public function name(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function end(): EnumBuilder
+    {
+        return $this->enumBuilder;
+    }
+
+    public static function childNames(): array
+    {
+        return ['name'];
+    }
+
+    public function builderName(): string
+    {
+        return $this->name;
+    }
+
+    public function build(): Case_
+    {
+        return new Case_($this->name, null, UpdatePolicy::fromModifiedState($this->isModified()));
+    }
+}

--- a/lib/CodeBuilder/Domain/Builder/EnumBuilder.php
+++ b/lib/CodeBuilder/Domain/Builder/EnumBuilder.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpactor\CodeBuilder\Domain\Builder;
+
+use Phpactor\CodeBuilder\Domain\Prototype\Cases;
+use Phpactor\CodeBuilder\Domain\Prototype\EnumPrototype;
+use Phpactor\CodeBuilder\Domain\Prototype\Methods;
+use Phpactor\CodeBuilder\Domain\Prototype\UpdatePolicy;
+
+class EnumBuilder extends ClassLikeBuilder
+{
+    /**
+     * @var CaseBuilder[]
+    */
+    protected array $cases = [];
+
+    public static function childNames(): array
+    {
+        return array_merge(parent::childNames(), ['cases']);
+    }
+
+    public function case(string $name): CaseBuilder
+    {
+        if (!isset($this->cases[$name])) {
+            $this->cases[$name] = new CaseBuilder($this, $name);
+        }
+
+        return $this->cases[$name];
+    }
+
+    public function build(): EnumPrototype
+    {
+        $updatePolicy = UpdatePolicy::fromModifiedState($this->isModified());
+        return new EnumPrototype(
+            $this->name,
+            Cases::fromCases(array_map(function (CaseBuilder $case) { return $case->build(); }, $this->cases)),
+            Methods::fromMethods(array_map(function (MethodBuilder $builder) { return $builder->build(); }, $this->methods)),
+            $updatePolicy
+        );
+    }
+}

--- a/lib/CodeBuilder/Domain/Builder/SourceCodeBuilder.php
+++ b/lib/CodeBuilder/Domain/Builder/SourceCodeBuilder.php
@@ -11,6 +11,7 @@ use Phpactor\CodeBuilder\Domain\Prototype\UpdatePolicy;
 use Phpactor\CodeBuilder\Domain\Prototype\UseStatements;
 use Phpactor\CodeBuilder\Domain\Prototype\Interfaces;
 use Phpactor\CodeBuilder\Domain\Prototype\Traits;
+use Phpactor\CodeBuilder\Domain\Prototype\Enums;
 use Phpactor\CodeBuilder\Domain\Prototype\UseStatement;
 
 class SourceCodeBuilder extends AbstractBuilder
@@ -37,6 +38,11 @@ class SourceCodeBuilder extends AbstractBuilder
      */
     protected array $traits = [];
 
+    /**
+    * @var EnumBuilder[]
+    */
+    protected array $enums = [];
+
     public static function create(): SourceCodeBuilder
     {
         return new self();
@@ -48,6 +54,7 @@ class SourceCodeBuilder extends AbstractBuilder
             'classes',
             'interfaces',
             'traits',
+            'enums',
         ];
     }
 
@@ -97,6 +104,10 @@ class SourceCodeBuilder extends AbstractBuilder
             return $this->traits[$name];
         }
 
+        if (isset($this->enums[$name])) {
+            return $this->enums[$name];
+        }
+
         throw new InvalidArgumentException(
             'classLike can only be called as an accessor. Use class() or interface() instead'
         );
@@ -124,6 +135,17 @@ class SourceCodeBuilder extends AbstractBuilder
         return $builder;
     }
 
+    public function enum(string $name): EnumBuilder
+    {
+        if (isset($this->enums[$name])) {
+            return $this->enums[$name];
+        }
+
+        $this->enums[$name] = $builder = new EnumBuilder($this, $name);
+
+        return $builder;
+    }
+
     public function build(): SourceCode
     {
         return new SourceCode(
@@ -138,6 +160,9 @@ class SourceCodeBuilder extends AbstractBuilder
             Traits::fromTraits(array_map(function (TraitBuilder $builder) {
                 return $builder->build();
             }, $this->traits)),
+            Enums::fromEnums(array_map(function (EnumBuilder $builder) {
+                return $builder->build();
+            }, $this->enums)),
             UpdatePolicy::fromModifiedState($this->isModified())
         );
     }

--- a/lib/CodeBuilder/Domain/Prototype/Case_.php
+++ b/lib/CodeBuilder/Domain/Prototype/Case_.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpactor\CodeBuilder\Domain\Prototype;
+
+class Case_ extends Prototype
+{
+    public function __construct(private string $name, private ?Value $value = null, UpdatePolicy $updatePolicy = null)
+    {
+        parent::__construct($updatePolicy);
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    public function value(): ?Value
+    {
+        return $this->value;
+    }
+}

--- a/lib/CodeBuilder/Domain/Prototype/Cases.php
+++ b/lib/CodeBuilder/Domain/Prototype/Cases.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Phpactor\CodeBuilder\Domain\Prototype;
+
+/**
+ * @extends Collection<Case>
+ */
+class Cases extends Collection
+{
+    /**
+     * @param Case[] $methods
+     */
+    public static function fromCases(array $cases): self
+    {
+        return new self(array_reduce($cases, function ($acc, $case) {
+            $acc[$case->name()] = $case;
+            return $acc;
+        }, []));
+    }
+
+    protected function singularName(): string
+    {
+        return 'case';
+    }
+}

--- a/lib/CodeBuilder/Domain/Prototype/Cases.php
+++ b/lib/CodeBuilder/Domain/Prototype/Cases.php
@@ -3,12 +3,12 @@
 namespace Phpactor\CodeBuilder\Domain\Prototype;
 
 /**
- * @extends Collection<Case>
+ * @extends Collection<Case_>
  */
 class Cases extends Collection
 {
     /**
-     * @param Case[] $methods
+     * @param Case_[] $cases
      */
     public static function fromCases(array $cases): self
     {

--- a/lib/CodeBuilder/Domain/Prototype/EnumPrototype.php
+++ b/lib/CodeBuilder/Domain/Prototype/EnumPrototype.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Phpactor\CodeBuilder\Domain\Prototype;
+
+final class EnumPrototype extends ClassLikePrototype
+{
+    public function __construct(
+        string $name,
+        private Cases $cases,
+        Methods $methods = null,
+        UpdatePolicy $updatePolicy = null
+    ) {
+        parent::__construct(name: $name, methods: $methods, updatePolicy: $updatePolicy);
+    }
+
+    public function cases(): Cases
+    {
+        return $this->cases;
+    }
+}
+

--- a/lib/CodeBuilder/Domain/Prototype/EnumPrototype.php
+++ b/lib/CodeBuilder/Domain/Prototype/EnumPrototype.php
@@ -18,4 +18,3 @@ final class EnumPrototype extends ClassLikePrototype
         return $this->cases;
     }
 }
-

--- a/lib/CodeBuilder/Domain/Prototype/Enums.php
+++ b/lib/CodeBuilder/Domain/Prototype/Enums.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Phpactor\CodeBuilder\Domain\Prototype;
+
+/**
+ * @extends Collection<EnumPrototype>
+ */
+class Enums extends Collection
+{
+    /**
+     * @param list<EnumPrototype> $enums
+     */
+    public static function fromEnums(array $enums): self
+    {
+        return new static(array_reduce($enums, function ($arr, EnumPrototype $enum) {
+            $arr[$enum->name()] = $enum;
+            return $arr;
+        }, []));
+    }
+
+    protected function singularName(): string
+    {
+        return 'trait';
+    }
+}

--- a/lib/CodeBuilder/Domain/Prototype/SourceCode.php
+++ b/lib/CodeBuilder/Domain/Prototype/SourceCode.php
@@ -14,12 +14,15 @@ class SourceCode extends Prototype
 
     private Traits $traits;
 
+    private Enums $enums;
+
     public function __construct(
         QualifiedName $namespace = null,
         UseStatements $useStatements = null,
         Classes $classes = null,
         Interfaces $interfaces = null,
         Traits $traits = null,
+        Enums $enums = null,
         UpdatePolicy $updatePolicy = null
     ) {
         parent::__construct($updatePolicy);
@@ -28,6 +31,7 @@ class SourceCode extends Prototype
         $this->classes = $classes ?: Classes::empty();
         $this->interfaces = $interfaces ?: Interfaces::empty();
         $this->traits = $traits ?: Traits::empty();
+        $this->enums = $enums ?: Enums::empty();
     }
 
     public function namespace(): QualifiedName
@@ -53,5 +57,10 @@ class SourceCode extends Prototype
     public function traits(): Traits
     {
         return $this->traits;
+    }
+
+    public function enums(): Enums
+    {
+        return $this->enums;
     }
 }

--- a/lib/CodeBuilder/Tests/Adapter/UpdaterTestCase.php
+++ b/lib/CodeBuilder/Tests/Adapter/UpdaterTestCase.php
@@ -747,6 +747,11 @@ abstract class UpdaterTestCase extends TestCase
 
     public function provideEnums(): Generator
     {
+        if (PHP_VERSION_ID <= 80000) {
+            // The support for enums in php 8 and lower is bad so skip the tests
+            return;
+        }
+
         yield 'Rendering an enum' => [
             '',
             SourceCodeBuilder::create()
@@ -782,6 +787,29 @@ abstract class UpdaterTestCase extends TestCase
                 {
                     case ONE;
                     case TWO;
+                    case THREE;
+
+                }
+                EOT,
+        ];
+        yield 'Adding a case to break a backed enum' => [
+            <<<'EOT'
+                enum SomeEnum: string
+                {
+                    case ONE = '1';
+                    case TWO = '2';
+                }
+                EOT,
+            SourceCodeBuilder::create()
+            ->enum('SomeEnum')
+                ->case('THREE')->end()
+            ->end()
+            ->build(),
+            <<<'EOT'
+                enum SomeEnum: string
+                {
+                    case ONE = '1';
+                    case TWO = '2';
                     case THREE;
 
                 }

--- a/lib/CodeBuilder/Tests/Adapter/UpdaterTestCase.php
+++ b/lib/CodeBuilder/Tests/Adapter/UpdaterTestCase.php
@@ -756,6 +756,7 @@ abstract class UpdaterTestCase extends TestCase
             ->end()
             ->build(),
             <<<'EOT'
+
                 enum SomeEnum
                 {
                     case ONE;
@@ -779,9 +780,10 @@ abstract class UpdaterTestCase extends TestCase
             <<<'EOT'
                 enum SomeEnum
                 {
-                    case THREE;
                     case ONE;
                     case TWO;
+                    case THREE;
+
                 }
                 EOT,
         ];

--- a/lib/CodeBuilder/Tests/Adapter/UpdaterTestCase.php
+++ b/lib/CodeBuilder/Tests/Adapter/UpdaterTestCase.php
@@ -738,6 +738,56 @@ abstract class UpdaterTestCase extends TestCase
     }
 
     /**
+     * @dataProvider provideEnums
+    */
+    public function testEnums(string $existingCode, SourceCode $prototype, string $expectedCode)
+    {
+        $this->assertUpdate($existingCode, $prototype, $expectedCode);
+    }
+
+    public function provideEnums(): Generator
+    {
+        yield 'Rendering an enum' => [
+            '',
+            SourceCodeBuilder::create()
+            ->enum('SomeEnum')
+                ->case('ONE')->end()
+                ->case('TWO')->end()
+            ->end()
+            ->build(),
+            <<<'EOT'
+                enum SomeEnum
+                {
+                    case ONE;
+                    case TWO;
+                }
+                EOT,
+        ];
+        yield 'Adding a case to an already existing enum' => [
+            <<<'EOT'
+                enum SomeEnum
+                {
+                    case ONE;
+                    case TWO;
+                }
+                EOT,
+            SourceCodeBuilder::create()
+            ->enum('SomeEnum')
+                ->case('THREE')->end()
+            ->end()
+            ->build(),
+            <<<'EOT'
+                enum SomeEnum
+                {
+                    case THREE;
+                    case ONE;
+                    case TWO;
+                }
+                EOT,
+        ];
+    }
+
+    /**
      * @dataProvider provideTraits
      */
     public function testTraits(string $existingCode, SourceCode $prototype, string $expectedCode): void
@@ -1948,7 +1998,7 @@ abstract class UpdaterTestCase extends TestCase
                         }
                     }
                     EOT
-            ];
+        ];
     }
 
     abstract protected function updater(): Updater;

--- a/lib/CodeBuilder/Tests/Adapter/UpdaterTestCase.php
+++ b/lib/CodeBuilder/Tests/Adapter/UpdaterTestCase.php
@@ -742,16 +742,15 @@ abstract class UpdaterTestCase extends TestCase
     */
     public function testEnums(string $existingCode, SourceCode $prototype, string $expectedCode): void
     {
+        if (version_compare(PHP_VERSION, '8.1', '<')) {
+            $this->markTestSkipped('Not supported in less than 8.1');
+        }
+
         $this->assertUpdate($existingCode, $prototype, $expectedCode);
     }
 
     public function provideEnums(): Generator
     {
-        if (PHP_VERSION_ID <= 80000) {
-            // The support for enums in php 8 and lower is bad so skip the tests
-            return;
-        }
-
         yield 'Rendering an enum' => [
             '',
             SourceCodeBuilder::create()

--- a/lib/CodeBuilder/Tests/Adapter/UpdaterTestCase.php
+++ b/lib/CodeBuilder/Tests/Adapter/UpdaterTestCase.php
@@ -740,7 +740,7 @@ abstract class UpdaterTestCase extends TestCase
     /**
      * @dataProvider provideEnums
     */
-    public function testEnums(string $existingCode, SourceCode $prototype, string $expectedCode)
+    public function testEnums(string $existingCode, SourceCode $prototype, string $expectedCode): void
     {
         $this->assertUpdate($existingCode, $prototype, $expectedCode);
     }

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseGenerateMethod.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseGenerateMethod.php
@@ -10,6 +10,9 @@ use Phpactor\CodeTransform\Domain\Refactor\GenerateMethod;
 use Phpactor\TextDocument\TextDocumentBuilder;
 use Phpactor\TextDocument\TextDocumentEdits;
 use Phpactor\TextDocument\TextDocumentUri;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionClass;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionEnum;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionInterface;
 use Phpactor\WorseReflection\Core\Type\ClassType;
 use Phpactor\WorseReflection\Reflector;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionArgument;
@@ -156,10 +159,11 @@ class WorseGenerateMethod implements GenerateMethod
 
     private function validate(ReflectionMethodCall $methodCall): void
     {
-        if (false === $methodCall->class()->isClass() && false === $methodCall->class()->isInterface()) {
+        $target = $methodCall->class();
+        if (!$target instanceof ReflectionClass && !$target instanceof ReflectionInterface && !$target instanceof ReflectionEnum) {
             throw new TransformException(sprintf(
                 'Can only generate methods on classes or interfaces (trying on %s)',
-                get_class($methodCall->class()->name())
+                get_class($target->name())
             ));
         }
     }

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseGenerateMethod.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseGenerateMethod.php
@@ -90,10 +90,7 @@ class WorseGenerateMethod implements GenerateMethod
         $reflectionClass = $methodCall->class();
         $builder = $this->factory->fromSource($reflectionClass->sourceCode());
 
-        $classBuilder = $reflectionClass->isClass() ?
-            $builder->class($reflectionClass->name()->short()) :
-            $builder->interface($reflectionClass->name()->short());
-
+        $classBuilder = $builder->classLike($reflectionClass->name()->short());
         $methodBuilder = $classBuilder->method($methodName);
         $methodBuilder->visibility((string) $visibility);
         if ($static) {

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/WorseGenerateMethodTest.php
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/WorseGenerateMethodTest.php
@@ -38,7 +38,9 @@ class WorseGenerateMethodTest extends WorseTestCase
         yield 'public accessor in another class' => [ 'generateMethod6.test' ];
         yield 'public accessor on interface' => [ 'generateMethod7.test' ];
         yield 'public accessor on interface with namespace' => [ 'generateMethod8.test' ];
-        yield 'public method on enum' => [ 'generateMethod_enum.test', 'play'];
+        if (version_compare(PHP_VERSION, '8.1', '>=')) {
+            yield 'public method on enum' => [ 'generateMethod_enum.test', 'play'];
+        }
         yield 'imports classes' => [ 'generateMethod9.test' ];
         yield 'static private method' => [ 'generateMethod10.test' ];
         yield 'static public method' => [ 'generateMethod11.test' ];

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/WorseGenerateMethodTest.php
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/WorseGenerateMethodTest.php
@@ -38,6 +38,7 @@ class WorseGenerateMethodTest extends WorseTestCase
         yield 'public accessor in another class' => [ 'generateMethod6.test' ];
         yield 'public accessor on interface' => [ 'generateMethod7.test' ];
         yield 'public accessor on interface with namespace' => [ 'generateMethod8.test' ];
+        yield 'public method on enum' => [ 'generateMethod_enum.test', 'play'];
         yield 'imports classes' => [ 'generateMethod9.test' ];
         yield 'static private method' => [ 'generateMethod10.test' ];
         yield 'static public method' => [ 'generateMethod11.test' ];
@@ -51,7 +52,7 @@ class WorseGenerateMethodTest extends WorseTestCase
         yield 'docblock for complex type' => [ 'generateMethod_complexTypeDocblock.test' ];
     }
 
-    public function testGenerateOnNonClassInterfaceException(): void
+    public function testGenerateOnTraitException(): void
     {
         $this->expectException(TransformException::class);
         $this->expectExceptionMessage('Can only generate methods on classes');

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/fixtures/generateMethod_enum.test
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/fixtures/generateMethod_enum.test
@@ -1,0 +1,28 @@
+// File: source
+
+<?php
+
+namespace Foobar;
+
+enum Game
+{
+    case ROCK;
+    case PAPER;
+    case SCISSORS;
+
+    public function testing() {
+    }
+
+    <>
+}
+// File: expected
+enum Game
+{
+    case ROCK;
+    case PAPER;
+    case SCISSORS;
+
+    public function play() {
+    }
+}
+

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/fixtures/generateMethod_enum.test
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/fixtures/generateMethod_enum.test
@@ -1,28 +1,28 @@
 // File: source
-
 <?php
 
-namespace Foobar;
-
 enum Game
 {
     case ROCK;
     case PAPER;
     case SCISSORS;
-
-    public function testing() {
-    }
-
-    <>
 }
+
+Game::pl<>ay();
+
 // File: expected
+<?php
+
 enum Game
 {
     case ROCK;
     case PAPER;
     case SCISSORS;
 
-    public function play() {
+    public static function play()
+    {
     }
 }
+
+Game::play();
 

--- a/lib/WorseReflection/Core/Inference/NodeReflector.php
+++ b/lib/WorseReflection/Core/Inference/NodeReflector.php
@@ -4,9 +4,11 @@ namespace Phpactor\WorseReflection\Core\Inference;
 
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\Attribute;
+use Microsoft\PhpParser\Node\EnumMembers;
 use Microsoft\PhpParser\Node\Expression\CallExpression;
 use Microsoft\PhpParser\Node\Expression\MemberAccessExpression;
 use Microsoft\PhpParser\Node\Expression\ObjectCreationExpression;
+use Microsoft\PhpParser\Node\Statement\EnumDeclaration;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Reflection\ReflectionAttribute;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Reflection\ReflectionMethodCall;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Reflection\ReflectionObjectCreationExpression as PhpactorReflectionObjectCreationExpression;
@@ -16,6 +18,7 @@ use Phpactor\WorseReflection\Core\Reflection\ReflectionObjectCreationExpression;
 use Phpactor\WorseReflection\Core\ServiceLocator;
 use Microsoft\PhpParser\Node\Expression\ScopedPropertyAccessExpression;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Reflection\ReflectionStaticMethodCall;
+use ReflectionMethod;
 
 class NodeReflector
 {
@@ -52,6 +55,7 @@ class NodeReflector
         if ($node->parent instanceof CallExpression) {
             return $this->reflectStaticMethodCall($frame, $node);
         }
+
         throw new CouldNotResolveNode(sprintf(
             'Did not know how to reflect node of type "%s"',
             get_class($node)

--- a/lib/WorseReflection/Core/Inference/NodeReflector.php
+++ b/lib/WorseReflection/Core/Inference/NodeReflector.php
@@ -4,11 +4,9 @@ namespace Phpactor\WorseReflection\Core\Inference;
 
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\Attribute;
-use Microsoft\PhpParser\Node\EnumMembers;
 use Microsoft\PhpParser\Node\Expression\CallExpression;
 use Microsoft\PhpParser\Node\Expression\MemberAccessExpression;
 use Microsoft\PhpParser\Node\Expression\ObjectCreationExpression;
-use Microsoft\PhpParser\Node\Statement\EnumDeclaration;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Reflection\ReflectionAttribute;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Reflection\ReflectionMethodCall;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Reflection\ReflectionObjectCreationExpression as PhpactorReflectionObjectCreationExpression;
@@ -18,7 +16,6 @@ use Phpactor\WorseReflection\Core\Reflection\ReflectionObjectCreationExpression;
 use Phpactor\WorseReflection\Core\ServiceLocator;
 use Microsoft\PhpParser\Node\Expression\ScopedPropertyAccessExpression;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Reflection\ReflectionStaticMethodCall;
-use ReflectionMethod;
 
 class NodeReflector
 {

--- a/lib/WorseReflection/Core/Reflector/CompositeReflector.php
+++ b/lib/WorseReflection/Core/Reflector/CompositeReflector.php
@@ -57,12 +57,10 @@ class CompositeReflector implements Reflector
         return $this->classReflector->reflectClassLike($className, $visited);
     }
 
-
     public function reflectClassesIn(TextDocument $sourceCode, array $visited = []): ReflectionClassLikeCollection
     {
         return $this->sourceCodeReflector->reflectClassesIn($sourceCode, $visited);
     }
-
 
     public function reflectOffset(TextDocument $sourceCode, $offset): ReflectionOffset
     {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -271,6 +271,11 @@ parameters:
 			path: lib/CodeBuilder/Domain/Prototype/Constants.php
 
 		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: lib/CodeBuilder/Domain/Prototype/Enums.php
+
+		-
 			message: "#^Method Phpactor\\\\CodeBuilder\\\\Domain\\\\Prototype\\\\ImplementsInterfaces\\:\\:fromTypes\\(\\) has parameter \\$types with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: lib/CodeBuilder/Domain/Prototype/ImplementsInterfaces.php
@@ -1179,11 +1184,6 @@ parameters:
 			message: "#^Cannot call method toString\\(\\) on Phpactor\\\\DocblockParser\\\\Ast\\\\TypeNode\\|null\\.$#"
 			count: 1
 			path: lib/DocblockParser/Tests/Unit/Ast/NodeTest.php
-
-		-
-			message: "#^Parameter \\#4 \\$path of class Phpactor\\\\Extension\\\\Behat\\\\Behat\\\\Step constructor expects string, string\\|null given\\.$#"
-			count: 1
-			path: lib/Extension/Behat/Adapter/Worse/WorseStepFactory.php
 
 		-
 			message: "#^Cannot access offset 'imports' on mixed\\.$#"
@@ -3469,11 +3469,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$probe of method Blackfire\\\\Client\\:\\:endProbe\\(\\) expects Blackfire\\\\Probe, Blackfire\\\\Probe\\|null given\\.$#"
 			count: 1
 			path: lib/Extension/LanguageServerBlackfire/BlackfireProfiler.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\LanguageServerBridge\\\\Converter\\\\LocationConverter\\:\\:toLspLocations\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Extension/LanguageServerBridge/Converter/LocationConverter.php
 
 		-
 			message: "#^Parameter \\#1 \\$workspace of class Phpactor\\\\Extension\\\\LanguageServerBridge\\\\TextDocument\\\\WorkspaceTextDocumentLocator constructor expects Phpactor\\\\LanguageServer\\\\Core\\\\Workspace\\\\Workspace, mixed given\\.$#"
@@ -5773,16 +5768,6 @@ parameters:
 		-
 			message: "#^Cannot call method path\\(\\) on Phpactor\\\\TextDocument\\\\TextDocumentUri\\|null\\.$#"
 			count: 2
-			path: lib/Indexer/Adapter/Tolerant/Indexer/AbstractClassLikeIndexer.php
-
-		-
-			message: "#^Parameter \\#1 \\$fqn of static method Phpactor\\\\Indexer\\\\Model\\\\Name\\\\FullyQualifiedName\\:\\:fromString\\(\\) expects string, Microsoft\\\\PhpParser\\\\ResolvedName\\|string\\|null given\\.$#"
-			count: 1
-			path: lib/Indexer/Adapter/Tolerant/Indexer/AbstractClassLikeIndexer.php
-
-		-
-			message: "#^Parameter \\#1 \\$name of static method Phpactor\\\\Indexer\\\\Model\\\\Record\\\\ClassRecord\\:\\:fromName\\(\\) expects string, Microsoft\\\\PhpParser\\\\ResolvedName\\|string\\|null given\\.$#"
-			count: 1
 			path: lib/Indexer/Adapter/Tolerant/Indexer/AbstractClassLikeIndexer.php
 
 		-

--- a/templates/code/Case_.php.twig
+++ b/templates/code/Case_.php.twig
@@ -1,0 +1,1 @@
+case {{ prototype.name }};

--- a/templates/code/EnumPrototype.php.twig
+++ b/templates/code/EnumPrototype.php.twig
@@ -1,0 +1,13 @@
+enum {{ prototype.name }}
+{
+{% for case in prototype.cases %}
+{{ generator.render(case, variant)|indent(1)|raw }}
+{% endfor %}
+{% for method in prototype.methods %}
+{% if prototype.properties|length or not loop.first %}
+
+{% endif %}
+{{ generator.render(method, variant)|indent(1)|raw }}
+{{ generator.render(method.body)|indent(1)|raw }}
+{% endfor %}
+}


### PR DESCRIPTION
Fixes: #2409

Adds the ability to generate methods on enum classes if they don't exist. In the process of implementing the feature I found out that phpactor doesn't have a code builder for enum classes which I added. However, the code builder only supports non-backed enums and might break enums that are backed. I'm not sure this is a requirement though or if I should just throw an error if the enum is backed and don't do anything.