### PR TITLE
Fix parsing/generating Windows-style file: URIs

### DIFF
--- a/lib/Extension/LanguageServer/Tests/Unit/LanguageServerExtensionTest.php
+++ b/lib/Extension/LanguageServer/Tests/Unit/LanguageServerExtensionTest.php
@@ -139,10 +139,10 @@ class LanguageServerExtensionTest extends LanguageServerTestCase
     public function testRegistersCodeActionProvider(): void
     {
         $serverTester = $this->createTester();
-        $serverTester->textDocument()->open('file://foo', 'bar');
+        $serverTester->textDocument()->open('file:///foo', 'bar');
         $response = $serverTester->mustRequestAndWait(CodeActionRequest::METHOD, [
             'textDocument' => [
-                'uri' => 'file://foo'
+                'uri' => 'file:///foo'
             ],
             'range' => [
                 'start' => [ 'line' => 0, 'character' => 0, ],

--- a/lib/Extension/LanguageServerBridge/Tests/Converter/LocationConverterTest.php
+++ b/lib/Extension/LanguageServerBridge/Tests/Converter/LocationConverterTest.php
@@ -11,6 +11,7 @@ use Phpactor\Extension\LanguageServerBridge\Tests\IntegrationTestCase;
 use Phpactor\TextDocument\Location;
 use Phpactor\TextDocument\Locations;
 use Phpactor\LanguageServerProtocol\Location as LspLocation;
+use Phpactor\TextDocument\TextDocumentUri;
 
 class LocationConverterTest extends IntegrationTestCase
 {
@@ -32,7 +33,7 @@ class LocationConverterTest extends IntegrationTestCase
         ]);
 
         $expected = [
-            new LspLocation('file://' . $this->workspace()->path('test.php'), new Range(
+            new LspLocation((string)TextDocumentUri::fromString($this->workspace()->path('test.php')), new Range(
                 new Position(0, 2),
                 new Position(0, 9),
             ))
@@ -51,7 +52,7 @@ class LocationConverterTest extends IntegrationTestCase
         ]);
 
         $expected = [
-            new LspLocation('file://' . $this->workspace()->path('test.php'), new Range(
+            new LspLocation((string)TextDocumentUri::fromString($this->workspace()->path('test.php')), new Range(
                 new Position(0, 2),
                 new Position(0, 4),
             ))
@@ -71,7 +72,7 @@ class LocationConverterTest extends IntegrationTestCase
 
         $location = Location::fromPathAndOffsets($this->workspace()->path('test.php'), $start, $end);
 
-        $uri = 'file://' . $this->workspace()->path('test.php');
+        $uri = (string)TextDocumentUri::fromString($this->workspace()->path('test.php'));
 
         self::assertEquals(
             expected: new LspLocation($uri, $expectedRange),

--- a/lib/Extension/LanguageServerPhpstan/Tests/Provider/PhpstanDiagnosticProviderTest.php
+++ b/lib/Extension/LanguageServerPhpstan/Tests/Provider/PhpstanDiagnosticProviderTest.php
@@ -37,7 +37,7 @@ class PhpstanDiagnosticProviderTest extends TestCase
      */
     public function testHandleSingle(): void
     {
-        $updated = new TextDocumentUpdated(ProtocolFactory::versionedTextDocumentIdentifier('file://path', 12), 'asd');
+        $updated = new TextDocumentUpdated(ProtocolFactory::versionedTextDocumentIdentifier('file:///path', 12), 'asd');
         $this->tester->textDocument()->open('file:///path', 'asd');
 
         wait(delay(10));

--- a/lib/Extension/LanguageServerPsalm/Tests/DiagnosticProvider/PsalmDiagnosticProviderTest.php
+++ b/lib/Extension/LanguageServerPsalm/Tests/DiagnosticProvider/PsalmDiagnosticProviderTest.php
@@ -33,7 +33,7 @@ class PsalmDiagnosticProviderTest extends TestCase
 
     public function testHandleSingle(): void
     {
-        $updated = new TextDocumentUpdated(ProtocolFactory::versionedTextDocumentIdentifier('file://path', 12), 'asd');
+        $updated = new TextDocumentUpdated(ProtocolFactory::versionedTextDocumentIdentifier('file:///path', 12), 'asd');
         $this->tester->textDocument()->open('file:///path', 'asd');
 
         wait(delay(10));

--- a/lib/Filesystem/Tests/Unit/Domain/FilePathTest.php
+++ b/lib/Filesystem/Tests/Unit/Domain/FilePathTest.php
@@ -5,6 +5,7 @@ namespace Phpactor\Filesystem\Tests\Unit\Domain;
 use PHPUnit\Framework\TestCase;
 use Phpactor\Filesystem\Domain\FilePath;
 use Phpactor\TextDocument\Exception\InvalidUriException;
+use Phpactor\TextDocument\TextDocumentUri;
 use RuntimeException;
 use SplFileInfo;
 use Symfony\Component\Filesystem\Path;
@@ -50,9 +51,14 @@ class FilePathTest extends TestCase
             '/foo.php'
         ];
 
-        yield 'URI string' => [
+        yield 'URI string (Unix style)' => [
             'file:///foo.php',
             '/foo.php',
+        ];
+
+        yield 'URI string (Windows style)' => [
+            'file:///C:/foo.php',
+            'C:/foo.php',
         ];
 
         yield 'PHAR string' => [
@@ -70,7 +76,7 @@ class FilePathTest extends TestCase
             Path::canonicalize(__FILE__)
         ];
         yield 'SplFileInfo with scheme' => [
-            new SplFileInfo('file://' . __FILE__),
+            new SplFileInfo((string)TextDocumentUri::fromString(__FILE__)),
             Path::canonicalize(__FILE__)
         ];
     }
@@ -180,7 +186,7 @@ class FilePathTest extends TestCase
 
     public function testAsSplFileInfo(): void
     {
-        $path1 = FilePath::fromUnknown(new SplFileInfo('file://' . __FILE__));
+        $path1 = FilePath::fromUnknown(new SplFileInfo((string)TextDocumentUri::fromString(__FILE__)));
         self::assertEquals(Path::canonicalize(__FILE__), $path1->__toString());
         self::assertEquals(Path::canonicalize(__FILE__), $path1->asSplFileInfo()->__toString());
     }

--- a/lib/TextDocument/Tests/Unit/TextDocumentBuilderTest.php
+++ b/lib/TextDocument/Tests/Unit/TextDocumentBuilderTest.php
@@ -5,7 +5,7 @@ namespace Phpactor\TextDocument\Tests\Unit;
 use PHPUnit\Framework\TestCase;
 use Phpactor\TextDocument\Exception\TextDocumentNotFound;
 use Phpactor\TextDocument\TextDocumentBuilder;
-use Symfony\Component\Filesystem\Path;
+use Phpactor\TextDocument\TextDocumentUri;
 
 class TextDocumentBuilderTest extends TestCase
 {
@@ -22,8 +22,9 @@ class TextDocumentBuilderTest extends TestCase
 
     public function testFromUri(): void
     {
-        $doc = TextDocumentBuilder::fromUri('file://' . __FILE__)->build();
-        $this->assertEquals('file://' . Path::canonicalize(__FILE__), $doc->uri());
+        $uri = (string)TextDocumentUri::fromString(__FILE__);
+        $doc = TextDocumentBuilder::fromUri($uri)->build();
+        $this->assertEquals($uri, $doc->uri());
         $this->assertEquals(file_get_contents(__FILE__), $doc->__toString());
     }
 

--- a/lib/TextDocument/Tests/Unit/TextDocumentUriTest.php
+++ b/lib/TextDocument/Tests/Unit/TextDocumentUriTest.php
@@ -5,14 +5,28 @@ namespace Phpactor\TextDocument\Tests\Unit;
 use PHPUnit\Framework\TestCase;
 use Phpactor\TextDocument\Exception\InvalidUriException;
 use Phpactor\TextDocument\TextDocumentUri;
-use Symfony\Component\Filesystem\Path;
 
 class TextDocumentUriTest extends TestCase
 {
     public function testCreate(): void
     {
-        $uri = TextDocumentUri::fromString('file://' . __FILE__);
-        $this->assertEquals('file://' . Path::canonicalize(__FILE__), (string) $uri);
+        $uri = TextDocumentUri::fromString('file:///foo/bar.php');
+        $this->assertEquals('file:///foo/bar.php', (string) $uri);
+
+        $uri = TextDocumentUri::fromString('file:///C:/foo/bar.php');
+        $this->assertEquals('file:///C:/foo/bar.php', (string) $uri);
+    }
+
+    public function testExceptionOnInvalidFormatUnix(): void
+    {
+        $this->expectException(InvalidUriException::class);
+        TextDocumentUri::fromString('file://foo/bar.php');
+    }
+
+    public function testExceptionOnInvalidFormatWindows(): void
+    {
+        $this->expectException(InvalidUriException::class);
+        TextDocumentUri::fromString('file://C:/foo/bar.php');
     }
 
     public function testCreateUntitled(): void
@@ -23,14 +37,16 @@ class TextDocumentUriTest extends TestCase
 
     public function testCreatePhar(): void
     {
-        $uri = TextDocumentUri::fromString('phar://' . __FILE__);
-        $this->assertEquals('phar://' . Path::canonicalize(__FILE__), (string) $uri);
+        $uri = TextDocumentUri::fromString('phar:///foo/bar.php');
+        $this->assertEquals('phar:///foo/bar.php', (string) $uri);
     }
 
     public function testNormalizesToFileScheme(): void
     {
-        $uri = TextDocumentUri::fromString(__FILE__);
-        $this->assertEquals('file://' . Path::canonicalize(__FILE__), (string) $uri);
+        $uri = TextDocumentUri::fromString('/foo/bar.php');
+        $this->assertEquals('file:///foo/bar.php', (string) $uri);
+        $uri = TextDocumentUri::fromString('C:/foo/bar.php');
+        $this->assertEquals('file:///C:/foo/bar.php', (string) $uri);
     }
 
     public function testExceptionOnNonAbsolutePath(): void
@@ -53,12 +69,6 @@ class TextDocumentUriTest extends TestCase
         TextDocumentUri::fromString('file://');
     }
 
-    public function testFromPath(): void
-    {
-        $uri = TextDocumentUri::fromString('/foobar');
-        $this->assertEquals('file:///foobar', $uri->__toString());
-    }
-
     public function testFromHttpUri(): void
     {
         $this->expectException(InvalidUriException::class);
@@ -66,16 +76,19 @@ class TextDocumentUriTest extends TestCase
         $uri = TextDocumentUri::fromString('http://foobar/foobar');
     }
 
-
     public function testReturnsPath(): void
     {
-        $uri = TextDocumentUri::fromString('file://' . __FILE__);
-        $this->assertEquals(Path::canonicalize(__FILE__), $uri->path());
+        $uri = TextDocumentUri::fromString('file:///foo/bar.php');
+        $this->assertEquals('/foo/bar.php', $uri->path());
+        $uri = TextDocumentUri::fromString('file:///C:/foo/bar.php');
+        $this->assertEquals('C:/foo/bar.php', $uri->path());
     }
 
     public function testScheme(): void
     {
-        $uri = TextDocumentUri::fromString('file://' . __FILE__);
+        $uri = TextDocumentUri::fromString('file:///foo/bar.php');
+        $this->assertEquals('file', $uri->scheme());
+        $uri = TextDocumentUri::fromString('file:///C:/foo/bar.php');
         $this->assertEquals('file', $uri->scheme());
     }
 }

--- a/lib/TextDocument/TextDocumentUri.php
+++ b/lib/TextDocument/TextDocumentUri.php
@@ -21,9 +21,12 @@ class TextDocumentUri
         if ($this->scheme === self::SCHEME_UNTITLED) {
             return sprintf('%s:%s', $this->scheme, $this->path);
         }
-        return sprintf('%s://%s', $this->scheme, $this->path);
+        return sprintf('%s:///%s', $this->scheme, ltrim($this->path, '/'));
     }
 
+    /**
+     * Construct a TextDocumentUri from a URI string or a filesystem path.
+     */
     public static function fromString(?string $uri): self
     {
         if ($uri === null || $uri === '') {
@@ -37,42 +40,50 @@ class TextDocumentUri
             return new self(self::SCHEME_UNTITLED, substr($uri, 9));
         }
 
-        $match = preg_match('{^(?<scheme>[a-z]+://){0,1}(?<path>.+)?}', $uri, $components);
+        $match = preg_match('{^(?<scheme>[a-z]+://)?(?<path>.+)?}', $uri, $components, PREG_UNMATCHED_AS_NULL);
+        ['scheme' => $scheme, 'path' => $path] = $components;
 
-        if (!isset($components['scheme']) || $components['scheme'] == '') {
-            $components['scheme'] = self::SCHEME_FILE;
-        } else {
-            $components['scheme'] = substr($components['scheme'], 0, -3);
-        }
-
-        if (!isset($components['path'])) {
+        if ($path === null) {
             throw new InvalidUriException(sprintf(
                 'URI "%s" has no path component',
                 $uri
             ));
         }
 
-        if (!in_array($components['scheme'], self::SCHEMES)) {
+        if ($scheme === null) {
+            // Allow this function to accept filesystem paths too (not URIs), convert to file: URIs
+
+            if (!Path::isAbsolute($path)) {
+                throw new InvalidUriException(sprintf(
+                    'Filesystem path must be absolute, got "%s"',
+                    $path
+                ));
+            }
+
+            $path = Path::canonicalize($path);
+            return new self(self::SCHEME_FILE, $path);
+        }
+
+
+        $scheme = substr($scheme, 0, -3);
+
+        if (!in_array($scheme, self::SCHEMES)) {
             throw new InvalidUriException(sprintf(
                 'Only "%s" schemes are supported, got "%s"',
                 implode('", "', self::SCHEMES),
-                $components['scheme']
+                $scheme
             ));
         }
 
-        if ($components['scheme'] === self::SCHEME_FILE && false === Path::isAbsolute($uri)) {
+        if ($scheme === self::SCHEME_FILE && !str_starts_with($path, '/')) {
             throw new InvalidUriException(sprintf(
                 'URI for file:// must be absolute, got "%s"',
                 $uri
             ));
         }
 
-        $components['path'] = Path::canonicalize($components['path']);
-
-        return new self(
-            $components['scheme'],
-            $components['path']
-        );
+        $path = Path::makeAbsolute(substr($path, 1), '/');
+        return new self($scheme, $path);
     }
 
     public function path(): string


### PR DESCRIPTION
This fixes features like "go to definition" on Windows.

In a file: URI, after the scheme, there are two slashes, then the 'host' (usually empty), then another slash, then the 'path'. For example:

  file:///foo/bar.php
  file:///C:/foo/bar.php

That's three leading slashes total, and the third slash is not a part of the path, but a part of the URI format itself; it just looks like that with Unix-style filesystem paths.

Unfortunately, this means you can't just prepend 'file://' to a filesystem path and get a valid file: URI. Fortunately, `TextDocumentUri::fromString(…)` accepts filesystem paths too, so document that and use it in test cases. Replace invalid URIs with two slashes in other test cases too to avoid confusion.

See: https://en.wikipedia.org/wiki/File_URI_scheme