### PR TITLE
Add enum to lsp symbol provider

### DIFF
--- a/lib/Extension/LanguageServerSymbolProvider/Adapter/TolerantDocumentSymbolProvider.php
+++ b/lib/Extension/LanguageServerSymbolProvider/Adapter/TolerantDocumentSymbolProvider.php
@@ -9,11 +9,14 @@ use Microsoft\PhpParser\Node\ClassMembersNode;
 use Microsoft\PhpParser\Node\ConstElement;
 use Microsoft\PhpParser\Node\DelimitedList\ConstElementList;
 use Microsoft\PhpParser\Node\DelimitedList\ExpressionList;
+use Microsoft\PhpParser\Node\EnumCaseDeclaration;
+use Microsoft\PhpParser\Node\EnumMembers;
 use Microsoft\PhpParser\Node\Expression\Variable;
 use Microsoft\PhpParser\Node\InterfaceMembers;
 use Microsoft\PhpParser\Node\MethodDeclaration;
 use Microsoft\PhpParser\Node\PropertyDeclaration;
 use Microsoft\PhpParser\Node\Statement\ClassDeclaration;
+use Microsoft\PhpParser\Node\Statement\EnumDeclaration;
 use Microsoft\PhpParser\Node\Statement\FunctionDeclaration;
 use Microsoft\PhpParser\Node\Statement\InterfaceDeclaration;
 use Microsoft\PhpParser\Node\Statement\TraitDeclaration;
@@ -133,7 +136,7 @@ class TolerantDocumentSymbolProvider implements DocumentSymbolProvider
                     PositionConverter::intByteOffsetToPosition($node->name->getStartPosition(), $source),
                     PositionConverter::intByteOffsetToPosition($node->name->getEndPosition(), $source)
                 ),
-                children: []
+                children: $this->buildNodes($this->memberNodes($node), $source)
             );
         }
 
@@ -171,6 +174,38 @@ class TolerantDocumentSymbolProvider implements DocumentSymbolProvider
             );
         }
 
+        if ($node instanceof EnumDeclaration) {
+            return new DocumentSymbol(
+                (string)$node->name->getText($source),
+                SymbolKind::ENUM,
+                new Range(
+                    PositionConverter::intByteOffsetToPosition($node->getStartPosition(), $source),
+                    PositionConverter::intByteOffsetToPosition($node->getEndPosition(), $source)
+                ),
+                new Range(
+                    PositionConverter::intByteOffsetToPosition($node->name->getStartPosition(), $source),
+                    PositionConverter::intByteOffsetToPosition($node->name->getEndPosition(), $source)
+                ),
+                children: $this->buildNodes($this->memberNodes($node), $source)
+            );
+        }
+
+        if ($node instanceof EnumCaseDeclaration) {
+            return new DocumentSymbol(
+                (string)$node->name->getText($source),
+                SymbolKind::ENUM_MEMBER,
+                new Range(
+                    PositionConverter::intByteOffsetToPosition($node->getStartPosition(), $source),
+                    PositionConverter::intByteOffsetToPosition($node->getEndPosition(), $source)
+                ),
+                new Range(
+                    PositionConverter::intByteOffsetToPosition($node->name->getStartPosition(), $source),
+                    PositionConverter::intByteOffsetToPosition($node->name->getEndPosition(), $source)
+                ),
+                children: $this->buildNodes($this->memberNodes($node), $source)
+            );
+        }
+
         return null;
     }
 
@@ -181,12 +216,12 @@ class TolerantDocumentSymbolProvider implements DocumentSymbolProvider
                 $node instanceof InterfaceMembers ||
                 $node instanceof TraitMembers ||
                 $node instanceof ClassMembersNode ||
+                $node instanceof EnumMembers ||
                 $node instanceof MethodDeclaration ||
                 $node instanceof PropertyDeclaration ||
                 $node instanceof ClassConstDeclaration ||
                 ($node instanceof ExpressionList && $node->parent instanceof PropertyDeclaration) ||
