### PR TITLE
Replacing empty with the corresponding type checks

### DIFF
--- a/lib/ClassMover/Domain/Name/QualifiedName.php
+++ b/lib/ClassMover/Domain/Name/QualifiedName.php
@@ -40,7 +40,7 @@ class QualifiedName
 
     public static function fromString(string $string): static
     {
-        if (empty($string)) {
+        if ($string === '') {
             throw new InvalidArgumentException(
                 'Name cannot be empty'
             );

--- a/lib/ClassMover/Domain/Reference/NamespacedClassReferences.php
+++ b/lib/ClassMover/Domain/Reference/NamespacedClassReferences.php
@@ -49,7 +49,7 @@ final class NamespacedClassReferences implements IteratorAggregate
 
     public function isEmpty(): bool
     {
-        return empty($this->classRefs);
+        return $this->classRefs === [];
     }
 
     public function getIterator(): Traversable

--- a/lib/CodeBuilder/Adapter/TolerantParser/TolerantUpdater.php
+++ b/lib/CodeBuilder/Adapter/TolerantParser/TolerantUpdater.php
@@ -77,7 +77,7 @@ class TolerantUpdater implements Updater
             return;
         }
 
-        if (empty((string) $prototype->namespace())) {
+        if (((string) $prototype->namespace()) === '') {
             return;
         }
 

--- a/lib/CodeBuilder/Adapter/TolerantParser/Updater/UseStatementUpdater.php
+++ b/lib/CodeBuilder/Adapter/TolerantParser/Updater/UseStatementUpdater.php
@@ -46,7 +46,7 @@ class UseStatementUpdater
 
         $usePrototypes = $this->resolveUseStatements($prototype, $startNode);
 
-        if (empty($usePrototypes)) {
+        if ($usePrototypes === []) {
             return;
         }
 

--- a/lib/CodeTransform/Adapter/TolerantParser/Refactor/TolerantExtractExpression.php
+++ b/lib/CodeTransform/Adapter/TolerantParser/Refactor/TolerantExtractExpression.php
@@ -78,7 +78,7 @@ class TolerantExtractExpression implements ExtractExpression
                     }
                 );
 
-                if (empty($expressions)) {
+                if ($expressions === []) {
                     return null;
                 }
 

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseExtractMethod.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseExtractMethod.php
@@ -359,7 +359,7 @@ class WorseExtractMethod implements ExtractMethod
             return false === in_array('$' . $variable->name(), $args);
         });
 
-        if (empty($returnVariables)) {
+        if ($returnVariables === []) {
             return null;
         }
 

--- a/lib/CodeTransform/Adapter/WorseReflection/Transformer/ImplementContracts.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Transformer/ImplementContracts.php
@@ -75,7 +75,7 @@ class ImplementContracts implements Transformer
                 $classBuilder = $sourceCodeBuilder->class($class->name()->short());
                 $missingMethods = $this->missingClassMethods($class);
 
-                if (empty($missingMethods)) {
+                if ($missingMethods === []) {
                     continue;
                 }
 

--- a/lib/CodeTransform/Domain/Utils/TextUtils.php
+++ b/lib/CodeTransform/Domain/Utils/TextUtils.php
@@ -9,10 +9,6 @@ class TextUtils
         $indentation = null;
         $lines = explode(PHP_EOL, $string);
 
-        if ($lines === []) {
-            return $string;
-        }
-
         foreach ($lines as $i => $line) {
             if ($line === '') {
                 continue;

--- a/lib/CodeTransform/Domain/Utils/TextUtils.php
+++ b/lib/CodeTransform/Domain/Utils/TextUtils.php
@@ -9,12 +9,12 @@ class TextUtils
         $indentation = null;
         $lines = explode(PHP_EOL, $string);
 
-        if (empty($lines)) {
+        if ($lines === []) {
             return $string;
         }
 
         foreach ($lines as $i => $line) {
-            if (empty($line)) {
+            if ($line === '') {
                 continue;
             }
 

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseConstructorCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseConstructorCompletor.php
@@ -42,7 +42,7 @@ class WorseConstructorCompletor extends AbstractParameterCompletor implements To
         $variables = $this->variableCompletionHelper->variableCompletions($node, $source, $offset);
 
         // no variables available for completion, return empty handed
-        if (empty($variables)) {
+        if ($variables === []) {
             return true;
         }
 

--- a/lib/Diff/RangesForDiff.php
+++ b/lib/Diff/RangesForDiff.php
@@ -56,7 +56,7 @@ class RangesForDiff
                 }
 
                 if ($lastChangedLine) {
-                    if (empty($changedLines) || $startLineNo === null) {
+                    if ($changedLines === [] || $startLineNo === null) {
                         throw new LogicException('Start line number was not resolved');
                     }
 

--- a/lib/DocblockParser/Tests/Unit/Printer/PrinterTest.php
+++ b/lib/DocblockParser/Tests/Unit/Printer/PrinterTest.php
@@ -21,7 +21,7 @@ class PrinterTest extends TestCase
 
         $parts = explode('---', $contents);
 
-        if (empty($parts[0])) {
+        if ($parts[0] === '') {
             $this->markTestIncomplete(sprintf('No example given for "%s"', $path));
         }
 

--- a/lib/Extension/Behat/Completor/FeatureStepCompletor.php
+++ b/lib/Extension/Behat/Completor/FeatureStepCompletor.php
@@ -31,7 +31,7 @@ class FeatureStepCompletor implements Completor
         $currentLine = $this->lineForOffset($source->__toString(), $byteOffset->toInt());
         $parsed = $this->parser->parseSteps($currentLine);
 
-        if (empty($parsed)) {
+        if ($parsed === []) {
             return false;
         }
         $partial = $parsed[0];

--- a/lib/Extension/ClassMover/Application/ClassMemberReferences.php
+++ b/lib/Extension/ClassMover/Application/ClassMemberReferences.php
@@ -73,7 +73,7 @@ class ClassMemberReferences
         return (string) $this->replaceReferencesInCode($source, $referenceList->withClasses(), $replacement);
     }
 
-    /** 
+    /**
      * @return array{references: array<mixed>, risky_references: array<mixed>, replacements: array<mixed>}
      */
     private function referencesInFile(
@@ -125,7 +125,7 @@ class ClassMemberReferences
         return $result;
     }
 
-    /** 
+    /**
      * @return list<array<string, mixed>>
      */
     private function serializeReferenceList(string $code, MemberReferences $referenceList): array
@@ -141,7 +141,7 @@ class ClassMemberReferences
         return $references;
     }
 
-    /** 
+    /**
      * @return array<string, mixed>
      */
     private function serializeReference(string $code, MemberReference $reference): array

--- a/lib/Extension/ClassMover/Application/ClassMemberReferences.php
+++ b/lib/Extension/ClassMover/Application/ClassMemberReferences.php
@@ -43,7 +43,7 @@ class ClassMemberReferences
         foreach ($filePaths as $filePath) {
             $references = $this->referencesInFile($filesystem, $filePath, $className, $memberName, $memberType, $replace, $dryRun);
 
-            if (empty($references['references']) && empty($references['risky_references'])) {
+            if ($references['references'] === [] && $references['risky_references'] === []) {
                 continue;
             }
 
@@ -81,7 +81,7 @@ class ClassMemberReferences
         string $memberType = null,
         string $replace = null,
         bool $dryRun = false
-    ) {
+    ): array {
         $code = $filesystem->getContents($filePath);
 
         $query = $this->createQuery($className, $memberName, $memberType);
@@ -122,7 +122,7 @@ class ClassMemberReferences
         return $result;
     }
 
-    private function serializeReferenceList(string $code, MemberReferences $referenceList)
+    private function serializeReferenceList(string $code, MemberReferences $referenceList): array
     {
         $references = [];
         /** @var MemberReference $reference */
@@ -135,7 +135,7 @@ class ClassMemberReferences
         return $references;
     }
 
-    private function serializeReference(string $code, MemberReference $reference)
+    private function serializeReference(string $code, MemberReference $reference): array
     {
         [$lineNumber, $colNumber, $line] = $this->line($code, $reference->position()->start());
         return [
@@ -149,7 +149,7 @@ class ClassMemberReferences
         ];
     }
 
-    private function line(string $code, int $offset)
+    private function line(string $code, int $offset):array
     {
         $lines = explode(PHP_EOL, $code);
         $number = 0;
@@ -177,7 +177,7 @@ class ClassMemberReferences
         return $this->memberReplacer->replaceMembers($code, $list, $replace);
     }
 
-    private function createQuery(string $className = null, string $memberName = null, $memberType = null)
+    private function createQuery(string $className = null, string $memberName = null, $memberType = null): ClassMemberQuery
     {
         $query = ClassMemberQuery::create();
 

--- a/lib/Extension/ClassMover/Application/ClassMemberReferences.php
+++ b/lib/Extension/ClassMover/Application/ClassMemberReferences.php
@@ -73,6 +73,9 @@ class ClassMemberReferences
         return (string) $this->replaceReferencesInCode($source, $referenceList->withClasses(), $replacement);
     }
 
+    /** 
+     * @return array{references: array<mixed>, risky_references: array<mixed>, replacements: array<mixed>}
+     */
     private function referencesInFile(
         Filesystem $filesystem,
         $filePath,
@@ -122,6 +125,9 @@ class ClassMemberReferences
         return $result;
     }
 
+    /** 
+     * @return list<array<string, mixed>>
+     */
     private function serializeReferenceList(string $code, MemberReferences $referenceList): array
     {
         $references = [];
@@ -135,6 +141,9 @@ class ClassMemberReferences
         return $references;
     }
 
+    /** 
+     * @return array<string, mixed>
+     */
     private function serializeReference(string $code, MemberReference $reference): array
     {
         [$lineNumber, $colNumber, $line] = $this->line($code, $reference->position()->start());
@@ -149,6 +158,9 @@ class ClassMemberReferences
         ];
     }
 
+    /**
+     * @return array{int, int, string}
+     */
     private function line(string $code, int $offset):array
     {
         $lines = explode(PHP_EOL, $code);

--- a/lib/Extension/ClassMover/Application/ClassReferences.php
+++ b/lib/Extension/ClassMover/Application/ClassReferences.php
@@ -57,7 +57,7 @@ class ClassReferences
         foreach ($filesystem->fileList()->phpFiles() as $filePath) {
             $references = $this->fileReferences($filesystem, $filePath, $className, $replace, $dryRun);
 
-            if (empty($references['references'])) {
+            if ($references['references'] === []) {
                 continue;
             }
 

--- a/lib/Extension/ClassMover/Application/Finder/FileFinder.php
+++ b/lib/Extension/ClassMover/Application/Finder/FileFinder.php
@@ -61,10 +61,8 @@ class FileFinder
     {
         $path = $reflection->sourceCode()->uri()?->path();
 
-        if (empty($path)) {
-            throw new RuntimeException(sprintf(
-                'Source has no path associated with it'
-            ));
+        if (!$path) {
+            throw new RuntimeException('Source has no path associated with it');
         }
 
         $filePaths = [ $path ];

--- a/lib/Extension/ClassMover/Rpc/ReferencesHandler.php
+++ b/lib/Extension/ClassMover/Rpc/ReferencesHandler.php
@@ -125,7 +125,7 @@ class ReferencesHandler extends AbstractHandler
         }
 
         $references = array_filter($references, function (array $referenceList) {
-            return false === empty($referenceList['references']);
+            return $referenceList['references'] !== [];
         });
 
         return CollectionResponse::fromActions([

--- a/lib/Extension/ClassToFile/ClassToFileExtension.php
+++ b/lib/Extension/ClassToFile/ClassToFileExtension.php
@@ -52,7 +52,7 @@ class ClassToFileExtension implements Extension
                 $classToFiles[] = new ComposerClassToFile($classLoader);
             }
 
-            if ($container->parameter(self::PARAM_BRUTE_FORCE_CONVERSION)->bool() && empty($classToFiles)) {
+            if ($container->parameter(self::PARAM_BRUTE_FORCE_CONVERSION)->bool() && $classToFiles === []) {
                 $projectDir = $container->get(FilePathResolverExtension::SERVICE_FILE_PATH_RESOLVER)->resolve($container->parameter(self::PARAM_PROJECT_ROOT)->string());
                 $classToFiles[] = new SimpleClassToFile($projectDir);
             }
@@ -66,7 +66,7 @@ class ClassToFileExtension implements Extension
                 $fileToClasses[] = new ComposerFileToClass($classLoader);
             }
 
-            if (empty($fileToClasses)) {
+            if ($fileToClasses === []) {
                 $fileToClasses[] = new SimpleFileToClass();
             }
 

--- a/lib/Extension/CodeTransformExtra/Rpc/ImportMissingClassesHandler.php
+++ b/lib/Extension/CodeTransformExtra/Rpc/ImportMissingClassesHandler.php
@@ -50,7 +50,7 @@ class ImportMissingClassesHandler implements Handler
             ]));
         }
 
-        if (empty($responses)) {
+        if ($responses === []) {
             return EchoResponse::fromMessage('No unresolved classes found');
         }
 

--- a/lib/Extension/LanguageServerCodeTransform/CodeAction/CreateClassProvider.php
+++ b/lib/Extension/LanguageServerCodeTransform/CodeAction/CreateClassProvider.php
@@ -45,7 +45,7 @@ class CreateClassProvider implements DiagnosticsProvider, CodeActionProvider
         return call(function () use ($textDocument) {
             $diagnostics = $this->getDiagnostics($textDocument);
 
-            if (empty($diagnostics)) {
+            if ($diagnostics === []) {
                 return [];
             }
 

--- a/lib/Extension/LanguageServerCodeTransform/Model/NameImport/NameImporterResult.php
+++ b/lib/Extension/LanguageServerCodeTransform/Model/NameImport/NameImporterResult.php
@@ -20,7 +20,7 @@ class NameImporterResult
 
     public function hasTextEdits(): bool
     {
-        return !empty($this->textEdits);
+        return $this->textEdits !== [];
     }
 
     /**

--- a/lib/Extension/LanguageServerReferenceFinder/Model/Highlights.php
+++ b/lib/Extension/LanguageServerReferenceFinder/Model/Highlights.php
@@ -26,10 +26,8 @@ class Highlights implements IteratorAggregate, Countable
 
     public function first(): DocumentHighlight
     {
-        if (empty($this->highlights)) {
-            throw new RuntimeException(
-                'Document highlights are empty'
-            );
+        if ($this->highlights === []) {
+            throw new RuntimeException('Document highlights are empty');
         }
 
         return $this->highlights[0];

--- a/lib/Extension/LanguageServerWorseReflection/Workspace/WorkspaceIndex.php
+++ b/lib/Extension/LanguageServerWorseReflection/Workspace/WorkspaceIndex.php
@@ -116,7 +116,7 @@ class WorkspaceIndex
             unset($this->byName[$name]);
         }
 
-        if (!empty($newNames)) {
+        if ($newNames !== []) {
             $this->documentToNameMap[(string)$textDocument->uri()] = $newNames;
         } else {
             unset($this->documentToNameMap[(string)$textDocument->uri()]);

--- a/lib/Filesystem/Adapter/Git/GitFilesystem.php
+++ b/lib/Filesystem/Adapter/Git/GitFilesystem.php
@@ -119,6 +119,6 @@ class GitFilesystem extends SimpleFilesystem
     {
         $out = $this->exec(['ls-files', (string) $file]);
 
-        return false === empty($out);
+        return !empty($out);
     }
 }

--- a/lib/Indexer/Adapter/Tolerant/Indexer/MemberIndexer.php
+++ b/lib/Indexer/Adapter/Tolerant/Indexer/MemberIndexer.php
@@ -75,7 +75,7 @@ class MemberIndexer implements TolerantIndexer
         $containerType = $this->resolveContainerType($containerType, $node);
         $memberName = $this->resolveScopedPropertyAccessName($node);
 
-        if (empty($memberName)) {
+        if ($memberName === '') {
             return;
         }
 

--- a/lib/Indexer/Adapter/Worse/IndexerClassSourceLocator.php
+++ b/lib/Indexer/Adapter/Worse/IndexerClassSourceLocator.php
@@ -19,7 +19,7 @@ class IndexerClassSourceLocator implements SourceCodeLocator
 
     public function locate(Name $name): TextDocument
     {
-        if (empty($name->__toString())) {
+        if ($name->__toString() === '') {
             throw new SourceNotFound('Name is empty');
         }
 

--- a/lib/Indexer/Adapter/Worse/IndexerFunctionSourceLocator.php
+++ b/lib/Indexer/Adapter/Worse/IndexerFunctionSourceLocator.php
@@ -19,7 +19,7 @@ class IndexerFunctionSourceLocator implements SourceCodeLocator
 
     public function locate(Name $name): TextDocument
     {
-        if (empty($name->__toString())) {
+        if ($name->__toString() === '') {
             throw new SourceNotFound('Name is empty');
         }
 

--- a/lib/Name/QualifiedName.php
+++ b/lib/Name/QualifiedName.php
@@ -12,10 +12,8 @@ final class QualifiedName implements Name
 
     private function __construct(array $parts)
     {
-        if (empty($parts)) {
-            throw new InvalidName(sprintf(
-                'Names must have at least one segment'
-            ));
+        if ($parts === []) {
+            throw new InvalidName('Names must have at least one segment');
         }
 
         $this->parts = $parts;

--- a/lib/WorseReflection/Bridge/Phpactor/DocblockParser/DocblockParserFactory.php
+++ b/lib/WorseReflection/Bridge/Phpactor/DocblockParser/DocblockParserFactory.php
@@ -44,7 +44,7 @@ class DocblockParserFactory implements DocBlockFactory
 
     public function create(string $docblock, ReflectionScope $scope): DocBlock
     {
-        if (empty(trim($docblock))) {
+        if (trim($docblock) === '') {
             return new PlainDocblock();
         }
 

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/TraitImport/TraitImports.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/TraitImport/TraitImports.php
@@ -50,7 +50,7 @@ final class TraitImports implements Countable, IteratorAggregate
                 return (string) TolerantQualifiedNameResolver::getResolvedName($name);
             }, iterator_to_array($memberDeclaration->traitNameList->getElements())));
 
-            if (empty($traitNames)) {
+            if ($traitNames === []) {
                 continue;
             }
 

--- a/lib/WorseReflection/Core/Reflection/Collection/AbstractReflectionCollection.php
+++ b/lib/WorseReflection/Core/Reflection/Collection/AbstractReflectionCollection.php
@@ -85,7 +85,7 @@ abstract class AbstractReflectionCollection implements ReflectionCollection
      */
     public function first()
     {
-        if (empty($this->items)) {
+        if ($this->items === []) {
             throw new ItemNotFound(
                 'Collection is empty, cannot get the first item'
             );

--- a/lib/WorseReflection/Core/Types.php
+++ b/lib/WorseReflection/Core/Types.php
@@ -37,7 +37,7 @@ final class Types implements IteratorAggregate
      */
     public function firstOrNull(): ?Type
     {
-        if (empty($this->types)) {
+        if ($this->types === []) {
             return null;
         }
 

--- a/lib/WorseReflection/ReflectorBuilder.php
+++ b/lib/WorseReflection/ReflectorBuilder.php
@@ -221,7 +221,7 @@ final class ReflectorBuilder
             return $locator[1];
         }, $locators);
 
-        if (empty($locators)) {
+        if ($locators === []) {
             return new NullSourceLocator();
         }
 


### PR DESCRIPTION
## Why

According to the documentation [empty](https://www.php.net/manual/en/function.empty.php) checks that the variable is present and not false. Which 
* Checks variables if they exist (we know they all exist)
* We possibly need to type cast values to bool
* This helps to make the code more readable (imo) because you can infer the type from the check.

So this might even be a little performance improvement (but very very negligable)