### PR TITLE
Include excluded files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+Bug fixes:
+  - Fixing include and exclude patterns #2593 @mamazu
+
 ## 2024-03-09
 
 Features:
@@ -51,7 +54,7 @@ Bug fixes:
 
 Documentation:
 
-  - Added Helix LSP instructions #2581 @lens0021 
+  - Added Helix LSP instructions #2581 @lens0021
   - Fix typos in Behat #2534 @vuon9
   - Fix broken external links #2500 @einenlum
 

--- a/lib/Filesystem/Domain/FileList.php
+++ b/lib/Filesystem/Domain/FileList.php
@@ -92,6 +92,10 @@ class FileList implements Iterator
     public function includeAndExclude(array $includePatterns = [], array $excludePatterns = []): self
     {
         $inclusionMap = [];
+        if ($includePatterns === []) {
+            $inclusionMap['/**/*'] = true;
+        }
+
         foreach ($includePatterns as $includePattern) {
             $inclusionMap[$includePattern] = true;
         }

--- a/lib/Filesystem/Domain/FileList.php
+++ b/lib/Filesystem/Domain/FileList.php
@@ -104,25 +104,26 @@ class FileList implements Iterator
         }
 
         // Sort map by keys so that more specific paths are getting matched first
-        uksort($inclusionMap, function (string $x, string $y) {
-            $partsX = explode(DIRECTORY_SEPARATOR, $x);
-            $partsY = explode(DIRECTORY_SEPARATOR, $y);
-            // Longer paths should come first
-            $countDiff = -(count($partsX) <=> count($partsY));
+        uksort($inclusionMap, function (string $a, string $b) {
+            $partsA = explode(DIRECTORY_SEPARATOR, $a);
+            $partsB = explode(DIRECTORY_SEPARATOR, $b);
+            $countDiff = count($partsA) <=> count($partsB);
             if ($countDiff !== 0) {
-                return $countDiff;
+                // Longer paths should come first
+                return -$countDiff;
             }
 
-            foreach ($partsX as $i => $pathPartX) {
-                if ($pathPartX === '**' || $pathPartX === '*') {
+            foreach ($partsA as $i => $pathPartA) {
+                if ($pathPartA === '**' || $pathPartA === '*') {
                     return 1;
                 }
 
-                $compare = strcmp($pathPartX, $partsY[$i]);
+                $compare = strcmp($pathPartA, $partsB[$i]);
                 if($compare !== 0) {
                     return $compare;
                 }
             }
+            // If none of the path segments were different, then they must be equal
             return 0;
         });
 

--- a/lib/Filesystem/Domain/FileList.php
+++ b/lib/Filesystem/Domain/FileList.php
@@ -104,7 +104,27 @@ class FileList implements Iterator
         }
 
         // Sort map by keys so that more specific paths are getting matched first
-        krsort($inclusionMap);
+        uksort($inclusionMap, function (string $x, string $y) {
+            $partsX = explode(DIRECTORY_SEPARATOR, $x);
+            $partsY = explode(DIRECTORY_SEPARATOR, $y);
+            // Longer paths should come first
+            $countDiff = -(count($partsX) <=> count($partsY));
+            if ($countDiff !== 0) {
+                return $countDiff;
+            }
+
+            foreach ($partsX as $i => $pathPartX) {
+                if ($pathPartX === '**' || $pathPartX === '*') {
+                    return 1;
+                }
+
+                $compare = strcmp($pathPartX, $partsY[$i]);
+                if($compare !== 0) {
+                    return $compare;
+                }
+            }
+            return 0;
+        });
 
         return $this->filter(function (SplFileInfo $info) use ($inclusionMap): bool {
             foreach($inclusionMap as $glob => $isIncluded) {

--- a/lib/Filesystem/Tests/Unit/Domain/FileListTest.php
+++ b/lib/Filesystem/Tests/Unit/Domain/FileListTest.php
@@ -140,6 +140,22 @@ class FileListTest extends IntegrationTestCase
         ]));
     }
 
+    public function testIncludesExcludePatterns(): void
+    {
+
+        $list = FileList::fromFilePaths([
+            FilePath::fromString('/vendor/cache/important/bartest.php'),
+            FilePath::fromString('/vendor/cache/important/footest.php'),
+            FilePath::fromString('/vendor/cache/bar.php'),
+            FilePath::fromString('/vendor/cache/foo.php'),
+        ])->includeAndExclude(
+            includePatterns: [ '/src/**/*', '/vendor/cache/important/**/*'],
+            excludePatterns: [ '/vendor/**/*' ],
+        );
+
+        self::assertCount(2, $list);
+    }
+
     public function testContainingString(): void
     {
         $this->workspace()->put('one', 'one two three');

--- a/lib/Filesystem/Tests/Unit/Domain/FileListTest.php
+++ b/lib/Filesystem/Tests/Unit/Domain/FileListTest.php
@@ -176,9 +176,9 @@ class FileListTest extends IntegrationTestCase
             iterator_to_array($list)
         );
     }
+
     public function testIncludesExcludePatterns(): void
     {
-
         $list = FileList::fromFilePaths([
             FilePath::fromString('/vendor/cache/important/bartest.php'),
             FilePath::fromString('/vendor/cache/important/footest.php'),
@@ -199,12 +199,13 @@ class FileListTest extends IntegrationTestCase
     }
 
     /**
-@param array<FilePath> $fileList
-@param array<string> $includePatterns
-@param array<string> $excludePatterns
-@param array<FilePath> $expected
-* @dataProvider provideExcludesWithShortFolderName()
-*/
+     * @param array<FilePath> $fileList
+     * @param array<string> $includePatterns
+     * @param array<string> $excludePatterns
+     * @param array<FilePath> $expected
+     *
+     * @dataProvider provideExcludesWithShortFolderName
+     */
     public function testExcludesWithShortFolderName(
         array $fileList,
         array $includePatterns,

--- a/lib/Filesystem/Tests/Unit/Domain/FileListTest.php
+++ b/lib/Filesystem/Tests/Unit/Domain/FileListTest.php
@@ -121,9 +121,16 @@ class FileListTest extends IntegrationTestCase
             FilePath::fromString('/vendor/foo/bar/src/foo.php'),
         ]);
 
-        self::assertCount(2, $list->excludePatterns([
-            '/vendor/**/tests/*',
-        ]));
+        self::assertEquals(
+            [
+                FilePath::fromString('/vendor/foo/bar/src/bar.php'),
+                FilePath::fromString('/vendor/foo/bar/src/foo.php'),
+            ],
+            iterator_to_array($list->includeAndExclude(
+                includePatterns: ['/**/*'],
+                excludePatterns: [ '/vendor/**/tests/*']
+            ))
+        );
     }
 
     public function testIncldesFilesMatchingPatterns(): void
@@ -135,9 +142,15 @@ class FileListTest extends IntegrationTestCase
             FilePath::fromString('/vendor/foo/bar/src/foo.php'),
         ]);
 