-                ($node instanceof ConstElementList && $node->parent instanceof ClassConstDeclaration)
-            ;
+                ($node instanceof ConstElementList && $node->parent instanceof ClassConstDeclaration);
         });
     }
 }

--- a/lib/Extension/LanguageServerSymbolProvider/Adapter/TolerantDocumentSymbolProvider.php
+++ b/lib/Extension/LanguageServerSymbolProvider/Adapter/TolerantDocumentSymbolProvider.php
@@ -136,7 +136,7 @@ class TolerantDocumentSymbolProvider implements DocumentSymbolProvider
                     PositionConverter::intByteOffsetToPosition($node->name->getStartPosition(), $source),
                     PositionConverter::intByteOffsetToPosition($node->name->getEndPosition(), $source)
                 ),
-                children: $this->buildNodes($this->memberNodes($node), $source)
+                children: []
             );
         }
 

--- a/lib/Extension/LanguageServerSymbolProvider/Adapter/TolerantDocumentSymbolProvider.php
+++ b/lib/Extension/LanguageServerSymbolProvider/Adapter/TolerantDocumentSymbolProvider.php
@@ -202,7 +202,7 @@ class TolerantDocumentSymbolProvider implements DocumentSymbolProvider
                     PositionConverter::intByteOffsetToPosition($node->name->getStartPosition(), $source),
                     PositionConverter::intByteOffsetToPosition($node->name->getEndPosition(), $source)
                 ),
-                children: $this->buildNodes($this->memberNodes($node), $source)
+                children: []
             );
         }
 

--- a/lib/Extension/LanguageServerSymbolProvider/Tests/Unit/Adapter/TolerantDocumentSymbolProviderTest.php
+++ b/lib/Extension/LanguageServerSymbolProvider/Tests/Unit/Adapter/TolerantDocumentSymbolProviderTest.php
@@ -2,31 +2,378 @@
 
 namespace Phpactor\Extension\LanguageServerSymbolProvider\Tests\Unit\Adapter;
 
+use Exception;
+use Generator;
+use Phpactor\LanguageServerProtocol\DocumentSymbol;
+use Phpactor\LanguageServerProtocol\Position;
+use Phpactor\LanguageServerProtocol\Range;
+use Phpactor\LanguageServerProtocol\SymbolKind;
+use Phpactor\LanguageServer\Test\ProtocolFactory;
 use Microsoft\PhpParser\Parser;
 use PHPUnit\Framework\TestCase;
 use Phpactor\Extension\LanguageServerSymbolProvider\Adapter\TolerantDocumentSymbolProvider;
