### PR TITLE
Draft: Pest Extension

### DIFF
--- a/lib/Extension/Pest/Completion/PestCompletion.php
+++ b/lib/Extension/Pest/Completion/PestCompletion.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpactor\Extension\Pest\Completion;
+
+use Generator;
+use Microsoft\PhpParser\Node;
+use Phpactor\Completion\Bridge\TolerantParser\TolerantCompletor;
+use Phpactor\Completion\Core\Suggestion;
+use Phpactor\TextDocument\ByteOffset;
+use Phpactor\TextDocument\TextDocument;
+
+class PestCompletion implements TolerantCompletor
+{
+    public function complete(Node $node, TextDocument $source, ByteOffset $offset): Generator
+    {
+        yield null;
+    }
+}

--- a/lib/Extension/Pest/Completion/PestCompletion.php
+++ b/lib/Extension/Pest/Completion/PestCompletion.php
@@ -13,8 +13,60 @@ use Phpactor\TextDocument\TextDocument;
 
 class PestCompletion implements TolerantCompletor
 {
+    public function __construct(private bool $laravelPluginEnabled)
+    {
+    }
+
+    private const UNIT_TEST_CASE_CLASS = 'PHPUnit\Framework\TestCase';
+    private const FEATURE_TEST_CASE_CLASS = 'Tests\\TestCase';
+    private const ILLUMINATE_REFRESH_DATABASE_CLASS = 'Illuminate\\Foundation\\Testing\\RefreshDatabase';
+
     public function complete(Node $node, TextDocument $source, ByteOffset $offset): Generator
     {
-        yield null;
+        $path = $source->uri()->path();
+        $testCases = $this->getParentTestCaseClasses($path);
+
+        // loop over test cases and yield suggestions
+
+        // for now this is a dummy one to make sure it works
+        yield Suggestion::createWithOptions('FOOBAR', [
+            'label' => 'A label',
+            'short_description' => 'A short description',
+            'documentation' => 'The doc',
+            'type' => Suggestion::TYPE_VALUE,
+            'name_import' => 'name import',
+            'priority' => 555,
+        ]);
+    }
+
+    private function getParentTestCaseClasses(string $path): array
+    {
+        if (false === mb_strpos($path, 'tests/')) {
+            return [];
+        }
+
+        if (str_ends_with($path, 'tests/Pest.php')) {
+            return $this->featureTestCases();
+        }
+
+        if (preg_match('{/tests/Feature/[^/]+Test\.php$}', $path)) {
+            return $this->featureTestCases();
+        }
+
+        return $this->unitTestCases();
+    }
+
+    private function unitTestCases(): array
+    {
+        return [self::UNIT_TEST_CASE_CLASS];
+    }
+
+    private function featureTestCases(): array
+    {
+        if ($this->laravelPluginEnabled) {
+            return [self::FEATURE_TEST_CASE_CLASS, self::ILLUMINATE_REFRESH_DATABASE_CLASS];
+        }
+
+        return [self::FEATURE_TEST_CASE_CLASS];
     }
 }

--- a/lib/Extension/Pest/PestExtension.php
+++ b/lib/Extension/Pest/PestExtension.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpactor\Extension\Pest;
+
+use Phpactor\Container\Container;
+use Phpactor\Container\ContainerBuilder;
+use Phpactor\Container\OptionalExtension;
+use Phpactor\Extension\CompletionWorse\CompletionWorseExtension;
+use Phpactor\Extension\Pest\Completion\PestCompletion;
+use Phpactor\MapResolver\Resolver;
+
+class PestExtension implements OptionalExtension
+{
+    const PARAM_COMPLETOR_ENABLED = 'completion_worse.completor.pest.enabled';
+    public const PARAM_ENABLED = 'pest.enabled';
+
+    public function load(ContainerBuilder $container): void
+    {
+        $container->register(
+            'pest.completor',
+            function (Container $container) {return new PestCompletion();},
+            [
+                CompletionWorseExtension::TAG_TOLERANT_COMPLETOR => [
+                    'name' => 'pest',
+                ],
+            ]
+        );
+    }
+
+    public function configure(Resolver $schema): void
+    {
+        $schema->setDefaults([
+            self::PARAM_COMPLETOR_ENABLED => true,
+        ]);
+    }
+
+    public function name(): string
+    {
+        return 'pest';
+    }
+}

--- a/lib/Extension/Pest/PestExtension.php
+++ b/lib/Extension/Pest/PestExtension.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Phpactor\Extension\Pest;
 
+use Phpactor\ComposerInspector\ComposerInspector;
+use Phpactor\Configurator\Model\JsonConfig;
 use Phpactor\Container\Container;
 use Phpactor\Container\ContainerBuilder;
 use Phpactor\Container\OptionalExtension;
 use Phpactor\Extension\CompletionWorse\CompletionWorseExtension;
+use Phpactor\Extension\Configuration\ConfigurationExtension;
 use Phpactor\Extension\Pest\Completion\PestCompletion;
 use Phpactor\MapResolver\Resolver;
 
