### PR TITLE
The missing LSP document symbols in PHP Traits

### DIFF
--- a/lib/Extension/LanguageServerSymbolProvider/Adapter/TolerantDocumentSymbolProvider.php
+++ b/lib/Extension/LanguageServerSymbolProvider/Adapter/TolerantDocumentSymbolProvider.php
@@ -17,6 +17,7 @@ use Microsoft\PhpParser\Node\Statement\ClassDeclaration;
 use Microsoft\PhpParser\Node\Statement\FunctionDeclaration;
 use Microsoft\PhpParser\Node\Statement\InterfaceDeclaration;
 use Microsoft\PhpParser\Node\Statement\TraitDeclaration;
+use Microsoft\PhpParser\Node\TraitMembers;
 use Microsoft\PhpParser\Parser;
 use Phpactor\Extension\LanguageServerBridge\Converter\PositionConverter;
 use Phpactor\Extension\LanguageServerSymbolProvider\Model\DocumentSymbolProvider;
@@ -178,6 +179,7 @@ class TolerantDocumentSymbolProvider implements DocumentSymbolProvider
         return $node->getDescendantNodes(function (Node $node) {
             return
                 $node instanceof InterfaceMembers ||
+                $node instanceof TraitMembers ||
                 $node instanceof ClassMembersNode ||
                 $node instanceof MethodDeclaration ||
                 $node instanceof PropertyDeclaration ||

--- a/lib/Extension/LanguageServerSymbolProvider/Tests/Unit/Adapter/TolerantDocumentSymbolProviderTest.php
+++ b/lib/Extension/LanguageServerSymbolProvider/Tests/Unit/Adapter/TolerantDocumentSymbolProviderTest.php
@@ -10,7 +10,7 @@ class TolerantDocumentSymbolProviderTest extends TestCase
 {
     public function testPropertiesInTraits(): void
     {
-        $provider = new TolerantDocumentSymbolProvider(new Parser);
+        $provider = new TolerantDocumentSymbolProvider(new Parser());
 
         $nodes = $provider->provideFor('<?php trait Foo { public $foo; }');
 
@@ -21,7 +21,7 @@ class TolerantDocumentSymbolProviderTest extends TestCase
 
     public function testMethodsInTraits(): void
     {
-        $provider = new TolerantDocumentSymbolProvider(new Parser);
+        $provider = new TolerantDocumentSymbolProvider(new Parser());
 
         $nodes = $provider->provideFor('<?php trait Foo { public function foo() {} }');
 

--- a/lib/Extension/LanguageServerSymbolProvider/Tests/Unit/Adapter/TolerantDocumentSymbolProviderTest.php
+++ b/lib/Extension/LanguageServerSymbolProvider/Tests/Unit/Adapter/TolerantDocumentSymbolProviderTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerSymbolProvider\Tests\Unit\Adapter;
+
+use Microsoft\PhpParser\Parser;
+use PHPUnit\Framework\TestCase;
+use Phpactor\Extension\LanguageServerSymbolProvider\Adapter\TolerantDocumentSymbolProvider;
+
+class TolerantDocumentSymbolProviderTest extends TestCase
+{
+    public function testPropertiesInTraits(): void
+    {
+        $provider = new TolerantDocumentSymbolProvider(new Parser);
+
+        $nodes = $provider->provideFor('<?php trait Foo { public $foo; }');
+
+        $this->assertCount(1, $nodes);
+        $this->assertIsArray($nodes[0]->children);
+        $this->assertCount(1, $nodes[0]->children);
+    }
+
+    public function testMethodsInTraits(): void
+    {
+        $provider = new TolerantDocumentSymbolProvider(new Parser);
+
+        $nodes = $provider->provideFor('<?php trait Foo { public function foo() {} }');
+
+        $this->assertCount(1, $nodes);
+        $this->assertIsArray($nodes[0]->children);
+        $this->assertCount(1, $nodes[0]->children);
+    }
+}


### PR DESCRIPTION
The pull request adds support for displaying LSP document symbols in Traits. As a new Phpactor user, I hope I haven't missed anything important. Thank you for your time.

## Before (Screenshot)

<img width="1270" alt="image" src="https://github.com/phpactor/phpactor/assets/2339485/9f0eead3-2992-4e6d-ae78-fda7d174e8b1">

## After (Screenshot)

<img width="1270" alt="image" src="https://github.com/phpactor/phpactor/assets/2339485/3875ad70-fd06-47b2-98f5-ceebe1206660">
