### PR TITLE
Replace all uses of PHP_EOL with "\n"

### DIFF
--- a/bin/phpactor
+++ b/bin/phpactor
@@ -23,7 +23,7 @@ ini_set('display_errors', 'stderr');
 
 if (!isset($autoloadFile)) {
     echo sprintf(
-        'Phpactor dependencies not installed. Run `composer install` (https://getcomposer.org) in "%s"' . PHP_EOL,
+        'Phpactor dependencies not installed. Run `composer install` (https://getcomposer.org) in "%s"' . "\n",
         realpath(__DIR__ . '/..')
     );
     exit(255);
@@ -32,7 +32,7 @@ if (!isset($autoloadFile)) {
 $minVersion = '8.1.0';
 
 if (version_compare(PHP_VERSION, $minVersion) < 0) {
-    fwrite(STDERR, sprintf('Phpactor requires at least PHP %s', $minVersion) . PHP_EOL);
+    fwrite(STDERR, sprintf('Phpactor requires at least PHP %s', $minVersion) . "\n");
     exit(255);
 }
 

--- a/lib/ClassMover/Domain/SourceCode.php
+++ b/lib/ClassMover/Domain/SourceCode.php
@@ -32,7 +32,7 @@ class SourceCode
         if (null !== $phpDeclarationLineNb) {
             return $this->insertAfter(
                 $phpDeclarationLineNb,
-                PHP_EOL . sprintf('namespace %s;', (string) $namespace)
+                "\n" . sprintf('namespace %s;', (string) $namespace)
             );
         }
 
@@ -54,11 +54,11 @@ class SourceCode
         }
 
         if ($namespaceLineNb) {
-            return $this->insertAfter($namespaceLineNb, PHP_EOL.$useStmt);
+            return $this->insertAfter($namespaceLineNb, "\n".$useStmt);
         }
 
         if (null !== $phpDeclarationLineNb) {
-            return $this->insertAfter($phpDeclarationLineNb, PHP_EOL.$useStmt);
+            return $this->insertAfter($phpDeclarationLineNb, "\n".$useStmt);
         }
 
         throw new InvalidArgumentException(
@@ -73,7 +73,7 @@ class SourceCode
 
     private function insertAfter(int $lineNb, string $text): self
     {
-        $lines = explode(PHP_EOL, $this->source);
+        $lines = explode("\n", $this->source);
         $newLines = [];
         foreach ($lines as $index => $line) {
             if ($line === $text) {
@@ -86,13 +86,13 @@ class SourceCode
             }
         }
 
-        return $this->replaceSource(implode(PHP_EOL, $newLines));
+        return $this->replaceSource(implode("\n", $newLines));
     }
 
     /** @return array{int|null, int|null, int|null} */
     private function significantLineNumbers(): array
     {
-        $lines = explode(PHP_EOL, $this->source);
+        $lines = explode("\n", $this->source);
         $phpDeclarationLineNb = $namespaceLineNb = $lastUseLineNb = null;
 
         foreach ($lines as $index => $line) {

--- a/lib/CodeBuilder/Adapter/TolerantParser/TolerantUpdater.php
+++ b/lib/CodeBuilder/Adapter/TolerantParser/TolerantUpdater.php
@@ -87,7 +87,7 @@ class TolerantUpdater implements Updater
         }
 
         $startTag = $node->getFirstChildNode(InlineHtml::class);
-        $edits->after($startTag, 'namespace ' . (string) $prototype->namespace() . ';' . PHP_EOL.PHP_EOL);
+        $edits->after($startTag, 'namespace ' . (string) $prototype->namespace() . ';' . "\n"."\n");
     }
 
     private function updateClasses(Edits $edits, SourceCode $prototype, SourceFileNode $node): void
@@ -147,14 +147,14 @@ class TolerantUpdater implements Updater
 
         $index = 0;
         foreach ($classes as $classPrototype) {
-            if (substr($lastStatement->getText(), -1) !== PHP_EOL) {
-                $edits->after($lastStatement, PHP_EOL);
+            if (substr($lastStatement->getText(), -1) !== "\n") {
+                $edits->after($lastStatement, "\n");
             }
 
             if ($index > 0 && $index + 1 == count($classes)) {
-                $edits->after($lastStatement, PHP_EOL);
+                $edits->after($lastStatement, "\n");
             }
-            $edits->after($lastStatement, PHP_EOL . $this->renderer->render($classPrototype));
+            $edits->after($lastStatement, "\n" . $this->renderer->render($classPrototype));
             $index++;
         }
     }

--- a/lib/CodeBuilder/Adapter/TolerantParser/Updater/AbstractMethodUpdater.php
+++ b/lib/CodeBuilder/Adapter/TolerantParser/Updater/AbstractMethodUpdater.php
@@ -103,7 +103,7 @@ abstract class AbstractMethodUpdater
         }
 
         if ($newLine) {
-            $edits->after($lastMember, PHP_EOL);
+            $edits->after($lastMember, "\n");
         }
 
         foreach ($methodPrototypes as $methodPrototype) {
@@ -112,12 +112,12 @@ abstract class AbstractMethodUpdater
                 if ($lastNonMethodMember === null) {
                     $edits->after(
                         $this->memberDeclarationsNode($classNode)->openBrace,
-                        PHP_EOL.$edits->indent($this->renderMethod($this->renderer, $methodPrototype), 1).PHP_EOL
+                        "\n".$edits->indent($this->renderMethod($this->renderer, $methodPrototype), 1)."\n"
                     );
                 } else {
                     $edits->after(
                         $lastNonMethodMember,
-                        PHP_EOL.PHP_EOL.$edits->indent($this->renderMethod($this->renderer, $methodPrototype), 1)
+                        "\n"."\n".$edits->indent($this->renderMethod($this->renderer, $methodPrototype), 1)
                     );
                 }
                 continue;
@@ -125,11 +125,11 @@ abstract class AbstractMethodUpdater
 
             $edits->after(
                 $lastMember,
-                PHP_EOL . $edits->indent($this->renderMethod($this->renderer, $methodPrototype), 1)
+                "\n" . $edits->indent($this->renderMethod($this->renderer, $methodPrototype), 1)
             );
 
             if (false === $classPrototype->methods()->isLast($methodPrototype)) {
-                $edits->after($lastMember, PHP_EOL);
+                $edits->after($lastMember, "\n");
             }
         }
     }
