### PR TITLE
Support setting --configuration setting of Phpstan

### DIFF
--- a/lib/Extension/LanguageServerPhpstan/LanguageServerPhpstanExtension.php
+++ b/lib/Extension/LanguageServerPhpstan/LanguageServerPhpstanExtension.php
@@ -20,6 +20,8 @@ class LanguageServerPhpstanExtension implements OptionalExtension
 {
     public const PARAM_PHPSTAN_BIN = 'language_server_phpstan.bin';
     public const PARAM_LEVEL = 'language_server_phpstan.level';
+    public const PARAM_CONFIG = 'language_server_phpstan.config';
+    public const PARAM_MEM_LIMIT = 'language_server_phpstan.mem_limit';
     public const PARAM_ENABLED = 'language_server_phpstan.enabled';
 
     public function load(ContainerBuilder $container): void
@@ -39,10 +41,11 @@ class LanguageServerPhpstanExtension implements OptionalExtension
         $container->register(PhpstanProcess::class, function (Container $container) {
             $binPath = $container->get(FilePathResolverExtension::SERVICE_FILE_PATH_RESOLVER)->resolve($container->getParameter(self::PARAM_PHPSTAN_BIN));
             $root = $container->get(FilePathResolverExtension::SERVICE_FILE_PATH_RESOLVER)->resolve('%project_root%');
+            $configPath = $container->getParameter(self::PARAM_CONFIG) ? $container->get(FilePathResolverExtension::SERVICE_FILE_PATH_RESOLVER)->resolve($container->getParameter(self::PARAM_CONFIG)) : null;
 
             return new PhpstanProcess(
                 $root,
-                new PhpstanConfig($binPath, $container->getParameter(self::PARAM_LEVEL)),
+                new PhpstanConfig($binPath, $container->getParameter(self::PARAM_LEVEL), $configPath, $container->getParameter(self::PARAM_MEM_LIMIT)),
                 LoggingExtension::channelLogger($container, 'phpstan'),
             );
         });
@@ -54,10 +57,14 @@ class LanguageServerPhpstanExtension implements OptionalExtension
         $schema->setDefaults([
             self::PARAM_PHPSTAN_BIN => '%project_root%/vendor/bin/phpstan',
             self::PARAM_LEVEL => null,
+            self::PARAM_CONFIG => null,
+            self::PARAM_MEM_LIMIT => null,
         ]);
         $schema->setDescriptions([
             self::PARAM_PHPSTAN_BIN => 'Path to the PHPStan executable',
             self::PARAM_LEVEL => 'Override the PHPStan level',
+            self::PARAM_CONFIG => 'Override the PHPStan configuration file',
+            self::PARAM_MEM_LIMIT => 'Override the PHPStan memory limit',
         ]);
     }
 

--- a/lib/Extension/LanguageServerPhpstan/Model/PhpstanConfig.php
+++ b/lib/Extension/LanguageServerPhpstan/Model/PhpstanConfig.php
@@ -4,7 +4,7 @@ namespace Phpactor\Extension\LanguageServerPhpstan\Model;
 
 final class PhpstanConfig
 {
-    public function __construct(private string $phpstanBin, private ?string $level = null)
+    public function __construct(private string $phpstanBin, private ?string $level = null, private ?string $config = null, private ?string $memLimit = null)
     {
     }
 
@@ -16,5 +16,15 @@ final class PhpstanConfig
     public function phpstanBin(): string
     {
         return $this->phpstanBin;
+    }
+
+    public function config(): ?string
+    {
+        return $this->config;
+    }
+
+    public function memLimit(): ?string
+    {
+        return $this->memLimit;
     }
 }

--- a/lib/Extension/LanguageServerPhpstan/Model/PhpstanProcess.php
+++ b/lib/Extension/LanguageServerPhpstan/Model/PhpstanProcess.php
@@ -38,6 +38,12 @@ class PhpstanProcess
             if (null !== $this->config->level()) {
                 $args[] = '--level=' . (string)$this->config->level();
             }
