### PR TITLE
Gh 2401 fill match arms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Bug fixes:
 Features:
 
   - Generate enum cases and class constants #2422
+  - Generate enum match arms #2401
 
 Improvements:
 

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseFillMatchArms.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseFillMatchArms.php
@@ -2,11 +2,11 @@
 
 namespace Phpactor\CodeTransform\Adapter\WorseReflection\Refactor;
 
+use Microsoft\PhpParser\MissingToken;
 use Microsoft\PhpParser\Node\Expression\MatchExpression;
 use Microsoft\PhpParser\Node\Expression\ScopedPropertyAccessExpression;
 use Microsoft\PhpParser\Node\MatchArm;
 use Microsoft\PhpParser\Parser;
-use Phpactor\CodeBuilder\Domain\Updater;
 use Phpactor\CodeTransform\Domain\Refactor\FillObject;
 use Phpactor\TextDocument\ByteOffset;
 use Phpactor\TextDocument\TextDocument;
@@ -15,13 +15,11 @@ use Phpactor\TextDocument\TextEdits;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Reflection\ReflectionMatchExpression;
 use Phpactor\WorseReflection\Core\Exception\NotFound;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionEnum;
-use Phpactor\WorseReflection\Core\Type;
-use Phpactor\WorseReflection\Core\Type\HasEmptyType;
 use Phpactor\WorseReflection\Core\Type\ReflectedClassType;
 use Phpactor\WorseReflection\Core\Util\NodeUtil;
 use Phpactor\WorseReflection\Reflector;
 
-class WorseFillMatchArms implements FillObject
+final class WorseFillMatchArms
 {
     public function __construct(
         private Reflector $reflector,
@@ -29,7 +27,7 @@ class WorseFillMatchArms implements FillObject
     ) {
     }
 
-    public function fillObject(TextDocument $document, ByteOffset $offset): TextEdits
+    public function fillMatchArms(TextDocument $document, ByteOffset $offset): TextEdits
     {
         $node = $this->parser->parseSourceFile($document->__toString())->getDescendantNodeAtPosition($offset->toInt());
         $node = $node instanceof MatchExpression ? $node : $node->getFirstAncestor(MatchExpression::class);
@@ -57,23 +55,37 @@ class WorseFillMatchArms implements FillObject
         }
 
         $edits = [];
-        [$start, $existingCases] = $this->existingCases($node);
+        [$prefix, $postfix, $start, $existingCases] = $this->existingCases($node);
+        if ($prefix) {
+            $edits[] = TextEdit::create($start, 0, $prefix);
+        }
         foreach ($enum->cases() as $case) {
             if (in_array($case->name(), $existingCases)) {
                 continue;
             }
             $edits[] = TextEdit::create($start, 0, sprintf('%s::%s => null,', $enum->name()->short(), $case->name()));
         }
+        if ($postfix) {
+            $edits[] = TextEdit::create($start, 0, $postfix);
+        }
 
         return TextEdits::fromTextEdits($edits);
     }
 
     /**
-     * @return array{int,string[]}
+     * @return array{?string,?string,int,string[]}
      */
     private function existingCases(MatchExpression $node): array
     {
         $start = $node->openBrace->getStartPosition() + 1;
+        $prefix = null;
+        $postfix = null;
+        if ($node->openBrace instanceof MissingToken) {
+            $prefix = '{';
+        }
+        if ($node->closeBrace instanceof MissingToken) {
+            $postfix = '}';
+        }
         $cases = [];
         foreach ($node->arms?->getChildNodes() ?? [] as $arm) {
             assert($arm instanceof MatchArm);
@@ -85,6 +97,6 @@ class WorseFillMatchArms implements FillObject
                 $cases[] = NodeUtil::nameFromTokenOrNode($node, $node->memberName);
             }
         }
-        return [$start, $cases];
+        return [$prefix, $postfix, $start, $cases];
     }
 }

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseFillMatchArms.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseFillMatchArms.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Phpactor\CodeTransform\Adapter\WorseReflection\Refactor;
+
+use Microsoft\PhpParser\Node\Expression\MatchExpression;
+use Microsoft\PhpParser\Node\Expression\ObjectCreationExpression;
+use Microsoft\PhpParser\Parser;
+use Phpactor\CodeBuilder\Domain\Builder\SourceCodeBuilder;
+use Phpactor\CodeBuilder\Domain\Code;
+use Phpactor\CodeBuilder\Domain\Updater;
+use Phpactor\CodeTransform\Adapter\WorseReflection\Helper\EmptyValueRenderer;
+use Phpactor\CodeTransform\Domain\Refactor\FillObject;
+use Phpactor\TextDocument\ByteOffset;
+use Phpactor\TextDocument\TextDocument;
+use Phpactor\TextDocument\TextEdit;
+use Phpactor\TextDocument\TextEdits;
+use Phpactor\WorseReflection\Bridge\TolerantParser\Reflection\ReflectionMatchExpression;
+use Phpactor\WorseReflection\Core\Exception\NotFound;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionEnum;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionObjectCreationExpression;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionParameter;
+use Phpactor\WorseReflection\Core\Type;
+use Phpactor\WorseReflection\Core\Type\HasEmptyType;
+use Phpactor\WorseReflection\Core\Type\ReflectedClassType;
+use Phpactor\WorseReflection\Reflector;
+
+class WorseFillMatchArms implements FillObject
+{
+    public function __construct(
+        private Reflector $reflector,
+        private Parser $parser,
+        private Updater $updater,
+        private bool $namedParameters = true,
+        private bool $hint = true
+    ) {
+    }
+
+    public function fillObject(TextDocument $document, ByteOffset $offset): TextEdits
+    {
+        $node = $this->parser->parseSourceFile($document->__toString())->getDescendantNodeAtPosition($offset->toInt());
+        $node = $node instanceof MatchExpression ? $node : $node->getFirstAncestor(MatchExpression::class);
+        if (!$node instanceof MatchExpression) {
+            return TextEdits::none();
+        }
+        try {
+            $reflectionNode = $this->reflector->reflectNode($document, $node->getStartPosition());
+        } catch (NotFound $notFound) {
+            return TextEdits::none();
+        }
+
+        if (!$reflectionNode instanceof ReflectionMatchExpression) {
+            return TextEdits::none();
+        }
+
+        $type = $reflectionNode->expressionType();
+        if (!$type instanceof ReflectedClassType) {
+            return TextEdits::none();
+        }
+
+        $enum = $type->reflectionOrNull();
+        if (!$enum instanceof ReflectionEnum) {
+            return TextEdits::none();
+        }
+
+        $edits = [];
+        $start = $node->openBrace->getStartPosition() + 1;
+        foreach ($enum->cases() as $case) {
+            $edits[] = TextEdit::create($start, 0, sprintf('%s::%s => null,', $enum->name()->short(), $case->name()));
+        }
+
+        return TextEdits::fromTextEdits($edits);
+    }
+
+    private function renderEmptyValue(Type $type): string
+    {
+        if (!$type instanceof HasEmptyType) {
+            return sprintf('/** %s */', $type->__toString());
+        }
+
+        return $this->valueRenderer->render($type->emptyType());
+    }
+}

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseFillMatchArms.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseFillMatchArms.php
@@ -7,6 +7,7 @@ use Microsoft\PhpParser\Node\Expression\MatchExpression;
 use Microsoft\PhpParser\Node\Expression\ScopedPropertyAccessExpression;
 use Microsoft\PhpParser\Node\MatchArm;
 use Microsoft\PhpParser\Parser;