+use SebastianBergmann\RecursionContext\InvalidArgumentException;
+use PHPUnit\Framework\Exception as FrameworkException;
+use PHPUnit\Framework\ExpectationFailedException;
 
 class TolerantDocumentSymbolProviderTest extends TestCase
 {
-    public function testPropertiesInTraits(): void
+    const DUMMY_RANGE = 10000;
+
+    /**
+     * @dataProvider provideClasses
+     * @dataProvider provideInterfaces
+     * @dataProvider provideTraits
+     * @dataProvider provideFunctions
+     * @dataProvider provideEnums
+     *
+     * @param DocumentSymbol[] $expected
+     * @throws Exception
+     * @throws InvalidArgumentException
+     * @throws FrameworkException
+     * @throws ExpectationFailedException
+     */
+    public function testBuildDocumentSymbol(string $source, array $expected): void
     {
-        $provider = new TolerantDocumentSymbolProvider(new Parser());
-
-        $nodes = $provider->provideFor('<?php trait Foo { public $foo; }');
-
-        $this->assertCount(1, $nodes);
-        $this->assertIsArray($nodes[0]->children);
-        $this->assertCount(1, $nodes[0]->children);
+        $actual = (new TolerantDocumentSymbolProvider(new Parser()))->provideFor($source);
+        $this->assertTree($actual, $expected);
     }
 
-    public function testMethodsInTraits(): void
+    public function provideFunctions(): Generator
     {
-        $provider = new TolerantDocumentSymbolProvider(new Parser());
+        yield 'functions' => [
+            '<?php function bar {}',
+            [
+                new DocumentSymbol(
+                    'bar',
+                    SymbolKind::FUNCTION,
+                    $this->dummyRange(),
+                    $this->dummyRange(),
+                    null,
+                    null,
+                    children: []
+                ),
+            ]
+        ];
+    }
 
-        $nodes = $provider->provideFor('<?php trait Foo { public function foo() {} }');
+    public function provideClasses(): Generator
+    {
+        yield 'class' => [
+            '<?php class Foo {}',
+            [
+                new DocumentSymbol(
+                    'Foo',
+                    SymbolKind::CLASS_,
+                    new Range(new Position(0, 6), new Position(0, 18)),
+                    new Range(new Position(0, 12), new Position(0, 15)),
+                    null,
+                    null,
+                    children: []
+                ),
+            ]
+        ];
 
-        $this->assertCount(1, $nodes);
-        $this->assertIsArray($nodes[0]->children);
-        $this->assertCount(1, $nodes[0]->children);
+        yield 'class method' => [
+            '<?php class Foo { public function bar() {}}',
+            [
+                DocumentSymbol::fromArray([
+                    'name' => 'Foo',
+                    'kind' => SymbolKind::CLASS_,
+                    'range' => $this->dummyRange(),
+                    'selectionRange' => $this->dummyRange(),
+                    'children' => [
+                        DocumentSymbol::fromArray([
+                            'name' => 'bar',
+                            'kind' => SymbolKind::METHOD,
+                            'range' => $this->dummyRange(),
+                            'selectionRange' => $this->dummyRange(),
+                            'children' => [],
+                        ]),
+                    ]
+                ])
+            ]
+        ];
+
+        yield 'class construct' => [
+            '<?php class Foo { public function __construct() {}}',
+            [
+                DocumentSymbol::fromArray([
+                    'name' => 'Foo',
+                    'kind' => SymbolKind::CLASS_,
+                    'range' => $this->dummyRange(),
+                    'selectionRange' => $this->dummyRange(),
+                    'children' => [
+                        DocumentSymbol::fromArray([
+                            'name' => '__construct',
+                            'kind' => SymbolKind::CONSTRUCTOR,
+                            'range' => $this->dummyRange(),
+                            'selectionRange' => $this->dummyRange(),
+                            'children' => [],
+                        ]),
+                    ]
+                ])
+            ]
+        ];
+
+        yield 'class property' => [
+            '<?php class Foo { private $bar; }',
+            [
+                DocumentSymbol::fromArray([
+                    'name' => 'Foo',
+                    'kind' => SymbolKind::CLASS_,
+                    'range' => $this->dummyRange(),
+                    'selectionRange' => $this->dummyRange(),
+                    'children' => [
+                        DocumentSymbol::fromArray([
+                            'name' => 'bar',
+                            'kind' => SymbolKind::PROPERTY,
+                            'range' => $this->dummyRange(),
+                            'selectionRange' => $this->dummyRange(),
+                            'children' => [],
+                        ]),
+                    ]
+                ])
+            ]
+        ];
+
+        yield 'class constant' => [
+            '<?php class Foo { const BAR="foo"; }',
+            [
+                DocumentSymbol::fromArray([
+                    'name' => 'Foo',
+                    'kind' => SymbolKind::CLASS_,
+                    'range' => $this->dummyRange(),
+                    'selectionRange' => $this->dummyRange(),
+                    'children' => [
+                        DocumentSymbol::fromArray([
+                            'name' => 'BAR',
+                            'kind' => SymbolKind::CONSTANT,
+                            'range' => $this->dummyRange(),
+                            'selectionRange' => $this->dummyRange(),
+                            'children' => [],
+                        ]),
+                    ]
+                ])
+            ]
+        ];
+    }
+
+    public function provideInterfaces(): Generator
+    {
+        yield 'interface' => [
+            '<?php interface Foo {}',
+            [
+                new DocumentSymbol(
+                    'Foo',
+                    SymbolKind::INTERFACE,
+                    new Range(new Position(0, 6), new Position(0, 22)),
+                    new Range(new Position(0, 16), new Position(0, 19)),
+                    null,
+                    null,
+                    children: []
+                ),
+            ]
+        ];
+
+        yield 'interface method' => [
+            '<?php interface Foo { public function bar() {}}',
+            [
+                DocumentSymbol::fromArray([
+                    'name' => 'Foo',
+                    'kind' => SymbolKind::INTERFACE,
+                    'range' => $this->dummyRange(),
+                    'selectionRange' => $this->dummyRange(),
+                    'children' => [
+                        DocumentSymbol::fromArray([
+                            'name' => 'bar',
+                            'kind' => SymbolKind::METHOD,
+                            'range' => $this->dummyRange(),
+                            'selectionRange' => $this->dummyRange(),
+                            'children' => [],
+                        ]),
+                    ]
+                ])
+            ]
+        ];
+
+        yield 'interface constant' => [
+            '<?php interface Foo { const BAR="foo"; {}}',
+            [
+                DocumentSymbol::fromArray([
+                    'name' => 'Foo',
+                    'kind' => SymbolKind::INTERFACE,
+                    'range' => $this->dummyRange(),
+                    'selectionRange' => $this->dummyRange(),
+                    'children' => [
+                        DocumentSymbol::fromArray([
+                            'name' => 'BAR',
+                            'kind' => SymbolKind::CONSTANT,
+                            'range' => $this->dummyRange(),
+                            'selectionRange' => $this->dummyRange(),
+                            'children' => [],
+                        ]),
+                    ]
+                ])
+            ]
+        ];
+    }
+
+    public function provideTraits(): Generator
+    {
+        yield 'trait' => [
+            '<?php trait Foo {}',
+            [
+                new DocumentSymbol(
+                    'Foo',
+                    SymbolKind::CLASS_,
+                    $this->dummyRange(),
+                    $this->dummyRange(),
+                    null,
+                    null,
+                    children: []
+                ),
+            ]
+        ];
+
+        yield 'property in trait' => [
+            '<?php trait Foo { public $foo; }',
+            [
+                new DocumentSymbol(
+                    'Foo',
+                    SymbolKind::CLASS_,
+                    $this->dummyRange(),
+                    $this->dummyRange(),
+                    null,
+                    null,
+                    children: [
+                        DocumentSymbol::fromArray([
+                            'name' => 'foo',
+                            'kind' => SymbolKind::PROPERTY,
+                            'range' => $this->dummyRange(),
+                            'selectionRange' => $this->dummyRange(),
+                            'children' => [],
+                        ]),
+                    ]
+                ),
+            ]
+        ];
+
+        yield 'method in trait' => [
+            '<?php trait Foo { public function foo() {} }',
+            [
+                new DocumentSymbol(
+                    'Foo',
+                    SymbolKind::CLASS_,
+                    $this->dummyRange(),
+                    $this->dummyRange(),
+                    null,
+                    null,
+                    children: [
+                        DocumentSymbol::fromArray([
+                            'name' => 'foo',
+                            'kind' => SymbolKind::METHOD,
+                            'range' => $this->dummyRange(),
+                            'selectionRange' => $this->dummyRange(),
+                            'children' => [],
+                        ]),
+                    ]
+                ),
+            ]
+        ];
+    }
+
+    public function provideEnums(): Generator
+    {
+        yield 'enum' => [
+            '<?php enum Foo {}',
+            [
+                new DocumentSymbol(
+                    'Foo',
+                    SymbolKind::ENUM,
+                    $this->dummyRange(),
+                    $this->dummyRange(),
+                    null,
+                    null,
+                    children: []
+                ),
+            ]
+        ];
+
+        yield 'members of enum' => [
+            '<?php enum Foo { case BAR; case SPAM; }',
+            [
+                new DocumentSymbol(
+                    'Foo',
+                    SymbolKind::ENUM,
+                    $this->dummyRange(),
+                    $this->dummyRange(),
+                    null,
+                    null,
+                    children: [
+                        DocumentSymbol::fromArray([
+                            'name' => 'BAR',
+                            'kind' => SymbolKind::ENUM_MEMBER,
+                            'range' => $this->dummyRange(),
+                            'selectionRange' => $this->dummyRange(),
+                            'children' => [],
+                        ]),
+                        DocumentSymbol::fromArray([
+                            'name' => 'SPAM',
+                            'kind' => SymbolKind::ENUM_MEMBER,
+                            'range' => $this->dummyRange(),
+                            'selectionRange' => $this->dummyRange(),
+                            'children' => [],
+                        ]),
+                    ]
+                ),
+            ]
+        ];
+    }
+
+    private function dummyRange(): Range
+    {
+        return ProtocolFactory::range(0, 0, self::DUMMY_RANGE, 0);
+    }
+
+    /**
+     * @param DocumentSymbol[] $actual
+     * @param DocumentSymbol[] $expected
+     * @throws InvalidArgumentException
+     * @throws FrameworkException
+     * @throws ExpectationFailedException
+     */
+    private function assertTree(array $actual, array $expected): void
+    {
+        self::assertCount(count($expected), $actual, 'Expected number of children');
+
+        foreach ($actual as $index => $symbol) {
+            assert($symbol instanceof DocumentSymbol);
+            $expectedSymbol = $expected[$index];
+            self::assertNotNull($expected, 'Missing document symbol');
+            assert($expectedSymbol instanceof DocumentSymbol);
+
+            if ($expectedSymbol->range->end->line === self::DUMMY_RANGE) {
+                $expectedSymbol->range = $symbol->range;
+            }
+            if ($expectedSymbol->selectionRange->end->line === self::DUMMY_RANGE) {
+                $expectedSymbol->selectionRange = $symbol->selectionRange;
+            }
+
+            $actualChildren = $symbol->children;
+            $symbol->children = [];
+            $expectedChildren = $expectedSymbol->children;
+            $expectedSymbol->children = [];
+
+            self::assertEquals($expectedSymbol, $symbol);
+            if (null !== $actualChildren) {
+                self::assertNotNull($expectedChildren);
+                if (null !== $expectedChildren) {
+                    $this->assertTree($actualChildren, $expectedChildren);
+                }
+            } else {
+                self::assertNull($expectedChildren);
+            }
+        }
     }
 }

