### PR TITLE
update actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
 
             -
                 name: "Composer install"
-                uses: "ramsey/composer-install@v1"
+                uses: "ramsey/composer-install@v2"
                 with:
                     composer-options: "--no-scripts"
             -
@@ -121,7 +121,7 @@ jobs:
 
             -
                 name: "Composer install"
-                uses: "ramsey/composer-install@v1"
+                uses: "ramsey/composer-install@v2"
                 with:
                     composer-options: "--no-scripts"
             -
@@ -152,7 +152,7 @@ jobs:
 
             -
                 name: "Composer install"
-                uses: "ramsey/composer-install@v1"
+                uses: "ramsey/composer-install@v2"
                 with:
                     composer-options: "--no-scripts"
             -
@@ -183,7 +183,7 @@ jobs:
 
             -
                 name: "Composer install"
-                uses: "ramsey/composer-install@v1"
+                uses: "ramsey/composer-install@v2"
                 with:
                     composer-options: "--no-scripts"
             -
@@ -214,7 +214,7 @@ jobs:
 
             -
                 name: "Composer install"
-                uses: "ramsey/composer-install@v1"
+                uses: "ramsey/composer-install@v2"
                 with:
                     composer-options: "--no-scripts"
             -

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         steps:
             -
                 name: "Checkout code"
-                uses: "actions/checkout@v2"
+                uses: "actions/checkout@v3"
 
             -
                 name: "Install PHP"
@@ -109,7 +109,7 @@ jobs:
         steps:
             -
                 name: "Checkout code"
-                uses: "actions/checkout@v2"
+                uses: "actions/checkout@v3"
             -
                 name: "Install PHP"
                 uses: "shivammathur/setup-php@v2"
@@ -140,7 +140,7 @@ jobs:
         steps:
             -
                 name: "Checkout code"
-                uses: "actions/checkout@v2"
+                uses: "actions/checkout@v3"
             -
                 name: "Install PHP"
                 uses: "shivammathur/setup-php@v2"
@@ -171,7 +171,7 @@ jobs:
         steps:
             -
                 name: "Checkout code"
-                uses: "actions/checkout@v2"
+                uses: "actions/checkout@v3"
             -
                 name: "Install PHP"
                 uses: "shivammathur/setup-php@v2"
@@ -202,7 +202,7 @@ jobs:
         steps:
             -
                 name: "Checkout code"
-                uses: "actions/checkout@v2"
+                uses: "actions/checkout@v3"
             -
                 name: "Install PHP"
                 uses: "shivammathur/setup-php@v2"
@@ -233,7 +233,7 @@ jobs:
         steps:
             -
                 name: "Checkout code"
-                uses: "actions/checkout@v2"
+                uses: "actions/checkout@v3"
             -
                 name: "Install PHP"
                 uses: "shivammathur/setup-php@v2"
@@ -259,7 +259,7 @@ jobs:
         steps:
             -
                 name: "Checkout code"
-                uses: "actions/checkout@v2"
+                uses: "actions/checkout@v3"
             -
                 name: "Make Docs"
                 run: "make docs"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Set PHP 8.1
               uses: shivammathur/setup-php@v2
@@ -64,7 +64,7 @@ jobs:
         steps:
             -
                 name: "Checkout code"
-                uses: "actions/checkout@v3"
+                uses: "actions/checkout@v4"
 
             -
                 name: "Install PHP"
@@ -109,7 +109,7 @@ jobs:
         steps:
             -
                 name: "Checkout code"
-                uses: "actions/checkout@v3"
+                uses: "actions/checkout@v4"
             -
                 name: "Install PHP"
                 uses: "shivammathur/setup-php@v2"
@@ -140,7 +140,7 @@ jobs:
         steps:
             -
                 name: "Checkout code"
-                uses: "actions/checkout@v3"
+                uses: "actions/checkout@v4"
             -
                 name: "Install PHP"
                 uses: "shivammathur/setup-php@v2"
@@ -171,7 +171,7 @@ jobs:
         steps:
             -
                 name: "Checkout code"
-                uses: "actions/checkout@v3"
+                uses: "actions/checkout@v4"
             -
                 name: "Install PHP"
                 uses: "shivammathur/setup-php@v2"
@@ -202,7 +202,7 @@ jobs:
         steps:
             -
                 name: "Checkout code"
-                uses: "actions/checkout@v3"
+                uses: "actions/checkout@v4"
             -
                 name: "Install PHP"
                 uses: "shivammathur/setup-php@v2"
@@ -233,7 +233,7 @@ jobs:
         steps:
             -
                 name: "Checkout code"
-                uses: "actions/checkout@v3"
+                uses: "actions/checkout@v4"
             -
                 name: "Install PHP"
                 uses: "shivammathur/setup-php@v2"
@@ -259,7 +259,7 @@ jobs:
         steps:
             -
                 name: "Checkout code"
-                uses: "actions/checkout@v3"
+                uses: "actions/checkout@v4"
             -
                 name: "Make Docs"
                 run: "make docs"


### PR DESCRIPTION
- build(ci): update actions/checkout v2 -> v3
- build(ci): update actions/checkout v3 -> v4
- build(ci): fix actions deprecation notices

  ```
  VIM Tests (8.1)
  The following actions uses node12 which is deprecated and will be forced to run on node16: ramsey/composer-install@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

  VIM Tests (8.1)
  The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

  VIM Tests (8.1)
  The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

  PHP-CS-Fixer (8.1)
  The following actions uses node12 which is deprecated and will be forced to run on node16: ramsey/composer-install@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

  PHP-CS-Fixer (8.1)
  The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

  PHP-CS-Fixer (8.1)
  The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

  PHP-CS-Fixer (8.1)
  The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

  PHPStan (8.1)
  The following actions uses node12 which is deprecated and will be forced to run on node16: ramsey/composer-install@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

  Phpactor Self Lint (8.1)
  The following actions uses node12 which is deprecated and will be forced to run on node16: ramsey/composer-install@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
  ```
