### PR TITLE
fix: does not comply with psr-4 autoloading standard

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Handle line endings automatically for files detected as text and leave all
+# files detected as binary untouched.
+* text=auto
+
+# Files and directories with the attribute export-ignore won’t be added to
+# archive files. See http://git-scm.com/docs/gitattributes for details.
+.gitattributes          export-ignore
+.gitignore              export-ignore
+/.github                export-ignore
+/.php-cs-fixer.dist.php export-ignore
+/phpunit.xml.dist       export-ignore
+/tests/                 export-ignore

--- a/lib/ClassMover/Tests/Adapter/TolerantParser/TolerantClassReplacerTest.php
+++ b/lib/ClassMover/Tests/Adapter/TolerantParser/TolerantClassReplacerTest.php
@@ -120,19 +120,19 @@ class TolerantClassReplacerTest extends TestCase
             ],
             'Change namespace of interface' => [
                 'Example5.php',
-                'Phpactor\ClassMover\Tests\Adapter\TolerantParser\Example5Interface',
-                'Phpactor\ClassMover\Tests\Adapter\TolerantParser\BarBar\FoobarInterface',
+                'Acme\ClassMover\Tests\Adapter\TolerantParser\Example5Interface',
+                'Acme\ClassMover\Tests\Adapter\TolerantParser\BarBar\FoobarInterface',
                 <<<'EOT'
                     <?php
-                    namespace Phpactor\ClassMover\Tests\Adapter\TolerantParser\BarBar;
+                    namespace Acme\ClassMover\Tests\Adapter\TolerantParser\BarBar;
                     EOT
             ],
             'Change namespace of trait' => [
                 'Example6.php',
-                'Phpactor\ClassMover\Tests\Adapter\TolerantParser\ExampleTrait',
-                'Phpactor\ClassMover\Tests\Adapter\TolerantParser\BarBar\FoobarTrait',
+                'Acme\ClassMover\Tests\Adapter\TolerantParser\ExampleTrait',
+                'Acme\ClassMover\Tests\Adapter\TolerantParser\BarBar\FoobarTrait',
                 <<<'EOT'
-                    namespace Phpactor\ClassMover\Tests\Adapter\TolerantParser\BarBar;
+                    namespace Acme\ClassMover\Tests\Adapter\TolerantParser\BarBar;
                     EOT
             ],
             'Change name of class expansion' => [
@@ -154,8 +154,8 @@ class TolerantClassReplacerTest extends TestCase
             ],
             'Class which includes use statement for itself' => [
                 'Example7.php',
-                'Phpactor\ClassMover\Tests\Adapter\TolerantParser\Example7',
-                'Phpactor\ClassMover\Tests\Adapter\TolerantParser\Example8',
+                'Acme\ClassMover\Tests\Adapter\TolerantParser\Example7',
+                'Acme\ClassMover\Tests\Adapter\TolerantParser\Example8',
                 <<<'EOT'
                     class Example8
                     EOT

--- a/lib/ClassMover/Tests/Adapter/TolerantParser/examples/Example5.php
+++ b/lib/ClassMover/Tests/Adapter/TolerantParser/examples/Example5.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Phpactor\ClassMover\Tests\Adapter\TolerantParser;
+namespace Acme\ClassMover\Tests\Adapter\TolerantParser;
 
 interface Example5Interface
 {

--- a/lib/ClassMover/Tests/Adapter/TolerantParser/examples/Example6.php
+++ b/lib/ClassMover/Tests/Adapter/TolerantParser/examples/Example6.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Phpactor\ClassMover\Tests\Adapter\TolerantParser;
+namespace Acme\ClassMover\Tests\Adapter\TolerantParser;
 
 trait ExampleTrait
 {

--- a/lib/ClassMover/Tests/Adapter/TolerantParser/examples/Example7.php
+++ b/lib/ClassMover/Tests/Adapter/TolerantParser/examples/Example7.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Phpactor\ClassMover\Tests\Adapter\TolerantParser;
+namespace Acme\ClassMover\Tests\Adapter\TolerantParser;
 
 class Example7
 {

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/WorseGenerateMemberTest.php
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/WorseGenerateMemberTest.php
@@ -10,7 +10,7 @@ use Phpactor\CodeTransform\Domain\Exception\TransformException;
 use Phpactor\CodeBuilder\Adapter\WorseReflection\WorseBuilderFactory;
 use Phpactor\TextDocument\TextDocumentBuilder;
 
-class WorseGenerateMethodTest extends WorseTestCase
+class WorseGenerateMemberTest extends WorseTestCase
 {
     /**
      * @dataProvider provideGenerateMember

--- a/lib/Extension/LanguageServerPhpstan/Model/Excepteion/PhpstanProcessError.php
+++ b/lib/Extension/LanguageServerPhpstan/Model/Excepteion/PhpstanProcessError.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace Phpactor\Extension\LanguageServerPhpstan\Model\Excepteion;
-
-use RuntimeException;
-
-class PhpstanProcessError extends RuntimeException
-{
-}

--- a/lib/Extension/LanguageServerPsalm/Model/Excepteion/PhpstanProcessError.php
+++ b/lib/Extension/LanguageServerPsalm/Model/Excepteion/PhpstanProcessError.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace Phpactor\Extension\LanguageServerPsalm\Model\Excepteion;
-
-use RuntimeException;
-
-class PsalmProcessError extends RuntimeException
-{
-}


### PR DESCRIPTION
Fixes PSR-4 autoloading issues as seen when installing via:

```
composer install --no-dev -o
```

These are the warnings that this PR fixes:

```
Class Phpactor\ClassMover\Tests\Adapter\TolerantParser\ExampleTrait located in ./lib/ClassMover/Tests/Adapter/TolerantParser/examples/Example6.php does not comply with psr-4 autoloading standard. Skipping.
Class Phpactor\ClassMover\Tests\Adapter\TolerantParser\Example7 located in ./lib/ClassMover/Tests/Adapter/TolerantParser/examples/Example7.php does not comply with psr-4 autoloading standard. Skipping.
Class Phpactor\ClassMover\Tests\Adapter\TolerantParser\Example5Interface located in ./lib/ClassMover/Tests/Adapter/TolerantParser/examples/Example5.php does not comply with psr-4 autoloading standard. Skipping.
Class Phpactor\Extension\LanguageServerPsalm\Model\Excepteion\PsalmProcessError located in ./lib/Extension/LanguageServerPsalm/Model/Excepteion/PhpstanProcessError.php does not comply with psr-4 autoloading standard. Skipping.
Class Phpactor\CodeTransform\Tests\Adapter\WorseReflection\Refactor\WorseGenerateMethodTest located in ./lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/WorseGenerateMemberTest.php does not comply with psr-4 autoloading standard. Skipping.
```
