### PR TITLE
GH-2412: Support for indexing and analyzing phars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
                     composer-options: "--no-scripts"
             -
                 name: "Run PHPUnit"
-                run: "php -dzend.assertions=1 vendor/bin/phpunit"
+                run: "php -dphar.readonly=0 -dzend.assertions=1 vendor/bin/phpunit"
     phpstan:
         name: "PHPStan (${{ matrix.php-version }})"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Changelog
 
 ## master
 
+Features:
+
+  - PHAR Indexing #2412 @dantleech
+
 Improvements:
 
   - Basic support for `array_reduce` stub #2576

--- a/doc/reference/configuration.rst
+++ b/doc/reference/configuration.rst
@@ -1614,7 +1614,7 @@ Type: array
 Glob patterns to include while indexing
 
 
-**Default**: ``["\/**\/*.php"]``
+**Default**: ``["\/**\/*.php","\/**\/*.phar"]``
 
 
 .. _param_indexer.exclude_patterns:
@@ -1758,7 +1758,7 @@ Type: array
 File extensions (e.g. `php`) for files that should be indexed
 
 
-**Default**: ``["php"]``
+**Default**: ``["php","phar"]``
 
 
 .. _ObjectRendererExtension:

--- a/lib/Indexer/Adapter/Filesystem/FilesystemFileListProvider.php
+++ b/lib/Indexer/Adapter/Filesystem/FilesystemFileListProvider.php
@@ -20,7 +20,7 @@ class FilesystemFileListProvider implements FileListProvider
         private Filesystem $filesystem,
         private array $includePatterns = [],
         private array $excludePatterns = [],
-        private array $supportedExtensions = ['php'],
+        private array $supportedExtensions = ['php', 'phar'],
     ) {
     }
 

--- a/lib/Indexer/Adapter/Php/Serialized/FileRepository.php
+++ b/lib/Indexer/Adapter/Php/Serialized/FileRepository.php
@@ -17,7 +17,7 @@ class FileRepository
     /**
      * Increment this number each time there is a B/C break in the index.
      */
-    private const VERSION = 1;
+    private const VERSION = 2;
 
     /**
      * Flush to the filesystem after BATCH_SIZE updates

--- a/lib/Indexer/Adapter/Tolerant/Indexer/AbstractClassLikeIndexer.php
+++ b/lib/Indexer/Adapter/Tolerant/Indexer/AbstractClassLikeIndexer.php
@@ -68,7 +68,13 @@ abstract class AbstractClassLikeIndexer implements TolerantIndexer
         if (empty($name)) {
             throw new CannotIndexNode(sprintf(
                 'Name is empty for file "%s"',
-                $document->uri()->__toString()
+                $document->uri()?->__toString() ?? 'unknown',
+            ));
+        }
+        if (!$document->uri()) {
+            throw new CannotIndexNode(sprintf(
+                'Document has no URI for class "%s"',
+                $name
             ));
         }
 

--- a/lib/Indexer/Adapter/Tolerant/Indexer/AbstractClassLikeIndexer.php
+++ b/lib/Indexer/Adapter/Tolerant/Indexer/AbstractClassLikeIndexer.php
@@ -68,7 +68,7 @@ abstract class AbstractClassLikeIndexer implements TolerantIndexer
         if (empty($name)) {
             throw new CannotIndexNode(sprintf(
                 'Name is empty for file "%s"',
-                $document->uri()->path()
+                $document->uri()->__toString()
             ));
         }
 
@@ -77,7 +77,7 @@ abstract class AbstractClassLikeIndexer implements TolerantIndexer
         /** @var ClassDeclaration|InterfaceDeclaration|EnumDeclaration|TraitDeclaration $node */
         $record->setStart(ByteOffset::fromInt($node->name->getStartPosition()));
         $record->setEnd(ByteOffset::fromInt($node->name->getEndPosition()));
-        $record->setFilePath($document->uri()->path());
+        $record->setFilePath($document->uri()->__toString());
         $record->setType($type);
 
         return $record;

--- a/lib/Indexer/Adapter/Tolerant/Indexer/AbstractClassLikeIndexer.php
+++ b/lib/Indexer/Adapter/Tolerant/Indexer/AbstractClassLikeIndexer.php
@@ -83,7 +83,7 @@ abstract class AbstractClassLikeIndexer implements TolerantIndexer
         /** @var ClassDeclaration|InterfaceDeclaration|EnumDeclaration|TraitDeclaration $node */
         $record->setStart(ByteOffset::fromInt($node->name->getStartPosition()));
         $record->setEnd(ByteOffset::fromInt($node->name->getEndPosition()));
-        $record->setFilePath($document->uri()->__toString());
+        $record->setFilePath($document->uriOrThrow());
         $record->setType($type);
 
         return $record;

--- a/lib/Indexer/Adapter/Tolerant/Indexer/ClassDeclarationIndexer.php
+++ b/lib/Indexer/Adapter/Tolerant/Indexer/ClassDeclarationIndexer.php
@@ -25,7 +25,7 @@ class ClassDeclarationIndexer extends AbstractClassLikeIndexer
         if ($node->name instanceof MissingToken) {
             throw new CannotIndexNode(sprintf(
                 'Class name is missing (maybe a reserved word) in: %s',
-                $document->uri()?->path() ?? '?',
+                $document->uri()?->__toString() ?? '?',
             ));
         }
         $record = $this->getClassLikeRecord(ClassRecord::TYPE_CLASS, $node, $index, $document);

