### PR TITLE
Gh 2378 enum cases

### DIFF
--- a/lib/Application.php
+++ b/lib/Application.php
@@ -72,6 +72,7 @@ class Application extends SymfonyApplication
     {
         $definition = parent::getDefaultInputDefinition();
         $definition->addOption(new InputOption('working-dir', 'd', InputOption::VALUE_REQUIRED, 'Working directory'));
+        $definition->addOption(new InputOption('config-extra', null, InputOption::VALUE_REQUIRED, 'Additional config to apply (JSON string)'));
 
         return $definition;
     }

--- a/lib/Extension/LanguageServer/Command/DiagnosticsCommand.php
+++ b/lib/Extension/LanguageServer/Command/DiagnosticsCommand.php
@@ -15,7 +15,7 @@ use function Amp\Promise\wait;
 class DiagnosticsCommand extends Command
 {
     public const NAME = 'language-server:diagnostics';
-    const PARAM_URI = 'uri';
+    private const PARAM_URI = 'uri';
 
 
     public function __construct(private DiagnosticsProvider $provider)

--- a/lib/Extension/LanguageServer/DiagnosticProvider/OutsourcedDiagnosticsProvider.php
+++ b/lib/Extension/LanguageServer/DiagnosticProvider/OutsourcedDiagnosticsProvider.php
@@ -34,7 +34,7 @@ class OutsourcedDiagnosticsProvider implements DiagnosticsProvider
         return call(function () use ($textDocument) {
             $process = new Process(array_merge($this->command, [
                 '--uri=' . $textDocument->uri,
-                sprintf('--config-extra=\'%s\'', sprintf('{"%s": false}', WorseReflectionExtension::PARAM_ENABLE_CONTEXT_LOCATION))
+                sprintf('--config-extra=%s', sprintf('{"%s": false}', WorseReflectionExtension::PARAM_ENABLE_CONTEXT_LOCATION))
             ]), $this->cwd);
             $pid = yield $process->start();
 

--- a/lib/Extension/LanguageServer/DiagnosticProvider/OutsourcedDiagnosticsProvider.php
+++ b/lib/Extension/LanguageServer/DiagnosticProvider/OutsourcedDiagnosticsProvider.php
@@ -7,6 +7,7 @@ use Amp\Process\Process;
 use Amp\Process\ProcessException;
 use Amp\Promise;
 use Phpactor\Amp\Process\ProcessUtil;
+use Phpactor\Extension\WorseReflection\WorseReflectionExtension;
 use Phpactor\LanguageServerProtocol\Diagnostic;
 use Phpactor\LanguageServerProtocol\TextDocumentItem;
 use Phpactor\LanguageServer\Core\Diagnostics\DiagnosticsProvider;
@@ -32,7 +33,8 @@ class OutsourcedDiagnosticsProvider implements DiagnosticsProvider
     {
         return call(function () use ($textDocument) {
             $process = new Process(array_merge($this->command, [
-                '--uri=' . $textDocument->uri
+                '--uri=' . $textDocument->uri,
+                sprintf('--config-extra=\'%s\'', sprintf('{"%s": false}', WorseReflectionExtension::PARAM_ENABLE_CONTEXT_LOCATION))
             ]), $this->cwd);
             $pid = yield $process->start();
 

--- a/lib/Phpactor.php
+++ b/lib/Phpactor.php
@@ -117,6 +117,17 @@ class Phpactor
             $config[FilePathResolverExtension::PARAM_PROJECT_ROOT] = $projectRoot;
         }
 
+        if ($input->hasParameterOption('--config-extra')) {
+            $rawJson = $input->getParameterOption('--config-extra');
+            $extraConfig = json_decode($rawJson, true);
+            if (!is_array($extraConfig)) {
+                throw new RuntimeException(sprintf(
+                    'Invalid JSON passed as config-extra: %s', $rawJson
+                ));
+            }
+            $config = array_merge($config, $extraConfig);
+        }
+
         if (!isset($config[CoreExtension::PARAM_XDEBUG_DISABLE]) || $config[CoreExtension::PARAM_XDEBUG_DISABLE]) {
             $xdebug = new XdebugHandler('PHPACTOR');
             $xdebug->check();

--- a/lib/Phpactor.php
+++ b/lib/Phpactor.php
@@ -119,10 +119,17 @@ class Phpactor
 
         if ($input->hasParameterOption('--config-extra')) {
             $rawJson = $input->getParameterOption('--config-extra');
+            if (!is_string($rawJson)) {
+                throw new RuntimeException(sprintf(
+                    'Expected string for config-extra, got: %s',
+                    gettype($rawJson)
+                ));
+            }
             $extraConfig = json_decode($rawJson, true);
             if (!is_array($extraConfig)) {
                 throw new RuntimeException(sprintf(
-                    'Invalid JSON passed as config-extra: %s', $rawJson
+                    'Invalid JSON passed as config-extra: %s',
+                    $rawJson
                 ));
             }
             $config = array_merge($config, $extraConfig);

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/MissingMemberProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/MissingMemberProvider.php
@@ -217,7 +217,23 @@ class MissingMemberProvider implements DiagnosticProvider
                 }
             );
             yield new DiagnosticExample(
-                title: 'enum static method call',
+                title: 'enum static method not existing',
+                source: <<<'PHP'
+                    <?php
+
+                    enum Foobar
+                    {
+                    }
+
+                    Foobar::foobar();
+                    PHP,
+                valid: false,
+                assertion: function (Diagnostics $diagnostics): void {
+                    Assert::assertCount(1, $diagnostics);
+                }
+            );
+            yield new DiagnosticExample(
+                title: 'enum cases',
                 source: <<<'PHP'
                     <?php
 
@@ -227,7 +243,7 @@ class MissingMemberProvider implements DiagnosticProvider
 
                     Foobar::cases();
                     PHP,
-                valid: false,
+                valid: true,
                 assertion: function (Diagnostics $diagnostics): void {
                     Assert::assertCount(0, $diagnostics);
                 }

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionEnum.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionEnum.php
@@ -56,7 +56,8 @@ class ReflectionEnum extends AbstractReflectionClass implements CoreReflectionEn
         }
         try {
             $enumType = $this->isBacked() ? 'BackedEnum' : 'UnitEnum';
-            $enumMethods = $this->serviceLocator()->reflector()->reflectInterface($enumType)->members();
+            $interface = $this->serviceLocator()->reflector()->reflectInterface($enumType);
+            $enumMethods = $interface->members();
             /** @phpstan-ignore-next-line It is fine */
             return $members->merge($enumMethods)->map(
                 fn (ReflectionMember $member) => $member->withClass($this)

--- a/lib/WorseReflection/Tests/Inference/enum/enum_case.test
+++ b/lib/WorseReflection/Tests/Inference/enum/enum_case.test
@@ -9,6 +9,7 @@ wrAssertType('enum(Foo::FOO)', Foo::FOO);
 wrAssertType('<missing>', Foo::FOO->value);
 wrAssertType('string', Foo::FOO->name);
 wrAssertType('"bar"', Foo::BAR);
+wrAssertType('UnitEnumCase[]', Foo::cases());
 
 class UnitEnumCase {
     public string $name;

--- a/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Reflection/ReflectionEnumTest.php
+++ b/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Reflection/ReflectionEnumTest.php
@@ -3,6 +3,7 @@
 namespace Phpactor\WorseReflection\Tests\Integration\Bridge\TolerantParser\Reflection;
 
 use Phpactor\WorseReflection\Core\Reflection\ReflectionEnumCase;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionMethod;
 use Phpactor\WorseReflection\Core\Type\EnumBackedCaseType;
 use Phpactor\WorseReflection\Core\Type\EnumCaseType;
 use Phpactor\WorseReflection\Core\Type\MissingType;
@@ -79,6 +80,7 @@ class ReflectionEnumTest extends IntegrationTestCase
         function (ReflectionEnum $class): void {
             $this->assertCount(4, $class->members());
             $this->assertInstanceOf(ReflectionEnumCase::class, $class->members()->get('FOOBAR'));
+            $this->assertInstanceOf(ReflectionMethod::class, $class->members()->get('cases'));
         },
         ];
 


### PR DESCRIPTION
Fixes #2378 

Fix enum cases false alarm.

Was because of "contextual source location" which is enabled by default but disabled in the LS process, but was still enabled in the diagnostics sub-process :roll_eyes: 