### PR TITLE
Fixes to path handling on Windows

### DIFF
--- a/lib/Extension/ComposerAutoloader/Tests/Unit/ClassLoaderFactoryTest.php
+++ b/lib/Extension/ComposerAutoloader/Tests/Unit/ClassLoaderFactoryTest.php
@@ -5,6 +5,7 @@ namespace Phpactor\Extension\ComposerAutoloader\Tests\Unit;
 use PHPUnit\Framework\TestCase;
 use Phpactor\Extension\ComposerAutoloader\ClassLoaderFactory;
 use Psr\Log\NullLogger;
+use Symfony\Component\Filesystem\Path;
 
 class ClassLoaderFactoryTest extends TestCase
 {
@@ -13,6 +14,6 @@ class ClassLoaderFactoryTest extends TestCase
         $logger = new NullLogger();
         $loader = (new ClassLoaderFactory(__DIR__ . '/../../../../../vendor/composer', $logger))->getLoader();
         $file = $loader->findFile(__CLASS__);
-        self::assertEquals(__FILE__, $file);
+        self::assertEquals(Path::canonicalize(__FILE__), Path::canonicalize((string) $file));
     }
 }

--- a/lib/Extension/WorseReferenceFinder/Tests/Unit/WorseReferenceFinderExtensionTest.php
+++ b/lib/Extension/WorseReferenceFinder/Tests/Unit/WorseReferenceFinderExtensionTest.php
@@ -17,6 +17,7 @@ use Phpactor\ReferenceFinder\ReferenceFinder;
 use Phpactor\ReferenceFinder\TypeLocator;
 use Phpactor\TextDocument\ByteOffset;
 use Phpactor\TextDocument\TextDocumentBuilder;
+use Symfony\Component\Filesystem\Path;
 
 class WorseReferenceFinderExtensionTest extends TestCase
 {
@@ -32,7 +33,7 @@ class WorseReferenceFinderExtensionTest extends TestCase
             ByteOffset::fromInt(3)
         )->first()->location();
 
-        $this->assertEquals(realpath(__DIR__ . '/../../WorseReferenceFinderExtension.php'), $location->uri()->path());
+        $this->assertEquals(Path::canonicalize(__DIR__ . '/../../WorseReferenceFinderExtension.php'), $location->uri()->path());
     }
 
     public function testLocateType(): void

--- a/lib/Filesystem/Domain/FilePath.php
+++ b/lib/Filesystem/Domain/FilePath.php
@@ -32,8 +32,9 @@ final class FilePath
     public static function fromParts(array $parts): FilePath
     {
         $path = Path::join(...$parts);
-        if (!str_starts_with($path, '/')) {
-            $path = '/'.$path;
+        if (!Path::isAbsolute($path)) {
+            // Not sure if this makes sense… Maybe it should just throw?
+            $path = Path::makeAbsolute($path, '/');
         }
 
         return self::fromString($path);
@@ -107,7 +108,7 @@ final class FilePath
 
     public function isWithin(FilePath $path): bool
     {
-        return str_starts_with($this->path(), $path->path().'/');
+        return Path::isBasePath($path->path(), $this->path());
     }
 
     public function isWithinOrSame(FilePath $path): bool

--- a/lib/Filesystem/Tests/Unit/Domain/FilePathTest.php
+++ b/lib/Filesystem/Tests/Unit/Domain/FilePathTest.php
@@ -7,6 +7,7 @@ use Phpactor\Filesystem\Domain\FilePath;
 use Phpactor\TextDocument\Exception\InvalidUriException;
 use RuntimeException;
 use SplFileInfo;
+use Symfony\Component\Filesystem\Path;
 use stdClass;
 
 class FilePathTest extends TestCase
@@ -66,11 +67,11 @@ class FilePathTest extends TestCase
 
         yield 'SplFileInfo' => [
             new SplFileInfo(__FILE__),
-            __FILE__
+            Path::canonicalize(__FILE__)
         ];
         yield 'SplFileInfo with scheme' => [
             new SplFileInfo('file://' . __FILE__),
-            __FILE__
+            Path::canonicalize(__FILE__)
         ];
     }
 
@@ -180,7 +181,7 @@ class FilePathTest extends TestCase
     public function testAsSplFileInfo(): void
     {
         $path1 = FilePath::fromUnknown(new SplFileInfo('file://' . __FILE__));
-        self::assertEquals(__FILE__, $path1->__toString());
-        self::assertEquals(__FILE__, $path1->asSplFileInfo()->__toString());
+        self::assertEquals(Path::canonicalize(__FILE__), $path1->__toString());
+        self::assertEquals(Path::canonicalize(__FILE__), $path1->asSplFileInfo()->__toString());
     }
 }

