### PR TITLE
Skip parent parameters on complete constructor

### DIFF
--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Transformer/CompleteConstructorTest.php
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Transformer/CompleteConstructorTest.php
@@ -211,6 +211,39 @@ class CompleteConstructorTest extends WorseTestCase
 
         ];
 
+        yield 'it does not add parameters of inherited classes' => [
+            <<<'EOT'
+                    <?php
+                    class ParentClass
+                    {
+                        public function __construct(private string $someParam) {}
+                    }
+
+                    class Foobar extends ParentClass
+                    {
+                        public function __construct(string $someParam) {
+
+                            parent::__construct($someParam);
+                        }
+                    }
+                EOT,
+            <<<'EOT'
+                    <?php
+                    class ParentClass
+                    {
+                        public function __construct(private string $someParam) {}
+                    }
+
+                    class Foobar extends ParentClass
+                    {
+                        public function __construct(string $someParam) {
+
+                            parent::__construct($someParam);
+                        }
+                    }
+                EOT,
+        ];
+
         yield  'It adds type docblocks' => [
             <<<'EOT'
                 <?php


### PR DESCRIPTION
This solution was already implemented for #2333 I just copied it over to the `transformAssign` function which should also close #374 for good.