+            if (null !== $this->config->config()) {
+                $args[] = '--configuration=' . (string)$this->config->config();
+            }
+            if (null !== $this->config->memLimit()) {
+                $args[] = '--memory-limit=' . (string)$this->config->memLimit();
+            }
             $process = new Process($args, $this->cwd);
 
             $start = microtime(true);

--- a/lib/Extension/LanguageServerPhpstan/Tests/Model/PhpstanProcessTest.php
+++ b/lib/Extension/LanguageServerPhpstan/Tests/Model/PhpstanProcessTest.php
@@ -25,7 +25,7 @@ class PhpstanProcessTest extends IntegrationTestCase
         $this->workspace()->put('test.php', $source);
         $linter = new PhpstanProcess(
             $this->workspace()->path(),
-            new PhpstanConfig(__DIR__ . '/../../../../../vendor/bin/phpstan', '7'),
+            new PhpstanConfig(__DIR__ . '/../../../../../vendor/bin/phpstan', '7', __DIR__ . '/../../../../../phpstan-baseline.neon', '200M'),
             new NullLogger()
         );
         $diagnostics = \Amp\Promise\wait($linter->analyse($this->workspace()->path('test.php')));

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4112,11 +4112,16 @@ parameters:
 
 		-
 			message: "#^Cannot call method resolve\\(\\) on mixed\\.$#"
-			count: 2
+			count: 3
 			path: lib/Extension/LanguageServerPhpstan/LanguageServerPhpstanExtension.php
 
 		-
 			message: "#^Parameter \\#2 \\$level of class Phpactor\\\\Extension\\\\LanguageServerPhpstan\\\\Model\\\\PhpstanConfig constructor expects string\\|null, mixed given\\.$#"
+			count: 1
+			path: lib/Extension/LanguageServerPhpstan/LanguageServerPhpstanExtension.php
+
+		-
+			message: "#^Parameter \\#4 \\$memLimit of class Phpactor\\\\Extension\\\\LanguageServerPhpstan\\\\Model\\\\PhpstanConfig constructor expects string\\|null, mixed given\\.$#"
 			count: 1
 			path: lib/Extension/LanguageServerPhpstan/LanguageServerPhpstanExtension.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4111,21 +4111,6 @@ parameters:
 			path: lib/Extension/LanguageServerPhpCsFixer/Tests/Model/PhpCsFixerProcessTest.php
 
 		-
-			message: "#^Cannot call method resolve\\(\\) on mixed\\.$#"
-			count: 3
-			path: lib/Extension/LanguageServerPhpstan/LanguageServerPhpstanExtension.php
-
-		-
-			message: "#^Parameter \\#2 \\$level of class Phpactor\\\\Extension\\\\LanguageServerPhpstan\\\\Model\\\\PhpstanConfig constructor expects string\\|null, mixed given\\.$#"
-			count: 1
-			path: lib/Extension/LanguageServerPhpstan/LanguageServerPhpstanExtension.php
-
-		-
-			message: "#^Parameter \\#4 \\$memLimit of class Phpactor\\\\Extension\\\\LanguageServerPhpstan\\\\Model\\\\PhpstanConfig constructor expects string\\|null, mixed given\\.$#"
-			count: 1
-			path: lib/Extension/LanguageServerPhpstan/LanguageServerPhpstanExtension.php
-
-		-
 			message: "#^Method Phpactor\\\\Extension\\\\LanguageServerPhpstan\\\\Model\\\\DiagnosticsParser\\:\\:decodeJson\\(\\) should return array but returns mixed\\.$#"
 			count: 1
 			path: lib/Extension/LanguageServerPhpstan/Model/DiagnosticsParser.php


### PR DESCRIPTION
Attempt to add --configuration and --memory-limit PHPstan cli option support as requested in ticket #2407

I haven't updated more than the code yet, and would request input on if the docs are auto generated in some way. I attemped to run `composer run integrate` but it failed with some memory issues that appeared unrelated