@@ -154,7 +154,7 @@ abstract class AbstractMethodUpdater
 
         foreach ($method->body()->lines() ?? [] as $line) {
             // do not add duplicate lines
-            $bodyNodeLines = explode(PHP_EOL, $bodyNode->getText());
+            $bodyNodeLines = explode("\n", $bodyNode->getText());
 
             foreach ($bodyNodeLines as $bodyNodeLine) {
                 if (trim($bodyNodeLine) == trim((string) $line)) {
@@ -164,7 +164,7 @@ abstract class AbstractMethodUpdater
 
             $edits->after(
                 $lastStatement,
-                PHP_EOL . $edits->indent((string) $line, 2)
+                "\n" . $edits->indent((string) $line, 2)
             );
         }
     }

--- a/lib/CodeBuilder/Adapter/TolerantParser/Updater/ClassLikeUpdater.php
+++ b/lib/CodeBuilder/Adapter/TolerantParser/Updater/ClassLikeUpdater.php
@@ -78,16 +78,16 @@ abstract class ClassLikeUpdater
         foreach ($classPrototype->properties()->notIn($existingPropertyNames) as $property) {
             // if property type exists then the last property has a docblock - add a line break
             if ($lastProperty instanceof PropertyDeclaration && $property->type() != Type::none()) {
-                $edits->after($lastProperty, PHP_EOL);
+                $edits->after($lastProperty, "\n");
             }
 
             $edits->after(
                 $lastProperty,
-                PHP_EOL . $edits->indent($this->renderer->render($property), 1)
+                "\n" . $edits->indent($this->renderer->render($property), 1)
             );
 
             if ($classPrototype->properties()->isLast($property) && $nextMember instanceof MethodDeclaration) {
-                $edits->after($lastProperty, PHP_EOL);
+                $edits->after($lastProperty, "\n");
             }
         }
     }

--- a/lib/CodeBuilder/Adapter/TolerantParser/Updater/ClassMethodUpdater.php
+++ b/lib/CodeBuilder/Adapter/TolerantParser/Updater/ClassMethodUpdater.php
@@ -43,7 +43,7 @@ class ClassMethodUpdater extends AbstractMethodUpdater
     public function renderMethod(Renderer $renderer, Method $method): string
     {
         return $renderer->render($method) .
-            PHP_EOL .
+            "\n" .
             $renderer->render($method->body());
     }
 

--- a/lib/CodeBuilder/Adapter/TolerantParser/Updater/ClassUpdater.php
+++ b/lib/CodeBuilder/Adapter/TolerantParser/Updater/ClassUpdater.php
@@ -62,14 +62,14 @@ class ClassUpdater extends ClassLikeUpdater
 
             $edits->after(
                 $lastConstant,
-                PHP_EOL . $edits->indent($this->renderer->render($constant), 1)
+                "\n" . $edits->indent($this->renderer->render($constant), 1)
             );
 
             if ($classPrototype->constants()->isLast($constant) && (
                 $nextMember instanceof MethodDeclaration ||
                 $nextMember instanceof PropertyDeclaration
             )) {
-                $edits->after($lastConstant, PHP_EOL);
+                $edits->after($lastConstant, "\n");
             }
         }
     }