--- a/lib/Indexer/Adapter/Tolerant/Indexer/ClassLikeReferenceIndexer.php
+++ b/lib/Indexer/Adapter/Tolerant/Indexer/ClassLikeReferenceIndexer.php
@@ -31,7 +31,7 @@ class ClassLikeReferenceIndexer extends AbstractClassLikeIndexer
 
     public function beforeParse(Index $index, TextDocument $document): void
     {
-        $fileRecord = $index->get(FileRecord::fromPath($document->uri()->__toString()));
+        $fileRecord = $index->get(FileRecord::fromPath($document->uriOrThrow()->__toString()));
         assert($fileRecord instanceof FileRecord);
 
         foreach ($fileRecord->references() as $outgoingReference) {
@@ -67,11 +67,11 @@ class ClassLikeReferenceIndexer extends AbstractClassLikeIndexer
 
         $targetRecord = $index->get(ClassRecord::fromName($name));
         assert($targetRecord instanceof ClassRecord);
-        $targetRecord->addReference($document->uri()->__toString());
+        $targetRecord->addReference($document->uriOrThrow()->__toString());
 
         $index->write($targetRecord);
 
-        $fileRecord = $index->get(FileRecord::fromPath($document->uri()->__toString()));
+        $fileRecord = $index->get(FileRecord::fromPath($document->uriOrThrow()->__toString()));
         assert($fileRecord instanceof FileRecord);
         $reference = new RecordReference(
             ClassRecord::RECORD_TYPE,

--- a/lib/Indexer/Adapter/Tolerant/Indexer/ClassLikeReferenceIndexer.php
+++ b/lib/Indexer/Adapter/Tolerant/Indexer/ClassLikeReferenceIndexer.php
@@ -31,7 +31,7 @@ class ClassLikeReferenceIndexer extends AbstractClassLikeIndexer
 
     public function beforeParse(Index $index, TextDocument $document): void
     {
-        $fileRecord = $index->get(FileRecord::fromPath($document->uri()->path()));
+        $fileRecord = $index->get(FileRecord::fromPath($document->uri()->__toString()));
         assert($fileRecord instanceof FileRecord);
 
         foreach ($fileRecord->references() as $outgoingReference) {
@@ -67,11 +67,11 @@ class ClassLikeReferenceIndexer extends AbstractClassLikeIndexer
 
         $targetRecord = $index->get(ClassRecord::fromName($name));
         assert($targetRecord instanceof ClassRecord);
-        $targetRecord->addReference($document->uri()->path());
+        $targetRecord->addReference($document->uri()->__toString());
 
         $index->write($targetRecord);
 
-        $fileRecord = $index->get(FileRecord::fromPath($document->uri()->path()));
+        $fileRecord = $index->get(FileRecord::fromPath($document->uri()->__toString()));
         assert($fileRecord instanceof FileRecord);
         $reference = new RecordReference(
             ClassRecord::RECORD_TYPE,

--- a/lib/Indexer/Adapter/Tolerant/Indexer/ConstantDeclarationIndexer.php
+++ b/lib/Indexer/Adapter/Tolerant/Indexer/ConstantDeclarationIndexer.php
@@ -95,7 +95,7 @@ class ConstantDeclarationIndexer implements TolerantIndexer
             assert($record instanceof ConstantRecord);
             $record->setStart(ByteOffset::fromInt($node->getStartPosition()));
             $record->setEnd(ByteOffset::fromInt($node->getEndPosition()));
-            $record->setFilePath($document->uri()->path());
+            $record->setFilePath($document->uriOrThrow()->__toString());
             $index->write($record);
 
             // Return after the first argument, because we only need the name of the constant.

--- a/lib/Indexer/Adapter/Tolerant/Indexer/ConstantDeclarationIndexer.php
+++ b/lib/Indexer/Adapter/Tolerant/Indexer/ConstantDeclarationIndexer.php
@@ -69,7 +69,7 @@ class ConstantDeclarationIndexer implements TolerantIndexer
             assert($record instanceof ConstantRecord);
             $record->setStart(ByteOffset::fromInt($node->getStartPosition()));
             $record->setEnd(ByteOffset::fromInt($node->getEndPosition()));
-            $record->setFilePath($document->uri()->path());
+            $record->setFilePath($document->uriOrThrow()->__toString());
             $index->write($record);
         }
     }

--- a/lib/Indexer/Adapter/Tolerant/Indexer/ConstantDeclarationIndexer.php
+++ b/lib/Indexer/Adapter/Tolerant/Indexer/ConstantDeclarationIndexer.php
@@ -69,7 +69,7 @@ class ConstantDeclarationIndexer implements TolerantIndexer
             assert($record instanceof ConstantRecord);
             $record->setStart(ByteOffset::fromInt($node->getStartPosition()));
             $record->setEnd(ByteOffset::fromInt($node->getEndPosition()));
-            $record->setFilePath($document->uriOrThrow()->__toString());
+            $record->setFilePath($document->uriOrThrow());
             $index->write($record);
         }
     }
@@ -95,7 +95,7 @@ class ConstantDeclarationIndexer implements TolerantIndexer
             assert($record instanceof ConstantRecord);
             $record->setStart(ByteOffset::fromInt($node->getStartPosition()));
             $record->setEnd(ByteOffset::fromInt($node->getEndPosition()));
-            $record->setFilePath($document->uriOrThrow()->__toString());
+            $record->setFilePath($document->uriOrThrow());
             $index->write($record);
 
             // Return after the first argument, because we only need the name of the constant.

--- a/lib/Indexer/Adapter/Tolerant/Indexer/EnumDeclarationIndexer.php
+++ b/lib/Indexer/Adapter/Tolerant/Indexer/EnumDeclarationIndexer.php
@@ -23,7 +23,7 @@ class EnumDeclarationIndexer extends AbstractClassLikeIndexer
         if ($node->name instanceof MissingToken) {
             throw new CannotIndexNode(sprintf(
                 'Class name is missing (maybe a reserved word) in: %s',
-                $document->uri()?->path() ?? '?',
+                $document->uri()?->__toString() ?? '?',
             ));
         }
         $record = $this->getClassLikeRecord(ClassRecord::TYPE_ENUM, $node, $index, $document);

--- a/lib/Indexer/Adapter/Tolerant/Indexer/FunctionDeclarationIndexer.php
+++ b/lib/Indexer/Adapter/Tolerant/Indexer/FunctionDeclarationIndexer.php
@@ -24,7 +24,7 @@ class FunctionDeclarationIndexer implements TolerantIndexer
         assert($record instanceof FunctionRecord);
         $record->setStart(ByteOffset::fromInt($node->getStartPosition()));
         $record->setEnd(ByteOffset::fromInt($node->getEndPosition()));
-        $record->setFilePath($document->uri()->path());
+        $record->setFilePath($document->uriOrThrow()->__toString());
         $index->write($record);
     }
 

--- a/lib/Indexer/Adapter/Tolerant/Indexer/FunctionDeclarationIndexer.php
+++ b/lib/Indexer/Adapter/Tolerant/Indexer/FunctionDeclarationIndexer.php
@@ -24,7 +24,7 @@ class FunctionDeclarationIndexer implements TolerantIndexer
         assert($record instanceof FunctionRecord);
         $record->setStart(ByteOffset::fromInt($node->getStartPosition()));
         $record->setEnd(ByteOffset::fromInt($node->getEndPosition()));
-        $record->setFilePath($document->uriOrThrow()->__toString());
+        $record->setFilePath($document->uriOrThrow());
         $index->write($record);
     }
 

--- a/lib/Indexer/Adapter/Tolerant/Indexer/FunctionReferenceIndexer.php
+++ b/lib/Indexer/Adapter/Tolerant/Indexer/FunctionReferenceIndexer.php
@@ -51,7 +51,7 @@ class FunctionReferenceIndexer extends AbstractClassLikeIndexer
         $targetRecord->addReference($document->uri()->path());
         $index->write($targetRecord);
 