@@ -20,7 +23,9 @@ class PestExtension implements OptionalExtension
     {
         $container->register(
             'pest.completor',
-            function (Container $container) {return new PestCompletion();},
+            function (Container $container) {
+                return new PestCompletion($this->hasLaravelPlugin($container));
+            },
             [
                 CompletionWorseExtension::TAG_TOLERANT_COMPLETOR => [
                     'name' => 'pest',
@@ -39,5 +44,16 @@ class PestExtension implements OptionalExtension
     public function name(): string
     {
         return 'pest';
+    }
+
+    private function hasLaravelPlugin(Container $container): bool
+    {
+        $config = $container->expect(
+            ConfigurationExtension::SERVICE_PHPACTOR_CONFIG_LOCAL,
+            JsonConfig::class
+        );
+        $inspector = $container->get(ComposerInspector::class);
+
+        return null !== $inspector->package('pestphp/pest-plugin-laravel');
     }
 }

--- a/lib/Extension/Pest/PestSuggestExtension.php
+++ b/lib/Extension/Pest/PestSuggestExtension.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Phpactor\Extension\Pest;
+
+use Phpactor\ComposerInspector\ComposerInspector;
+use Phpactor\Configurator\Adapter\Phpactor\PhpactorConfigChange;
+use Phpactor\Configurator\Model\Changes;
+use Phpactor\Configurator\Model\JsonConfig;
+use Phpactor\Container\Container;
+use Phpactor\Container\ContainerBuilder;
+use Phpactor\Container\Extension;
+use Phpactor\Extension\Configuration\ChangeSuggestor\PhpactorComposerSuggestor;
+use Phpactor\Extension\Configuration\ConfigurationExtension;
+use Phpactor\MapResolver\Resolver;
+
+class PestSuggestExtension implements Extension
+{
+    public function load(ContainerBuilder $container): void
+    {
+        $container->register('pest.suggest', function (Container $container) {
+            return new PhpactorComposerSuggestor(
+                $container->expect(
+                    ConfigurationExtension::SERVICE_PHPACTOR_CONFIG_LOCAL,
+                    JsonConfig::class
+                ),
+                $container->get(ComposerInspector::class),
+                function (JsonConfig $config, ComposerInspector $inspector) {
+                    if ($config->has(PestExtension::PARAM_ENABLED)) {
+                        return Changes::none();
+                    }
+
+                    if (!$inspector->package('pestphp/pest')) {
+                        return Changes::none();
+                    }
+
+                    return Changes::from([
+                        new PhpactorConfigChange('Pest testing framework detected, enable Pest extension?', function (bool $enable) {
+                            return [
+                                PestExtension::PARAM_ENABLED => $enable,
+                            ];
+                        })
+                    ]);
+                }
+            );
+        }, [
+            ConfigurationExtension::TAG_SUGGESTOR => [],
+        ]);
+    }
+
+    public function configure(Resolver $schema): void
+    {
+    }
+}

--- a/lib/Phpactor.php
+++ b/lib/Phpactor.php
@@ -33,6 +33,8 @@ use Phpactor\Extension\LanguageServerWorseReflection\LanguageServerWorseReflecti
 use Phpactor\Extension\LanguageServer\LanguageServerExtension;
 use Phpactor\Extension\LanguageServer\LanguageServerExtraExtension;
 use Phpactor\Extension\ObjectRenderer\ObjectRendererExtension;
+use Phpactor\Extension\Pest\PestExtension;
+use Phpactor\Extension\Pest\PestSuggestExtension;
 use Phpactor\Extension\PhpCodeSniffer\PhpCodeSnifferExtension;
 use Phpactor\Extension\PhpCodeSniffer\PhpCodeSnifferSuggestExtension;
 use Phpactor\Extension\PHPUnit\PHPUnitExtension;
@@ -209,6 +211,8 @@ class Phpactor
             SymfonyExtension::class,
             SymfonySuggestExtension::class,
             PHPUnitExtension::class,
+            PestExtension::class,
+            PestSuggestExtension::class,
         ];
 
         if (class_exists(DebugExtension::class)) {


### PR DESCRIPTION
Only a very early draft for now.

Not sure where I'm going with this but if you have some input/suggestions, it's very welcome :blue_heart: 

Tries solving #2344.

Goals:
- [x] Suggest Pest if it's installed
- [ ] Suggest completion if in a test file (for that we need to detect we're in a closure and suggest methods to `$this` as if it were bound to a TestCase class)
- [ ] For a first step, give completions from `PHPUnit\Framework\TestCase` if in `Unit` folder and from `Tests\TestCase` if in `Feature` folder. Not sure yet, but I think `Illuminate\\Foundation\\Testing\\RefreshDatabase` is only used by default if [pest laravel plugin](https://github.com/pestphp/pest-plugin-laravel) is installed (I need to check that).
- [ ] Then it would be great to analyze the [Pest.php](https://pestphp.com/docs/configuring-tests) to check which TestCase is used in which folder.