--- a/lib/CodeBuilder/Adapter/TolerantParser/Updater/EnumUpdater.php
+++ b/lib/CodeBuilder/Adapter/TolerantParser/Updater/EnumUpdater.php
@@ -50,14 +50,14 @@ class EnumUpdater
         foreach ($classPrototype->cases()->notIn($existingCasesNames) as $case) {
             $edits->after(
                 $lastConstant,
-                PHP_EOL . $edits->indent($this->renderer->render($case), 1)
+                "\n" . $edits->indent($this->renderer->render($case), 1)
             );
 
             if ($classPrototype->cases()->isLast($case) && (
                 $nextMember instanceof MethodDeclaration ||
                 $nextMember instanceof EnumCaseDeclaration
             )) {
-                $edits->after($lastConstant, PHP_EOL);
+                $edits->after($lastConstant, "\n");
             }
         }
     }

--- a/lib/CodeBuilder/Adapter/TolerantParser/Updater/UseStatementUpdater.php
+++ b/lib/CodeBuilder/Adapter/TolerantParser/Updater/UseStatementUpdater.php
@@ -61,7 +61,7 @@ class UseStatementUpdater
 
         if ($startNode instanceof NamespaceDefinition) {
             // Add a new line to be in the same case that if it was an InlineHtml node
-            $edits->after($startNode, PHP_EOL);
+            $edits->after($startNode, "\n");
         }
 
         foreach ($usePrototypes as $usePrototype) {
@@ -90,7 +90,7 @@ class UseStatementUpdater
                         if ($cmp > 0) {
                             // Add before one of the use import and add a new
                             // line so the new import is on its own line
-                            $edits->before($childNode, $editText . PHP_EOL);
+                            $edits->before($childNode, $editText . "\n");
                             continue 3;
                         }
                     }
@@ -102,14 +102,14 @@ class UseStatementUpdater
             // Since it will add before the lasts new line of the node we
             // preprend with another one so that the use statement is on its
             // own line
-            $newUseStatement = PHP_EOL . $editText;
+            $newUseStatement = "\n" . $editText;
             $edits->after($startNode, $newUseStatement);
         }
 
         if ($startNode instanceof InlineHtml) {
             // Add a new line after the last use statement so that it's on its
             // own line
-            $edits->after($startNode, PHP_EOL);
+            $edits->after($startNode, "\n");
         }
 
         // Add another new line to separate the new use declaration from
@@ -118,7 +118,7 @@ class UseStatementUpdater
             !$startNode instanceof NamespaceUseDeclaration &&
             $bodyNode && NodeHelper::emptyLinesPrecedingNode($bodyNode) === 0
         ) {
-            $edits->after($startNode, PHP_EOL);
+            $edits->after($startNode, "\n");
         }
     }
 

--- a/lib/CodeBuilder/Domain/Prototype/Docblock.php
+++ b/lib/CodeBuilder/Domain/Prototype/Docblock.php
@@ -37,6 +37,6 @@ class Docblock
             return [];
         }
 
-        return explode(PHP_EOL, $this->docblock);
+        return explode("\n", $this->docblock);
     }
 }

