### PR TITLE
Add files not needed at runtime to export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,7 +6,17 @@
 # archive files. See http://git-scm.com/docs/gitattributes for details.
 .gitattributes          export-ignore
 .gitignore              export-ignore
+/*.neon                 export-ignore
 /.github                export-ignore
 /.php-cs-fixer.dist.php export-ignore
+/Makefile               export-ignore
+/box.json               export-ignore
+/doc/                   export-ignore
+/docker-compose.yml     export-ignore
+/docker/                export-ignore
+/flake.*                export-ignore
+/lib/**/Tests/          export-ignore
+/phpbench.json          export-ignore
 /phpunit.xml.dist       export-ignore
+/test.php               export-ignore
 /tests/                 export-ignore


### PR DESCRIPTION
Add files that are not needed for execution, such as test code, documentation, configuration files for CI, to `.gitattributes`.

refs https://github.com/phpactor/phpactor/pull/2435, https://github.com/phpactor/phpactor/pull/2433

You can check the list of exported files by following the steps below:

```
$ git checkout master
$ git archive HEAD | tar -t > ~/before-files.txt
$ git checkout add-export-ignore
$ git archive HEAD | tar -t > ~/after-files.txt
$ diff -u ~/before-files.txt ~/after-files.txt
```

Complete file list and diff here: https://gist.github.com/zonuexe/61481728806abd351ba405e8a7166af0#file-files-diff