### PR TITLE
Initialize instances with parentheses

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -44,6 +44,10 @@ return (new Config())
         'global_namespace_import' => true,
         'no_trailing_whitespace' => true,
         'no_whitespace_in_blank_line' => true,
+        'new_with_parentheses' => [
+            'anonymous_class' => true,
+            'named_class' => true,
+        ],
     ])
     ->setFinder($finder)
 ;

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     },
     "require-dev": {
         "dantleech/what-changed": "~0.4",
-        "friendsofphp/php-cs-fixer": "^3.15",
+        "friendsofphp/php-cs-fixer": "^v3.32",
         "phpstan/phpstan": "^1.0",
         "phpunit/phpunit": "^9.0",
         "phpspec/prophecy-phpunit": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     },
     "require-dev": {
         "dantleech/what-changed": "~0.4",
-        "friendsofphp/php-cs-fixer": "^v3.32",
+        "friendsofphp/php-cs-fixer": "^3.32",
         "phpstan/phpstan": "^1.0",
         "phpunit/phpunit": "^9.0",
         "phpspec/prophecy-phpunit": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3dccef1bbb4a751be67099ebbd8196c9",
+    "content-hash": "fbc404a2d08188b4671cbde2aa8a6b13",
     "packages": [
         {
             "name": "amphp/amp",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8d9ef0cb247406ce05d74dc10b37b7ce",
+    "content-hash": "3dccef1bbb4a751be67099ebbd8196c9",
     "packages": [
         {
             "name": "amphp/amp",
@@ -4603,16 +4603,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.27.0",
+            "version": "v3.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "e73ccaae1208f017bb7860986eebb3da48bd25d6"
+                "reference": "8e9e270c521720c242741caba888fc5a0a134757"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/e73ccaae1208f017bb7860986eebb3da48bd25d6",
-                "reference": "e73ccaae1208f017bb7860986eebb3da48bd25d6",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/8e9e270c521720c242741caba888fc5a0a134757",
+                "reference": "8e9e270c521720c242741caba888fc5a0a134757",
                 "shasum": ""
             },
             "require": {
@@ -4632,6 +4632,9 @@
                 "symfony/polyfill-php81": "^1.27",
                 "symfony/process": "^5.4 || ^6.0",
                 "symfony/stopwatch": "^5.4 || ^6.0"
+            },
+            "conflict": {
+                "stevebauman/unfinalize": "*"
             },
             "require-dev": {
                 "facile-it/paraunit": "^1.3 || ^2.0",
@@ -4686,7 +4689,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.27.0"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.32.0"
             },
             "funding": [
                 {
@@ -4694,7 +4697,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-17T14:37:54+00:00"
+            "time": "2023-09-29T14:36:20+00:00"
         },
         {
             "name": "jangregor/phpstan-prophecy",

--- a/lib/Extension/Configuration/Tests/Unit/Model/JsonSchemaBuilderTest.php
+++ b/lib/Extension/Configuration/Tests/Unit/Model/JsonSchemaBuilderTest.php
@@ -62,7 +62,7 @@ class JsonSchemaBuilderTest extends TestCase
 
     private function createExtension1(): Extension
     {
-        return new class implements Extension {
+        return new class() implements Extension {
             public function configure(Resolver $resolver): void
             {
                 $resolver->setDefaults([

--- a/lib/Extension/Debug/Model/ExtensionDocumentor.php
+++ b/lib/Extension/Debug/Model/ExtensionDocumentor.php
@@ -63,7 +63,7 @@ class ExtensionDocumentor implements Documentor
             "\n",
         ];
 
-        $extension = new $extensionClass;
+        $extension = new $extensionClass();
 
         if (!$extension instanceof Extension) {
             throw new RuntimeException(sprintf(

--- a/lib/Extension/LanguageServer/Dispatcher/PhpactorDispatcherFactory.php
+++ b/lib/Extension/LanguageServer/Dispatcher/PhpactorDispatcherFactory.php
@@ -81,7 +81,7 @@ class PhpactorDispatcherFactory implements DispatcherFactory
 
         $extensions = array_map(function (string $class): Extension {
             /** @var Extension $class */
-            return new $class;
+            return new $class();
         }, $extensionClasses);
         $extensions[] = new LanguageServerSessionExtension($transmitter, $params);
 

--- a/lib/Extension/LanguageServer/Tests/Example/TestExtension.php
+++ b/lib/Extension/LanguageServer/Tests/Example/TestExtension.php
@@ -30,7 +30,7 @@ class TestExtension implements Extension
     public function load(ContainerBuilder $container): void
     {
         $container->register('test.handler', function (Container $container) {
-            return new class implements Handler {
+            return new class() implements Handler {
                 public function methods(): array
                 {
                     return ['test' => 'test'];
@@ -69,7 +69,7 @@ class TestExtension implements Extension
         }, [ LanguageServerExtension::TAG_SERVICE_PROVIDER => []]);
 
         $container->register('test.command', function (Container $container) {
-            return new class implements CoreCommand {
+            return new class() implements CoreCommand {
                 public function __invoke(string $text): Promise
                 {
                     return new Success($text);
@@ -82,7 +82,7 @@ class TestExtension implements Extension
         ]);
 
         $container->register('test.code_action_provider', function (Container $container) {
-            return new class implements CodeActionProvider {
+            return new class() implements CodeActionProvider {
                 public function describe(): string
                 {
                     return 'foobar';
@@ -114,7 +114,7 @@ class TestExtension implements Extension
         }, [ LanguageServerExtension::TAG_CODE_ACTION_PROVIDER => []]);
 
         $container->register('test.diagnostic_provider', function (Container $container) {
-            return new class implements DiagnosticsProvider {
+            return new class() implements DiagnosticsProvider {
                 /**
                  * @return Promise<array<Diagnostic>>
                  */
@@ -132,7 +132,7 @@ class TestExtension implements Extension
         }, [ LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => DiagnosticProviderTag::create('dp1', false)]);
 
         $container->register('test.diagnostic_provider.outsourced', function (Container $container) {
-            return new class implements DiagnosticsProvider {
+            return new class() implements DiagnosticsProvider {
                 /**
                  * @return Promise<array<Diagnostic>>
                  */

--- a/lib/Extension/LanguageServerCodeTransform/Tests/Unit/CodeAction/CreateUnresolvableClassProviderTest.php
+++ b/lib/Extension/LanguageServerCodeTransform/Tests/Unit/CodeAction/CreateUnresolvableClassProviderTest.php
@@ -53,7 +53,7 @@ class CreateUnresolvableClassProviderTest extends IntegrationTestCase
         $actions = wait($provider->provideActionsFor(
             ProtocolFactory::textDocumentItem('file:///foo', $source),
             RangeConverter::toLspRange(ByteOffsetRange::fromInts((int)$start, (int)$end), $source),
-            (new CancellationTokenSource)->getToken(),
+            (new CancellationTokenSource())->getToken(),
         ));
         $assertion(...$actions);
     }

--- a/lib/Extension/ReferenceFinderRpc/Tests/Unit/Handler/GotoTypeHandlerTest.php
+++ b/lib/Extension/ReferenceFinderRpc/Tests/Unit/Handler/GotoTypeHandlerTest.php
@@ -36,7 +36,7 @@ class GotoTypeHandlerTest extends TestCase
 
     public function create(): HandlerTester
     {
-        $locator = new class implements TypeLocator {
+        $locator = new class() implements TypeLocator {
             public function locateTypes(TextDocument $document, ByteOffset $byteOffset): TypeLocations
             {
                 return

--- a/lib/Indexer/Tests/IntegrationTestCase.php
+++ b/lib/Indexer/Tests/IntegrationTestCase.php
@@ -133,7 +133,7 @@ class IntegrationTestCase extends TestCase
 
     private function createLogger(): LoggerInterface
     {
-        return new class extends AbstractLogger {
+        return new class() extends AbstractLogger {
             public function log($level, $message, array $context = []): void
             {
                 fwrite(STDOUT, sprintf("[%s] %s\n", $level, $message));

--- a/lib/WorseReflection/Tests/Unit/Core/ClassNameTest.php
+++ b/lib/WorseReflection/Tests/Unit/Core/ClassNameTest.php
@@ -28,7 +28,7 @@ class ClassNameTest extends TestCase
     public function testFromUnknownInvalid(): void
     {
         $this->expectExceptionMessage('Do not know how to create class');
-        ClassName::fromUnknown(new stdClass);
+        ClassName::fromUnknown(new stdClass());
     }
 
     public function testFromUnknownClassName(): void

--- a/lib/WorseReflection/Tests/Unit/Core/TypeFactoryTest.php
+++ b/lib/WorseReflection/Tests/Unit/Core/TypeFactoryTest.php
@@ -20,7 +20,7 @@ class TypeFactoryTest extends TestCase
 
     public function testFalse(): void
     {
-        self::assertEquals(new FalseType, TypeFactory::fromString('false'));
+        self::assertEquals(new FalseType(), TypeFactory::fromString('false'));
     }
 
     /**


### PR DESCRIPTION
Added style fixer [new_with_parentheses](https://mlocati.github.io/php-cs-fixer-configurator/#version:3.40|fixer:new_with_parentheses) and bumped the minimum version of PHP CS Fixer to **v3.32** which deprecated the `new_with_braces` fixer and introduced its successor `new_with_parentheses`.