--- a/lib/Indexer/Tests/Unit/Adapter/Worse/IndexerClassSourceLocatorTest.php
+++ b/lib/Indexer/Tests/Unit/Adapter/Worse/IndexerClassSourceLocatorTest.php
@@ -9,6 +9,7 @@ use Phpactor\Indexer\Adapter\Php\InMemory\InMemoryIndex;
 use Phpactor\Indexer\Adapter\Worse\IndexerClassSourceLocator;
 use Phpactor\WorseReflection\Core\Exception\SourceNotFound;
 use Phpactor\WorseReflection\Core\Name;
+use Symfony\Component\Filesystem\Path;
 
 class IndexerClassSourceLocatorTest extends TestCase
 {
@@ -48,7 +49,7 @@ class IndexerClassSourceLocatorTest extends TestCase
         $index->write($record);
         $locator = $this->createLocator($index);
         $sourceCode = $locator->locate(Name::fromString('Foobar'));
-        $this->assertEquals(__FILE__, $sourceCode->uri()?->path());
+        $this->assertEquals(Path::canonicalize(__FILE__), $sourceCode->uri()?->path());
     }
 
     private function createLocator(InMemoryIndex $index): IndexerClassSourceLocator

--- a/lib/Indexer/Tests/Unit/Adapter/Worse/IndexerFunctionSourceLocatorTest.php
+++ b/lib/Indexer/Tests/Unit/Adapter/Worse/IndexerFunctionSourceLocatorTest.php
@@ -7,6 +7,7 @@ use Phpactor\Indexer\Model\Name\FullyQualifiedName;
 use Phpactor\Indexer\Adapter\Php\InMemory\InMemoryIndex;
 use Phpactor\Indexer\Adapter\Worse\IndexerFunctionSourceLocator;
 use Phpactor\Indexer\Model\Record\FunctionRecord;
+use Symfony\Component\Filesystem\Path;
 use Phpactor\WorseReflection\Core\Exception\SourceNotFound;
 use Phpactor\WorseReflection\Core\Name;
 
@@ -44,7 +45,7 @@ class IndexerFunctionSourceLocatorTest extends TestCase
         $index->write($record);
         $locator = $this->createLocator($index);
         $sourceCode = $locator->locate(Name::fromString('Foobar'));
-        $this->assertEquals(__FILE__, $sourceCode->uri()?->path());
+        $this->assertEquals(Path::canonicalize(__FILE__), $sourceCode->uri()?->path());
     }
 
     private function createLocator(InMemoryIndex $index): IndexerFunctionSourceLocator

