### PR TITLE
Run Composer post-install-cmd with the same PHP executable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -111,7 +111,7 @@
     ],
     "scripts": {
         "post-install-cmd": [
-            "bin/phpactor config:json-schema phpactor.schema.json"
+            "@php bin/phpactor config:json-schema phpactor.schema.json"
         ],
         "integrate": [
             "composer validate --strict",


### PR DESCRIPTION
As documented here:
https://getcomposer.org/doc/articles/scripts.md#executing-php-scripts

Add `@php` to the `post-install-cmd` script, so that bin/phpactor is executed using the same executable used to run Composer itself. This is important when you have several versions of PHP installed, and the default one isn't at least PHP 8.1 as required by Phpactor.