### PR TITLE
Revert "Revert "Add snippet to type suggestions for object creation (…

### DIFF
--- a/lib/Completion/Bridge/TolerantParser/SourceCodeFilesystem/ScfClassCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/SourceCodeFilesystem/ScfClassCompletor.php
@@ -4,6 +4,7 @@ namespace Phpactor\Completion\Bridge\TolerantParser\SourceCodeFilesystem;
 
 use Generator;
 use Microsoft\PhpParser\Node;
+use Microsoft\PhpParser\Node\Expression\ObjectCreationExpression;
 use Microsoft\PhpParser\Node\QualifiedName;
 use Microsoft\PhpParser\ResolvedName;
 use Phpactor\ClassFileConverter\Domain\ClassName;
@@ -61,9 +62,12 @@ class ScfClassCompletor implements TolerantCompletor, TolerantQualifiable
             }
 
             foreach ($candidates as $candidate) {
+                $snippet = ($node instanceof ObjectCreationExpression || $node->parent instanceof ObjectCreationExpression)
+                    ? ['snippet' => $candidate->name() . '($1)$0']
+                    : [];
                 yield Suggestion::createWithOptions(
                     $candidate->name(),
-                    [
+                    $snippet + [
                         'type' => Suggestion::TYPE_CLASS,
                         'short_description' => $candidate->__toString(),
                         'class_import' => $this->getClassNameForImport($candidate, $imports, $currentNamespace),

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/ImportedNameCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/ImportedNameCompletor.php
@@ -4,6 +4,7 @@ namespace Phpactor\Completion\Bridge\TolerantParser\WorseReflection;
 
 use Generator;
 use Microsoft\PhpParser\Node;
+use Microsoft\PhpParser\Node\Expression\ObjectCreationExpression;
 use Microsoft\PhpParser\Node\QualifiedName;
 use Microsoft\PhpParser\ResolvedName;
 use Phpactor\Completion\Bridge\TolerantParser\CompletionContext;
@@ -41,13 +42,17 @@ class ImportedNameCompletor implements TolerantCompletor, TolerantQualifiable
 
         /** @var ResolvedName $resolvedName */
         foreach ($namespaceImports as $alias => $resolvedName) {
+            $snippet = ($node instanceof ObjectCreationExpression || $node->parent instanceof ObjectCreationExpression)
+                ? ['snippet' => $alias . '($1)$0']
+                : [];
+
             yield Suggestion::createWithOptions(
                 $alias,
                 [
                     'type' => Suggestion::TYPE_CLASS,
                     'short_description' => sprintf('%s', $resolvedName->__toString()),
                     'fqn' => $resolvedName->__toString(),
-                ]
+                ] + $snippet
             );
         }
 

--- a/lib/Completion/Core/Completor/NameSearcherCompletor.php
+++ b/lib/Completion/Core/Completor/NameSearcherCompletor.php
@@ -4,6 +4,7 @@ namespace Phpactor\Completion\Core\Completor;
 
 use Generator;
 use Microsoft\PhpParser\Node;
+use Microsoft\PhpParser\Node\Expression\ObjectCreationExpression;
 use Microsoft\PhpParser\Node\NamespaceUseClause;
 use Phpactor\Completion\Core\DocumentPrioritizer\DefaultResultPrioritizer;
 use Phpactor\Completion\Core\DocumentPrioritizer\DocumentPrioritizer;
@@ -85,6 +86,10 @@ abstract class NameSearcherCompletor
             'name_import' => null,
             'priority' => $this->prioritizer->priority($result->uri(), $sourceUri)
         ];
+
+        $options += ($node instanceof ObjectCreationExpression || $node !== null && $node->parent instanceof ObjectCreationExpression)
+            ? ['snippet' => $result->name()->head() . '($1)$0']
+            : [];
 
         if (!$wasFullyQualified && ($node === null || !($node->getParent() instanceof NamespaceUseClause))) {
             $options['class_import'] = $this->classImport($result);

--- a/lib/Completion/Tests/Integration/Bridge/TolerantParser/SourceCodeFilesystem/ScfClassCompletorTest.php
+++ b/lib/Completion/Tests/Integration/Bridge/TolerantParser/SourceCodeFilesystem/ScfClassCompletorTest.php
@@ -82,21 +82,25 @@ class ScfClassCompletorTest extends TolerantCompletorTestCase
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Alphabet',
                     'short_description' => 'Test\Name\Alphabet',
+                    'snippet' => 'Alphabet($1)$0',
                 ],
                 [
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Backwards',
                     'short_description' => 'Test\Name\Backwards',
+                    'snippet' => 'Backwards($1)$0',
                 ],
                 [
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Clapping',
                     'short_description' => 'Test\Name\Clapping',
+                    'snippet' => 'Clapping($1)$0',
                 ],
                 [
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'WithoutNS',
                     'short_description' => 'WithoutNS',
+                    'snippet' => 'WithoutNS($1)$0',
                 ],
             ],
         ];