--- a/lib/Phpactor.php
+++ b/lib/Phpactor.php
@@ -296,13 +296,13 @@ class Phpactor
      */
     public static function normalizePath(string $path): string
     {
-        return Path::makeAbsolute($path, (string) getcwd());
+        return Path::makeAbsolute($path, (string)getcwd());
     }
 
     public static function relativizePath(string $path): string
     {
-        if (str_starts_with($path, (string)getcwd())) {
-            return substr($path, strlen((string) getcwd()) + 1);
+        if (Path::isBasePath((string)getcwd(), $path)) {
+            return Path::makeRelative($path, (string)getcwd());
         }
 
         return $path;

--- a/lib/TextDocument/Tests/Unit/TextDocumentBuilderTest.php
+++ b/lib/TextDocument/Tests/Unit/TextDocumentBuilderTest.php
@@ -5,6 +5,7 @@ namespace Phpactor\TextDocument\Tests\Unit;
 use PHPUnit\Framework\TestCase;
 use Phpactor\TextDocument\Exception\TextDocumentNotFound;
 use Phpactor\TextDocument\TextDocumentBuilder;
+use Symfony\Component\Filesystem\Path;
 
 class TextDocumentBuilderTest extends TestCase
 {
@@ -22,7 +23,7 @@ class TextDocumentBuilderTest extends TestCase
     public function testFromUri(): void
     {
         $doc = TextDocumentBuilder::fromUri('file://' . __FILE__)->build();
-        $this->assertEquals('file://' . __FILE__, $doc->uri());
+        $this->assertEquals('file://' . Path::canonicalize(__FILE__), $doc->uri());
         $this->assertEquals(file_get_contents(__FILE__), $doc->__toString());
     }
 

--- a/lib/TextDocument/Tests/Unit/TextDocumentUriTest.php
+++ b/lib/TextDocument/Tests/Unit/TextDocumentUriTest.php
@@ -5,13 +5,14 @@ namespace Phpactor\TextDocument\Tests\Unit;
 use PHPUnit\Framework\TestCase;
 use Phpactor\TextDocument\Exception\InvalidUriException;
 use Phpactor\TextDocument\TextDocumentUri;
+use Symfony\Component\Filesystem\Path;
 
 class TextDocumentUriTest extends TestCase
 {
     public function testCreate(): void
     {
         $uri = TextDocumentUri::fromString('file://' . __FILE__);
-        $this->assertEquals('file://' . __FILE__, (string) $uri);
+        $this->assertEquals('file://' . Path::canonicalize(__FILE__), (string) $uri);
     }
 
     public function testCreateUntitled(): void
@@ -23,13 +24,13 @@ class TextDocumentUriTest extends TestCase
     public function testCreatePhar(): void
     {
         $uri = TextDocumentUri::fromString('phar://' . __FILE__);
-        $this->assertEquals('phar://' . __FILE__, (string) $uri);
+        $this->assertEquals('phar://' . Path::canonicalize(__FILE__), (string) $uri);
     }
 
     public function testNormalizesToFileScheme(): void
     {
         $uri = TextDocumentUri::fromString(__FILE__);
-        $this->assertEquals('file://' . __FILE__, (string) $uri);
+        $this->assertEquals('file://' . Path::canonicalize(__FILE__), (string) $uri);
     }
 
     public function testExceptionOnNonAbsolutePath(): void
@@ -69,7 +70,7 @@ class TextDocumentUriTest extends TestCase
     public function testReturnsPath(): void
     {
         $uri = TextDocumentUri::fromString('file://' . __FILE__);
-        $this->assertEquals(__FILE__, $uri->path());
+        $this->assertEquals(Path::canonicalize(__FILE__), $uri->path());
     }
 
     public function testScheme(): void

--- a/lib/WorseReflection/Tests/Integration/Bridge/Phpactor/ClassToFileSourceLocatorTest.php
+++ b/lib/WorseReflection/Tests/Integration/Bridge/Phpactor/ClassToFileSourceLocatorTest.php
@@ -7,6 +7,7 @@ use Phpactor\ClassFileConverter\ClassToFileConverter;
 use Phpactor\WorseReflection\Bridge\Phpactor\ClassToFileSourceLocator;
 use Phpactor\WorseReflection\Core\ClassName;
 use Phpactor\WorseReflection\Core\Exception\SourceNotFound;
+use Symfony\Component\Filesystem\Path;
 
 class ClassToFileSourceLocatorTest extends IntegrationTestCase
 {
@@ -25,7 +26,7 @@ class ClassToFileSourceLocatorTest extends IntegrationTestCase
     {
         $source = $this->locator->locate(ClassName::fromString(__CLASS__));
         $this->assertEquals(file_get_contents(__FILE__), (string) $source);
-        $this->assertEquals(__FILE__, $source->uri()->path());
+        $this->assertEquals(Path::canonicalize(__FILE__), $source->uri()->path());
     }
 
     /**

--- a/lib/WorseReflection/Tests/Unit/Bridge/Composer/ComposerSourceLocatorTest.php
+++ b/lib/WorseReflection/Tests/Unit/Bridge/Composer/ComposerSourceLocatorTest.php
@@ -5,6 +5,7 @@ namespace Phpactor\WorseReflection\Tests\Unit\Bridge\Composer;
 use PHPUnit\Framework\TestCase;
 use Phpactor\WorseReflection\Bridge\Composer\ComposerSourceLocator;
 use Phpactor\WorseReflection\Core\Name;
+use Symfony\Component\Filesystem\Path;
 
 class ComposerSourceLocatorTest extends TestCase
 {
@@ -13,6 +14,6 @@ class ComposerSourceLocatorTest extends TestCase
         $autoloader = require(__DIR__ . '/../../../../../../vendor/autoload.php');
         $locator = new ComposerSourceLocator($autoloader);
         $sourceCode = $locator->locate(Name::fromString(ComposerSourceLocatorTest::class));
-        $this->assertEquals(__FILE__, realpath($sourceCode->uri()->path()));
+        $this->assertEquals(Path::canonicalize(__FILE__), $sourceCode->uri()->path());
     }
 }

--- a/lib/WorseReflection/Tests/Unit/Core/SourceCodeLocator/NativeReflectionFunctionSourceLocatorTest.php
+++ b/lib/WorseReflection/Tests/Unit/Core/SourceCodeLocator/NativeReflectionFunctionSourceLocatorTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Phpactor\WorseReflection\Core\Exception\SourceNotFound;
 use Phpactor\WorseReflection\Core\Name;
 use Phpactor\WorseReflection\Core\SourceCodeLocator\NativeReflectionFunctionSourceLocator;
+use Symfony\Component\Filesystem\Path;
 
 class NativeReflectionFunctionSourceLocatorTest extends TestCase
 {
@@ -22,7 +23,7 @@ class NativeReflectionFunctionSourceLocatorTest extends TestCase
     public function testLocatesAFunction(): void
     {
         $location = $this->locator->locate(Name::fromString(__NAMESPACE__ . '\\test_function'));
-        $this->assertEquals(__FILE__, $location->uri()->path());
+        $this->assertEquals(Path::canonicalize(__FILE__), $location->uri()->path());
         $this->assertEquals(file_get_contents(__FILE__), $location->__toString());
     }
 

--- a/tests/Unit/Extension/CodeTransformExtra/Rpc/GenerateMethodHandlerTest.php
+++ b/tests/Unit/Extension/CodeTransformExtra/Rpc/GenerateMethodHandlerTest.php
@@ -13,6 +13,7 @@ use Phpactor\TextDocument\TextDocumentUri;
 use Phpactor\TextDocument\TextEdit;
 use Phpactor\TextDocument\TextEdits;
 use Prophecy\Prophecy\ObjectProphecy;
+use Symfony\Component\Filesystem\Path;
 use function Safe\file_get_contents;
 
 class GenerateMethodHandlerTest extends HandlerTestCase
@@ -52,7 +53,7 @@ class GenerateMethodHandlerTest extends HandlerTestCase
 
         $this->assertInstanceOf(UpdateFileSourceResponse::class, $response);
         assert($response instanceof UpdateFileSourceResponse);
-        $this->assertEquals(__FILE__, $response->path());
+        $this->assertEquals(Path::canonicalize(__FILE__), $response->path());
         $this->assertEquals($thisFileContents, $response->oldSource());
         $this->assertEquals($thisFileContents.'1', $response->newSource());
     }


### PR DESCRIPTION
Paths don't start with '/', so use helpers for absolute/relative path, and may use both '/' and '\\', so canonicalize before comparing them.

This resolves 26 test failures on Windows.