### PR TITLE
Remove /doc/_build from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,9 +24,6 @@
 # Logging
 /application.log
 
-# docs
-/doc/_build
-
 /.php-cs-fixer.cache
 /build
 __pycache__


### PR DESCRIPTION
It seems an outdated entry. I've searched `_build` in the code but nothing found but this gitignore.

And `make docs` builds the output at `/build/html`.