--- a/lib/CodeBuilder/Domain/Prototype/Lines.php
+++ b/lib/CodeBuilder/Domain/Prototype/Lines.php
@@ -9,7 +9,7 @@ class Lines extends Collection
 {
     public function __toString(): string
     {
-        return implode(PHP_EOL, $this->items);
+        return implode("\n", $this->items);
     }
 
     /**

--- a/lib/CodeBuilder/Tests/Adapter/GeneratorTestCase.php
+++ b/lib/CodeBuilder/Tests/Adapter/GeneratorTestCase.php
@@ -46,7 +46,7 @@ abstract class GeneratorTestCase extends TestCase
     public function testRender(Prototype $prototype, string $expectedCode): void
     {
         $code = $this->renderer()->render($prototype);
-        $this->assertEquals(rtrim(Code::fromString($expectedCode), PHP_EOL), rtrim($code, PHP_EOL));
+        $this->assertEquals(rtrim(Code::fromString($expectedCode), "\n"), rtrim($code, "\n"));
     }
 
     /**

--- a/lib/CodeBuilder/Tests/Adapter/UpdaterTestCase.php
+++ b/lib/CodeBuilder/Tests/Adapter/UpdaterTestCase.php
@@ -2030,8 +2030,8 @@ abstract class UpdaterTestCase extends TestCase
 
     private function assertUpdate(string $existingCode, SourceCode $prototype, string $expectedCode): void
     {
-        $existingCode = '<?php'.PHP_EOL.$existingCode;
+        $existingCode = '<?php'."\n".$existingCode;
         $edits = $this->updater()->textEditsFor($prototype, Code::fromString($existingCode));
-        $this->assertEquals('<?php' . PHP_EOL . $expectedCode, $edits->apply($existingCode));
+        $this->assertEquals('<?php' . "\n" . $expectedCode, $edits->apply($existingCode));
     }
 }

--- a/lib/CodeTransform/Adapter/TolerantParser/ClassToFile/Transformer/ClassNameFixerTransformer.php
+++ b/lib/CodeTransform/Adapter/TolerantParser/ClassToFile/Transformer/ClassNameFixerTransformer.php
@@ -141,10 +141,10 @@ class ClassNameFixerTransformer implements Transformer
             $scriptStart = $rootNode->getFirstDescendantNode(InlineHtml::class);
             $scriptStart = $scriptStart ? $scriptStart->getEndPosition() : 0;
 
-            $statement = PHP_EOL . $statement . PHP_EOL;
+            $statement = "\n" . $statement . "\n";
 
             if (0 === $scriptStart) {
-                $statement = '<?php' . PHP_EOL . $statement;
+                $statement = '<?php' . "\n" . $statement;
             }
 
 

--- a/lib/CodeTransform/Adapter/TolerantParser/Refactor/TolerantExtractExpression.php
+++ b/lib/CodeTransform/Adapter/TolerantParser/Refactor/TolerantExtractExpression.php
@@ -41,7 +41,7 @@ class TolerantExtractExpression implements ExtractExpression
         $endPosition = $expression->getEndPosition();
 
         $extractedString = rtrim(trim($source->extractSelection($startPosition, $endPosition)), ';');
-        $assigment = sprintf('$%s = %s;', $variableName, $extractedString) . PHP_EOL;
+        $assigment = sprintf('$%s = %s;', $variableName, $extractedString) . "\n";
 
         $statement = $expression->getFirstAncestor(StatementNode::class);
         assert($statement instanceof StatementNode);

--- a/lib/CodeTransform/Domain/Utils/TextUtils.php
+++ b/lib/CodeTransform/Domain/Utils/TextUtils.php
@@ -7,7 +7,7 @@ class TextUtils
     public static function removeIndentation(string $string): string
     {
         $indentation = null;
-        $lines = explode(PHP_EOL, $string);
+        $lines = explode("\n", $string);
 
         foreach ($lines as $i => $line) {
             if ($line === '') {
@@ -36,12 +36,12 @@ class TextUtils
             $line = substr($line, $indentation);
         }
 
-        return trim(implode(PHP_EOL, $lines), PHP_EOL);
+        return trim(implode("\n", $lines), "\n");
     }
 
     public static function stringIndentation(string $string): int
     {
-        $lines = explode(PHP_EOL, $string);
+        $lines = explode("\n", $string);
 
         if (empty($lines)) {
             return 0;

--- a/lib/Completion/Bridge/WorseReflection/Formatter/ParameterFormatter.php
+++ b/lib/Completion/Bridge/WorseReflection/Formatter/ParameterFormatter.php
@@ -25,7 +25,7 @@ class ParameterFormatter implements Formatter
         $paramInfo[] = '$' . $object->name();
 
         if ($object->default()->isDefined()) {
-            $paramInfo[] = '= '. str_replace(PHP_EOL, '', var_export($object->default()->value(), true));
+            $paramInfo[] = '= '. str_replace("\n", '', var_export($object->default()->value(), true));
         }
         return implode(' ', $paramInfo);
     }

--- a/lib/Completion/Tests/Benchmark/Code/Example1.php.test
+++ b/lib/Completion/Tests/Benchmark/Code/Example1.php.test
@@ -75,7 +75,7 @@ class Example1
     private function getOffetToReflect($source, $offset)
     {
         /** @var string $source */
-        $source = str_replace(PHP_EOL, ' ', $source);
+        $source = str_replace("\n", ' ', $source);
         $untilCursor = substr($source, 0, $offset);
 
         $pos = strlen($untilCursor) - 1;
@@ -123,7 +123,7 @@ class Example1
             $paramInfo[] = '$' . $parameter->name();
 
             if ($parameter->default()->isDefined()) {
-                $paramInfo[] = '= '. str_replace(PHP_EOL, '', var_export($parameter->default()->value(), true));
+                $paramInfo[] = '= '. str_replace("\n", '', var_export($parameter->default()->value(), true));
             }
             $paramInfos[] = implode(' ', $paramInfo);
         }

