### PR TITLE
Get PHPUnit running on Windows

### DIFF
--- a/lib/Extension/LanguageServer/Tests/Unit/Command/StartCommandTest.php
+++ b/lib/Extension/LanguageServer/Tests/Unit/Command/StartCommandTest.php
@@ -19,6 +19,7 @@ class StartCommandTest extends LanguageServerTestCase
     {
         $exitCode = $this->tester->execute([
             '--no-loop' => true,
+            '--address' => '127.0.0.1:0',
         ]);
         self::assertEquals(0, $exitCode);
     }


### PR DESCRIPTION
With these patches, `vendor/bin/phpunit` runs to completion on my Windows machine, without crashing the test runner or hanging forever. 


```
Tests: 3550, Assertions: 6277, Errors: 188, Failures: 410, Skipped: 5, Risky: 1.
```

:)

(the number of errors varies slightly, something must be flapping)