### PR TITLE
Add docs for Helix Editor

### DIFF
--- a/doc/lsp/clients.rst
+++ b/doc/lsp/clients.rst
@@ -10,6 +10,7 @@ Clients
    sublime
    vscode
    emacs
+   helix
 
 .. toctree::
    :hidden:

--- a/doc/lsp/helix.rst
+++ b/doc/lsp/helix.rst
@@ -1,0 +1,23 @@
+.. _lsp_client_helix:
+
+Helix Editor
+============
+
+Install Phpactor with :ref:`installation_global` then add the
+Phpactor language server configuration in your `languages.toml`
+as follows:
+
+.. code:: toml
+
+	# in <config_dir>/helix/languages.toml
+
+	[[language]]
+	name = "php"
+	scope = "source.php"
+	injection-regex = "php"
+	file-types = ["php", "inc", "php4", "php5", "phtml", "ctp"]
+	shebangs = ["php"]
+	roots = ["composer.json", "index.php"]
+	comment-token = "//"
+	language-servers = [ "phpactor" ]
+	indent = { tab-width = 4, unit = "    " }


### PR DESCRIPTION
I am using this configuration for a while.

References are:

- https://docs.helix-editor.com/languages.html
- https://github.com/helix-editor/helix/blob/d769fadde085169c26a850966a6d5d8da7cc1c12/languages.toml#L920-L929

This is the first time I edit readthedocs file, so if the format or something is bad, feel free to request me changes.