--- a/lib/Completion/Tests/Unit/Core/Util/OffsetHelperTest.php
+++ b/lib/Completion/Tests/Unit/Core/Util/OffsetHelperTest.php
@@ -38,7 +38,7 @@ class OffsetHelperTest extends TestCase
         ];
 
         yield 'extra newline' => [
-            'foobar<>' . PHP_EOL,
+            'foobar<>' . "\n",
         ];
 
         yield 'extra windows newline' => [

--- a/lib/Extension/ClassMover/Application/ClassMemberReferences.php
+++ b/lib/Extension/ClassMover/Application/ClassMemberReferences.php
@@ -163,7 +163,7 @@ class ClassMemberReferences
      */
     private function line(string $code, int $offset):array
     {
-        $lines = explode(PHP_EOL, $code);
+        $lines = explode("\n", $code);
         $number = 0;
         $startPosition = 0;
 

--- a/lib/Extension/ClassMover/Application/ClassReferences.php
+++ b/lib/Extension/ClassMover/Application/ClassReferences.php
@@ -155,7 +155,7 @@ class ClassReferences
     /** @return array{int, int, string} */
     private function line(string $code, int $offset): array
     {
-        $lines = explode(PHP_EOL, $code);
+        $lines = explode("\n", $code);
         $lineNumber = 0;
         $startPosition = 0;
 

--- a/lib/Extension/ClassMover/Command/ReferencesClassCommand.php
+++ b/lib/Extension/ClassMover/Command/ReferencesClassCommand.php
@@ -58,12 +58,12 @@ class ReferencesClassCommand extends Command
         $count = $this->renderTable($output, $results, 'references', $output->isDecorated());
 
         if ($replace) {
-            $output->write(PHP_EOL);
+            $output->write("\n");
             $output->writeln('<comment># Replacements:</>');
             $this->renderTable($output, $results, 'replacements', $output->isDecorated());
         }
 
-        $output->write(PHP_EOL);
+        $output->write("\n");
         $output->writeln(sprintf('%s reference(s)', $count));
 
         return 0;

--- a/lib/Extension/ClassMover/Command/ReferencesMemberCommand.php
+++ b/lib/Extension/ClassMover/Command/ReferencesMemberCommand.php
@@ -71,7 +71,7 @@ class ReferencesMemberCommand extends Command
         $count = $this->renderTable($output, $results, 'references', $output->isDecorated());
 
         if ($risky) {
-            $output->write(PHP_EOL);
+            $output->write("\n");
             $output->writeln('<comment># Risky (unknown classes):</>');
             $riskyCount = $this->renderTable($output, $results, 'risky_references', $output->isDecorated());
         } else {
@@ -83,12 +83,12 @@ class ReferencesMemberCommand extends Command
         }
 
         if ($replace) {
-            $output->write(PHP_EOL);
+            $output->write("\n");
             $output->writeln('<comment># Replacements:</>');
             $this->renderTable($output, $results, 'replacements', $output->isDecorated());
         }
 
-        $output->write(PHP_EOL);
+        $output->write("\n");
         $output->writeln(sprintf('%s reference(s), %s risky references', $count, $riskyCount));
 
         return 0;

--- a/lib/Extension/ClassMover/Rpc/ClassMoveHandler.php
+++ b/lib/Extension/ClassMover/Rpc/ClassMoveHandler.php
@@ -61,8 +61,8 @@ class ClassMoveHandler extends AbstractHandler
         ) {
             $this->requireInput(ConfirmInput::fromNameAndLabel(
                 self::PARAM_CONFIRMED,
-                'WARNING: This command will move the class and update ALL references in the git tree.' . PHP_EOL .
-                '         It is not guaranteed to succeed. COMMIT YOUR WORK FIRST!' . PHP_EOL .
+                'WARNING: This command will move the class and update ALL references in the git tree.' . "\n" .
+                '         It is not guaranteed to succeed. COMMIT YOUR WORK FIRST!' . "\n" .
                 'Are you sure? :'
             ));
         }

--- a/lib/Extension/Core/Command/ConfigDumpCommand.php
+++ b/lib/Extension/Core/Command/ConfigDumpCommand.php
@@ -42,7 +42,7 @@ class ConfigDumpCommand extends Command
     private function dumpMetaInformation(OutputInterface $output): void
     {
         $output->writeln('<info>Config files:</>');
-        $output->write(PHP_EOL);
+        $output->write("\n");
         foreach ($this->paths as $candidate) {
             if (!file_exists($candidate->path())) {
                 $output->write('  [✖]');
@@ -52,15 +52,15 @@ class ConfigDumpCommand extends Command
             $output->writeln(' ' .$candidate->path());
         }
 
-        $output->write(PHP_EOL);
+        $output->write("\n");
         $output->writeln('<info>File path tokens:</info>');
-        $output->write(PHP_EOL);
+        $output->write("\n");
         foreach ($this->expanders->toArray() as $tokenName => $value) {
             $output->writeln(sprintf('  <comment>%%%s%%</>: %s', $tokenName, $value));
         }
         $terminal = new Terminal();
-        $output->write(PHP_EOL);
+        $output->write("\n");
         $output->writeln(str_repeat('-', $terminal->getWidth()));
-        $output->write(PHP_EOL);
+        $output->write("\n");
     }
 }

--- a/lib/Extension/Core/Command/StatusCommand.php
+++ b/lib/Extension/Core/Command/StatusCommand.php
@@ -29,19 +29,19 @@ class StatusCommand extends Command
             implode(', ', $diagnostics['filesystems'])
         ));
         $output->writeln('<info>Working directory:</info> ' . $diagnostics['cwd']);
