### PR TITLE
Remove deprecated composer 1 methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Requirements
 ------------
 
 - PHP 8.1+
-- [Composer](https://getcomposer.org/)
+- [Composer 2](https://getcomposer.org/)
 
 Project Recommendations
 -----------------------

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Requirements
 ------------
 
 - PHP 8.1+
-- [Composer 2](https://getcomposer.org/)
+- [Composer](https://getcomposer.org/)
 
 Project Recommendations
 -----------------------

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
-        "composer/package-versions-deprecated": "^1.0",
         "composer/xdebug-handler": "^3.0",
         "symfony/yaml": "^5.1",
         "phpactor/container": "^2.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c9eafb7ab6e1516c5556302e730ed63e",
+    "content-hash": "9baaf27ae14cd3c21c3fb4ac80771bb9",
     "packages": [
         {
             "name": "amphp/amp",
@@ -767,79 +767,6 @@
                 }
             ],
             "time": "2023-01-15T23:15:59+00:00"
-        },
-        {
-            "name": "composer/package-versions-deprecated",
-            "version": "1.11.99.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/package-versions-deprecated.git",
-                "reference": "b4f54f74ef3453349c24a845d22392cd31e65f1d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/b4f54f74ef3453349c24a845d22392cd31e65f1d",
-                "reference": "b4f54f74ef3453349c24a845d22392cd31e65f1d",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.1.0 || ^2.0",
-                "php": "^7 || ^8"
-            },
-            "replace": {
-                "ocramius/package-versions": "1.11.99"
-            },
-            "require-dev": {
-                "composer/composer": "^1.9.3 || ^2.0@dev",
-                "ext-zip": "^1.13",
-                "phpunit/phpunit": "^6.5 || ^7"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "PackageVersions\\Installer",
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PackageVersions\\": "src/PackageVersions"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com"
-                },
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be"
-                }
-            ],
-            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
-            "support": {
-                "issues": "https://github.com/composer/package-versions-deprecated/issues",
-                "source": "https://github.com/composer/package-versions-deprecated/tree/1.11.99.5"
-            },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-01-17T14:14:24+00:00"
         },
         {
             "name": "composer/pcre",
@@ -7948,5 +7875,5 @@
     "platform-overrides": {
         "php": "8.1.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/lib/Application.php
+++ b/lib/Application.php
@@ -2,7 +2,7 @@
 
 namespace Phpactor;
 
-use PackageVersions\Versions;
+use Composer\InstalledVersions;
 use Phpactor\Cast\Cast;
 use Phpactor\Extension\Logger\Formatter\PrettyFormatter;
 use Symfony\Component\Console\Application as SymfonyApplication;
@@ -25,7 +25,7 @@ class Application extends SymfonyApplication
 
     public function __construct(private string $vendorDir, private ?string $phpactorBin = null)
     {
-        parent::__construct('Phpactor', Cast::toString(Versions::getVersion('phpactor/phpactor')));
+        parent::__construct('Phpactor', Cast::toString(InstalledVersions::getVersion('phpactor/phpactor')));
     }
 
     public function doRun(InputInterface $input, OutputInterface $output): int


### PR DESCRIPTION
* Explicitly documenting composer 2 as a dependency (as we already use the `InstalledVersions` class in the project somewhere else
* Replacing `PackageVersions\Version` with the not deprecated version.