### PR TITLE
fix tests

### DIFF
--- a/lib/CodeBuilder/Tests/Unit/Domain/TemplatePathResolver/FilterPhpVersionDirectoryIteratorTest.php
+++ b/lib/CodeBuilder/Tests/Unit/Domain/TemplatePathResolver/FilterPhpVersionDirectoryIteratorTest.php
@@ -6,11 +6,12 @@ use ArrayIterator;
 use Iterator;
 use PHPUnit\Framework\TestCase;
 use Phpactor\CodeBuilder\Domain\TemplatePathResolver\FilterPhpVersionDirectoryIterator;
+use Prophecy\PhpUnit\ProphecyTrait;
 use SplFileInfo;
 
 class FilterPhpVersionDirectoryIteratorTest extends TestCase
 {
-    use \Prophecy\PhpUnit\ProphecyTrait;
+    use ProphecyTrait;
 
     /**
      * @dataProvider provideDirectoriesToFilter
@@ -56,7 +57,7 @@ class FilterPhpVersionDirectoryIteratorTest extends TestCase
 
     private function createFakeSplFileInfo(string $filename, bool $isDir = false): SplFileInfo
     {
-        $file = $this->prophesize(SplFileInfo::class);
+        $file = $this->prophesize(\Symfony\Component\Finder\SplFileInfo::class);
         $file->getFilename()->willReturn($filename);
         $file->isDir()->willReturn($isDir);
 

--- a/lib/Extension/LanguageServerPhpCsFixer/Tests/PhpCsFixerTestCase.php
+++ b/lib/Extension/LanguageServerPhpCsFixer/Tests/PhpCsFixerTestCase.php
@@ -2,6 +2,7 @@
 
 namespace Phpactor\Extension\LanguageServerPhpCsFixer\Tests;
 
+use Amp\Promise;
 use PHPUnit\Framework\TestCase;
 use Phpactor\Extension\LanguageServerPhpCsFixer\Model\PhpCsFixerProcess;
 use Psr\Log\NullLogger;
@@ -10,13 +11,16 @@ class PhpCsFixerTestCase extends TestCase
 {
     public function getPhpCsFixer(): PhpCsFixerProcess
     {
-        return new PhpCsFixerProcess(
-            __DIR__ . '/../../../../vendor/bin/php-cs-fixer',
-            new NullLogger(),
-            [
-                'PHP_CS_FIXER_IGNORE_ENV' => '1',
-                'XDEBUG_MODE' => 'off'
-            ],
-        );
+        return new class(__DIR__ . '/../../../../vendor/bin/php-cs-fixer', new NullLogger(), [ 'PHP_CS_FIXER_IGNORE_ENV' => '1', 'XDEBUG_MODE' => 'off' ], ) extends PhpCsFixerProcess {
+            public function fix(string $content, array $options = []): Promise
+            {
+                return parent::fix($content, array_merge($options, ['--no-ansi']));
+            }
+
+            public function describe(string $rule, array $options = []): Promise
+            {
+                return parent::describe($rule, array_merge($options, ['--no-ansi']));
+            }
+        };
     }
 }

--- a/tests/System/SystemTestCase.php
+++ b/tests/System/SystemTestCase.php
@@ -11,7 +11,7 @@ abstract class SystemTestCase extends IntegrationTestCase
     {
         chdir($this->workspaceDir());
 
-        $bin = __DIR__ . '/../../bin/phpactor --verbose ';
+        $bin = __DIR__ . '/../../bin/phpactor --no-ansi --verbose ';
         $process = Process::fromShellCommandline(sprintf(
             '%s %s',
             $bin,


### PR DESCRIPTION
- fix(tests): ansi output causes test failures

  On some terminals, e.g. gnome-terminal, kitty (ubuntu), some tests fail
  because the output of process contain color codes. For example in
  the following assertion:

      $this->assertStringContainsString('class ⟶Badger⟵', $process->getOutput());

  The characters surrounding "Badger" will be in color and so the
  assertion fails because there are color codes in the string.

  This patch adds `--no-ansi` to the `-php-cs-fixer` test command so that
  the output never has color codes.

- fix(test): passing null to type string is deprecated

  When error reporting includes deprecations, the follow notice is emitted
  when running the tests:

  ```
  Deprecated: SplFileInfo::__construct(): Passing null to parameter #1 ($filename) of type string is deprecated in vendor/phpspec/prophecy/src/Prophecy/Doubler/Generator/ClassCreator.php(44) : eval()'d code on line 6
  ```

  The test has been updated to use Symfony's SplFileInfo class which
  Prophecy has an internal patch to help avoid the deprecations.
