### PR TITLE
Adding more types in the FileFinder

### DIFF
--- a/lib/Extension/ClassMover/Application/Finder/FileFinder.php
+++ b/lib/Extension/ClassMover/Application/Finder/FileFinder.php
@@ -57,7 +57,7 @@ class FileFinder
         return $this->pathsFromReflectionClass($reflection, $private);
     }
 
-    private function pathsFromReflectionClass(ReflectionClass $reflection, bool $private)
+    private function pathsFromReflectionClass(ReflectionClass $reflection, bool $private): FileList
     {
         $path = $reflection->sourceCode()->uri()?->path();
 
@@ -78,13 +78,17 @@ class FileFinder
         return FileList::fromFilePaths($filePaths);
     }
 
-    private function allPhpFiles(Filesystem $filesystem)
+    private function allPhpFiles(Filesystem $filesystem): FileList
     {
-        $filePaths = $filesystem->fileList()->existing()->phpFiles();
-        return $filePaths;
+        return $filesystem->fileList()->existing()->phpFiles();
     }
 
-    private function parentFilePaths(ReflectionClass $reflection, $filePaths)
+    /**
+     * @param array<string|null> $filePaths
+     *
+     * @return array<string|null>
+     */
+    private function parentFilePaths(ReflectionClass $reflection, array $filePaths): array
     {
         $context = $reflection->parent();
         while ($context) {
@@ -95,7 +99,12 @@ class FileFinder
         return $filePaths;
     }
 
-    private function traitFilePaths(ReflectionClass $reflection, $filePaths)
+    /**
+     * @param array<string|null> $filePaths
+     *
+     * @return array<string|null>
+     */
+    private function traitFilePaths(ReflectionClass $reflection, array $filePaths): array
     {
         foreach ($reflection->traits() as $trait) {
             $filePaths[] = $trait->sourceCode()->uri()?->path();
@@ -103,7 +112,12 @@ class FileFinder
         return $filePaths;
     }
 
-    private function interfaceFilePaths(ReflectionClass $reflection, $filePaths)
+    /**
+     * @param array<string|null> $filePaths
+     *
+     * @return array<string|null>
+     */
+    private function interfaceFilePaths(ReflectionClass $reflection, array $filePaths): array
     {
         foreach ($reflection->interfaces() as $interface) {
             $filePaths[] = $interface->sourceCode()->uri()?->path();

--- a/lib/Extension/ClassMover/Application/Finder/FileFinder.php
+++ b/lib/Extension/ClassMover/Application/Finder/FileFinder.php
@@ -95,10 +95,8 @@ class FileFinder
         $context = $reflection->parent();
         while ($context) {
             $path = $context->sourceCode()->uri()?->path();
-            if (!$path) {
-                throw new RuntimeException(
-                    sprintf('Source class "%s" has no path associated with it', $context->name()),
-                );
+            if ($path === null) {
+                continue;
             }
             $filePaths[] = $path;
             $context = $context->parent();
@@ -116,10 +114,8 @@ class FileFinder
     {
         foreach ($reflection->traits() as $trait) {
             $path = $trait->sourceCode()->uri()?->path();
-            if (!$path) {
-                throw new RuntimeException(
-                    sprintf('Source trait "%s" has no path associated with it', $trait->name()),
-                );
+            if ($path === null) {
+                continue;
             }
             $filePaths[] = $path;
         }
@@ -135,12 +131,9 @@ class FileFinder
     {
         foreach ($reflection->interfaces() as $interface) {
             $path = $interface->sourceCode()->uri()?->path();
-            if (!$path) {
-                throw new RuntimeException(
-                    sprintf('Source interface "%s" has no path associated with it', $interface->name()),
-                );
+            if ($path === null) {
+                continue;
             }
-
             $filePaths[] = $path;
         }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1296,46 +1296,6 @@ parameters:
 			path: lib/Extension/ClassMover/Application/ClassReferences.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\Finder\\\\FileFinder\\:\\:allPhpFiles\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Application/Finder/FileFinder.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\Finder\\\\FileFinder\\:\\:interfaceFilePaths\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Application/Finder/FileFinder.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\Finder\\\\FileFinder\\:\\:interfaceFilePaths\\(\\) has parameter \\$filePaths with no type specified\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Application/Finder/FileFinder.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\Finder\\\\FileFinder\\:\\:parentFilePaths\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Application/Finder/FileFinder.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\Finder\\\\FileFinder\\:\\:parentFilePaths\\(\\) has parameter \\$filePaths with no type specified\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Application/Finder/FileFinder.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\Finder\\\\FileFinder\\:\\:pathsFromReflectionClass\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Application/Finder/FileFinder.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\Finder\\\\FileFinder\\:\\:traitFilePaths\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Application/Finder/FileFinder.php
-
-		-
-			message: "#^Method Phpactor\\\\Extension\\\\ClassMover\\\\Application\\\\Finder\\\\FileFinder\\:\\:traitFilePaths\\(\\) has parameter \\$filePaths with no type specified\\.$#"
-			count: 1
-			path: lib/Extension/ClassMover/Application/Finder/FileFinder.php
-
-		-
 			message: "#^Parameter \\#2 \\$subject of function preg_match expects string, string\\|false given\\.$#"
 			count: 1
 			path: lib/Extension/ClassMover/Application/Finder/FileFinder.php


### PR DESCRIPTION
Todo maybe: This class does a lot of copying with file path arrays maybe it would make more sense to refactor this to either append the arrays or to copy only once with the spread operator.

Either:
```php
$filePaths = [];
$this->parentFilePaths($reflection, $filePaths);
$this->interfaceFilePaths($reflection, $filePaths);

return FileList::fromFilePaths($filePaths);
````
or: 
```php
return FileList::fromFilePaths([
    ...$filePaths,
    ...$this->parentFilePaths($reflection),
    ...$this->interfaceFilePaths($reflection),
]);
````