### PR TITLE
Gh 2518 errors renaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Improvements:
 
 Bug fixes:
 
+  - Fix division by zero edge case
   - Fix crash if referenced file no longer exists on class rename #2518
   - Fix diagnostic process concurrency and do not lint outdated files #2538
   - Fix detection of import used relatively in an annotation #2539

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Improvements:
 
 Bug fixes:
 
+  - Fix crash if referenced file no longer exists on class rename #2518
+  - Fix diagnostic process concurrency and do not lint outdated files #2538
   - Fix detection of import used relatively in an annotation #2539
   - Fix PHAR crashing issue on PHP8.3 #2533
   - Fix UTF-16 conversion for LSP #2530 #2557

--- a/lib/Rename/Adapter/ReferenceFinder/ClassMover/ClassRenamer.php
+++ b/lib/Rename/Adapter/ReferenceFinder/ClassMover/ClassRenamer.php
@@ -24,6 +24,7 @@ use Phpactor\Rename\Model\Renamer;
 use Phpactor\ReferenceFinder\ReferenceFinder;
 use Phpactor\TextDocument\ByteOffset;
 use Phpactor\TextDocument\ByteOffsetRange;
+use Phpactor\TextDocument\Exception\TextDocumentNotFound;
 use Phpactor\TextDocument\TextDocument;
 use Phpactor\TextDocument\TextDocumentLocator;
 use RuntimeException;
@@ -96,7 +97,11 @@ final class ClassRenamer implements Renamer
                 continue;
             }
 
-            $referenceDocument = $this->locator->get($reference->location()->uri());
+            try {
+                $referenceDocument = $this->locator->get($reference->location()->uri());
+            } catch (TextDocumentNotFound) {
+                continue;
+            }
 
             $edits = $this->classMover->replaceReferences(
                 $this->classMover->findReferences($referenceDocument->__toString(), $originalName->__toString()),

--- a/lib/Rename/Adapter/Test/TestNameToUriConverter.php
+++ b/lib/Rename/Adapter/Test/TestNameToUriConverter.php
@@ -8,6 +8,9 @@ use RuntimeException;
 
 final class TestNameToUriConverter implements NameToUriConverter
 {
+    /**
+     * @param array<string,TextDocumentUri> $map
+     */
     public function __construct(private array $map)
     {
     }

--- a/lib/Rename/Adapter/Test/TestNameToUriConverter.php
+++ b/lib/Rename/Adapter/Test/TestNameToUriConverter.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Phpactor\Rename\Adapter\Test;
+
+use Phpactor\Rename\Model\NameToUriConverter;
+use Phpactor\TextDocument\TextDocumentUri;
+use RuntimeException;
+
+final class TestNameToUriConverter implements NameToUriConverter
+{
+    public function __construct(private array $map)
+    {
+    }
+
+    public function convert(string $className): TextDocumentUri
+    {
+        if (!isset($this->map[$className])) {
+            throw new RuntimeException(sprintf(
+                'Test class name "%s" not mapped to file',
+                $className
+            ));
+        }
+
+        return $this->map[$className];
+    }
+
+}

--- a/lib/Rename/Model/NameToUriConverter.php
+++ b/lib/Rename/Model/NameToUriConverter.php
@@ -10,5 +10,5 @@ interface NameToUriConverter
     /**
      * @throws CouldNotConvertUriToClass
      */
-    public function convert(string $uri): TextDocumentUri;
+    public function convert(string $className): TextDocumentUri;
 }

--- a/lib/Rename/Tests/Adapter/ReferenceFinder/ClassMover/ClassRenamerTest.php
+++ b/lib/Rename/Tests/Adapter/ReferenceFinder/ClassMover/ClassRenamerTest.php
@@ -30,7 +30,7 @@ class ClassRenamerTest extends ReferenceRenamerIntegrationTestCase
             PotentialLocation::surely(
                 new Location(
                     TextDocumentUri::fromString('file:///not-existing'),
-                    ByteOffsetRange::fromInts(1,1)
+                    ByteOffsetRange::fromInts(1, 1)
                 )
             )
         );

