### PR TITLE
Gh 2529 other UTF-16 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Bug fixes:
 
   - Fix detection of import used relatively in an annotation #2539
   - Fix PHAR crashing issue on PHP8.3 #2533
-  - Fix UTF-16 conversion for LSP #2530
+  - Fix UTF-16 conversion for LSP #2530 #2557
   - Fix support for Attributes on readonly classes #2493
   - Fix `$this` undefined var false positive in anon. class #2469 @mamazu
   - Fix `$argv` undefined var false positives #2468 @mamazu

--- a/lib/Extension/LanguageServerBridge/Converter/PositionConverter.php
+++ b/lib/Extension/LanguageServerBridge/Converter/PositionConverter.php
@@ -44,12 +44,16 @@ class PositionConverter
 
         // convert line to UTF-16 as Position character is UTF-16 code unit position
         $rest = substr($text, $byteOffset->toInt());
+        $lineEnd = strpos($rest, "\n");
+        if ($lineEnd !== false) {
+            $rest = substr($rest, 0, $lineEnd);
+        }
         $rest = self::normalizeUtf16($rest);
 
-        // string is now at least twice as big
         $seg = substr($rest, 0, $position->character * 2);
+        $utf8 = \mb_convert_encoding($seg, 'UTF-8', 'UTF-16');
 
-        return ByteOffset::fromInt($byteOffset->toInt() + strlen($seg) / 2);
+        return ByteOffset::fromInt($byteOffset->toInt() + strlen($utf8));
     }
 
     private static function countUtf16CodeUnits(string $string): int

--- a/lib/Extension/LanguageServerBridge/Converter/PositionConverter.php
+++ b/lib/Extension/LanguageServerBridge/Converter/PositionConverter.php
@@ -5,7 +5,6 @@ namespace Phpactor\Extension\LanguageServerBridge\Converter;
 use Phpactor\LanguageServerProtocol\Position;
 use Phpactor\TextDocument\ByteOffset;
 use Phpactor\TextDocument\LineCol;
-use Phpactor\TextDocument\Util\LineAtOffset;
 use RuntimeException;
 
 class PositionConverter
@@ -46,11 +45,6 @@ class PositionConverter
         $utf8 = \mb_convert_encoding($seg, 'UTF-8', 'UTF-16');
 
         return ByteOffset::fromInt($byteOffset->toInt() + strlen($utf8));