+use Phpactor\CodeTransform\Domain\Refactor\ByteOffsetRefactor;
 use Phpactor\TextDocument\ByteOffset;
 use Phpactor\TextDocument\TextDocument;
 use Phpactor\TextDocument\TextEdit;
@@ -18,7 +19,7 @@ use Phpactor\WorseReflection\Core\Type\ReflectedClassType;
 use Phpactor\WorseReflection\Core\Util\NodeUtil;
 use Phpactor\WorseReflection\Reflector;
 
-final class WorseFillMatchArms
+final class WorseFillMatchArms implements ByteOffsetRefactor
 {
     public function __construct(
         private Reflector $reflector,
@@ -26,7 +27,7 @@ final class WorseFillMatchArms
     ) {
     }
 
-    public function fillMatchArms(TextDocument $document, ByteOffset $offset): TextEdits
+    public function refactor(TextDocument $document, ByteOffset $offset): TextEdits
     {
         $node = $this->parser->parseSourceFile($document->__toString())->getDescendantNodeAtPosition($offset->toInt());
         $node = $node instanceof MatchExpression ? $node : $node->getFirstAncestor(MatchExpression::class);

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseFillMatchArms.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseFillMatchArms.php
@@ -3,12 +3,8 @@
 namespace Phpactor\CodeTransform\Adapter\WorseReflection\Refactor;
 
 use Microsoft\PhpParser\Node\Expression\MatchExpression;
-use Microsoft\PhpParser\Node\Expression\ObjectCreationExpression;
 use Microsoft\PhpParser\Parser;
-use Phpactor\CodeBuilder\Domain\Builder\SourceCodeBuilder;
-use Phpactor\CodeBuilder\Domain\Code;
 use Phpactor\CodeBuilder\Domain\Updater;
-use Phpactor\CodeTransform\Adapter\WorseReflection\Helper\EmptyValueRenderer;
 use Phpactor\CodeTransform\Domain\Refactor\FillObject;
 use Phpactor\TextDocument\ByteOffset;
 use Phpactor\TextDocument\TextDocument;
@@ -17,8 +13,6 @@ use Phpactor\TextDocument\TextEdits;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Reflection\ReflectionMatchExpression;
 use Phpactor\WorseReflection\Core\Exception\NotFound;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionEnum;
-use Phpactor\WorseReflection\Core\Reflection\ReflectionObjectCreationExpression;
-use Phpactor\WorseReflection\Core\Reflection\ReflectionParameter;
 use Phpactor\WorseReflection\Core\Type;
 use Phpactor\WorseReflection\Core\Type\HasEmptyType;
 use Phpactor\WorseReflection\Core\Type\ReflectedClassType;
@@ -29,9 +23,6 @@ class WorseFillMatchArms implements FillObject
     public function __construct(
         private Reflector $reflector,
         private Parser $parser,
-        private Updater $updater,
-        private bool $namedParameters = true,
-        private bool $hint = true
     ) {
     }
 

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseFillMatchArms.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseFillMatchArms.php
@@ -2,16 +2,13 @@
 
 namespace Phpactor\CodeTransform\Adapter\WorseReflection\Refactor;
 
-use Doctrine\DBAL\Types\TextType;
 use Microsoft\PhpParser\MissingToken;
 use Microsoft\PhpParser\Node\Expression\MatchExpression;
 use Microsoft\PhpParser\Node\Expression\ScopedPropertyAccessExpression;
 use Microsoft\PhpParser\Node\MatchArm;
 use Microsoft\PhpParser\Parser;
-use Phpactor\CodeBuilder\Domain\Prototype\Line;
 use Phpactor\CodeTransform\Domain\Refactor\ByteOffsetRefactor;
 use Phpactor\TextDocument\ByteOffset;
-use Phpactor\TextDocument\LineCol;
 use Phpactor\TextDocument\TextDocument;
 use Phpactor\TextDocument\TextEdit;
 use Phpactor\TextDocument\TextEdits;
@@ -63,7 +60,7 @@ final class WorseFillMatchArms implements ByteOffsetRefactor
         if ($prefix) {
             $edits[] = TextEdit::create($start, 0, $prefix);
         }
-            $edits[] = TextEdit::create($start, 0, "\n");
+        $edits[] = TextEdit::create($start, 0, "\n");
         foreach ($enum->cases() as $case) {
             if (in_array($case->name(), $existingCases)) {
                 continue;
@@ -79,7 +76,7 @@ final class WorseFillMatchArms implements ByteOffsetRefactor
     }
 
     /**
-     * @return array{?string,?string,int,string[]}
+     * @return array{?string,string,?string,int,string[]}
      */
     private function existingCases(MatchExpression $node): array
     {

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseFillMatchArms.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseFillMatchArms.php
@@ -7,7 +7,7 @@ use Microsoft\PhpParser\Node\Expression\MatchExpression;
 use Microsoft\PhpParser\Node\Expression\ScopedPropertyAccessExpression;
 use Microsoft\PhpParser\Node\MatchArm;
 use Microsoft\PhpParser\Parser;
-use Phpactor\CodeTransform\Domain\Refactor\FillObject;
+use Phpactor\CodeTransform\Domain\Refactor\ByteOffsetRefactor;
 use Phpactor\TextDocument\ByteOffset;
 use Phpactor\TextDocument\TextDocument;
 use Phpactor\TextDocument\TextEdit;

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseFillMatchArms.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseFillMatchArms.php
@@ -7,7 +7,6 @@ use Microsoft\PhpParser\Node\Expression\MatchExpression;
 use Microsoft\PhpParser\Node\Expression\ScopedPropertyAccessExpression;
 use Microsoft\PhpParser\Node\MatchArm;
 use Microsoft\PhpParser\Parser;
-use Phpactor\CodeTransform\Domain\Refactor\ByteOffsetRefactor;
 use Phpactor\TextDocument\ByteOffset;
 use Phpactor\TextDocument\TextDocument;
 use Phpactor\TextDocument\TextEdit;

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseFillObject.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseFillObject.php
@@ -8,7 +8,7 @@ use Phpactor\CodeBuilder\Domain\Builder\SourceCodeBuilder;
 use Phpactor\CodeBuilder\Domain\Code;
 use Phpactor\CodeBuilder\Domain\Updater;
 use Phpactor\CodeTransform\Adapter\WorseReflection\Helper\EmptyValueRenderer;
-use Phpactor\CodeTransform\Domain\Refactor\FillObject;
+use Phpactor\CodeTransform\Domain\Refactor\ByteOffsetRefactor;
 use Phpactor\TextDocument\ByteOffset;
 use Phpactor\TextDocument\TextDocument;
 use Phpactor\TextDocument\TextEdit;
@@ -21,7 +21,7 @@ use Phpactor\WorseReflection\Core\Type\HasEmptyType;
 use Phpactor\WorseReflection\Core\Type\ReflectedClassType;
 use Phpactor\WorseReflection\Reflector;
 
-class WorseFillObject implements FillObject
+class WorseFillObject implements ByteOffsetRefactor
 {
     private EmptyValueRenderer $valueRenderer;
 
@@ -35,7 +35,7 @@ class WorseFillObject implements FillObject
         $this->valueRenderer = new EmptyValueRenderer();
     }
 
-    public function fillObject(TextDocument $document, ByteOffset $offset): TextEdits
+    public function refactor(TextDocument $document, ByteOffset $offset): TextEdits
     {
         $node = $this->parser->parseSourceFile($document->__toString())->getDescendantNodeAtPosition($offset->toInt());
         $node = $node->getFirstAncestor(ObjectCreationExpression::class);

--- a/lib/CodeTransform/Domain/Refactor/ByteOffsetRefactor.php
+++ b/lib/CodeTransform/Domain/Refactor/ByteOffsetRefactor.php
@@ -6,7 +6,7 @@ use Phpactor\TextDocument\ByteOffset;
 use Phpactor\TextDocument\TextDocument;
 use Phpactor\TextDocument\TextEdits;
 
-interface FillObject
+interface ByteOffsetRefactor
 {
-    public function fillObject(TextDocument $document, ByteOffset $offset): TextEdits;
+    public function refactor(TextDocument $document, ByteOffset $offset): TextEdits;
 }

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/WorseFillMatchArmsTest.php
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/WorseFillMatchArmsTest.php
@@ -22,7 +22,7 @@ class WorseFillMatchArmsTest extends WorseTestCase
     ): void {
         [$source, $expected, $offset] = $this->sourceExpectedAndOffset($path);
 
-        $fill = $this->createFillObject($source);
+        $fill = $this->createRefactor($source);
         $transformed = $fill->fillObject(
             TextDocumentBuilder::create($source)->build(),
             ByteOffset::fromInt($offset)
@@ -44,7 +44,7 @@ class WorseFillMatchArmsTest extends WorseTestCase
         }
     }
 
-    private function createFillObject(string $source): WorseFillMatchArms
+    private function createRefactor(string $source): WorseFillMatchArms
     {
         $fill = new WorseFillMatchArms(
             $this->reflectorForWorkspace($source),

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/WorseFillMatchArmsTest.php
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/WorseFillMatchArmsTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Phpactor\CodeTransform\Tests\Adapter\WorseReflection\Refactor;
+
+use Generator;
+use GlobIterator;
+use Microsoft\PhpParser\Parser;
+use Phpactor\CodeTransform\Adapter\WorseReflection\Refactor\WorseFillMatchArms;
+use Phpactor\CodeTransform\Adapter\WorseReflection\Refactor\WorseFillObject;
+use Phpactor\CodeTransform\Tests\Adapter\WorseReflection\WorseTestCase;
+use Phpactor\TextDocument\ByteOffset;
+use Phpactor\TextDocument\TextDocumentBuilder;
+use SplFileInfo;
+
+class WorseFillMatchArmsTest extends WorseTestCase
+{
+    /**
+     * @dataProvider provideFill
+     */
+    public function testFill(
+        string $path
+    ): void {
+        [$source, $expected, $offset] = $this->sourceExpectedAndOffset($path);
+
+        $fill = $this->createFillObject($source, true, false);
+        $transformed = $fill->fillObject(
+            TextDocumentBuilder::create($source)->build(),
+            ByteOffset::fromInt($offset)
+        )->apply($source);
+
+        $this->assertEquals(trim($expected), trim($transformed));
+    }
+
+    /**
+     * @return Generator<string,array{string}>
+     */
+    public function provideFill(): Generator
+    {
+        foreach ((new GlobIterator(__DIR__ . '/fixtures/fillMatchArms*.test')) as $fileInfo) {
+            assert($fileInfo instanceof SplFileInfo);
+            yield $fileInfo->getBasename() => [
+                $fileInfo->getPathname()
+            ];
+        }
+    }
+
+    private function createFillObject(string $source, bool $named = true, bool $hint = false): WorseFillMatchArms
+    {
+        $fill = new WorseFillMatchArms(
+            $this->reflectorForWorkspace($source),
+            new Parser(),
+            $this->updater(),
+            $named,
+            $hint
+        );
+        return $fill;
+    }
+}

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/WorseFillMatchArmsTest.php
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/WorseFillMatchArmsTest.php
@@ -19,6 +19,9 @@ class WorseFillMatchArmsTest extends WorseTestCase
     public function testFill(
         string $path
     ): void {
+        if (!version_compare(PHP_VERSION, '8.1', '>=')) {
+            $this->markTestSkipped('Not supported');
+        }
         [$source, $expected, $offset] = $this->sourceExpectedAndOffset($path);
 
         $fill = $this->createRefactor($source);

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/WorseFillMatchArmsTest.php
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/WorseFillMatchArmsTest.php
@@ -6,7 +6,6 @@ use Generator;
 use GlobIterator;
 use Microsoft\PhpParser\Parser;
 use Phpactor\CodeTransform\Adapter\WorseReflection\Refactor\WorseFillMatchArms;
-use Phpactor\CodeTransform\Adapter\WorseReflection\Refactor\WorseFillObject;
 use Phpactor\CodeTransform\Tests\Adapter\WorseReflection\WorseTestCase;
 use Phpactor\TextDocument\ByteOffset;
 use Phpactor\TextDocument\TextDocumentBuilder;
@@ -23,7 +22,7 @@ class WorseFillMatchArmsTest extends WorseTestCase
         [$source, $expected, $offset] = $this->sourceExpectedAndOffset($path);
 
         $fill = $this->createRefactor($source);
-        $transformed = $fill->fillObject(
+        $transformed = $fill->fillMatchArms(
             TextDocumentBuilder::create($source)->build(),
             ByteOffset::fromInt($offset)
         )->apply($source);

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/WorseFillMatchArmsTest.php
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/WorseFillMatchArmsTest.php
@@ -22,7 +22,7 @@ class WorseFillMatchArmsTest extends WorseTestCase
     ): void {
         [$source, $expected, $offset] = $this->sourceExpectedAndOffset($path);
 
-        $fill = $this->createFillObject($source, true, false);
+        $fill = $this->createFillObject($source);
         $transformed = $fill->fillObject(
             TextDocumentBuilder::create($source)->build(),
             ByteOffset::fromInt($offset)
@@ -44,14 +44,11 @@ class WorseFillMatchArmsTest extends WorseTestCase
         }
     }
 
-    private function createFillObject(string $source, bool $named = true, bool $hint = false): WorseFillMatchArms
+    private function createFillObject(string $source): WorseFillMatchArms
     {
         $fill = new WorseFillMatchArms(
             $this->reflectorForWorkspace($source),
             new Parser(),
-            $this->updater(),
-            $named,
-            $hint
         );
         return $fill;
     }

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/WorseFillMatchArmsTest.php
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/WorseFillMatchArmsTest.php
@@ -22,7 +22,7 @@ class WorseFillMatchArmsTest extends WorseTestCase
         [$source, $expected, $offset] = $this->sourceExpectedAndOffset($path);
 
         $fill = $this->createRefactor($source);
-        $transformed = $fill->fillMatchArms(
+        $transformed = $fill->refactor(
             TextDocumentBuilder::create($source)->build(),
             ByteOffset::fromInt($offset)
         )->apply($source);

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/WorseFillObjectTest.php
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/WorseFillObjectTest.php
@@ -22,7 +22,7 @@ class WorseFillObjectTest extends WorseTestCase
         [$source, $expected, $offset] = $this->sourceExpectedAndOffset($path);
 
         $fill = $this->createFillObject($source, true, false);
-        $transformed = $fill->fillObject(
+        $transformed = $fill->refactor(
             TextDocumentBuilder::create($source)->build(),
             ByteOffset::fromInt($offset)
         )->apply($source);
@@ -40,7 +40,7 @@ class WorseFillObjectTest extends WorseTestCase
         $expected = $this->workspace()->getContents('nonamed');
 
         $fill = $this->createFillObject($source, false, true);
-        $transformed = $fill->fillObject(
+        $transformed = $fill->refactor(
             TextDocumentBuilder::create($source)->build(),
             ByteOffset::fromInt($offset),
         )->apply($source);
@@ -51,7 +51,7 @@ class WorseFillObjectTest extends WorseTestCase
     public function testOffsetNotObject(): void
     {
         $fill = $this->createFillObject('');
-        $edits = $fill->fillObject(
+        $edits = $fill->refactor(
             TextDocumentBuilder::create('<?php echo "hello";')->build(),
             ByteOffset::fromInt(10)
         );

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/fixtures/fillMatchArms_existingCases.test
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/fixtures/fillMatchArms_existingCases.test
@@ -13,7 +13,7 @@ enum Page
 
 function render(Page $page) {
     return match ($page) <>{
-        case Page::Blog => null,
+        Page::Blog => null,
     };
 }
 // File: expected

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/fixtures/fillMatchArms_existingCases.test
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/fixtures/fillMatchArms_existingCases.test
@@ -1,0 +1,36 @@
+// File: source
+<?php
+
+namespace Phpactor;
+
+enum Page
+{
+    case AboutUs;
+    case Blog;
+    case Websites;
+}
+
+
+function render(Page $page) {
+    return match ($page) <>{
+        case Page::Blog => null,
+    };
+}
+// File: expected
+<?php
+
+namespace Phpactor;
+
+enum Page
+{
+    case AboutUs;
+    case Blog;
+    case Websites;
+}
+
+
+function render(Page $page) {
+    return match ($page) {
+        Page::Blog => null,Page::AboutUs => null,Page::Websites => null,
+    };
+}

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/fixtures/fillMatchArms_existingCases.test
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/fixtures/fillMatchArms_existingCases.test
@@ -31,6 +31,8 @@ enum Page
 
 function render(Page $page) {
     return match ($page) {
-        Page::Blog => null,Page::AboutUs => null,Page::Websites => null,
+        Page::Blog => null,
+        Page::AboutUs => null,
+        Page::Websites => null,
     };
 }

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/fixtures/fillMatchArms_existingCases.test
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/fixtures/fillMatchArms_existingCases.test
@@ -34,5 +34,6 @@ function render(Page $page) {
         Page::Blog => null,
         Page::AboutUs => null,
         Page::Websites => null,
+        
     };
 }

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/fixtures/fillMatchArms_fill.test
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/fixtures/fillMatchArms_fill.test
@@ -28,5 +28,9 @@ enum Page
 
 
 function render(Page $page) {
-    return match ($page) {Page::AboutUs => null,Page::Blog => null,Page::Websites => null,};
+    return match ($page) {
+    Page::AboutUs => null,
+    Page::Blog => null,
+    Page::Websites => null,
+    };
 }

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/fixtures/fillMatchArms_fill.test
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/fixtures/fillMatchArms_fill.test
@@ -1,0 +1,32 @@
+// File: source
+<?php
+
+namespace Phpactor;
+
+enum Page
+{
+    case AboutUs;
+    case Blog;
+    case Websites;
+}
+
+
+function render(Page $page) {
+    return match ($page) <>{};
+}
+// File: expected
+<?php
+
+namespace Phpactor;
+
+enum Page
+{
+    case AboutUs;
+    case Blog;
+    case Websites;
+}
+
+
+function render(Page $page) {
+    return match ($page) {Page::AboutUs => null,Page::Blog => null,Page::Websites => null,};
+}

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/fixtures/fillMatchArms_noStartBrace.test
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/fixtures/fillMatchArms_noStartBrace.test
@@ -28,5 +28,10 @@ enum Page
 
 
 function render(Page $page) {
-    return match ($page) {Page::AboutUs => null,Page::Blog => null,Page::Websites => null,};
+    return match ($page) {
+
+    Page::AboutUs => null,
+    Page::Blog => null,
+    Page::Websites => null,
+    };
 }

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/fixtures/fillMatchArms_noStartBrace.test
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/fixtures/fillMatchArms_noStartBrace.test
@@ -1,0 +1,32 @@
+// File: source
+<?php
+
+namespace Phpactor;
+
+enum Page
+{
+    case AboutUs;
+    case Blog;
+    case Websites;
+}
+
+
+function render(Page $page) {
+    return match ($page) <>};
+}
+// File: expected
+<?php
+
+namespace Phpactor;
+
+enum Page
+{
+    case AboutUs;
+    case Blog;
+    case Websites;
+}
+
+
+function render(Page $page) {
+    return match ($page) {Page::AboutUs => null,Page::Blog => null,Page::Websites => null,};
+}

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/fixtures/fillMatchArms_notEnum.test
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/fixtures/fillMatchArms_notEnum.test
@@ -1,0 +1,16 @@
+// File: source
+<?php
+
+namespace Phpactor;
+
+function render(int $page) {
+    return match ($page) <>};
+}
+// File: expected
+<?php
+
+namespace Phpactor;
+
+function render(int $page) {
+    return match ($page) };
+}

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/fixtures/fillMatchArms_unitEnumCase.test
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/fixtures/fillMatchArms_unitEnumCase.test
@@ -28,5 +28,9 @@ enum Page
 
 
 foreach (Page::cases() as $case) {
-    match ($case) {Page::AboutUs => null,Page::Blog => null,Page::Websites => null,};
+    match ($case) {
+    Page::AboutUs => null,
+    Page::Blog => null,
+    Page::Websites => null,
+    };
 }

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/fixtures/fillMatchArms_unitEnumCase.test
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Refactor/fixtures/fillMatchArms_unitEnumCase.test
@@ -1,0 +1,32 @@
+// File: source
+<?php
+
+namespace Phpactor;
+
+enum Page
+{
+    case AboutUs;
+    case Blog;
+    case Websites;
+}
+
+
+foreach (Page::cases() as $case) {
+    match ($case) <>{};
+}
+// File: expected
+<?php
+
+namespace Phpactor;
+
+enum Page
+{
+    case AboutUs;
+    case Blog;
+    case Websites;
+}
+
+
+foreach (Page::cases() as $case) {
+    match ($case) {Page::AboutUs => null,Page::Blog => null,Page::Websites => null,};
+}

--- a/lib/Extension/CodeTransform/CodeTransformExtension.php
+++ b/lib/Extension/CodeTransform/CodeTransformExtension.php
@@ -2,6 +2,7 @@
 
 namespace Phpactor\Extension\CodeTransform;
 
+use Microsoft\PhpParser\Parser;
 use Phpactor\CodeBuilder\Adapter\WorseReflection\TypeRenderer\WorseTypeRenderer;
 use Phpactor\CodeBuilder\Adapter\WorseReflection\TypeRenderer\WorseTypeRenderer74;
 use Phpactor\CodeBuilder\Adapter\WorseReflection\TypeRenderer\WorseTypeRenderer80;
@@ -26,6 +27,7 @@ use Phpactor\CodeTransform\Adapter\WorseReflection\GenerateFromExisting\Interfac
 use Phpactor\CodeTransform\Adapter\TolerantParser\Refactor\TolerantRenameVariable;
 use Phpactor\CodeTransform\Adapter\WorseReflection\Helper\WorseMissingMemberFinder;
 use Phpactor\CodeTransform\Adapter\WorseReflection\Refactor\WorseExtractMethod;
+use Phpactor\CodeTransform\Adapter\WorseReflection\Refactor\WorseFillMatchArms;
 use Phpactor\CodeTransform\Adapter\WorseReflection\Refactor\WorseFillObject;
 use Phpactor\CodeTransform\Adapter\WorseReflection\Refactor\WorseGenerateConstructor;
 use Phpactor\CodeTransform\Adapter\WorseReflection\Refactor\WorseGenerateMutator;
@@ -285,10 +287,16 @@ class CodeTransformExtension implements Extension
         $container->register(WorseFillObject::class, function (Container $container) {
             return new WorseFillObject(
                 $container->expect(WorseReflectionExtension::SERVICE_REFLECTOR, Reflector::class),
-                $container->get(WorseReflectionExtension::SERVICE_PARSER),
+                $container->expect(WorseReflectionExtension::SERVICE_PARSER, Parser::class),
                 $container->get(Updater::class),
                 $container->parameter(self::PARAM_OBJECT_FILL_NAMED)->bool(),
                 $container->parameter(self::PARAM_OBJECT_FILL_HINT)->bool(),
+            );
+        });
+        $container->register(WorseFillMatchArms::class, function (Container $container) {
+            return new WorseFillMatchArms(
+                $container->expect(WorseReflectionExtension::SERVICE_REFLECTOR, Reflector::class),
+                $container->expect(WorseReflectionExtension::SERVICE_PARSER, Parser::class),
             );
         });
 

--- a/lib/Extension/CodeTransform/CodeTransformExtension.php
+++ b/lib/Extension/CodeTransform/CodeTransformExtension.php
@@ -53,7 +53,7 @@ use Phpactor\CodeTransform\Domain\Refactor\ChangeVisiblity;
 use Phpactor\CodeTransform\Domain\Refactor\ExtractConstant;
 use Phpactor\CodeTransform\Domain\Refactor\ExtractExpression;
 use Phpactor\CodeTransform\Domain\Refactor\ExtractMethod;
-use Phpactor\CodeTransform\Domain\Refactor\FillObject;
+use Phpactor\CodeTransform\Domain\Refactor\ByteOffsetRefactor;
 use Phpactor\CodeTransform\Domain\Refactor\GenerateConstructor;
 use Phpactor\CodeTransform\Domain\Refactor\GenerateDecorator;
 use Phpactor\CodeTransform\Domain\Refactor\ImportName;
@@ -283,7 +283,7 @@ class CodeTransformExtension implements Extension
                 $container->parameter(self::PARAM_IMPORT_GLOBALS)->bool(),
             );
         });
-        $container->register(FillObject::class, function (Container $container) {
+        $container->register(ByteOffsetRefactor::class, function (Container $container) {
             return new WorseFillObject(
                 $container->expect(WorseReflectionExtension::SERVICE_REFLECTOR, Reflector::class),
                 $container->get(WorseReflectionExtension::SERVICE_PARSER),

--- a/lib/Extension/CodeTransform/CodeTransformExtension.php
+++ b/lib/Extension/CodeTransform/CodeTransformExtension.php
@@ -53,7 +53,6 @@ use Phpactor\CodeTransform\Domain\Refactor\ChangeVisiblity;
 use Phpactor\CodeTransform\Domain\Refactor\ExtractConstant;
 use Phpactor\CodeTransform\Domain\Refactor\ExtractExpression;
 use Phpactor\CodeTransform\Domain\Refactor\ExtractMethod;
-use Phpactor\CodeTransform\Domain\Refactor\ByteOffsetRefactor;
 use Phpactor\CodeTransform\Domain\Refactor\GenerateConstructor;
 use Phpactor\CodeTransform\Domain\Refactor\GenerateDecorator;
 use Phpactor\CodeTransform\Domain\Refactor\ImportName;
@@ -283,7 +282,7 @@ class CodeTransformExtension implements Extension
                 $container->parameter(self::PARAM_IMPORT_GLOBALS)->bool(),
             );
         });
-        $container->register(ByteOffsetRefactor::class, function (Container $container) {
+        $container->register(WorseFillObject::class, function (Container $container) {
             return new WorseFillObject(
                 $container->expect(WorseReflectionExtension::SERVICE_REFLECTOR, Reflector::class),
                 $container->get(WorseReflectionExtension::SERVICE_PARSER),

--- a/lib/Extension/LanguageServerCodeTransform/CodeAction/ByteOffsetRefactorProvider.php
+++ b/lib/Extension/LanguageServerCodeTransform/CodeAction/ByteOffsetRefactorProvider.php
@@ -15,12 +15,14 @@ use Phpactor\LanguageServerProtocol\TextDocumentItem;
 use Phpactor\LanguageServerProtocol\WorkspaceEdit;
 use Phpactor\LanguageServer\Core\CodeAction\CodeActionProvider;
 
-class FillObjectProvider implements CodeActionProvider
+class ByteOffsetRefactorProvider implements CodeActionProvider
 {
-    const KIND = 'quickfix.fill.object';
-
-    public function __construct(private ByteOffsetRefactor $fillObject)
-    {
+    public function __construct(
+        private ByteOffsetRefactor $fillObject,
+        private string $kind,
+        private string $title,
+        private string $description,
+    ) {
     }
 
     public function provideActionsFor(TextDocumentItem $textDocument, Range $range, CancellationToken $cancel): Promise
@@ -36,8 +38,8 @@ class FillObjectProvider implements CodeActionProvider
 
         return new Success([
             new CodeAction(
-                title: 'Fill object',
-                kind: self::KIND,
+                title: $this->title,
+                kind: $this->kind,
                 diagnostics: [],
                 isPreferred: false,
                 edit: new WorkspaceEdit([
@@ -49,10 +51,10 @@ class FillObjectProvider implements CodeActionProvider
 
     public function kinds(): array
     {
-        return [self::KIND];
+        return [$this->kind];
     }
     public function describe(): string
     {
-        return 'fill new object construct with named parameters';
+        return $this->description;
     }
 }

--- a/lib/Extension/LanguageServerCodeTransform/CodeAction/ByteOffsetRefactorProvider.php
+++ b/lib/Extension/LanguageServerCodeTransform/CodeAction/ByteOffsetRefactorProvider.php
@@ -18,7 +18,7 @@ use Phpactor\LanguageServer\Core\CodeAction\CodeActionProvider;
 class ByteOffsetRefactorProvider implements CodeActionProvider
 {
     public function __construct(
-        private ByteOffsetRefactor $fillObject,
+        private ByteOffsetRefactor $refactor,
         private string $kind,
         private string $title,
         private string $description,
@@ -27,7 +27,7 @@ class ByteOffsetRefactorProvider implements CodeActionProvider
 
     public function provideActionsFor(TextDocumentItem $textDocument, Range $range, CancellationToken $cancel): Promise
     {
-        $edits = $this->fillObject->refactor(
+        $edits = $this->refactor->refactor(
             TextDocumentConverter::fromLspTextItem($textDocument),
             RangeConverter::toPhpactorRange($range, $textDocument->text)->start()
         );

--- a/lib/Extension/LanguageServerCodeTransform/CodeAction/FillObjectProvider.php
+++ b/lib/Extension/LanguageServerCodeTransform/CodeAction/FillObjectProvider.php
@@ -5,7 +5,7 @@ namespace Phpactor\Extension\LanguageServerCodeTransform\CodeAction;
 use Amp\CancellationToken;
 use Amp\Promise;
 use Amp\Success;
-use Phpactor\CodeTransform\Domain\Refactor\FillObject;
+use Phpactor\CodeTransform\Domain\Refactor\ByteOffsetRefactor;
 use Phpactor\Extension\LanguageServerBridge\Converter\RangeConverter;
 use Phpactor\Extension\LanguageServerBridge\Converter\TextDocumentConverter;
 use Phpactor\Extension\LanguageServerBridge\Converter\TextEditConverter;
@@ -19,13 +19,13 @@ class FillObjectProvider implements CodeActionProvider
 {
     const KIND = 'quickfix.fill.object';
 
-    public function __construct(private FillObject $fillObject)
+    public function __construct(private ByteOffsetRefactor $fillObject)
     {
     }
 
     public function provideActionsFor(TextDocumentItem $textDocument, Range $range, CancellationToken $cancel): Promise
     {
-        $edits = $this->fillObject->fillObject(
+        $edits = $this->fillObject->refactor(
             TextDocumentConverter::fromLspTextItem($textDocument),
             RangeConverter::toPhpactorRange($range, $textDocument->text)->start()
         );

--- a/lib/Extension/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
+++ b/lib/Extension/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
@@ -3,6 +3,7 @@
 namespace Phpactor\Extension\LanguageServerCodeTransform;
 
 use Phpactor\ClassFileConverter\Domain\FileToClass;
+use Phpactor\CodeTransform\Adapter\WorseReflection\Refactor\WorseFillObject;
 use Phpactor\CodeTransform\Domain\Generators;
 use Phpactor\CodeTransform\Domain\Helper\MissingMemberFinder;
 use Phpactor\CodeTransform\Domain\Refactor\PropertyAccessGenerator;
@@ -10,7 +11,6 @@ use Phpactor\CodeTransform\Domain\Refactor\ReplaceQualifierWithImport;
 use Phpactor\CodeTransform\Domain\Refactor\ExtractConstant;
 use Phpactor\CodeTransform\Domain\Refactor\ExtractExpression;
 use Phpactor\CodeTransform\Domain\Refactor\ExtractMethod;
-use Phpactor\CodeTransform\Domain\Refactor\ByteOffsetRefactor;
 use Phpactor\CodeTransform\Domain\Refactor\GenerateConstructor;
 use Phpactor\CodeTransform\Domain\Refactor\GenerateDecorator;
 use Phpactor\CodeTransform\Domain\Refactor\GenerateMember;
@@ -27,7 +27,7 @@ use Phpactor\Extension\LanguageServerCodeTransform\CodeAction\CreateUnresolvable
 use Phpactor\Extension\LanguageServerCodeTransform\CodeAction\ExtractConstantProvider;
 use Phpactor\Extension\LanguageServerCodeTransform\CodeAction\ExtractExpressionProvider;
 use Phpactor\Extension\LanguageServerCodeTransform\CodeAction\ExtractMethodProvider;
-use Phpactor\Extension\LanguageServerCodeTransform\CodeAction\FillObjectProvider;
+use Phpactor\Extension\LanguageServerCodeTransform\CodeAction\ByteOffsetRefactorProvider;
 use Phpactor\Extension\LanguageServerCodeTransform\CodeAction\CorrectUndefinedVariableCodeAction;
 use Phpactor\Extension\LanguageServerCodeTransform\CodeAction\GenerateConstructorProvider;
 use Phpactor\Extension\LanguageServerCodeTransform\CodeAction\GenerateDecoratorProvider;
@@ -460,9 +460,12 @@ class LanguageServerCodeTransformExtension implements Extension
             LanguageServerExtension::TAG_CODE_ACTION_PROVIDER => []
         ]);
 
-        $container->register(FillObjectProvider::class, function (Container $container) {
-            return new FillObjectProvider(
-                $container->get(ByteOffsetRefactor::class)
+        $container->register(ByteOffsetRefactorProvider::class.'.fill_object', function (Container $container) {
+            return new ByteOffsetRefactorProvider(
+                $container->get(WorseFillObject::class),
+                'quickfix.fill.object',
+                'Fill object',
+                'fill new object construct with named parameters',
             );
         }, [
             LanguageServerExtension::TAG_CODE_ACTION_PROVIDER => []

--- a/lib/Extension/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
+++ b/lib/Extension/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
@@ -10,7 +10,7 @@ use Phpactor\CodeTransform\Domain\Refactor\ReplaceQualifierWithImport;
 use Phpactor\CodeTransform\Domain\Refactor\ExtractConstant;
 use Phpactor\CodeTransform\Domain\Refactor\ExtractExpression;
 use Phpactor\CodeTransform\Domain\Refactor\ExtractMethod;
-use Phpactor\CodeTransform\Domain\Refactor\FillObject;
+use Phpactor\CodeTransform\Domain\Refactor\ByteOffsetRefactor;
 use Phpactor\CodeTransform\Domain\Refactor\GenerateConstructor;
 use Phpactor\CodeTransform\Domain\Refactor\GenerateDecorator;
 use Phpactor\CodeTransform\Domain\Refactor\GenerateMember;
@@ -462,7 +462,7 @@ class LanguageServerCodeTransformExtension implements Extension
 
         $container->register(FillObjectProvider::class, function (Container $container) {
             return new FillObjectProvider(
-                $container->get(FillObject::class)
+                $container->get(ByteOffsetRefactor::class)
             );
         }, [
             LanguageServerExtension::TAG_CODE_ACTION_PROVIDER => []

--- a/lib/Extension/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
+++ b/lib/Extension/LanguageServerCodeTransform/LanguageServerCodeTransformExtension.php
@@ -3,6 +3,7 @@
 namespace Phpactor\Extension\LanguageServerCodeTransform;
 
 use Phpactor\ClassFileConverter\Domain\FileToClass;
+use Phpactor\CodeTransform\Adapter\WorseReflection\Refactor\WorseFillMatchArms;
 use Phpactor\CodeTransform\Adapter\WorseReflection\Refactor\WorseFillObject;
 use Phpactor\CodeTransform\Domain\Generators;
 use Phpactor\CodeTransform\Domain\Helper\MissingMemberFinder;
@@ -466,6 +467,16 @@ class LanguageServerCodeTransformExtension implements Extension
                 'quickfix.fill.object',
                 'Fill object',
                 'fill new object construct with named parameters',
+            );
+        }, [
+            LanguageServerExtension::TAG_CODE_ACTION_PROVIDER => []
+        ]);
+        $container->register(ByteOffsetRefactorProvider::class.'.fill_match_arms', function (Container $container) {
+            return new ByteOffsetRefactorProvider(
+                $container->get(WorseFillMatchArms::class),
+                'quickfix.fill.matchArms',
+                'Fill match arms',
+                'fill missing match arms for an enum',
             );
         }, [
             LanguageServerExtension::TAG_CODE_ACTION_PROVIDER => []

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionMatchExpression.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionMatchExpression.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Phpactor\WorseReflection\Bridge\TolerantParser\Reflection;
+
+use Microsoft\PhpParser\Node;
+use Microsoft\PhpParser\Node\Expression\MemberAccessExpression;
+use Microsoft\PhpParser\Node\Expression\ScopedPropertyAccessExpression;
+use Phpactor\WorseReflection\Core\Exception\CouldNotResolveNode;
+use Phpactor\TextDocument\ByteOffsetRange;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionClassLike;
+use Phpactor\WorseReflection\Core\Inference\Frame;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionNode;
+use Phpactor\WorseReflection\Core\ServiceLocator;
+use Phpactor\WorseReflection\Core\Type\ReflectedClassType;
+use Phpactor\WorseReflection\Core\Util\NodeUtil;
+
+class ReflectionStaticMemberAccess implements ReflectionNode
+{
+    /**
+     * @param ScopedPropertyAccessExpression|MemberAccessExpression $node
+     */
+    public function __construct(
+        private ServiceLocator $services,
+        private Frame $frame,
+        private Node $node
+    ) {
+    }
+
+    public function position(): ByteOffsetRange
+    {
+        return ByteOffsetRange::fromInts(
+            $this->node->getStartPosition(),
+            $this->node->getEndPosition()
+        );
+    }
+
+    public function class(): ReflectionClassLike
+    {
+        $info = $this->services->nodeContextResolver()->resolveNode($this->frame, $this->node);
+        $containerType = $info->containerType();
+
+        if (!$containerType instanceof ReflectedClassType) {
+            throw new CouldNotResolveNode(sprintf(
+                'Class for member "%s" could not be determined',
+                $this->name()
+            ));
+        }
+
+        $reflection = $containerType->reflectionOrNull();
+
+        if (null === $reflection) {
+            throw new CouldNotResolveNode(sprintf(
+                'Class for member "%s" could not be determined',
+                $this->name()
+            ));
+        }
+
+        return $reflection;
+    }
+
+    public function name(): string
+    {
+        return NodeUtil::nameFromTokenOrNode($this->node, $this->node->memberName);
+    }
+
+    public function scope(): ReflectionScope
+    {
+        return new ReflectionScope($this->services->reflector(), $this->node);
+    }
+
+    public function nameRange(): ByteOffsetRange
+    {
+        $memberName = $this->node->memberName;
+        return ByteOffsetRange::fromInts(
+            $memberName->getStartPosition(),
+            $memberName->getEndPosition()
+        );
+    }
+}

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionMatchExpression.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionMatchExpression.php
@@ -4,17 +4,12 @@ namespace Phpactor\WorseReflection\Bridge\TolerantParser\Reflection;
 
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\Expression\MatchExpression;
-use Microsoft\PhpParser\Node\Expression\MemberAccessExpression;
-use Microsoft\PhpParser\Node\Expression\ScopedPropertyAccessExpression;
-use Phpactor\WorseReflection\Core\Exception\CouldNotResolveNode;
 use Phpactor\TextDocument\ByteOffsetRange;
-use Phpactor\WorseReflection\Core\Reflection\ReflectionClassLike;
 use Phpactor\WorseReflection\Core\Inference\Frame;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionNode;
 use Phpactor\WorseReflection\Core\ServiceLocator;
 use Phpactor\WorseReflection\Core\Type;
-use Phpactor\WorseReflection\Core\Type\ReflectedClassType;
-use Phpactor\WorseReflection\Core\Util\NodeUtil;
+use Phpactor\WorseReflection\Core\TypeFactory;
 
 class ReflectionMatchExpression implements ReflectionNode
 {
@@ -38,6 +33,9 @@ class ReflectionMatchExpression implements ReflectionNode
 
     public function expressionType(): Type
     {
+        if ($this->node->expression === null) {
+            return TypeFactory::unknown();
+        }
         $expr = $this->services->nodeContextResolver()->resolveNode($this->frame, $this->node->expression);
         return $expr->type();
     }

--- a/lib/WorseReflection/Core/Inference/NodeReflector.php
+++ b/lib/WorseReflection/Core/Inference/NodeReflector.php
@@ -5,9 +5,11 @@ namespace Phpactor\WorseReflection\Core\Inference;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\Attribute;
 use Microsoft\PhpParser\Node\Expression\CallExpression;
+use Microsoft\PhpParser\Node\Expression\MatchExpression;
 use Microsoft\PhpParser\Node\Expression\MemberAccessExpression;
 use Microsoft\PhpParser\Node\Expression\ObjectCreationExpression;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Reflection\ReflectionAttribute;
+use Phpactor\WorseReflection\Bridge\TolerantParser\Reflection\ReflectionMatchExpression;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Reflection\ReflectionMethodCall;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Reflection\ReflectionObjectCreationExpression as PhpactorReflectionObjectCreationExpression;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Reflection\ReflectionStaticMemberAccess;
@@ -36,6 +38,10 @@ class NodeReflector
 
         if ($node instanceof ObjectCreationExpression) {
             return $this->reflectObjectCreationExpression($frame, $node);
+        }
+
+        if ($node instanceof MatchExpression) {
+            return $this->reflectMatchExpression($frame, $node);
         }
 
         if ($node->parent instanceof Attribute) {
@@ -107,6 +113,15 @@ class NodeReflector
     private function reflectCaseOrConstant(Frame $frame, ScopedPropertyAccessExpression $node): ReflectionStaticMemberAccess
     {
         return new ReflectionStaticMemberAccess(
+            $this->services,
+            $frame,
+            $node
+        );
+    }
+
+    private function reflectMatchExpression(Frame $frame, MatchExpression $node): ReflectionNode
+    {
+        return new ReflectionMatchExpression(
             $this->services,
             $frame,
             $node

--- a/lib/WorseReflection/Core/Inference/Resolver/MemberAccess/NodeContextFromMemberAccess.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/MemberAccess/NodeContextFromMemberAccess.php
@@ -167,6 +167,10 @@ class NodeContextFromMemberAccess
                     break;
                 }
             }
+            if ($reflection instanceof ReflectionEnum && $memberName === 'cases') {
+                $memberType = TypeFactory::array(TypeFactory::reflectedClass($resolver->reflector(), $reflection->name()));
+                break;
+            }
 
             foreach ($subType->members()->byMemberType($memberTypeName)->byName($memberName) as $member) {
                 // if multiple classes declare a member, always take the "top" one

--- a/lib/WorseReflection/Tests/Inference/enum/enum_case.test
+++ b/lib/WorseReflection/Tests/Inference/enum/enum_case.test
@@ -9,7 +9,7 @@ wrAssertType('enum(Foo::FOO)', Foo::FOO);
 wrAssertType('<missing>', Foo::FOO->value);
 wrAssertType('string', Foo::FOO->name);
 wrAssertType('"bar"', Foo::BAR);
-wrAssertType('UnitEnumCase[]', Foo::cases());
+wrAssertType('Foo[]', Foo::cases());
 
 class UnitEnumCase {
     public string $name;


### PR DESCRIPTION
Fixes #2401

- Adds code action for generating match arms
- Refactors to have a `ByteRangeRefactor` interface which can use the same provider for all implementations
- Fixes the unit enum resolution type

TODO:

- Make some utility for fixing whitespace...
- Refactor any other classes that can fit into the ByteRangeRefactor interface.