### PR TITLE
Make the use of POSIX signals optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,6 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
-        "ext-pcntl": "*",
-        "ext-posix": "*",
         "composer/package-versions-deprecated": "^1.0",
         "composer/xdebug-handler": "^3.0",
         "symfony/yaml": "^5.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a044eaa949abdb83f0b7016bce043818",
+    "content-hash": "55d034d81228b48fcbd465b90d17ce93",
     "packages": [
         {
             "name": "amphp/amp",
@@ -7940,9 +7940,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.1",
-        "ext-pcntl": "*",
-        "ext-posix": "*"
+        "php": "^8.1"
     },
     "platform-dev": [],
     "platform-overrides": {

--- a/lib/Indexer/Extension/Command/IndexBuildCommand.php
+++ b/lib/Indexer/Extension/Command/IndexBuildCommand.php
@@ -106,12 +106,15 @@ class IndexBuildCommand extends Command
         Loop::run(function () use ($output) {
             $process = yield $this->watcher->watch();
 
-            Loop::onSignal(SIGINT, function () use ($output, $process): void {
-                $output->write('Shutting down watchers...');
-                $process->stop();
-                $output->writeln('done');
-                Loop::stop();
-            });
+            // Signals are not supported on Windows
+            if(defined('SIGINT')) {
+                Loop::onSignal(SIGINT, function () use ($output, $process): void {
+                    $output->write('Shutting down watchers...');
+                    $process->stop();
+                    $output->writeln('done');
+                    Loop::stop();
+                });
+            }
 
             $output->writeln(sprintf('<info>Watching for file changes with </>%s<info>...</>', $this->watcher->describe()));
 


### PR DESCRIPTION
Signals are not supported on Windows, and gracefully shutting down everything doesn't seem necessary if we're about to exit anyway.