-    }
-
-    private static function countUtf16CodeUnits(string $string): int
-    {
-        return (int)(strlen(self::normalizeUtf16($string)) / 2);
     }
 
     /**

--- a/lib/Extension/LanguageServerBridge/Converter/PositionConverter.php
+++ b/lib/Extension/LanguageServerBridge/Converter/PositionConverter.php
@@ -42,7 +42,6 @@ class PositionConverter
             $rest = substr($rest, 0, $lineEnd);
         }
         $rest = self::normalizeUtf16($rest);
-
         $seg = substr($rest, 0, $position->character * 2);
         $utf8 = \mb_convert_encoding($seg, 'UTF-8', 'UTF-16');
 

--- a/lib/Extension/LanguageServerBridge/Converter/PositionConverter.php
+++ b/lib/Extension/LanguageServerBridge/Converter/PositionConverter.php
@@ -21,16 +21,9 @@ class PositionConverter
             $offset = ByteOffset::fromInt(strlen($text));
         }
 
-        $lineCol = LineCol::fromByteOffset($text, $offset);
-        $lineAtOffset = LineAtOffset::lineAtByteOffset($text, $offset);
+        $lineCol = LineCol::fromByteOffset($text, $offset, true);
 
-        $lineAtOffset = mb_substr(
-            $lineAtOffset,
-            0,
-            $lineCol->col() - 1
-        );
-
-        return new Position($lineCol->line() - 1, self::countUtf16CodeUnits($lineAtOffset));
+        return new Position($lineCol->line() - 1, $lineCol->col() - 1);
     }
 
     /**

--- a/lib/Extension/LanguageServerBridge/Tests/Converter/LocationConverterTest.php
+++ b/lib/Extension/LanguageServerBridge/Tests/Converter/LocationConverterTest.php
@@ -101,21 +101,21 @@ class LocationConverterTest extends IntegrationTestCase
             '😼😼😼😼😼',
             2,
             2,
-            $this->createRange(0, 2, 0, 2)
+            $this->createRange(0, 1, 0, 1)
         ];
 
         yield '4 byte char 2nd char' => [
             '😼😼😼😼😼',
             2,
             5,
-            $this->createRange(0, 2, 0, 4)
+            $this->createRange(0, 1, 0, 3)
         ];
 
         yield '4 byte char 4th char' => [
             '😼😼😼😼😼',
             2,
             16,
-            $this->createRange(0, 2, 0, 8)
+            $this->createRange(0, 1, 0, 8)
         ];
     }
 

--- a/lib/Extension/LanguageServerBridge/Tests/Unit/Converter/PositionConverterTest.php
+++ b/lib/Extension/LanguageServerBridge/Tests/Unit/Converter/PositionConverterTest.php
@@ -78,7 +78,7 @@ class PositionConverterTest extends TestCase
             )
         );
         self::assertEquals(
-            new Position(0, 3),
+            new Position(0, 2),
             PositionConverter::byteOffsetToPosition(
                 ByteOffset::fromInt(2),
                 'a𐐀b'

--- a/lib/Extension/LanguageServerBridge/Tests/Unit/Converter/PositionConverterTest.php
+++ b/lib/Extension/LanguageServerBridge/Tests/Unit/Converter/PositionConverterTest.php
@@ -2,6 +2,7 @@
 
 namespace Phpactor\Extension\LanguageServerBridge\Tests\Unit\Converter;
 
+use Aerospike\Bytes;
 use PHPUnit\Framework\TestCase;
 use Phpactor\Extension\LanguageServerBridge\Converter\PositionConverter;
 use Phpactor\LanguageServerProtocol\Position;
@@ -9,6 +10,34 @@ use Phpactor\TextDocument\ByteOffset;
 
 class PositionConverterTest extends TestCase
 {
+    public function testPositionToByteOffset(): void
+    {
+        self::assertEquals(
+            ByteOffset::fromInt(15),
+            PositionConverter::positionToByteOffset(
+                new Position(2, 3),
+                <<<'EOT'
+                Hello
+                Carld
+                World
+                Farld
+                EOT
+            )
+        );
+        self::assertEquals(
+            ByteOffset::fromInt(37),
+            PositionConverter::positionToByteOffset(
+                new Position(2, 3),
+                <<<'EOT'
+                👩👨👦👧
+                👩👨👦👧
+                👩👨👦👧
+                👩👨👦👧
+                EOT
+            )
+        );
+
+    }
     public function testWhenOutOfBoundsAssumeEndOfDocument(): void
     {
         self::assertEquals(

--- a/lib/Extension/LanguageServerBridge/Tests/Unit/Converter/PositionConverterTest.php
+++ b/lib/Extension/LanguageServerBridge/Tests/Unit/Converter/PositionConverterTest.php
@@ -2,7 +2,6 @@
 
 namespace Phpactor\Extension\LanguageServerBridge\Tests\Unit\Converter;
 
-use Aerospike\Bytes;
 use PHPUnit\Framework\TestCase;
 use Phpactor\Extension\LanguageServerBridge\Converter\PositionConverter;
 use Phpactor\LanguageServerProtocol\Position;
@@ -17,11 +16,11 @@ class PositionConverterTest extends TestCase
             PositionConverter::positionToByteOffset(
                 new Position(2, 3),
                 <<<'EOT'
-                Hello
-                Carld
-                World
-                Farld
-                EOT
+                    Hello
+                    Carld
+                    World
+                    Farld
+                    EOT
             )
         );
         self::assertEquals(
@@ -29,11 +28,11 @@ class PositionConverterTest extends TestCase
             PositionConverter::positionToByteOffset(
                 new Position(2, 3),
                 <<<'EOT'
-                👩👨👦👧
-                👩👨👦👧
-                👩👨👦👧
-                👩👨👦👧
-                EOT
+                    👩👨👦👧
+                    👩👨👦👧
+                    👩👨👦👧
+                    👩👨👦👧
+                    EOT
             )
         );
 
@@ -42,10 +41,10 @@ class PositionConverterTest extends TestCase
             PositionConverter::positionToByteOffset(
                 new Position(2, 30),
                 <<<'PHP'
-                <?php
+                    <?php
 
-                echo '👩👨👦👧' . invalid() . strlen('Lorem ipsum dolor sit amet');
-                PHP
+                    echo '👩👨👦👧' . invalid() . strlen('Lorem ipsum dolor sit amet');
+                    PHP
             )
         );
     }

--- a/lib/Extension/LanguageServerBridge/Tests/Unit/Converter/PositionConverterTest.php
+++ b/lib/Extension/LanguageServerBridge/Tests/Unit/Converter/PositionConverterTest.php
@@ -25,7 +25,7 @@ class PositionConverterTest extends TestCase
             )
         );
         self::assertEquals(
-            ByteOffset::fromInt(37),
+            ByteOffset::fromInt(39),
             PositionConverter::positionToByteOffset(
                 new Position(2, 3),
                 <<<'EOT'
@@ -37,6 +37,17 @@ class PositionConverterTest extends TestCase
             )
         );
 
+        self::assertEquals(
+            ByteOffset::fromInt(45),
+            PositionConverter::positionToByteOffset(
+                new Position(2, 30),
+                <<<'PHP'
+                <?php
+
+                echo '👩👨👦👧' . invalid() . strlen('Lorem ipsum dolor sit amet');
+                PHP
+            )
+        );
     }
     public function testWhenOutOfBoundsAssumeEndOfDocument(): void
     {

--- a/lib/TextDocument/EfficientLineCols.php
+++ b/lib/TextDocument/EfficientLineCols.php
@@ -76,7 +76,7 @@ final class EfficientLineCols
                     $utf16 = \mb_convert_encoding($section, 'UTF-16', 'UTF-8');
                     $positions[$byteOffset] = new LineCol(
                         $lineNb,
-                        strlen($utf16) / 2 + 1,
+                        intval(strlen($utf16) / 2) + 1,
                     );
                 } else {
                     $positions[$byteOffset] = new LineCol(

--- a/lib/TextDocument/LineCol.php
+++ b/lib/TextDocument/LineCol.php
@@ -76,7 +76,7 @@ final class LineCol
         return ByteOffset::fromInt(strlen($text));
     }
 
-    public static function fromByteOffset(string $text, ByteOffset $byteOffset): self
+    public static function fromByteOffset(string $text, ByteOffset $byteOffset, bool $lspPosition = false): self
     {
         if ($byteOffset->toInt() > strlen($text)) {
             $byteOffset = ByteOffset::fromInt(strlen($text));
@@ -111,6 +111,13 @@ final class LineCol
                     0,
                     $byteOffset->toInt() - $start
                 );
+                if ($lspPosition) {
+                    $utf16 = \mb_convert_encoding($section, 'UTF-16', 'UTF-8');
+                    return new self(
+                        $lineNb,
+                        strlen($utf16) / 2 + 1,
+                    );
+                }
 
                 return new self($lineNb, mb_strlen($section) + 1);
             }

--- a/lib/TextDocument/LineCol.php
+++ b/lib/TextDocument/LineCol.php
@@ -115,7 +115,7 @@ final class LineCol
                     $utf16 = \mb_convert_encoding($section, 'UTF-16', 'UTF-8');
                     return new self(
                         $lineNb,
-                        strlen($utf16) / 2 + 1,
+                        intval(strlen($utf16) / 2) + 1,
                     );
                 }
 

--- a/lib/TextDocument/Tests/Benchmark/EfficientLineColsBench.php
+++ b/lib/TextDocument/Tests/Benchmark/EfficientLineColsBench.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Phpactor\TextDocument\Tests\Benchmark;
+
+use PhpBench\Attributes\BeforeMethods;
+use Phpactor\TextDocument\ByteOffset;
+use Phpactor\TextDocument\EfficientLineCols;
+use Phpactor\TextDocument\LineCol;
+
+#[BeforeMethods("setUp")]
+class EfficientLineColsBench
+{
+    private string $contents;
+
+    public function setUp(): void
+    {
+        $this->contents = (string)file_get_contents(__DIR__ . '/example/code.test');
+    }
+    public function benchLineCols(): void
+    {
+        EfficientLineCols::fromByteOffsetInts(
+            $this->contents,
+            [89,191,274,326,373,480,552,2000],
+        );
+    }
+
+    public function benchLineColsUtf16Positions(): void
+    {
+        EfficientLineCols::fromByteOffsetInts(
+            $this->contents,
+            [89,191,274,326,373,480,552,2000],
+            true
+        );
+    }
+
+    public function benchIneffificentLineCols(): void
+    {
+        foreach (
+            [89,191,274,326,373,480,552,2000] as $byteOffset
+        ) {
+            LineCol::fromByteOffset($this->contents, ByteOffset::fromInt($byteOffset));
+        }
+    }
+}

--- a/lib/TextDocument/Tests/Benchmark/EfficientLineColsBench.php
+++ b/lib/TextDocument/Tests/Benchmark/EfficientLineColsBench.php
@@ -7,7 +7,7 @@ use Phpactor\TextDocument\ByteOffset;
 use Phpactor\TextDocument\EfficientLineCols;
 use Phpactor\TextDocument\LineCol;
 
-#[BeforeMethods("setUp")]
+#[BeforeMethods('setUp')]
 class EfficientLineColsBench
 {
     private string $contents;

--- a/lib/TextDocument/Tests/Benchmark/example/code.test
+++ b/lib/TextDocument/Tests/Benchmark/example/code.test
@@ -1,0 +1,108 @@
+<?php
+
+class PositionConverter
+{
+    public static function intByteOffsetToPosition(int $offset, string $text): Position
+    {
+        return self::byteOffsetToPosition(ByteOffset::fromInt($offset), $text);
+    }
+
+    public static function byteOffsetToPosition(ByteOffset $offset, string $text): Position
+    {
+        if ($offset->toInt() > strlen($text)) {
+            $offset = ByteOffset::fromInt(strlen($text));
+        }
+
+        $lineCol = LineCol::fromByteOffset($text, $offset);
+        $lineAtOffset = LineAtOffset::lineAtByteOffset($text, $offset);
+
+        $lineAtOffset = mb_substr(
+            $lineAtOffset,
+            0,
+            $lineCol->col() - 1
+        );
+
+        return new Position($lineCol->line() - 1, self::countUtf16CodeUnits($lineAtOffset));
+    }
+}
+<?php
+
+class PositionConverter
+{
+    public static function intByteOffsetToPosition(int $offset, string $text): Position
+    {
+        return self::byteOffsetToPosition(ByteOffset::fromInt($offset), $text);
+    }
+
+    public static function byteOffsetToPosition(ByteOffset $offset, string $text): Position
+    {
+        if ($offset->toInt() > strlen($text)) {
+            $offset = ByteOffset::fromInt(strlen($text));
+        }
+
+        $lineCol = LineCol::fromByteOffset($text, $offset);
+        $lineAtOffset = LineAtOffset::lineAtByteOffset($text, $offset);
+
+        $lineAtOffset = mb_substr(
+            $lineAtOffset,
+            0,
+            $lineCol->col() - 1
+        );
+
+        return new Position($lineCol->line() - 1, self::countUtf16CodeUnits($lineAtOffset));
+    }
+}
+<?php
+
+class PositionConverter
+{
+    public static function intByteOffsetToPosition(int $offset, string $text): Position
+    {
+        return self::byteOffsetToPosition(ByteOffset::fromInt($offset), $text);
+    }
+
+    public static function byteOffsetToPosition(ByteOffset $offset, string $text): Position
+    {
+        if ($offset->toInt() > strlen($text)) {
+            $offset = ByteOffset::fromInt(strlen($text));
+        }
+
+        $lineCol = LineCol::fromByteOffset($text, $offset);
+        $lineAtOffset = LineAtOffset::lineAtByteOffset($text, $offset);
+
+        $lineAtOffset = mb_substr(
+            $lineAtOffset,
+            0,
+            $lineCol->col() - 1
+        );
+
+        return new Position($lineCol->line() - 1, self::countUtf16CodeUnits($lineAtOffset));
+    }
+}
+<?php
+
+class PositionConverter
+{
+    public static function intByteOffsetToPosition(int $offset, string $text): Position
+    {
+        return self::byteOffsetToPosition(ByteOffset::fromInt($offset), $text);
+    }
+
+    public static function byteOffsetToPosition(ByteOffset $offset, string $text): Position
+    {
+        if ($offset->toInt() > strlen($text)) {
+            $offset = ByteOffset::fromInt(strlen($text));
+        }
+
+        $lineCol = LineCol::fromByteOffset($text, $offset);
+        $lineAtOffset = LineAtOffset::lineAtByteOffset($text, $offset);
+
+        $lineAtOffset = mb_substr(
+            $lineAtOffset,
+            0,
+            $lineCol->col() - 1
+        );
+
+        return new Position($lineCol->line() - 1, self::countUtf16CodeUnits($lineAtOffset));
+    }
+}

--- a/lib/TextDocument/Tests/Unit/EfficientLineColsTest.php
+++ b/lib/TextDocument/Tests/Unit/EfficientLineColsTest.php
@@ -82,7 +82,7 @@ class EfficientLineColsTest extends TestCase
             PHP,
             function (EfficientLineCols $lineCols): void {
                 self::assertEquals(3, $lineCols->get(46)->line());
-                self::assertEquals(30, $lineCols->get(46)->col());
+                self::assertEquals(32, $lineCols->get(46)->col());
             }
         ];
     }

--- a/lib/TextDocument/Tests/Unit/EfficientLineColsTest.php
+++ b/lib/TextDocument/Tests/Unit/EfficientLineColsTest.php
@@ -66,11 +66,11 @@ class EfficientLineColsTest extends TestCase
      */
     public function provideConvertOffsetsToLineColAsOffset(): Generator
     {
-        yield 'cat is 4 bytes' => [
+        yield 'cat' => [
             [5],
             'a😸bc',
             function (EfficientLineCols $lineCols): void {
-                self::assertEquals(6, $lineCols->get(5)->col());
+                self::assertEquals(4, $lineCols->get(5)->col());
             }
         ];
         yield 'utf16' => [

--- a/lib/TextDocument/Tests/Unit/EfficientLineColsTest.php
+++ b/lib/TextDocument/Tests/Unit/EfficientLineColsTest.php
@@ -73,5 +73,17 @@ class EfficientLineColsTest extends TestCase
                 self::assertEquals(6, $lineCols->get(5)->col());
             }
         ];
+        yield 'utf16' => [
+            [46],
+            <<<'PHP'
+            <?php
+
+            echo '👩👨👦👧' . invalid() . strlen('Lorem ipsum dolor sit amet');
+            PHP,
+            function (EfficientLineCols $lineCols): void {
+                self::assertEquals(3, $lineCols->get(46)->line());
+                self::assertEquals(30, $lineCols->get(46)->col());
+            }
+        ];
     }
 }

--- a/lib/TextDocument/Tests/Unit/EfficientLineColsTest.php
+++ b/lib/TextDocument/Tests/Unit/EfficientLineColsTest.php
@@ -76,10 +76,10 @@ class EfficientLineColsTest extends TestCase
         yield 'utf16' => [
             [46],
             <<<'PHP'
-            <?php
+                <?php
 
-            echo '👩👨👦👧' . invalid() . strlen('Lorem ipsum dolor sit amet');
-            PHP,
+                echo '👩👨👦👧' . invalid() . strlen('Lorem ipsum dolor sit amet');
+                PHP,
             function (EfficientLineCols $lineCols): void {
                 self::assertEquals(3, $lineCols->get(46)->line());
                 self::assertEquals(32, $lineCols->get(46)->col());


### PR DESCRIPTION
Fixes #2529 

Updates position converter and document highlighting to convert to Positions with UTF-16 character offsets as per expected LSP defaults. It's somewhat +1/-1.