-        self::assertCount(2, $list->excludePatterns([
-            '/vendor/**/tests/*',
-        ]));
+        self::assertEquals(
+            [
+                FilePath::fromString('/vendor/foo/bar/tests/bartest.php'),
+                FilePath::fromString('/vendor/foo/bar/tests/footest.php'),
+            ],
+            iterator_to_array($list->includeAndExclude(
+                includePatterns: [ '/vendor/**/tests/*'],
+            ))
+        );
     }
 
     public function testIncludesExcludePatterns(): void
@@ -153,7 +166,31 @@ class FileListTest extends IntegrationTestCase
             excludePatterns: [ '/vendor/**/*' ],
         );
 
-        self::assertCount(2, $list);
+        self::assertEquals(
+            [
+                FilePath::fromString('/vendor/cache/important/bartest.php'),
+                FilePath::fromString('/vendor/cache/important/footest.php'),
+            ],
+            iterator_to_array($list)
+        );
+    }
+
+    public function testExcludesWithShortFolderName(): void
+    {
+        $list = FileList::fromFilePaths([
+            FilePath::fromString('/src/package/test.php'),
+            FilePath::fromString('/src/a/test.php'),
+        ])->includeAndExclude(
+            includePatterns: [ '/src/**/*'],
+            excludePatterns: [ '/src/a/*' ],
+        );
+
+        self::assertEquals(
+            [
+                FilePath::fromString('/src/package/test.php'),
+            ],
+            iterator_to_array($list)
+        );
     }
 
     public function testContainingString(): void

