### PR TITLE
Fix call to renamed renderException() in bin/phpactor

### DIFF
--- a/bin/phpactor
+++ b/bin/phpactor
@@ -45,6 +45,6 @@ $output = new ConsoleOutput();
 try {
     $application->run(null, $output);
 } catch (Exception $e) {
-    $application->renderException($e, $output);
+    $application->renderThrowable($e, $output);
     exit(255);
 }


### PR DESCRIPTION
renderException() was renamed to renderThrowable() in Symfony. I guess this file is excluded from static analysis that would have caught it.

I found this by accident when running `phpactor help` with a command that doesn't exist.