### PR TITLE
Gh 2429 Fix LSP UTF-16 support

### DIFF
--- a/lib/Extension/LanguageServer/Transmitter/TraceMessageTransmitter.php
+++ b/lib/Extension/LanguageServer/Transmitter/TraceMessageTransmitter.php
@@ -30,6 +30,6 @@ class TraceMessageTransmitter implements MessageTransmitter
             return $value;
         })($encoded));
 
-        $this->logger->info($message, json_decode($encoded, true));
+        $this->logger->info($message, (array)json_decode($encoded, true));
     }
 }

--- a/lib/Extension/LanguageServer/Transmitter/TraceMessageTransmitter.php
+++ b/lib/Extension/LanguageServer/Transmitter/TraceMessageTransmitter.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServer\Transmitter;
+
+use Phpactor\LanguageServer\Core\Rpc\Message;
+use Phpactor\LanguageServer\Core\Server\Transmitter\MessageTransmitter;
+use Psr\Log\LoggerInterface;
+
+class TraceMessageTransmitter implements MessageTransmitter
+{
+    public function __construct(private MessageTransmitter $transmitter, private LoggerInterface $logger)
+    {
+    }
+
+    public function transmit(Message $message): void
+    {
+        $this->transmitter->transmit($message);
+        $encoded = json_encode($message);
+
+        if (false === $encoded) {
+            $encoded = '<could not encode request>';
+        }
+
+        $direction = '!!';
+
+        $message = sprintf('TRAC %s %s', $direction, (function (string $value) {
+            if (strlen($value) > 80) {
+                return substr($value, 0, 79).'⋯';
+            }
+            return $value;
+        })($encoded));
+
+        $this->logger->info($message, json_decode($encoded, true));
+    }
+}

--- a/lib/Extension/LanguageServerBridge/Converter/PositionConverter.php
+++ b/lib/Extension/LanguageServerBridge/Converter/PositionConverter.php
@@ -23,13 +23,23 @@ class PositionConverter
         $lineCol = LineCol::fromByteOffset($text, $offset);
         $lineAtOffset = LineAtOffset::lineAtByteOffset($text, $offset);
 
-        $lineAtOffset = mb_substr(
+        $lineAtOffset = self::normalizeUTF16(mb_substr(
             $lineAtOffset,
             0,
             $lineCol->col() - 1
-        );
+        ));
 
-        return new Position($lineCol->line() - 1, strlen($lineAtOffset));
+        return new Position($lineCol->line() - 1, strlen($lineAtOffset) / 2);
+    }
+    
+    private static function normalizeUTF16(string $string): string
+    {
+        $utf16 = \mb_convert_encoding($string, 'UTF-16', 'UTF-8');
+        if ($utf16 === false) {
+            throw new RuntimeException('String cannot be converted to UTF-16');
+        }
+
+        return $utf16;
     }
 
     public static function positionToByteOffset(Position $position, string $text): ByteOffset

--- a/lib/Extension/LanguageServerBridge/Tests/Converter/LocationConverterTest.php
+++ b/lib/Extension/LanguageServerBridge/Tests/Converter/LocationConverterTest.php
@@ -100,22 +100,22 @@ class LocationConverterTest extends IntegrationTestCase
         yield '4 byte char 1st char' => [
             '😼😼😼😼😼',
             2,
-            4,
-            $this->createRange(0, 4, 0, 4)
+            2,
+            $this->createRange(0, 2, 0, 2)
         ];
 
         yield '4 byte char 2nd char' => [
             '😼😼😼😼😼',
             2,
             5,
-            $this->createRange(0, 4, 0, 8)
+            $this->createRange(0, 2, 0, 4)
         ];
 
         yield '4 byte char 4th char' => [
             '😼😼😼😼😼',
             2,
             16,
-            $this->createRange(0, 4, 0, 16)
+            $this->createRange(0, 2, 0, 8)
         ];
     }
 

--- a/lib/Extension/LanguageServerBridge/Tests/Unit/Converter/PositionConverterTest.php
+++ b/lib/Extension/LanguageServerBridge/Tests/Unit/Converter/PositionConverterTest.php
@@ -19,4 +19,30 @@ class PositionConverterTest extends TestCase
             )
         );
     }
+
+    public function testUtf16(): void
+    {
+        self::assertEquals(
+            new Position(0, 0),
+            PositionConverter::byteOffsetToPosition(
+                ByteOffset::fromInt(0),
+                'a𐐀b'
+            )
+        );
+
+        self::assertEquals(
+            new Position(0, 1),
+            PositionConverter::byteOffsetToPosition(
+                ByteOffset::fromInt(1),
+                'a𐐀b'
+            )
+        );
+        self::assertEquals(
+            new Position(0, 3),
+            PositionConverter::byteOffsetToPosition(
+                ByteOffset::fromInt(2),
+                'a𐐀b'
+            )
+        );
+    }
 }


### PR DESCRIPTION
LSP uses UTF-16 by default. We were using UTF-8 as the Position character offset

This MR hopes to ensure that we are using UTF-16 for the character offset..