### PR TITLE
[Docs][vim-lsp] code command snippets were broken

### DIFF
--- a/doc/lsp/vim-lsp.rst
+++ b/doc/lsp/vim-lsp.rst
@@ -73,13 +73,13 @@ If you want to profile Phpactor for debugging purposes:
     function LspPhpactorDumpConfig()
         local results, _ = vim.lsp.buf_request_sync(0, "phpactor/debug/config", {["return"]=true})
         for _, res in pairs(results or {}) do
-            showWindow("Phpactor LSP Configuration", "json", res["result"])
+            pcall(showWindow, 'Phpactor LSP Configuration', 'json', res['result'])
         end
     end
     function LspPhpactorStatus()
         local results, _ = vim.lsp.buf_request_sync(0, "phpactor/status", {["return"]=true})
         for _, res in pairs(results or {}) do
-            showWindow("Phpactor Status", "markdown", res["result"])
+            pcall(showWindow, 'Phpactor Status', 'markdown', res['result'])
         end
     end
 


### PR DESCRIPTION
Hiya,

This is a fix for one of the documentation pages on the website. On the vim-lsp page it shows a few lua scripts to help in using phpactor with neovim. 

However showWindow would throw an error whenever res['result'] is not a proper string causing the function to stop and no information to be displayed. I fixed this by adding some protected call functions so that we make sure each result is added to the popup window. 