-        $output->write(PHP_EOL);
+        $output->write("\n");
 
         $output->writeln('<comment>Config files (missing is not bad):</>');
-        $output->write(PHP_EOL);
+        $output->write("\n");
         foreach ($diagnostics['config_files'] as $configFile => $exists) {
             $check = $exists ? '<info>✔</>' : '<error>✘</>';
             $output->writeln(sprintf('  %s %s', $check, $configFile));
         }
 
-        $output->write(PHP_EOL);
+        $output->write("\n");
 
         $output->writeln('<comment>Diagnostics:</comment>');
-        $output->write(PHP_EOL);
+        $output->write("\n");
         foreach ($diagnostics['good'] as $good) {
             $output->writeln('  <info>✔</> ' . $good);
         }
@@ -49,7 +49,7 @@ class StatusCommand extends Command
         foreach ($diagnostics['bad'] as $bad) {
             $output->writeln('  <error>✘</> ' . $bad);
         }
-        $output->write(PHP_EOL);
+        $output->write("\n");
 
         return 0;
     }

--- a/lib/Extension/Core/Rpc/StatusHandler.php
+++ b/lib/Extension/Core/Rpc/StatusHandler.php
@@ -66,7 +66,7 @@ class StatusHandler implements Handler
             'Version: ' . $diagnostics['phpactor_version'],
             'PHP: ' . sprintf('%s (supporting %s)', phpversion(), $diagnostics['php_version']),
             'Phpactor dir: ' . realpath(__DIR__ . '/../../../../'),
-            'Work dir: ' . $diagnostics['cwd'] . PHP_EOL,
+            'Work dir: ' . $diagnostics['cwd'] . "\n",
             'Diagnostics',
             '-----------',
             $this->buildSupportMessage($diagnostics),
@@ -74,16 +74,16 @@ class StatusHandler implements Handler
             '------------',
             $this->buildConfigFileMessage(),
         ];