@@ -108,6 +112,7 @@ class ScfClassCompletorTest extends TolerantCompletorTestCase
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Clapping',
                     'short_description' => 'Test\Name\Clapping',
+                    'snippet' => 'Clapping($1)$0',
                 ],
             ],
         ];

--- a/lib/Completion/Tests/Integration/Bridge/TolerantParser/WorseReflection/ImportedNameCompletorTest.php
+++ b/lib/Completion/Tests/Integration/Bridge/TolerantParser/WorseReflection/ImportedNameCompletorTest.php
@@ -34,6 +34,25 @@ class ImportedNameCompletorTest extends TolerantCompletorTestCase
             []
         ];
 
+        yield 'import local with no prefix' => [
+            <<<'EOT'
+                <?php
+
+                use Barfoo;
+
+                $class = new <>
+                EOT
+        ,
+        [
+                [
+                    'type' => Suggestion::TYPE_CLASS,
+                    'name' => 'Barfoo',
+                    'short_description' => 'Barfoo',
+                    'snippet' => 'Barfoo($1)$0'
+                ]
+        ]
+        ];
+
         yield 'import local' => [
             <<<'EOT'
                 <?php
@@ -48,6 +67,7 @@ class ImportedNameCompletorTest extends TolerantCompletorTestCase
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Barfoo',
                     'short_description' => 'Barfoo',
+                    'snippet' => 'Barfoo($1)$0'
                 ]
         ]
         ];
@@ -66,6 +86,7 @@ class ImportedNameCompletorTest extends TolerantCompletorTestCase
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'BarfooThis',
                     'short_description' => 'Barfoo',
+                    'snippet' => 'BarfooThis($1)$0'
                 ]
             ]
         ];
@@ -85,11 +106,13 @@ class ImportedNameCompletorTest extends TolerantCompletorTestCase
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Barbar',
                     'short_description' => 'Barbar',
+                    'snippet' => 'Barbar($1)$0'
                 ],
                 [
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'BarfooThis',
                     'short_description' => 'Barfoo',
+                    'snippet' => 'BarfooThis($1)$0'
                 ]
             ]
         ];
@@ -110,11 +133,13 @@ class ImportedNameCompletorTest extends TolerantCompletorTestCase
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Barbar',
                     'short_description' => 'Foo\\Bar\\Barbar',
+                    'snippet' => 'Barbar($1)$0'
                 ],
                 [
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Barfoo',
                     'short_description' => 'Foo\\Bar\\Barfoo',
+                    'snippet' => 'Barfoo($1)$0'
                 ]
             ]
         ];

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -722,7 +722,7 @@ parameters:
 
 		-
 			message: "#^Cannot call method name\\(\\) on mixed\\.$#"
-			count: 1
+			count: 2
 			path: lib/Completion/Bridge/TolerantParser/SourceCodeFilesystem/ScfClassCompletor.php
 
 		-


### PR DESCRIPTION
…#2515)""

This reverts commit 0d1053036af67320a9c13524bd670b5eeb7e7688.

Have reverted the original PR as it causes a behavioral regression:

If I want to change the class:

```
new Barfoo()
```

to 

```
new Foo<>()
```

then it's completed as:

```
new Foo()()
```