--- a/phpbench.json
+++ b/phpbench.json
@@ -1,6 +1,9 @@
 {
     "$schema": "vendor/phpbench/phpbench/phpbench.schema.json",
     "runner.file_pattern": "*Bench.php",
+    "runner.php_config": {
+        "memory_limit": -1
+    },
     "runner.annotation_import_use": false,
     "runner.path": [
         "lib/**/Tests/Benchmark",


### PR DESCRIPTION
This PR adds enum (and enum members) support in symbol provider for the LSP. When doing a "textDocument/symbol" LSP request on a document with an enum, the result was an empty array. Now with this document : 

```php
<?php

enum TestEnum {
    case MY_CASE;
}
```

The result is this JSON : 

```json
{
  "jsonrpc": "2.0",
  "id": 3,
  "result": [
    {
      "name": "TestEnum",
      "kind": 10,
      "range": {
        "start": {
          "line": 2,
          "character": 0
        },
        "end": {
          "line": 4,
          "character": 1
        }
      },
      "selectionRange": {
        "start": {
          "line": 2,
          "character": 5
        },
        "end": {
          "line": 2,
          "character": 13
        }
      },
      "children": [
        {
          "name": "MY_CASE",
          "kind": 22,
          "range": {
            "start": {
              "line": 3,
              "character": 4
            },
            "end": {
              "line": 3,
              "character": 17
            }
          },
          "selectionRange": {
            "start": {
              "line": 3,
              "character": 9
            },
            "end": {
              "line": 3,
              "character": 16
            }
          },
          "children": []
        }
      ]
    }
  ]
}
```