### PR TITLE
GH-2510: Include shell scripts in build for console

### DIFF
--- a/box.json
+++ b/box.json
@@ -14,7 +14,7 @@
       "in": "lib"
     },
     {
-      "name": "{\\.[php|bash|fish|zsh]}",
+      "name": "{\\.(php|bash|fish|zsh)}",
       "exclude": [
         "tests",
         "test"

--- a/box.json
+++ b/box.json
@@ -14,7 +14,7 @@
       "in": "lib"
     },
     {
-      "name": "{\\.[php]}",
+      "name": "{\\.[php|bash|fish|zsh]}",
       "exclude": [
         "tests",
         "test"


### PR DESCRIPTION
Include the shell completion files from symfony console in the PHAR build. Fixes #2510 