### PR TITLE
Fix representation of int range min/max

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Bug fixes:
   - Fix crash on resolveItem() caused by race condition (?) #2434
   - Fix false positive for undefined var where vardoc not counting as variable definition #2437
   - Render variadics as variadics in help, not as arrays #2448
+  - Fix representation of int-range min/max #2444
   - Render default value for enum when filling object #2441
 
 Features:
@@ -28,7 +29,7 @@ Improvements:
 
 Breaking changes:
 
-  - Drop support for PHP 8.0. Minimum version is now 8.0
+  - Drop support for PHP 8.0. Minimum version is now 8.1
 
 ## 2023.09.24
 

--- a/lib/DocblockParser/Tests/Unit/Printer/examples/int-range-min.test
+++ b/lib/DocblockParser/Tests/Unit/Printer/examples/int-range-min.test
@@ -1,0 +1,14 @@
+/**
+ * @var int<min, max>
+ */
+---
+Docblock: = 
+ ElementList: = /**
+ * 
+  VarTag: = @var
+   GenericNode: = 
+    ScalarNode: = int<
+    TypeList: = 
+     ClassNode: = min,
+     ClassNode: = max>
+ */

--- a/lib/WorseReflection/Bridge/Phpactor/DocblockParser/TypeConverter.php
+++ b/lib/WorseReflection/Bridge/Phpactor/DocblockParser/TypeConverter.php
@@ -217,9 +217,21 @@ class TypeConverter
         if ($type->type instanceof ScalarNode && $type->type->name->value === 'int') {
             $parameters = array_values(iterator_to_array($type->parameters()->types()));
             if (count($parameters) === 2) {
+                $start = $this->convert($parameters[0]);
+                $end = $this->convert($parameters[1]);
+                if ($start instanceof ClassType) {
+                    if ($start->name()->short() === 'min') {
+                        $start = null;
+                    }
+                }
+                if ($end instanceof ClassType) {
+                    if ($end->name()->short() === 'max') {
+                        $end = null;
+                    }
+                }
                 return new IntRangeType(
-                    $this->convert($parameters[0]),
-                    $this->convert($parameters[1]),
+                    $start,
+                    $end,
                 );
             }
         }

--- a/lib/WorseReflection/Core/Type/IntRangeType.php
+++ b/lib/WorseReflection/Core/Type/IntRangeType.php
@@ -6,12 +6,12 @@ use Phpactor\WorseReflection\Core\Type;
 
 final class IntRangeType extends IntType
 {
-    public function __construct(public Type $lower, public Type $upper)
+    public function __construct(public ?Type $lower, public ?Type $upper)
     {
     }
 
     public function __toString(): string
     {
-        return sprintf('int<%s, %s>', $this->lower->__toString(), $this->upper->__toString());
+        return sprintf('int<%s, %s>', $this->lower ?? 'min', $this->upper ?? 'max');
     }
 }

--- a/lib/WorseReflection/Tests/Inference/type/int-range.test
+++ b/lib/WorseReflection/Tests/Inference/type/int-range.test
@@ -7,9 +7,9 @@ namespace Foo;
  * @param int<min, 1> $min
  * @param int<1, 2> $range
  */
-function foo(int $minMax, int $max, $int $min, int $range) {
-    wrAssertType('int<1, max>', $max);
+function foo(int $minMax, int $max, int $min, int $range) {
     wrAssertType('int<min, 1>', $min);
+    wrAssertType('int<1, max>', $max);
     wrAssertType('int<min,max>', $minMax);
     wrAssertType('int<1,2>', $min);
 }

--- a/lib/WorseReflection/Tests/Inference/type/int-range.test
+++ b/lib/WorseReflection/Tests/Inference/type/int-range.test
@@ -2,16 +2,16 @@
 namespace Foo;
 
 /**
- * @param int<min,max> $scale
+ * @param int<min,max> $minMax
  * @param int<1,max> $max
  * @param int<min, 1> $min
  * @param int<1, 2> $range
  */
 function foo(int $minMax, int $max, int $min, int $range) {
+    wrAssertType('int<min, max>', $minMax);
     wrAssertType('int<min, 1>', $min);
     wrAssertType('int<1, max>', $max);
-    wrAssertType('int<min,max>', $minMax);
-    wrAssertType('int<1,2>', $min);
+    wrAssertType('int<1, 2>', $range);
 }
 
 

--- a/lib/WorseReflection/Tests/Inference/type/int-range.test
+++ b/lib/WorseReflection/Tests/Inference/type/int-range.test
@@ -1,0 +1,17 @@
+<?php
+namespace Foo;
+
+/**
+ * @param int<min,max> $scale
+ * @param int<1,max> $max
+ * @param int<min, 1> $min
+ * @param int<1, 2> $range
+ */
+function foo(int $minMax, int $max, $int $min, int $range) {
+    wrAssertType('int<1,max>', $max);
+    wrAssertType('int<min,1>', $min);
+    wrAssertType('int<min,max>', $minMax);
+    wrAssertType('int<1,2>', $min);
+}
+
+

--- a/lib/WorseReflection/Tests/Inference/type/int-range.test
+++ b/lib/WorseReflection/Tests/Inference/type/int-range.test
@@ -8,8 +8,8 @@ namespace Foo;
  * @param int<1, 2> $range
  */
 function foo(int $minMax, int $max, $int $min, int $range) {
-    wrAssertType('int<1,max>', $max);
-    wrAssertType('int<min,1>', $min);
+    wrAssertType('int<1, max>', $max);
+    wrAssertType('int<min, 1>', $min);
     wrAssertType('int<min,max>', $minMax);
     wrAssertType('int<1,2>', $min);
 }

--- a/test.php
+++ b/test.php
@@ -1,0 +1,4 @@
+<?php
+
+$foo = fgets(STDIN);
+echo $foo;


### PR DESCRIPTION
Fixes #2444

- Remove php 8.1 guards and update composer
- Failing test
- Fix min
- Failing for min,nmax
- Add parser test
- Fix range representation
- Fix bug