--- a/lib/Rename/Tests/Adapter/ReferenceFinder/ClassMover/ClassRenamerTest.php
+++ b/lib/Rename/Tests/Adapter/ReferenceFinder/ClassMover/ClassRenamerTest.php
@@ -5,13 +5,18 @@ namespace Phpactor\Rename\Tests\Adapter\ReferenceFinder\ClassMover;
 use Generator;
 use Microsoft\PhpParser\Parser;
 use Phpactor\ClassMover\ClassMover;
+use Phpactor\ReferenceFinder\PotentialLocation;
 use Phpactor\Rename\Adapter\ReferenceFinder\ClassMover\ClassRenamer;
+use Phpactor\Rename\Adapter\Test\TestNameToUriConverter;
 use Phpactor\Rename\Model\LocatedTextEdits;
 use Phpactor\Rename\Model\LocatedTextEditsMap;
 use Phpactor\Rename\Model\NameToUriConverter;
+use Phpactor\Rename\Model\ReferenceFinder\PredefinedReferenceFinder;
 use Phpactor\Rename\Tests\Adapter\ReferenceFinder\ReferenceRenamerIntegrationTestCase;
 use Phpactor\Extension\LanguageServerRename\Tests\Util\OffsetExtractor;
 use Phpactor\TextDocument\ByteOffset;
+use Phpactor\TextDocument\ByteOffsetRange;
+use Phpactor\TextDocument\Location;
 use Phpactor\TextDocument\TextDocument;
 use Phpactor\TextDocument\TextDocumentBuilder;
 use Phpactor\TextDocument\TextDocumentLocator\InMemoryDocumentLocator;
@@ -19,6 +24,35 @@ use Phpactor\TextDocument\TextDocumentUri;
 
 class ClassRenamerTest extends ReferenceRenamerIntegrationTestCase
 {
+    public function testRenameWithReferenceToNonExistingFile(): void
+    {
+        $finder = new PredefinedReferenceFinder(
+            PotentialLocation::surely(
+                new Location(
+                    TextDocumentUri::fromString('file:///not-existing'),
+                    ByteOffsetRange::fromInts(1,1)
+                )
+            )
+        );
+
+        $converter =  new TestNameToUriConverter([
+            'Foobar' => TextDocumentUri::fromString('file:///foobar'),
+            'FoobarBaz' => TextDocumentUri::fromString('file:///foobar-new'),
+        ]);
+        $renamer = new ClassRenamer(
+            $converter,
+            $converter,
+            $finder,
+            InMemoryDocumentLocator::fromTextDocuments([]),
+            new Parser(),
+            new ClassMover()
+        );
+
+        $textDocument = TextDocumentBuilder::fromPathAndString('/path', '<?php class Foobar{}');
+        iterator_to_array($renamer->rename($textDocument, ByteOffset::fromInt(12), 'FoobarBaz'), false);
+        $this->addToAssertionCount(1);
+    }
+
     /**
      * @dataProvider provideRename
      */

--- a/lib/WorseReflection/Core/Type/NumericType.php
+++ b/lib/WorseReflection/Core/Type/NumericType.php
@@ -33,7 +33,8 @@ abstract class NumericType extends ScalarType
     public function divide(NumericType $right): NumericType
     {
         if ($this instanceof Literal && $right instanceof Literal) {
-            if ($right->value() === 0) {
+            /** @phpstan-ignore-next-line it's a scalar */
+            if (intval($right->value()) === 0) {
                 return $this->withValue(0);
             }
 

--- a/lib/WorseReflection/Tests/Inference/arithmetic/zero-division.test
+++ b/lib/WorseReflection/Tests/Inference/arithmetic/zero-division.test
@@ -1,0 +1,6 @@
+<?php
+
+wrAssertType('0', 0/0);
+wrAssertType('0', 0/0.0);
+wrAssertType('0', 0.0/0.0);
+wrAssertType('0', 1/0.0);

--- a/lib/WorseReflection/TypeUtil.php
+++ b/lib/WorseReflection/TypeUtil.php
@@ -63,6 +63,9 @@ class TypeUtil
 
     public static function toNumber(Type $type): NumericType
     {
+        if ($type instanceof NumericType) {
+            return $type;
+        }
         if ($type instanceof Literal && $type instanceof ScalarType) {
             $value = (string)$type->value();
             return TypeFactory::fromNumericString($value);


### PR DESCRIPTION
Ignore "text document not found" errors for no-longer-existing references when renaming classes

Fixes #2518 