--- a/lib/Filesystem/Tests/Unit/Domain/FileListTest.php
+++ b/lib/Filesystem/Tests/Unit/Domain/FileListTest.php
@@ -153,6 +153,28 @@ class FileListTest extends IntegrationTestCase
         );
     }
 
+    public function testIncludesEverythingByDefault(): void
+    {
+        $list = FileList::fromFilePaths([
+            FilePath::fromString('/vendor/cache/important/bartest.php'),
+            FilePath::fromString('/vendor/cache/important/footest.php'),
+            FilePath::fromString('/vendor/cache/bar.php'),
+            FilePath::fromString('/vendor/cache/foo.php'),
+        ])->includeAndExclude(
+            includePatterns: [],
+            excludePatterns: [],
+        );
+
+        self::assertEquals(
+            [
+                FilePath::fromString('/vendor/cache/important/bartest.php'),
+                FilePath::fromString('/vendor/cache/important/footest.php'),
+                FilePath::fromString('/vendor/cache/bar.php'),
+                FilePath::fromString('/vendor/cache/foo.php'),
+            ],
+            iterator_to_array($list)
+        );
+    }
     public function testIncludesExcludePatterns(): void
     {
 

--- a/lib/Indexer/Adapter/Filesystem/FilesystemFileListProvider.php
+++ b/lib/Indexer/Adapter/Filesystem/FilesystemFileListProvider.php
@@ -30,15 +30,10 @@ class FilesystemFileListProvider implements FileListProvider
             return FileList::fromSingleFilePath($subPath);
         }
 
-        $files = $this->filesystem->fileList()->byExtensions($this->supportedExtensions);
-
-        if ($this->includePatterns) {
-            $files = $files->includePatterns($this->includePatterns);
-        }
-
-        if ($this->excludePatterns) {
-            $files = $files->excludePatterns($this->excludePatterns);
-        }
+        $files = $this->filesystem->fileList()
+            ->byExtensions($this->supportedExtensions)
+            ->includeAndExclude($this->includePatterns, $this->excludePatterns)
+        ;
 
         if ($subPath) {
             $files = $files->within(FilePath::fromString($subPath));

--- a/lib/Indexer/Extension/IndexerExtension.php
+++ b/lib/Indexer/Extension/IndexerExtension.php
@@ -224,9 +224,7 @@ class IndexerExtension implements Extension
                 ->setIncludePatterns($container->get(self::SERVICE_INDEXER_INCLUDE_PATTERNS))
                 /** @phpstan-ignore-next-line */
                 ->setSupportedExtensions($container->parameter(self::PARAM_SUPPORTED_EXTENSIONS)->value())
-                ->setFollowSymlinks(
-                    (bool) $container->getParameter(self::PARAM_INDEXER_FOLLOW_SYMLINKS),
-                )
+                ->setFollowSymlinks($container->parameter(self::PARAM_INDEXER_FOLLOW_SYMLINKS)->bool())
                 ->setStubPaths($container->getParameter(self::PARAM_STUB_PATHS));
         });
 


### PR DESCRIPTION
Fixes #2485 

The include and exclude logic now allows for included paths inside excluded paths.
Also the tests for the file provider now also check that it returns the correct files and not just the count.

## How this worked before
Call `includes` to filter the list of files to include and then call `exclude` to remove files from that list that are excluded.

## How it works now
Build a map of paths and if they are included or not and tries to match all files against that map to see if they should be included or not.