### PR TITLE
Matching class names case insensitive

### DIFF
--- a/lib/Indexer/Model/Query/Criteria/ShortNameBeginsWith.php
+++ b/lib/Indexer/Model/Query/Criteria/ShortNameBeginsWith.php
@@ -8,8 +8,11 @@ use Phpactor\Indexer\Model\Record\HasShortName;
 
 class ShortNameBeginsWith extends Criteria
 {
-    public function __construct(private string $name)
+    private string $name;
+
+    public function __construct(string $name)
     {
+        $this->name = strtolower($name);
     }
 
     public function isSatisfiedBy(Record $record): bool
@@ -22,6 +25,6 @@ class ShortNameBeginsWith extends Criteria
             return false;
         }
 
-        return str_starts_with($record->shortName(), $this->name);
+        return str_starts_with(strtolower($record->shortName()), $this->name);
     }
 }

--- a/lib/Indexer/Tests/Unit/Model/Query/Criteria/ShortNameBeginsWithTest.php
+++ b/lib/Indexer/Tests/Unit/Model/Query/Criteria/ShortNameBeginsWithTest.php
@@ -21,6 +21,12 @@ class ShortNameBeginsWithTest extends TestCase
         self::assertTrue((new ShortNameBeginsWith('Barfoo'))->isSatisfiedBy($record));
     }
 
+    public function testMatchesCaseInsensitive(): void
+    {
+        $record = ClassRecord::fromName('Foobar\\Barfoo');
+        self::assertTrue((new ShortNameBeginsWith('barfoo'))->isSatisfiedBy($record));
+    }
+
     public function testNotMatches(): void
     {
         $record = ClassRecord::fromName('Foobar\\Bazfoo');


### PR DESCRIPTION
This only changes the behaviour of the ShortName search as searching with an FQN sould be case sensitive. Or what do you think?