### PR TITLE
Fixing the documentation

### DIFF
--- a/doc/development/language-server/code-action.rst
+++ b/doc/development/language-server/code-action.rst
@@ -47,7 +47,7 @@ The ``CodeAction`` list can then reference a command by name and provide argumen
                     $interfaceFQN,
                 ]
             )
-        ]),
+        ),
     ];
 
 The command is defined in our example in the ``GenerateDecoratorCommand`` which

--- a/doc/reference/types.rst
+++ b/doc/reference/types.rst
@@ -107,7 +107,7 @@ Conditional Types
 Phpactor undestands conditional return types of the form:
 
 
-.. code-block::
+.. code-block:: php
 
     /**
      * @return (


### PR DESCRIPTION
I've built a little documentation parser and validator to validate that the code in the documentation is actually syntactically correct and it found somethings that I fixed.