### PR TITLE
Indexer: fix `#[\Attribute]` resolution

### DIFF
--- a/lib/Indexer/Adapter/Tolerant/Indexer/ClassDeclarationIndexer.php
+++ b/lib/Indexer/Adapter/Tolerant/Indexer/ClassDeclarationIndexer.php
@@ -54,7 +54,7 @@ class ClassDeclarationIndexer extends AbstractClassLikeIndexer
                     continue;
                 }
                 /** @phpstan-ignore-next-line */
-                if (ltrim($attribute->name?->getText(), '\\') === 'Attribute') {
+                if ((string) $attribute->name?->getResolvedName() === \Attribute::class) {
                     $record->addFlag(ClassRecord::FLAG_ATTRIBUTE);
                     return;
                 }

--- a/lib/Indexer/Adapter/Tolerant/Indexer/ClassDeclarationIndexer.php
+++ b/lib/Indexer/Adapter/Tolerant/Indexer/ClassDeclarationIndexer.php
@@ -54,7 +54,7 @@ class ClassDeclarationIndexer extends AbstractClassLikeIndexer
                     continue;
                 }
                 /** @phpstan-ignore-next-line */
-                if ($attribute->name?->getText() === 'Attribute') {
+                if (ltrim($attribute->name?->getText(), '\\') === 'Attribute') {
                     $record->addFlag(ClassRecord::FLAG_ATTRIBUTE);
                     return;
                 }

--- a/lib/Indexer/Tests/Adapter/ReferenceFinder/IndexedNameSearcherTest.php
+++ b/lib/Indexer/Tests/Adapter/ReferenceFinder/IndexedNameSearcherTest.php
@@ -90,6 +90,7 @@ class IndexedNameSearcherTest extends IndexTestCase
 
     public function testSearcherForAttribute(): void
     {
+        $this->workspace()->put('project/Bap.php', '<?php use Attribute as PHPAttribute; #[PHPAttribute] class Bap {}');
         $this->workspace()->put('project/Bar.php', '<?php #[\Attribute] class Bar {}');
         $this->workspace()->put('project/Baj.php', '<?php #[Attribute] class Baj {}');
         $this->workspace()->put('project/Foo/Bax.php', '<?php namespace Foo; use Not\Attribute; #[Attribute] class Bax {}');
@@ -100,8 +101,8 @@ class IndexedNameSearcherTest extends IndexTestCase
 
         foreach ($searcher->search('Ba', NameSearcherType::ATTRIBUTE) as $result) {
             assert($result instanceof NameSearchResult);
-            self::assertContainsEquals($result->name()->head()->__toString(), ['Bar', 'Baj']);
-            self::assertMatchesRegularExpression('#project/Ba[rj].php$#', $result->uri()->__toString());
+            self::assertContainsEquals($result->name()->head()->__toString(), ['Bar', 'Baj', 'Bap']);
+            self::assertMatchesRegularExpression('#project/Ba[rjp].php$#', $result->uri()->__toString());
         }
     }
 }

--- a/lib/Indexer/Tests/Adapter/ReferenceFinder/IndexedNameSearcherTest.php
+++ b/lib/Indexer/Tests/Adapter/ReferenceFinder/IndexedNameSearcherTest.php
@@ -92,6 +92,7 @@ class IndexedNameSearcherTest extends IndexTestCase
     {
         $this->workspace()->put('project/Bar.php', '<?php #[\Attribute] class Bar {}');
         $this->workspace()->put('project/Baj.php', '<?php #[Attribute] class Baj {}');
+        $this->workspace()->put('project/Foo/Bax.php', '<?php namespace Foo; use Not\Attribute; #[Attribute] class Bax {}');
         $this->workspace()->put('project/Baz.php', '<?php class Baz {}');
         $agent = $this->indexAgent();
         $agent->indexer()->getJob()->run();

--- a/lib/Indexer/Tests/Adapter/ReferenceFinder/IndexedNameSearcherTest.php
+++ b/lib/Indexer/Tests/Adapter/ReferenceFinder/IndexedNameSearcherTest.php
@@ -90,7 +90,8 @@ class IndexedNameSearcherTest extends IndexTestCase
 
     public function testSearcherForAttribute(): void
     {
-        $this->workspace()->put('project/Bar.php', '<?php #[Attribute] class Bar {}');
+        $this->workspace()->put('project/Bar.php', '<?php #[\Attribute] class Bar {}');
+        $this->workspace()->put('project/Baj.php', '<?php #[Attribute] class Baj {}');
         $this->workspace()->put('project/Baz.php', '<?php class Baz {}');
         $agent = $this->indexAgent();
         $agent->indexer()->getJob()->run();
@@ -98,8 +99,8 @@ class IndexedNameSearcherTest extends IndexTestCase
 
         foreach ($searcher->search('Ba', NameSearcherType::ATTRIBUTE) as $result) {
             assert($result instanceof NameSearchResult);
-            self::assertEquals('Bar', $result->name()->head()->__toString());
-            self::assertStringContainsString('Bar.php', $result->uri()->__toString());
+            self::assertContainsEquals($result->name()->head()->__toString(), ['Bar', 'Baj']);
+            self::assertMatchesRegularExpression('#project/Ba[rj].php$#', $result->uri()->__toString());
         }
     }
 }


### PR DESCRIPTION
It's not perfect because 

```php
        $this->workspace()->put('project/Bax.php', '<?php use Not\Attribute; #[Attribute] class Bax {}');
```
still can be considered attribute. 