### PR TITLE
Exclude Tests files in PHAR archive

### DIFF
--- a/box.json
+++ b/box.json
@@ -1,13 +1,18 @@
 {
   "compression": "GZ",
   "directories": [
-    "lib",
     "templates"
   ],
   "files": [
     "LICENSE"
   ],
   "finder": [
+    {
+      "exclude": [
+        "Tests"
+      ],
+      "in": "lib"
+    },
     {
       "name": "{\\.[php]}",
       "exclude": [


### PR DESCRIPTION
Excluding the test code reduces the file size of the archive slightly.

```
% ls -la build/*.phar
-rwxr-xr-x  1 megurine  staff  5214175 11 16 00:02 build/before.phar
-rwxr-xr-x  1 megurine  staff  4551252 11 16 00:03 build/after.phar

% ls -lah build/*.phar
-rwxr-xr-x  1 megurine  staff   5.0M 11 16 00:02 build/before.phar
-rwxr-xr-x  1 megurine  staff   4.3M 11 16 00:03 build/after.phar
```

See the Gist below for a list of files included in the archive:
https://gist.github.com/zonuexe/f378b2d966f2c4c3497af1343451ecaf#file-diff-patch