-        return EchoResponse::fromMessage(implode(PHP_EOL, $info));
+        return EchoResponse::fromMessage(implode("\n", $info));
     }
 
     private function buildSupportMessage(array $diagnostics)
     {
-        return implode(PHP_EOL, [
-            implode(PHP_EOL, array_map(function (string $message) {
+        return implode("\n", [
+            implode("\n", array_map(function (string $message) {
                 return '[✔] ' . $message;
             }, $diagnostics['good'])),
-            implode(PHP_EOL, array_map(function (string $message) {
+            implode("\n", array_map(function (string $message) {
                 return '[✘] ' . $message;
             }, $diagnostics['bad'])),
         ]);
@@ -91,7 +91,7 @@ class StatusHandler implements Handler
 
     private function buildConfigFileMessage()
     {
-        return implode(PHP_EOL, array_map(function (PathCandidate $file) {
+        return implode("\n", array_map(function (PathCandidate $file) {
             if (file_exists($file->path())) {
                 return '[✔] ' . $file->path();
             }

--- a/lib/Extension/LanguageServer/Handler/DebugHandler.php
+++ b/lib/Extension/LanguageServer/Handler/DebugHandler.php
@@ -74,7 +74,7 @@ class DebugHandler implements Handler
             return new Success($json);
         }
 
-        $this->client->window()->logMessage()->info(implode(PHP_EOL, $message));
+        $this->client->window()->logMessage()->info(implode("\n", $message));
         return new Success(null);
     }
 
@@ -136,7 +136,7 @@ class DebugHandler implements Handler
             }
         }
 
-        return new Success(implode(PHP_EOL, $info));
+        return new Success(implode("\n", $info));
     }
 
     /**

--- a/lib/Extension/Rpc/Response/ErrorResponse.php
+++ b/lib/Extension/Rpc/Response/ErrorResponse.php
@@ -65,6 +65,6 @@ class ErrorResponse implements Response
             );
         }
 
-        return implode(PHP_EOL . PHP_EOL, $details);
+        return implode("\n" . "\n", $details);
     }
 }

--- a/lib/Extension/Rpc/Tests/Unit/Diff/TextEditBuilderTest.php
+++ b/lib/Extension/Rpc/Tests/Unit/Diff/TextEditBuilderTest.php
@@ -53,7 +53,7 @@ class TextEditBuilderTest extends TestCase
                 [
                     'start' => [ 'line' => 0, 'character' => 0 ],
                     'end' => [ 'line' => 0, 'character' => 0 ],
-                    'text' => 'new' . PHP_EOL,
+                    'text' => 'new' . "\n",
                 ],
             ],
         ];
@@ -80,7 +80,7 @@ class TextEditBuilderTest extends TestCase
                 [
                     'start' => [ 'line' => 0, 'character' => 0 ],
                     'end' => [ 'line' => 0, 'character' => 0 ],
-                    'text' => 'neworiginal' . PHP_EOL,
+                    'text' => 'neworiginal' . "\n",
                 ],
             ],
         ];

--- a/lib/Extension/WorseReflectionExtra/Application/ClassReflector.php
+++ b/lib/Extension/WorseReflectionExtra/Application/ClassReflector.php
@@ -60,7 +60,7 @@ class ClassReflector
                 }
                 $paramInfo[] = '$' . $parameter->name();
                 if ($parameter->default()->isDefined()) {
-                    $paramInfo[] = ' = ' . str_replace(PHP_EOL, '', var_export($parameter->default()->value(), true));
+                    $paramInfo[] = ' = ' . str_replace("\n", '', var_export($parameter->default()->value(), true));
                 }
                 $paramInfos[] = implode(' ', $paramInfo);
 

--- a/lib/Extension/WorseReflectionExtra/Application/OffsetInfo.php
+++ b/lib/Extension/WorseReflectionExtra/Application/OffsetInfo.php
@@ -52,7 +52,7 @@ final class OffsetInfo
                         '%s = (%s) %s',
                         $local->name(),
                         $local->nodeContext()->type(),
-                        str_replace(PHP_EOL, '', var_export($local->nodeContext()->value(), true))
+                        str_replace("\n", '', var_export($local->nodeContext()->value(), true))
                     );
 
                     $frame[$assignmentType][$local->offset()->toInt()] = $info;

--- a/lib/Extension/WorseReflectionExtra/Rpc/OffsetInfoHandler.php
+++ b/lib/Extension/WorseReflectionExtra/Rpc/OffsetInfoHandler.php
@@ -73,7 +73,7 @@ class OffsetInfoHandler implements Handler
                     '%s = (%s) %s',
                     $local->name(),
                     $local->type(),
-                    str_replace(PHP_EOL, '', var_export(TypeUtil::valueOrNull($local->type()), true))
+                    str_replace("\n", '', var_export(TypeUtil::valueOrNull($local->type()), true))
                 );
 
                 $frame[$assignmentType][$local->offset()] = $info;

--- a/lib/Indexer/Extension/Command/IndexBuildCommand.php
+++ b/lib/Indexer/Extension/Command/IndexBuildCommand.php
@@ -70,7 +70,7 @@ class IndexBuildCommand extends Command
         $job = $this->indexer->getJob($subPath);
         $output->writeln('done');
         $output->writeln('<info>Building index:</info>');
-        $output->write(PHP_EOL);
+        $output->write("\n");
 
         if ($job->size() === 0) {
             $output->writeln('No files found');
@@ -91,8 +91,8 @@ class IndexBuildCommand extends Command
         }
 
         $progress->finish();
-        $output->write(PHP_EOL);
-        $output->write(PHP_EOL);
+        $output->write("\n");
+        $output->write("\n");
 
         $output->writeln(sprintf(
             '<bg=green;fg=black;option>Done in %s seconds using %sb of memory</>',

--- a/lib/Phpactor.php
+++ b/lib/Phpactor.php
@@ -226,7 +226,7 @@ class Phpactor
 
             if (!class_exists($extensionClass)) {
                 if ($output instanceof ConsoleOutputInterface) {
-                    $output->getErrorOutput()->writeln(sprintf('<error>Extension "%s" does not exist</>', $extensionClass). PHP_EOL);
+                    $output->getErrorOutput()->writeln(sprintf('<error>Extension "%s" does not exist</>', $extensionClass). "\n");
                 }
                 continue;
             }

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UndefinedVariableProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UndefinedVariableProvider.php
@@ -329,7 +329,7 @@ class UndefinedVariableProvider implements DiagnosticProvider
             source: <<<'PHP'
                     <?php
                     if ($argc === 2) {
-                        echo "Hello ".$argv[1].PHP_EOL;
+                        echo "Hello ".$argv[1]."\n";
                     } else {
                         echo "Usage ".__FILE__. " <name>";
                     }

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionMethod.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionMethod.php
@@ -127,7 +127,7 @@ class ReflectionMethod extends AbstractReflectionClassMember implements CoreRefl
             return NodeText::fromString('');
         }
         $statements = $statement->statements;
-        return NodeText::fromString(implode(PHP_EOL, array_reduce($statements, function ($acc, $statement) {
+        return NodeText::fromString(implode("\n", array_reduce($statements, function ($acc, $statement) {
             $acc[] = (string) $statement->getText();
             return $acc;
         }, [])));

--- a/lib/WorseReflection/Core/Inference/Problems.php
+++ b/lib/WorseReflection/Core/Inference/Problems.php
@@ -30,7 +30,7 @@ final class Problems implements IteratorAggregate, Countable
             );
         }
 
-        return implode(PHP_EOL, $lines);
+        return implode("\n", $lines);
     }
 
     public static function create(): Problems

--- a/lib/WorseReflection/Tests/Smoke/smoke_test.php
+++ b/lib/WorseReflection/Tests/Smoke/smoke_test.php
@@ -48,7 +48,7 @@ $files  = new RegexIterator($files, '{.*' . $opts['pattern'] . '.*}');
 $exceptions = [];
 $count = 0;
 
-echo 'Legend: N = Not found, E = Error' . PHP_EOL . PHP_EOL;
+echo 'Legend: N = Not found, E = Error' . "\n" . "\n";
 
 /** @var SplFileInfo $file */
 foreach ($files as $file) {
@@ -61,7 +61,7 @@ foreach ($files as $file) {
         break;
     }
 
-    echo $count++ . ' ' . Path::makeRelative($file->getPathname(), getcwd()) . PHP_EOL;
+    echo $count++ . ' ' . Path::makeRelative($file->getPathname(), getcwd()) . "\n";
     $message = $file->getPathname();
     try {
         $source = TextDocumentBuilder::create(file_get_contents($file->getPathname()))->uri($file->getPathname())->build();
@@ -77,17 +77,17 @@ foreach ($files as $file) {
                 $time = microtime(true) - $time;
 
                 if ($time > $slowThreshold) {
-                    fwrite($logHandle, sprintf('%s#%s (%ss)', $class->name()->full(), $method->name(), number_format($time, 2)) . PHP_EOL);
+                    fwrite($logHandle, sprintf('%s#%s (%ss)', $class->name()->full(), $method->name(), number_format($time, 2)) . "\n");
                     echo 'S';
                 }
             }
         }
     } catch (NotFound $e) {
-        fwrite($logHandle, sprintf('%s %s %s: ', 'NOT FOUND', Path::makeRelative($file->getPathname(), getcwd()), $e->getMessage()). PHP_EOL);
+        fwrite($logHandle, sprintf('%s %s %s: ', 'NOT FOUND', Path::makeRelative($file->getPathname(), getcwd()), $e->getMessage()). "\n");
         echo 'N';
     } catch (Exception $e) {
         echo 'E';
-        fwrite($logHandle, sprintf('%s %s [%s] %s', 'ERROR', $message, get_class($e), $e->getMessage()).PHP_EOL);
+        fwrite($logHandle, sprintf('%s %s [%s] %s', 'ERROR', $message, get_class($e), $e->getMessage())."\n");
         ;
         $exceptions[] = $e;
     } finally {

--- a/tests/Unit/Extension/Core/Console/Dumper/JsonDumperTest.php
+++ b/tests/Unit/Extension/Core/Console/Dumper/JsonDumperTest.php
@@ -12,7 +12,7 @@ class JsonDumperTest extends DumperTestCase
     public function testDumpsJson(): void
     {
         $output = $this->dump(['hello' => 'test']);
-        $this->assertEquals('{"hello":"test"}'.PHP_EOL, $output);
+        $this->assertEquals('{"hello":"test"}'."\n", $output);
     }
 
     protected function dumper()


### PR DESCRIPTION
It may be counterintuitive, but using PHP_EOL is usually wrong.

Just find-and-replace all occurrences. This resolves 80 test failures on Windows (out of 410).

Windows defines PHP_EOL to "\r\n" (also known as CRLF), while all other platforms define it to "\n" (a.k.a. LF). Therefore this won't break any code that works on any currently supported platform.

Some of this code may need to handle both CRLF and LF. I will look into it on a case-by-case basis as I work through the failing tests, or if I see issues in practice in an editor.

----

Why is using PHP_EOL is usually wrong?
======================================

When reading input
------------------
When reading input and trying to split it in lines, you can't assume the line endings based on the OS. Windows users often work with files using LF line endings, because that's usually how the source code of cross-platform projects is stored, and every text editor on Windows supports them, even the built-in Windows Notepad (since 2018: https://devblogs.microsoft.com/commandline/extended-eol-in-notepad/). Similarly, one could have files with CRLF line endings on Linux, if they were originally created by someone on Windows.

Git on Windows by default enables the `core.autocrlf` setting to replace LF in source code with CRLF when checking out and back when checking in, but these days it's often recommended to change it, e.g. https://jvns.ca/blog/2024/02/16/popular-git-config-options/#and-more (it used to be a good default around the time of Windows XP). If a tool replaces CRLF with LF, that's not problematic regardless of this setting (lone LF is accepted when checking in), but if it replaces LF with CRLF, that will cause line-ending diffs if that setting is disabled.

By the way, Language Server Protocol requires all of CRLF, lone LF, and lone CR to be treated as line breaks, regardless of platform: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocuments

When writing output
--------------------
When writing output consisting of multiple lines, LF line endings will usually be converted to CRLF if needed (e.g. when writing to console, or to a file opened in text mode). If they aren't converted when writing to a file, that's not a problem, because (as explained above) every text editor on Windows supports LF line endings too, and it's handled well by Git.

Using different line endings internally often causes test failures that only occur on Windows, unless you also define multiple variants of expected output.