### PR TITLE
Gh 2538: Disable include walker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Improvements:
   - Skip parent parameters on complete constructor #2471 @mamazu
   - Support generics on `@mixin` #2463
   - Remove "on develop warning" service #2533
+  - Disable the processing of includes/requires, it doesn't work very well but
+    it has massive performance impact on certain projects #2580
 
 Bug fixes:
 

--- a/lib/WorseReflection/Core/Inference/Walker/IncludeWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/IncludeWalker.php
@@ -17,6 +17,10 @@ use Phpactor\WorseReflection\TypeUtil;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Path;
 
+/**
+ * This walker doesn't seem to work properly, and in addition it can cause massive performance
+ * problems on legacy projects that use lots of `includes`.
+ */
 class IncludeWalker implements Walker
 {
     private Parser $parser;

--- a/lib/WorseReflection/Core/ServiceLocator.php
+++ b/lib/WorseReflection/Core/ServiceLocator.php
@@ -61,7 +61,7 @@ class ServiceLocator
         private array $memberContextResolvers,
         Cache $cache,
         private CacheForDocument $cacheForDocument,
-        bool $enableContextualLocation = false
+        bool $enableContextualLocation = false,
     ) {
         $sourceReflector = $reflectorFactory->create($this);
 
@@ -148,16 +148,6 @@ class ServiceLocator
                 new FunctionLikeWalker(),
                 new PassThroughWalker(),
                 new VariableWalker($this->docblockFactory),
-
-                // enable subset of frame walkers to enable include variables
-                // to be merged into current frame
-                new IncludeWalker($this->logger, FrameResolver::create(
-                    $this->nodeContextResolver(),
-                    [
-                        new VariableWalker($this->docblockFactory),
-                        new PassThroughWalker(),
-                    ]
-                )),
             ], $this->frameWalkers),
         );
     }

--- a/lib/WorseReflection/Core/ServiceLocator.php
+++ b/lib/WorseReflection/Core/ServiceLocator.php
@@ -13,7 +13,6 @@ use Phpactor\WorseReflection\Core\Inference\Walker;
 use Phpactor\WorseReflection\Core\Inference\Walker\DiagnosticsWalker;
 use Phpactor\WorseReflection\Core\Inference\Walker\PassThroughWalker;
 use Phpactor\WorseReflection\Core\Inference\Walker\FunctionLikeWalker;
-use Phpactor\WorseReflection\Core\Inference\Walker\IncludeWalker;
 use Phpactor\WorseReflection\Core\Inference\Walker\VariableWalker;
 use Phpactor\WorseReflection\Core\Inference\NodeToTypeConverter;
 use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;

--- a/lib/WorseReflection/Tests/Inference/SelfTest.php
+++ b/lib/WorseReflection/Tests/Inference/SelfTest.php
@@ -8,6 +8,12 @@ use Phpactor\WorseReflection\Tests\Integration\IntegrationTestCase;
 
 class SelfTest extends IntegrationTestCase
 {
+    public const DISABLED_TESTS = [
+        // disabling the includeWalker because it barely works
+        // and it causes severe performance issues.
+        'require_and_include',
+    ];
+
     /**
      * @dataProvider provideSelf
      */
@@ -29,6 +35,9 @@ class SelfTest extends IntegrationTestCase
     {
         foreach ((array)glob(__DIR__ . '/*/*.test') as $fname) {
             $dirName = basename(dirname((string)$fname));
+            if (in_array($dirName, self::DISABLED_TESTS)) {
+                continue;
+            }
             yield $dirName .' ' . basename((string)$fname) => [
                 $fname
             ];

--- a/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/IncludeWalkerTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/IncludeWalkerTest.php
@@ -18,6 +18,9 @@ class IncludeWalkerTest extends FrameWalkerTestCase
 
     public function provideWalk(): Generator
     {
+        // disabled this walker for now due to perforamnce and behavioral
+        // issues.
+        return;
         yield 'Require relative' => [
             <<<'EOT'
                 <?php


### PR DESCRIPTION
One of the contributing factores to #2438 is the include walker, which can cause a 3-5x performance penalty in certain projects.

When investigating this I noticed that it doesn't actually seem to work, at least as far as completion is concerned, and I don't want to burn more time on this so I'm just removing this functionaltiy for now.

If anybody was using this successfully we can consider ways to optimise it and include it again, but as I can't actually see any benefits in keeping it right now I'm removing it.