### PR TITLE
Run various PHP subprocesses using `PHP_BINARY`

### DIFF
--- a/lib/Extension/LanguageServer/DiagnosticProvider/OutsourcedDiagnosticsProvider.php
+++ b/lib/Extension/LanguageServer/DiagnosticProvider/OutsourcedDiagnosticsProvider.php
@@ -32,7 +32,7 @@ class OutsourcedDiagnosticsProvider implements DiagnosticsProvider
     public function provideDiagnostics(TextDocumentItem $textDocument, CancellationToken $cancel): Promise
     {
         return call(function () use ($textDocument) {
-            $process = new Process(array_merge($this->command, [
+            $process = new Process(array_merge([PHP_BINARY], $this->command, [
                 '--uri=' . $textDocument->uri,
                 sprintf('--config-extra=%s', sprintf('{"%s": false}', WorseReflectionExtension::PARAM_ENABLE_CONTEXT_LOCATION))
             ]), $this->cwd);

--- a/lib/Extension/LanguageServer/Tests/Unit/Command/DiagnosticsCommandTest.php
+++ b/lib/Extension/LanguageServer/Tests/Unit/Command/DiagnosticsCommandTest.php
@@ -27,6 +27,7 @@ class DiagnosticsCommandTest extends LanguageServerTestCase
     private function diagnosticsFor(string $sourceCode): array
     {
         $process = new Process([
+            PHP_BINARY,
             __DIR__ . '/../../../../../../bin/phpactor',
             'language-server:diagnostics',
             '--uri=file:///foo',

--- a/lib/Extension/LanguageServerPhpCsFixer/Model/PhpCsFixerProcess.php
+++ b/lib/Extension/LanguageServerPhpCsFixer/Model/PhpCsFixerProcess.php
@@ -99,7 +99,7 @@ class PhpCsFixerProcess
     public function run(string ...$args): Promise
     {
         return call(function () use ($args) {
-            $process = ProcessBuilder::create([$this->binPath, ...$args])->mergeParentEnv()->env($this->env)->build();
+            $process = ProcessBuilder::create([PHP_BINARY, $this->binPath, ...$args])->mergeParentEnv()->env($this->env)->build();
             yield $process->start();
 
             $process->join()

--- a/lib/Extension/LanguageServerPhpstan/Model/PhpstanProcess.php
+++ b/lib/Extension/LanguageServerPhpstan/Model/PhpstanProcess.php
@@ -28,6 +28,7 @@ class PhpstanProcess
     {
         return \Amp\call(function () use ($filename) {
             $args = [
+                PHP_BINARY,
                 $this->config->phpstanBin(),
                 'analyse',
                 '--no-progress',

--- a/lib/Extension/LanguageServerPsalm/Model/PsalmProcess.php
+++ b/lib/Extension/LanguageServerPsalm/Model/PsalmProcess.php
@@ -32,6 +32,7 @@ class PsalmProcess
     {
         return \Amp\call(function () use ($filename) {
             $command = [
+                PHP_BINARY,
                 $this->config->psalmBin(),
                 sprintf(
                     '--show-info=%s',

--- a/lib/Extension/LanguageServerPsalm/Tests/Model/PsalmProcessTest.php
+++ b/lib/Extension/LanguageServerPsalm/Tests/Model/PsalmProcessTest.php
@@ -51,7 +51,7 @@ class PsalmProcessTest extends IntegrationTestCase
         );
         (Process::fromShellCommandline('composer dump', $this->workspace()->path()))->mustRun();
 
-        (new Process([$psalmBin, '--init', 'src', $initLevel], $this->workspace()->path()))->mustRun();
+        (new Process([PHP_BINARY, $psalmBin, '--init', 'src', $initLevel], $this->workspace()->path()))->mustRun();
         $this->workspace()->put('src/test.php', $source);
         $linter = new PsalmProcess(
             $this->workspace()->path(),

--- a/lib/Indexer/Tests/Extension/Command/IndexBuildCommandTest.php
+++ b/lib/Indexer/Tests/Extension/Command/IndexBuildCommandTest.php
@@ -16,6 +16,7 @@ class IndexBuildCommandTest extends IntegrationTestCase
         $this->initProject();
 
         $process = new Process([
+            PHP_BINARY,
             __DIR__ . '/../../bin/console',
             'index:build',
         ], $this->workspace()->path());

--- a/lib/Indexer/Tests/Extension/Command/IndexCleanCommandTest.php
+++ b/lib/Indexer/Tests/Extension/Command/IndexCleanCommandTest.php
@@ -19,7 +19,7 @@ class IndexCleanCommandTest extends IntegrationTestCase
         $this->initProject();
         self::assertFalse($this->workspace()->exists('cache'));
 
-        $process = new Process($command, $this->workspace()->path(), null, $input);
+        $process = new Process([PHP_BINARY, ...$command], $this->workspace()->path(), null, $input);
         $process->mustRun();
 
         self::assertEquals(0, $process->getExitCode());
@@ -61,7 +61,7 @@ class IndexCleanCommandTest extends IntegrationTestCase
     {
         $this->initProject();
 
-        $process = new Process($command, $this->workspace()->path(), null, $input);
+        $process = new Process([PHP_BINARY, ...$command], $this->workspace()->path(), null, $input);
         $process->mustRun();
 
         self::assertEquals(0, $process->getExitCode());
@@ -99,7 +99,7 @@ class IndexCleanCommandTest extends IntegrationTestCase
     {
         $this->initProject();
 
-        $process = new Process($arguments, $this->workspace()->path(), null, null);
+        $process = new Process([PHP_BINARY, ...$arguments], $this->workspace()->path(), null, null);
         $process->mustRun();
 
         self::assertEquals(0, $process->getExitCode());

--- a/lib/Indexer/Tests/Extension/Command/IndexQueryCommandTest.php
+++ b/lib/Indexer/Tests/Extension/Command/IndexQueryCommandTest.php
@@ -16,6 +16,7 @@ class IndexQueryCommandTest extends IntegrationTestCase
         $this->initProject();
 
         $process = new Process([
+            PHP_BINARY,
             __DIR__ . '/../../bin/console',
             'index:query',
             $query

--- a/lib/Indexer/Tests/Extension/Command/IndexSearchCommandTest.php
+++ b/lib/Indexer/Tests/Extension/Command/IndexSearchCommandTest.php
@@ -16,6 +16,7 @@ class IndexSearchCommandTest extends IntegrationTestCase
         $this->initProject();
 
         $process = new Process(array_merge([
+            PHP_BINARY,
             __DIR__ . '/../../bin/console',
             'index:search',
         ], $args), $this->workspace()->path());

--- a/tests/IntegrationTestCase.php
+++ b/tests/IntegrationTestCase.php
@@ -19,7 +19,7 @@ abstract class IntegrationTestCase extends TestCase
     public function phpactor(array $cmd): Process
     {
         $p = new Process(array_merge(
-            [__DIR__ . '/../bin/phpactor'],
+            [PHP_BINARY, __DIR__ . '/../bin/phpactor'],
             $cmd
         ), $this->workspace()->path());
 

--- a/tests/System/SystemTestCase.php
+++ b/tests/System/SystemTestCase.php
@@ -13,7 +13,8 @@ abstract class SystemTestCase extends IntegrationTestCase
 
         $bin = __DIR__ . '/../../bin/phpactor --no-ansi --verbose ';
         $process = Process::fromShellCommandline(sprintf(
-            '%s %s',
+            '%s %s %s',
+            PHP_BINARY,
             $bin,
             $args
         ), null, [


### PR DESCRIPTION
This ensures that the subprocesses use the same PHP executable as the main one, which is important in case the user has multiple PHP versions installed.

It's also needed for Windows support, because it can't execute PHP scripts directly (only files with specific extensions are executable).