### PR TITLE
GH-2445: Fix enum renaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Bug fixes:
   - Fix incorrect enum import #2400
   - Fix undefined var false positive for arra unpacking #2403
   - Fix autoloading class conflcits with test files #2535 @gerardroche
+  - Fix enum renaming in legacy renamer #2445
+  - Fix enum renaming on "new" renamer #2445
   - Fix crash on resolveItem() caused by race condition (?) #2434
   - Fix false positive for undefined var where vardoc not counting as variable definition #2437
   - Render variadics as variadics in help, not as arrays #2448

--- a/lib/ClassMover/Adapter/TolerantParser/TolerantClassFinder.php
+++ b/lib/ClassMover/Adapter/TolerantParser/TolerantClassFinder.php
@@ -9,6 +9,7 @@ use Microsoft\PhpParser\Node\NamespaceUseClause;
 use Microsoft\PhpParser\Node\QualifiedName as ParserQualifiedName;
 use Microsoft\PhpParser\Node\SourceFileNode;
 use Microsoft\PhpParser\Node\Statement\ClassDeclaration;
+use Microsoft\PhpParser\Node\Statement\EnumDeclaration;
 use Microsoft\PhpParser\Node\Statement\InterfaceDeclaration;
 use Microsoft\PhpParser\Node\Statement\NamespaceDefinition;
 use Microsoft\PhpParser\Node\Statement\NamespaceUseDeclaration;
@@ -57,6 +58,7 @@ class TolerantClassFinder implements ClassFinder
         foreach ($nodes as $node) {
             if (
                 $node instanceof ClassDeclaration ||
+                $node instanceof EnumDeclaration ||
                 $node instanceof InterfaceDeclaration ||
                 $node instanceof TraitDeclaration
             ) {

--- a/lib/ClassMover/Tests/Adapter/TolerantParser/TolerantClassReplacerTest.php
+++ b/lib/ClassMover/Tests/Adapter/TolerantParser/TolerantClassReplacerTest.php
@@ -232,6 +232,21 @@ class TolerantClassReplacerTest extends TestCase
                         }
                     }
                     EOT,
+            ],
+            'Rename Enum' => [
+                'Enum1.php',
+                'Acme\Hello',
+                'Acme\Goodbye',
+                <<<EOT
+                    <?php
+
+                    namespace Acme;
+
+                    enum Goodbye 
+                    {
+                        case Foo;
+                    }
+                    EOT,
             ]
         ];
     }

--- a/lib/ClassMover/Tests/Adapter/TolerantParser/TolerantClassReplacerTest.php
+++ b/lib/ClassMover/Tests/Adapter/TolerantParser/TolerantClassReplacerTest.php
@@ -239,10 +239,8 @@ class TolerantClassReplacerTest extends TestCase
                 'Acme\Goodbye',
                 <<<EOT
                     <?php
-
                     namespace Acme;
-
-                    enum Goodbye 
+                    enum Goodbye
                     {
                         case Foo;
                     }

--- a/lib/ClassMover/Tests/Adapter/TolerantParser/examples/Enum1.php
+++ b/lib/ClassMover/Tests/Adapter/TolerantParser/examples/Enum1.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Acme;
+
+enum Hello
+{
+    case Foo;
+}

--- a/lib/Rename/Adapter/ReferenceFinder/ClassMover/ClassRenamer.php
+++ b/lib/Rename/Adapter/ReferenceFinder/ClassMover/ClassRenamer.php
@@ -7,6 +7,7 @@ use Microsoft\PhpParser\NamespacedNameInterface;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\QualifiedName as MicrosoftQualifiedName;
 use Microsoft\PhpParser\Node\Statement\ClassDeclaration;
+use Microsoft\PhpParser\Node\Statement\EnumDeclaration;
 use Microsoft\PhpParser\Node\Statement\InterfaceDeclaration;
 use Microsoft\PhpParser\Node\Statement\TraitDeclaration;
 use Microsoft\PhpParser\Parser;
@@ -44,6 +45,10 @@ final class ClassRenamer implements Renamer
         $node = $this->parser->parseSourceFile($textDocument->__toString())->getDescendantNodeAtPosition($offset->toInt());
 
         if ($node instanceof ClassDeclaration) {
+            return TokenUtil::offsetRangeFromToken($node->name, false);
+        }
+
+        if ($node instanceof EnumDeclaration) {
             return TokenUtil::offsetRangeFromToken($node->name, false);
         }
 

--- a/lib/Rename/Tests/Adapter/ReferenceFinder/ClassMover/ClassRenamerTest.php
+++ b/lib/Rename/Tests/Adapter/ReferenceFinder/ClassMover/ClassRenamerTest.php
@@ -95,6 +95,15 @@ class ClassRenamerTest extends ReferenceRenamerIntegrationTestCase
             '<?php interface Interface2 { }',
         ];
 
+        yield 'enum' => [
+            '/foo/Enum1.php',
+            '<?php <r>enum Mar<>ker { }',
+            'Pony',
+            'file:///foo/Pony.php',
+            1,
+            '<?php enum Pony { }',
+        ];
+
         yield 'interface: updates implements' => [
             '/foo/Interface1.php',
             '<?php <r>interface Inter<>face1 { } class Class1 implements Interface1 { }',


### PR DESCRIPTION
Fixes #2445
- Failing test for rename enum
- Fix enum renaming
- Fix "new" renamer for enums
- Update CL