-        $fileRecord = $index->get(FileRecord::fromPath($document->uri()->path()));
+        $fileRecord = $index->get(FileRecord::fromPath($document->uriOrThrow()->__toString()));
         assert($fileRecord instanceof FileRecord);
 
         $fileRecord->addReference(

--- a/lib/Indexer/Adapter/Tolerant/Indexer/FunctionReferenceIndexer.php
+++ b/lib/Indexer/Adapter/Tolerant/Indexer/FunctionReferenceIndexer.php
@@ -48,7 +48,7 @@ class FunctionReferenceIndexer extends AbstractClassLikeIndexer
 
         $targetRecord = $index->get(FunctionRecord::fromName($name));
         assert($targetRecord instanceof FunctionRecord);
-        $targetRecord->addReference($document->uri()->path());
+        $targetRecord->addReference($document->uriOrThrow());
         $index->write($targetRecord);
 
         $fileRecord = $index->get(FileRecord::fromPath($document->uriOrThrow()->__toString()));

--- a/lib/Indexer/Adapter/Tolerant/Indexer/FunctionReferenceIndexer.php
+++ b/lib/Indexer/Adapter/Tolerant/Indexer/FunctionReferenceIndexer.php
@@ -20,7 +20,7 @@ class FunctionReferenceIndexer extends AbstractClassLikeIndexer
 
     public function beforeParse(Index $index, TextDocument $document): void
     {
-        $fileRecord = $index->get(FileRecord::fromPath($document->uri()->path()));
+        $fileRecord = $index->get(FileRecord::fromPath($document->uriOrThrow()->__toString()));
         assert($fileRecord instanceof FileRecord);
 
         foreach ($fileRecord->references() as $outgoingReference) {

--- a/lib/Indexer/Adapter/Tolerant/Indexer/InterfaceDeclarationIndexer.php
+++ b/lib/Indexer/Adapter/Tolerant/Indexer/InterfaceDeclarationIndexer.php
@@ -23,7 +23,7 @@ class InterfaceDeclarationIndexer extends AbstractClassLikeIndexer
         if ($node->name instanceof MissingToken) {
             throw new CannotIndexNode(sprintf(
                 'Class name is missing (maybe a reserved word) in: %s',
-                $document->uri()?->path() ?? '?',
+                $document->uri()?->__toString() ?? '?',
             ));
         }
         $record = $this->getClassLikeRecord(ClassRecord::TYPE_INTERFACE, $node, $index, $document);

--- a/lib/Indexer/Adapter/Tolerant/Indexer/MemberIndexer.php
+++ b/lib/Indexer/Adapter/Tolerant/Indexer/MemberIndexer.php
@@ -27,7 +27,7 @@ class MemberIndexer implements TolerantIndexer
 
     public function beforeParse(Index $index, TextDocument $document): void
     {
-        $fileRecord = $index->get(FileRecord::fromPath($document->uri()->path()));
+        $fileRecord = $index->get(FileRecord::fromPath($document->uriOrThrow()->__toString()));
         assert($fileRecord instanceof FileRecord);
 
         foreach ($fileRecord->references() as $outgoingReference) {
@@ -181,10 +181,10 @@ class MemberIndexer implements TolerantIndexer
     ): void {
         $record = $index->get(MemberRecord::fromMemberReference(MemberReference::create($memberType, $containerFqn, $memberName)));
         assert($record instanceof MemberRecord);
-        $record->addReference($document->uri()->path());
+        $record->addReference($document->uriOrThrow()->__toString());
         $index->write($record);
 
-        $fileRecord = $index->get(FileRecord::fromPath($document->uri()->path()));
+        $fileRecord = $index->get(FileRecord::fromPath($document->uriOrThrow()->__toString()));
         assert($fileRecord instanceof FileRecord);
         $fileRecord->addReference(
             RecordReference::fromRecordAndOffsetAndContainerType($record, $offsetStart, $offsetEnd, $containerFqn)

--- a/lib/Indexer/Adapter/Tolerant/Indexer/TraitDeclarationIndexer.php
+++ b/lib/Indexer/Adapter/Tolerant/Indexer/TraitDeclarationIndexer.php
@@ -23,7 +23,7 @@ class TraitDeclarationIndexer extends AbstractClassLikeIndexer
         if ($node->name instanceof MissingToken) {
             throw new CannotIndexNode(sprintf(
                 'Class name is missing (maybe a reserved word) in: %s',
-                $document->uri()?->path() ?? '?',
+                $document->uri()?->__toString() ?? '?',
             ));
         }
         $record = $this->getClassLikeRecord(ClassRecord::TYPE_TRAIT, $node, $index, $document);

--- a/lib/Indexer/Adapter/Tolerant/TolerantIndexBuilder.php
+++ b/lib/Indexer/Adapter/Tolerant/TolerantIndexBuilder.php
@@ -18,6 +18,7 @@ use Phpactor\Indexer\Model\Exception\CannotIndexNode;
 use Phpactor\Indexer\Model\Index;
 use Phpactor\Indexer\Model\IndexBuilder;
 use Phpactor\TextDocument\TextDocument;
+use Phpactor\WorseReflection\Core\Util\NodeUtil;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
@@ -63,7 +64,7 @@ final class TolerantIndexBuilder implements IndexBuilder
             $indexer->beforeParse($this->index, $document);
         }
 
-        $node = $this->parser->parseSourceFile($document->__toString(), $document->uri()->path());
+        $node = $this->parser->parseSourceFile($document->__toString(), $document->uri()->__toString());
         $this->indexNode($document, $node);
     }
 
@@ -83,7 +84,7 @@ final class TolerantIndexBuilder implements IndexBuilder
                 $this->logger->warning(sprintf(
                     'Cannot index node of class "%s" in file "%s": %s',
                     get_class($node),
-                    $document->uri()->__toString(),
+                    $document->uri()?->__toString() ?? 'unknown',
                     $cannotIndexNode->getMessage()
                 ));
             }

--- a/lib/Indexer/Adapter/Tolerant/TolerantIndexBuilder.php
+++ b/lib/Indexer/Adapter/Tolerant/TolerantIndexBuilder.php
@@ -18,7 +18,6 @@ use Phpactor\Indexer\Model\Exception\CannotIndexNode;
 use Phpactor\Indexer\Model\Index;
 use Phpactor\Indexer\Model\IndexBuilder;
 use Phpactor\TextDocument\TextDocument;
-use Phpactor\WorseReflection\Core\Util\NodeUtil;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 

--- a/lib/Indexer/Extension/IndexerExtension.php
+++ b/lib/Indexer/Extension/IndexerExtension.php
@@ -79,6 +79,7 @@ class IndexerExtension implements Extension
             self::PARAM_INDEX_PATH => '%cache%/index/%project_id%',
             self::PARAM_INCLUDE_PATTERNS => [
                 '/**/*.php',
+                '/**/*.phar',
             ],
             self::PARAM_EXCLUDE_PATTERNS => [
                 '/vendor/**/Tests/**/*',
@@ -92,7 +93,7 @@ class IndexerExtension implements Extension
             self::PARAM_PROJECT_ROOT => '%project_root%',
             self::PARAM_REFERENCES_DEEP_REFERENCES => true,
             self::PARAM_IMPLEMENTATIONS_DEEP_REFERENCES => true,
-            self::PARAM_SUPPORTED_EXTENSIONS => ['php'],
+            self::PARAM_SUPPORTED_EXTENSIONS => ['php', 'phar'],
         ]);
         $schema->setDescriptions([
             self::PARAM_ENABLED_WATCHERS => 'List of allowed watchers. The first watcher that supports the current system will be used',

--- a/lib/Indexer/Extension/IndexerExtension.php
+++ b/lib/Indexer/Extension/IndexerExtension.php
@@ -66,7 +66,7 @@ class IndexerExtension implements Extension
     public const PARAM_IMPLEMENTATIONS_DEEP_REFERENCES = 'indexer.implementation_finder.deep';
     public const PARAM_STUB_PATHS = 'indexer.stub_paths';
     public const PARAM_SUPPORTED_EXTENSIONS = 'indexer.supported_extensions';
-    const TAG_WATCHER = 'indexer.watcher';
+    public const TAG_WATCHER = 'indexer.watcher';
     private const SERVICE_INDEXER_EXCLUDE_PATTERNS = 'indexer.exclude_patterns';
     private const SERVICE_INDEXER_INCLUDE_PATTERNS = 'indexer.include_patterns';
     private const PARAM_PROJECT_ROOT = 'indexer.project_root';

--- a/lib/Indexer/IndexAgentBuilder.php
+++ b/lib/Indexer/IndexAgentBuilder.php
@@ -45,6 +45,7 @@ final class IndexAgentBuilder
      */
     private array $includePatterns = [
         '/**/*.php',
+        '/**/*.phar',
     ];
 
     /**
@@ -68,7 +69,7 @@ final class IndexAgentBuilder
     /**
      * @var list<string>
      */
-    private array $supportedExtensions = ['php'];
+    private array $supportedExtensions = ['php', 'phar'];
 
     private LoggerInterface $logger;
 

--- a/lib/Indexer/Model/IndexJob.php
+++ b/lib/Indexer/Model/IndexJob.php
@@ -21,6 +21,7 @@ class IndexJob
      */
     public function generator(): Generator
     {
+
         foreach ($this->fileList as $fileInfo) {
             assert($fileInfo instanceof SplFileInfo);
 

--- a/lib/Indexer/Model/IndexJob.php
+++ b/lib/Indexer/Model/IndexJob.php
@@ -25,6 +25,7 @@ class IndexJob
         foreach ($this->fileList as $fileInfo) {
             assert($fileInfo instanceof SplFileInfo);
 
+            // TODO: could refactor this to iterate the PHAR in the file list provider.
             if ($fileInfo->getExtension() === 'phar') {
                 $phar = new Phar($fileInfo->getPathname(), FilesystemIterator::CURRENT_AS_FILEINFO | FilesystemIterator::KEY_AS_FILENAME);
                 yield from $this->indexPharFile($phar);

--- a/lib/Indexer/Model/Query/Criteria/FileAbsolutePathBeginsWith.php
+++ b/lib/Indexer/Model/Query/Criteria/FileAbsolutePathBeginsWith.php
@@ -18,7 +18,14 @@ class FileAbsolutePathBeginsWith extends Criteria
         if (!$record instanceof HasPath) {
             return false;
         }
+        $path = $record->filePath();
+        if (!$path) {
+            return false;
+        }
+        if ($pos = strpos($path, ':///')) {
+            $path = substr($path, $pos + 3);
+        }
 
-        return str_starts_with($record->filePath() ?? '', $this->prefix);
+        return str_starts_with($path, $this->prefix);
     }
 }

--- a/lib/Indexer/Model/Record/FileRecord.php
+++ b/lib/Indexer/Model/Record/FileRecord.php
@@ -18,9 +18,9 @@ class FileRecord implements HasPath, Record
      */
     private array $references = [];
 
-    public function __construct(string $filePath)
+    private function __construct(string $filePath)
     {
-        $this->setFilePath($filePath);
+        $this->filePath = $filePath;
     }
 
     public function __wakeup(): void

--- a/lib/Indexer/Model/Record/HasPath.php
+++ b/lib/Indexer/Model/Record/HasPath.php
@@ -2,12 +2,17 @@
 
 namespace Phpactor\Indexer\Model\Record;
 
+use Phpactor\TextDocument\TextDocumentUri;
+
 interface HasPath
 {
     /**
      * @return $this
      */
-    public function setFilePath(string $filePath);
+    public function setFilePath(TextDocumentUri $filePath);
 
+    /**
+     * Rename to URI
+     */
     public function filePath(): ?string;
 }

--- a/lib/Indexer/Model/Record/HasPathTrait.php
+++ b/lib/Indexer/Model/Record/HasPathTrait.php
@@ -2,18 +2,15 @@
 
 namespace Phpactor\Indexer\Model\Record;
 
-use RuntimeException;
+use Phpactor\TextDocument\TextDocumentUri;
 
 trait HasPathTrait
 {
     protected ?string $filePath = null;
 
-    public function setFilePath(string $filePath): self
+    public function setFilePath(TextDocumentUri $uri): self
     {
-        if (!strpos($filePath, ':/')) {
-            throw new RuntimeException('Invalid file path: '.$filePath);
-        }
-        $this->filePath = $filePath;
+        $this->filePath = $uri->__toString();
         return $this;
     }
 

--- a/lib/Indexer/Model/Record/HasPathTrait.php
+++ b/lib/Indexer/Model/Record/HasPathTrait.php
@@ -2,12 +2,17 @@
 
 namespace Phpactor\Indexer\Model\Record;
 
+use RuntimeException;
+
 trait HasPathTrait
 {
     protected ?string $filePath = null;
 
     public function setFilePath(string $filePath): self
     {
+        if (!strpos($filePath, ':/')) {
+            throw new RuntimeException('Invalid file path: '.$filePath);
+        }
         $this->filePath = $filePath;
         return $this;
     }

--- a/lib/Indexer/Model/SearchIndex/ValidatingSearchIndex.php
+++ b/lib/Indexer/Model/SearchIndex/ValidatingSearchIndex.php
@@ -3,7 +3,6 @@
 namespace Phpactor\Indexer\Model\SearchIndex;
 
 use Generator;
-use PHPStan\Rules\UnusedFunctionParametersCheck;
 use Phpactor\Indexer\Model\IndexAccess;
 use Phpactor\Indexer\Model\Query\Criteria;
 use Phpactor\Indexer\Model\Record;

--- a/lib/Indexer/Model/SearchIndex/ValidatingSearchIndex.php
+++ b/lib/Indexer/Model/SearchIndex/ValidatingSearchIndex.php
@@ -3,6 +3,7 @@
 namespace Phpactor\Indexer\Model\SearchIndex;
 
 use Generator;
+use PHPStan\Rules\UnusedFunctionParametersCheck;
 use Phpactor\Indexer\Model\IndexAccess;
 use Phpactor\Indexer\Model\Query\Criteria;
 use Phpactor\Indexer\Model\Record;
@@ -23,6 +24,7 @@ class ValidatingSearchIndex implements SearchIndex
     public function search(Criteria $criteria): Generator
     {
         foreach ($this->innerIndex->search($criteria) as $result) {
+
             if (!$this->index->has($result)) {
                 $this->innerIndex->remove($result);
 

--- a/lib/Indexer/Tests/Adapter/IndexBuilderTestCase.php
+++ b/lib/Indexer/Tests/Adapter/IndexBuilderTestCase.php
@@ -49,7 +49,7 @@ abstract class IndexBuilderTestCase extends IntegrationTestCase
             'IamAnAttribute',
             function (ClassRecord $record): void {
                 self::assertInstanceOf(ClassRecord::class, $record);
-                self::assertEquals($this->workspace()->path('project/attribute.php'), $record->filePath());
+                self::assertEquals('file://' . $this->workspace()->path('project/attribute.php'), $record->filePath());
                 self::assertEquals('IamAnAttribute', $record->fqn());
                 self::assertEquals(38, $record->start()->toInt());
                 self::assertEquals(52, $record->end()->toInt());
@@ -62,7 +62,7 @@ abstract class IndexBuilderTestCase extends IntegrationTestCase
             'ThisClass',
             function (ClassRecord $record): void {
                 self::assertInstanceOf(ClassRecord::class, $record);
-                self::assertEquals($this->workspace()->path('project/test.php'), $record->filePath());
+                self::assertEquals('file://' . $this->workspace()->path('project/test.php'), $record->filePath());
                 self::assertEquals('ThisClass', $record->fqn());
                 self::assertEquals(12, $record->start()->toInt());
                 self::assertEquals(21, $record->end()->toInt());
@@ -163,7 +163,7 @@ abstract class IndexBuilderTestCase extends IntegrationTestCase
             'ThisInterface',
             function (ClassRecord $record): void {
                 self::assertInstanceOf(ClassRecord::class, $record);
-                self::assertEquals($this->workspace()->path('project/test.php'), $record->filePath());
+                self::assertEquals('file://' . $this->workspace()->path('project/test.php'), $record->filePath());
                 self::assertEquals('ThisInterface', $record->fqn());
                 self::assertEquals(16, $record->start()->toInt());
                 self::assertEquals(29, $record->end()->toInt());
@@ -184,7 +184,7 @@ abstract class IndexBuilderTestCase extends IntegrationTestCase
             'ThisTrait',
             function (ClassRecord $record): void {
                 self::assertInstanceOf(ClassRecord::class, $record);
-                self::assertEquals($this->workspace()->path('project/test.php'), $record->filePath());
+                self::assertEquals('file://' . $this->workspace()->path('project/test.php'), $record->filePath());
                 self::assertEquals('ThisTrait', $record->fqn());
                 self::assertEquals(12, $record->start()->toInt());
                 self::assertEquals(21, $record->end()->toInt());
@@ -221,7 +221,7 @@ abstract class IndexBuilderTestCase extends IntegrationTestCase
             'SomeEnum',
             function (ClassRecord $record): void {
                 self::assertInstanceOf(ClassRecord::class, $record);
-                self::assertEquals($this->workspace()->path('project/test.php'), $record->filePath());
+                self::assertEquals('file://' . $this->workspace()->path('project/test.php'), $record->filePath());
                 self::assertEquals('SomeEnum', $record->fqn());
                 self::assertEquals(11, $record->start()->toInt());
                 self::assertEquals(19, $record->end()->toInt());
@@ -433,7 +433,7 @@ abstract class IndexBuilderTestCase extends IntegrationTestCase
             , 'Barfoos\foobar',
             function (FunctionRecord $record): void {
                 self::assertCount(1, $record->references());
-                self::assertEquals($this->workspace()->path('project/test1.php'), $record->filePath());
+                self::assertEquals('file://' . $this->workspace()->path('project/test1.php'), $record->filePath());
             }
         ];
     }

--- a/lib/Indexer/Tests/Adapter/PharIndexTest.php
+++ b/lib/Indexer/Tests/Adapter/PharIndexTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Phpactor\Indexer\Tests\Adapter;
+
+use Phar;
+use Phpactor\Indexer\Model\Query\Criteria;
+use Phpactor\Indexer\Tests\IntegrationTestCase;
+
+class PharIndexTest extends IntegrationTestCase
+{
+    protected function setUp(): void
+    {
+        $this->workspace()->reset();
+    }
+
+    public function testIndexPhar(): void
+    {
+        if (ini_get('phar.readonly') != 0) {
+            $this->markTestSkipped('PHAR is in readonly not set');
+        }
+
+        $this->workspace()->put('phar/index.php', '<?php class Hello{}');
+        $this->workspace()->mkdir('repo');
+
+        // create phar
+        $phar = new Phar($this->workspace()->path('repo/index.phar'), 0, 'index.phar');
+        $phar->buildFromDirectory($this->workspace()->path('phar'));
+
+        $agent = $this->indexAgentBuilder('repo')->buildTestAgent();
+        $agent->indexer()->getJob()->run();
+        $hellos = iterator_to_array($agent->search()->search(Criteria::shortNameContains('Hello')));
+        self::assertCount(1, $hellos);
+    }
+
+}

--- a/lib/Indexer/Tests/Adapter/Tolerant/Indexer/ClassLikeDeclarationIndexerTest.php
+++ b/lib/Indexer/Tests/Adapter/Tolerant/Indexer/ClassLikeDeclarationIndexerTest.php
@@ -122,13 +122,13 @@ class ClassLikeDeclarationIndexerTest extends TolerantIndexerTestCase
         yield 'exact match' => [
             "// File: src/file1.php\n<?php class Barfoo implements Foobar{}",
             'Barfoo',
-            [ClassRecord::fromName('Barfoo')->setFilePath($this->workspace()->path('src/file1.php'))]
+            [ClassRecord::fromName('Barfoo')->setFilePath($this->workspacePath('src/file1.php'))]
         ];
 
         yield 'namespaced match' => [
             "// File: src/file1.php\n<?php namespace Bar; class Barfoo implements Foobar{}",
             'Barfoo',
-            [ClassRecord::fromName('Bar\Barfoo')->setFilePath($this->workspace()->path('src/file1.php'))]
+            [ClassRecord::fromName('Bar\Barfoo')->setFilePath($this->workspacePath('src/file1.php'))]
         ];
 
         yield 'gh-2098: does not index reserved class name' => [
@@ -168,5 +168,10 @@ class ClassLikeDeclarationIndexerTest extends TolerantIndexerTestCase
             "// File: src/file1.php\n<?php class {}",
             'Class name is missing',
         ];
+    }
+
+    private function workspacePath(string $path): string
+    {
+        return 'file://'.$this->workspace()->path($path);
     }
 }

--- a/lib/Indexer/Tests/Adapter/Tolerant/Indexer/ClassLikeDeclarationIndexerTest.php
+++ b/lib/Indexer/Tests/Adapter/Tolerant/Indexer/ClassLikeDeclarationIndexerTest.php
@@ -10,6 +10,7 @@ use Phpactor\Indexer\Adapter\Tolerant\Indexer\TraitDeclarationIndexer;
 use Phpactor\Indexer\Model\Query\Criteria\ShortNameBeginsWith;
 use Phpactor\Indexer\Model\Record\ClassRecord;
 use Phpactor\Indexer\Tests\Adapter\Tolerant\TolerantIndexerTestCase;
+use Phpactor\TextDocument\TextDocumentUri;
 use Prophecy\Argument;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
@@ -170,8 +171,8 @@ class ClassLikeDeclarationIndexerTest extends TolerantIndexerTestCase
         ];
     }
 
-    private function workspacePath(string $path): string
+    private function workspacePath(string $path): TextDocumentUri
     {
-        return 'file://'.$this->workspace()->path($path);
+        return TextDocumentUri::fromString($this->workspace()->path($path));
     }
 }

--- a/lib/Indexer/Tests/Unit/Adapter/Worse/IndexerClassSourceLocatorTest.php
+++ b/lib/Indexer/Tests/Unit/Adapter/Worse/IndexerClassSourceLocatorTest.php
@@ -7,6 +7,7 @@ use Phpactor\Indexer\Model\Record\ClassRecord;
 use Phpactor\TextDocument\ByteOffset;
 use Phpactor\Indexer\Adapter\Php\InMemory\InMemoryIndex;
 use Phpactor\Indexer\Adapter\Worse\IndexerClassSourceLocator;
+use Phpactor\TextDocument\TextDocumentUri;
 use Phpactor\WorseReflection\Core\Exception\SourceNotFound;
 use Phpactor\WorseReflection\Core\Name;
 use Symfony\Component\Filesystem\Path;
@@ -29,7 +30,7 @@ class IndexerClassSourceLocatorTest extends TestCase
             ->setType('class')
             ->setStart(ByteOffset::fromInt(0))
             ->setEnd(ByteOffset::fromInt(0))
-            ->setFilePath('nope.php');
+            ->setFilePath(TextDocumentUri::fromString('/nope.php'));
 
         $index = new InMemoryIndex();
         $index->write($record);
@@ -43,7 +44,7 @@ class IndexerClassSourceLocatorTest extends TestCase
             ->setType('class')
             ->setStart(ByteOffset::fromInt(0))
             ->setEnd(ByteOffset::fromInt(10))
-            ->setFilePath(__FILE__);
+            ->setFilePath(TextDocumentUri::fromString(__FILE__));
 
         $index = new InMemoryIndex();
         $index->write($record);

--- a/lib/Indexer/Tests/Unit/Adapter/Worse/IndexerClassSourceLocatorTest.php
+++ b/lib/Indexer/Tests/Unit/Adapter/Worse/IndexerClassSourceLocatorTest.php
@@ -2,6 +2,7 @@
 
 namespace Phpactor\Indexer\Tests\Unit\Adapter\Worse;
 
+use PHPStan\Command\AnalyseApplication;
 use PHPUnit\Framework\TestCase;
 use Phpactor\Indexer\Model\Record\ClassRecord;
 use Phpactor\TextDocument\ByteOffset;
@@ -44,6 +45,21 @@ class IndexerClassSourceLocatorTest extends TestCase
             ->setStart(ByteOffset::fromInt(0))
             ->setEnd(ByteOffset::fromInt(10))
             ->setFilePath(__FILE__);
+
+        $index = new InMemoryIndex();
+        $index->write($record);
+        $locator = $this->createLocator($index);
+        $sourceCode = $locator->locate(Name::fromString('Foobar'));
+        $this->assertEquals(Path::canonicalize(__FILE__), $sourceCode->uri()?->path());
+    }
+
+    public function testForPhar(): void
+    {
+        $record = ClassRecord::fromName('Foobar')
+            ->setType('class')
+            ->setStart(ByteOffset::fromInt(0))
+            ->setEnd(ByteOffset::fromInt(10))
+            ->setFilePath('phar://' . __FILE__);
 
         $index = new InMemoryIndex();
         $index->write($record);

--- a/lib/Indexer/Tests/Unit/Adapter/Worse/IndexerClassSourceLocatorTest.php
+++ b/lib/Indexer/Tests/Unit/Adapter/Worse/IndexerClassSourceLocatorTest.php
@@ -2,7 +2,6 @@
 
 namespace Phpactor\Indexer\Tests\Unit\Adapter\Worse;
 
-use PHPStan\Command\AnalyseApplication;
 use PHPUnit\Framework\TestCase;
 use Phpactor\Indexer\Model\Record\ClassRecord;
 use Phpactor\TextDocument\ByteOffset;
@@ -45,21 +44,6 @@ class IndexerClassSourceLocatorTest extends TestCase
             ->setStart(ByteOffset::fromInt(0))
             ->setEnd(ByteOffset::fromInt(10))
             ->setFilePath(__FILE__);
-
-        $index = new InMemoryIndex();
-        $index->write($record);
-        $locator = $this->createLocator($index);
-        $sourceCode = $locator->locate(Name::fromString('Foobar'));
-        $this->assertEquals(Path::canonicalize(__FILE__), $sourceCode->uri()?->path());
-    }
-
-    public function testForPhar(): void
-    {
-        $record = ClassRecord::fromName('Foobar')
-            ->setType('class')
-            ->setStart(ByteOffset::fromInt(0))
-            ->setEnd(ByteOffset::fromInt(10))
-            ->setFilePath('phar://' . __FILE__);
 
         $index = new InMemoryIndex();
         $index->write($record);

--- a/lib/Indexer/Tests/Unit/Adapter/Worse/IndexerFunctionSourceLocatorTest.php
+++ b/lib/Indexer/Tests/Unit/Adapter/Worse/IndexerFunctionSourceLocatorTest.php
@@ -7,6 +7,7 @@ use Phpactor\Indexer\Model\Name\FullyQualifiedName;
 use Phpactor\Indexer\Adapter\Php\InMemory\InMemoryIndex;
 use Phpactor\Indexer\Adapter\Worse\IndexerFunctionSourceLocator;
 use Phpactor\Indexer\Model\Record\FunctionRecord;
+use Phpactor\TextDocument\TextDocumentUri;
 use Symfony\Component\Filesystem\Path;
 use Phpactor\WorseReflection\Core\Exception\SourceNotFound;
 use Phpactor\WorseReflection\Core\Name;
@@ -28,7 +29,7 @@ class IndexerFunctionSourceLocatorTest extends TestCase
         $record = new FunctionRecord(
             FullyQualifiedName::fromString('Foobar')
         );
-        $record->setFilePath('nope.php');
+        $record->setFilePath(TextDocumentUri::fromString('/nope.php'));
         $index = new InMemoryIndex();
         $index->write($record);
         $locator = $this->createLocator($index);
@@ -40,7 +41,7 @@ class IndexerFunctionSourceLocatorTest extends TestCase
         $record = new FunctionRecord(
             FullyQualifiedName::fromString('Foobar')
         );
-        $record->setFilePath(__FILE__);
+        $record->setFilePath(TextDocumentUri::fromString(__FILE__));
         $index = new InMemoryIndex();
         $index->write($record);
         $locator = $this->createLocator($index);

--- a/lib/Indexer/Tests/Unit/Model/Query/Criteria/FileAbsolutePathBeginsWithTest.php
+++ b/lib/Indexer/Tests/Unit/Model/Query/Criteria/FileAbsolutePathBeginsWithTest.php
@@ -5,25 +5,26 @@ namespace Phpactor\Indexer\Tests\Unit\Model\Query\Criteria;
 use PHPUnit\Framework\TestCase;
 use Phpactor\Indexer\Model\Query\Criteria;
 use Phpactor\Indexer\Model\Record\ClassRecord;
+use Phpactor\TextDocument\TextDocumentUri;
 
 class FileAbsolutePathBeginsWithTest extends TestCase
 {
     public function testDoesNotBeginWith(): void
     {
-        $record = ClassRecord::fromName('Foobar\\Barfoo')->setFilePath('/foobar');
+        $record = ClassRecord::fromName('Foobar\\Barfoo')->setFilePath(TextDocumentUri::fromString('/foobar'));
         self::assertFalse(Criteria::fileAbsolutePathBeginsWith('/baz')->isSatisfiedBy($record));
     }
 
     public function testBeginsWith(): void
     {
-        $record = ClassRecord::fromName('Foobar\\Barfoo')->setFilePath('/foobar/bazboo/baz.php');
+        $record = ClassRecord::fromName('Foobar\\Barfoo')->setFilePath(TextDocumentUri::fromString('/foobar/bazboo/baz.php'));
         self::assertTrue(Criteria::fileAbsolutePathBeginsWith('/foobar')->isSatisfiedBy($record));
     }
 
     public function testBeginsWithTrailingSlash(): void
     {
         $record = ClassRecord::fromName('Foobar\\Barfoo')
-            ->setFilePath('/foobar/bazboo/baz.php');
+            ->setFilePath(TextDocumentUri::fromString('/foobar/bazboo/baz.php'));
 
         self::assertTrue(
             Criteria::fileAbsolutePathBeginsWith('/foobar/')->isSatisfiedBy($record)

--- a/lib/Indexer/Tests/Unit/Model/SearchIndex/ValidatingSearchIndexTest.php
+++ b/lib/Indexer/Tests/Unit/Model/SearchIndex/ValidatingSearchIndexTest.php
@@ -10,6 +10,7 @@ use Phpactor\Indexer\Model\Record\ClassRecord;
 use Phpactor\Indexer\Model\Record\MemberRecord;
 use Phpactor\Indexer\Model\SearchIndex\ValidatingSearchIndex;
 use Phpactor\Indexer\Tests\IntegrationTestCase;
+use Phpactor\TextDocument\TextDocumentUri;
 use Psr\Log\NullLogger;
 
 class ValidatingSearchIndexTest extends IntegrationTestCase
@@ -52,7 +53,7 @@ class ValidatingSearchIndexTest extends IntegrationTestCase
     public function testRemovesFromIndexIfFileDoesNotExist(): void
     {
         $record = ClassRecord::fromName('Foobar')
-            ->setFilePath($this->workspace()->path('nope.php'));
+            ->setFilePath($this->workspacePath('nope.php'));
 
         $this->index->write($record);
         $this->innerSearchIndex->write($record);
@@ -65,7 +66,7 @@ class ValidatingSearchIndexTest extends IntegrationTestCase
     {
         $this->workspace()->put('yep.php', 'foo');
         $record = ClassRecord::fromName('Foobar')
-            ->setFilePath($this->workspace()->path('yep.php'));
+            ->setFilePath($this->workspacePath('yep.php'));
 
         $this->index->write($record);
         $this->innerSearchIndex->write($record);
@@ -77,5 +78,10 @@ class ValidatingSearchIndexTest extends IntegrationTestCase
     private static function assertSearchCount(int $int, Generator $generator): void
     {
         self::assertEquals($int, count(iterator_to_array($generator)));
+    }
+
+    private function workspacePath(string $string): TextDocumentUri
+    {
+        return TextDocumentUri::fromString($this->workspace()->path($string));
     }
 }

--- a/lib/Rename/Adapter/ClassMover/FileRenamer.php
+++ b/lib/Rename/Adapter/ClassMover/FileRenamer.php
@@ -48,11 +48,11 @@ class FileRenamer implements PhpactorFileRenamer
             $edits = TextEdits::none();
             $seen = [];
             foreach ($references as $reference) {
-                if (isset($seen[$reference->location()->uri()->path()])) {
+                if (isset($seen[$reference->location()->uri()->__toString()])) {
                     continue;
                 }
 
-                $seen[$reference->location()->uri()->path()] = true;
+                $seen[$reference->location()->uri()->__toString()] = true;
 
                 try {
                     $document = $this->locator->get($reference->location()->uri());

--- a/lib/Rename/Tests/Adapter/ClassMover/FileRenamerTest.php
+++ b/lib/Rename/Tests/Adapter/ClassMover/FileRenamerTest.php
@@ -37,10 +37,10 @@ class FileRenamerTest extends IntegrationTestCase
 
         $renamer = $this->createRenamer([$document1, $document2, $document3, $document4], [
             (new ClassRecord('One'))->setType('class')->addReference($this->path('3.php'))->addReference($this->path('4.php')),
-            (new FileRecord($this->path('3.php')))->addReference(
+            FileRecord::fromPath('file://' . $this->path('3.php'))->addReference(
                 new RecordReference(ClassRecord::RECORD_TYPE, 'One', 10, end: 20)
             ),
-            (new FileRecord($this->path('4.php')))->addReference(
+            FileRecord::fromPath('file://' . $this->path('4.php'))->addReference(
                 new RecordReference(ClassRecord::RECORD_TYPE, 'One', 10, end: 20)
             )
         ]);

--- a/lib/Rename/Tests/Adapter/ClassMover/FileRenamerTest.php
+++ b/lib/Rename/Tests/Adapter/ClassMover/FileRenamerTest.php
@@ -36,7 +36,9 @@ class FileRenamerTest extends IntegrationTestCase
         $document4 = $this->createDocument('4.php', '<?php One::class;');
 
         $renamer = $this->createRenamer([$document1, $document2, $document3, $document4], [
-            (new ClassRecord('One'))->setType('class')->addReference($this->path('3.php'))->addReference($this->path('4.php')),
+            (new ClassRecord('One'))->setType('class')->addReference(
+                'file://' . $this->path('3.php')
+            )->addReference('file://' . $this->path('4.php')),
             FileRecord::fromPath('file://' . $this->path('3.php'))->addReference(
                 new RecordReference(ClassRecord::RECORD_TYPE, 'One', 10, end: 20)
             ),
@@ -45,7 +47,7 @@ class FileRenamerTest extends IntegrationTestCase
             )
         ]);
 
-        $edits = wait($renamer->renameFile($document1->uri(), $document2->uri()));
+        $edits = wait($renamer->renameFile($document1->uriOrThrow(), $document2->uriOrThrow()));
 
         self::assertInstanceOf(LocatedTextEditsMap::class, $edits);
         assert($edits instanceof LocatedTextEditsMap);

--- a/lib/TextDocument/Exception/TextDocumentNotFound.php
+++ b/lib/TextDocument/Exception/TextDocumentNotFound.php
@@ -4,6 +4,7 @@ namespace Phpactor\TextDocument\Exception;
 
 use Phpactor\TextDocument\TextDocumentUri;
 use RuntimeException;
+use Exception;
 
 final class TextDocumentNotFound extends RuntimeException
 {
@@ -12,6 +13,6 @@ final class TextDocumentNotFound extends RuntimeException
         return new self(sprintf(
             'Text document "%s" not found',
             $uri
-        ).(new \Exception())->getTraceAsString());
+        ).(new Exception())->getTraceAsString());
     }
 }

--- a/lib/TextDocument/Exception/TextDocumentNotFound.php
+++ b/lib/TextDocument/Exception/TextDocumentNotFound.php
@@ -12,6 +12,6 @@ final class TextDocumentNotFound extends RuntimeException
         return new self(sprintf(
             'Text document "%s" not found',
             $uri
-        ));
+        ).(new \Exception())->getTraceAsString());
     }
 }

--- a/lib/TextDocument/Exception/TextDocumentNotFound.php
+++ b/lib/TextDocument/Exception/TextDocumentNotFound.php
@@ -4,7 +4,6 @@ namespace Phpactor\TextDocument\Exception;
 
 use Phpactor\TextDocument\TextDocumentUri;
 use RuntimeException;
-use Exception;
 
 final class TextDocumentNotFound extends RuntimeException
 {
@@ -13,6 +12,6 @@ final class TextDocumentNotFound extends RuntimeException
         return new self(sprintf(
             'Text document "%s" not found',
             $uri
-        ).(new Exception())->getTraceAsString());
+        ));
     }
 }

--- a/lib/TextDocument/FilesystemTextDocumentLocator.php
+++ b/lib/TextDocument/FilesystemTextDocumentLocator.php
@@ -8,7 +8,7 @@ class FilesystemTextDocumentLocator implements TextDocumentLocator
 {
     public function get(TextDocumentUri $uri): TextDocument
     {
-        if (!file_exists($uri->path())) {
+        if (!file_exists($uri->__toString())) {
             throw TextDocumentNotFound::fromUri($uri);
         }
 

--- a/lib/TextDocument/Tests/Unit/TextDocumentUriTest.php
+++ b/lib/TextDocument/Tests/Unit/TextDocumentUriTest.php
@@ -17,6 +17,12 @@ class TextDocumentUriTest extends TestCase
         $this->assertEquals('file:///C:/foo/bar.php', (string) $uri);
     }
 
+    public function testFromPhar(): void
+    {
+        $uri = TextDocumentUri::fromString('phar:///home/daniel/www/phpactor/phpactor/vendor/phpstan/phpstan/phpstan.phar/resources/functionMap.php');
+        $this->assertEquals('phar:///home/daniel/www/phpactor/phpactor/vendor/phpstan/phpstan/phpstan.phar/resources/functionMap.php', (string) $uri);
+    }
+
     public function testExceptionOnInvalidFormatUnix(): void
     {
         $this->expectException(InvalidUriException::class);

--- a/lib/WorseReferenceFinder/WorseReflectionDefinitionLocator.php
+++ b/lib/WorseReferenceFinder/WorseReflectionDefinitionLocator.php
@@ -97,7 +97,7 @@ class WorseReflectionDefinitionLocator implements DefinitionLocator
             throw new CouldNotLocateDefinition($e->getMessage(), 0, $e);
         }
 
-        $path = $class->sourceCode()->uri()?->path();
+        $path = $class->sourceCode()->uri();
 
         if (null === $path) {
             throw new CouldNotLocateDefinition(sprintf(


### PR DESCRIPTION
Indexing and analysing PHARs is prerty simple we just need to ensure we preserve the `phar:///` scheme internally. The clients will not open `phar://` files however.