### PR TITLE
Specify executables in `composer integrate`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -114,11 +114,11 @@
             "@php bin/phpactor config:json-schema phpactor.schema.json"
         ],
         "integrate": [
-            "composer validate --strict",
-            "vendor/bin/php-cs-fixer fix",
-            "vendor/bin/phpstan analyse --memory-limit=-1",
-            "vendor/bin/phpunit",
-            "vendor/bin/phpbench run --iterations=1 --revs=1",
+            "@composer validate --strict",
+            "@php vendor/bin/php-cs-fixer fix",
+            "@php vendor/bin/phpstan analyse --memory-limit=-1",
+            "@php vendor/bin/phpunit",
+            "@php vendor/bin/phpbench run --iterations=1 --revs=1",
             "make docs"
         ]
     }


### PR DESCRIPTION
Similar to 346e7278d61242fa10e06510fed4139b41b4d9ce. Makes the commands run on Windows (where only files with specific extensions, like .exe, can be executable).