### PR TITLE
Adding better types

### DIFF
--- a/doc/reference/configuration.rst
+++ b/doc/reference/configuration.rst
@@ -894,7 +894,7 @@ FilePathResolverExtension
 """""""""""""""""""""""""""""""""""
 
 
-**Default**: ``"\/home\/daniel\/www\/phpactor\/phpactor"``
+**Default**: ``"\/home\/mamazu\/packages\/phpactor\/phpactor"``
 
 
 .. _param_file_path_resolver.app_name:
@@ -1348,7 +1348,7 @@ Amount of time (in milliseconds) to wait before responding to a shutdown notific
 Internal use only - name path to Phpactor binary
 
 
-**Default**: ``"\/home\/daniel\/www\/phpactor\/phpactor\/lib\/Extension\/LanguageServer\/..\/..\/..\/bin\/phpactor"``
+**Default**: ``"\/home\/mamazu\/packages\/phpactor\/phpactor\/lib\/Extension\/LanguageServer\/..\/..\/..\/bin\/phpactor"``
 
 
 .. _param_language_server.self_destruct_timeout:

--- a/lib/Filesystem/Adapter/Git/GitFilesystem.php
+++ b/lib/Filesystem/Adapter/Git/GitFilesystem.php
@@ -49,7 +49,7 @@ class GitFilesystem extends SimpleFilesystem
 
     public function remove(FilePath|string $path): void
     {
-        $path = FilePath::fromUnknown($path);
+        $path = FilePath::fromFilePathOrString($path);
         if (false === $this->trackedByGit($path)) {
             parent::remove($path);
             return;
@@ -65,8 +65,8 @@ class GitFilesystem extends SimpleFilesystem
 
     public function move(FilePath|string $srcPath, FilePath|string $destPath): void
     {
-        $srcPath = FilePath::fromUnknown($srcPath);
-        $destPath = FilePath::fromUnknown($destPath);
+        $srcPath = FilePath::fromFilePathOrString($srcPath);
+        $destPath = FilePath::fromFilePathOrString($destPath);
 
         if (false === $this->trackedByGit($srcPath)) {
             parent::move($srcPath, $destPath);
@@ -82,8 +82,8 @@ class GitFilesystem extends SimpleFilesystem
 
     public function copy(FilePath|string $srcPath, FilePath|string $destPath): CopyReport
     {
-        $srcPath = FilePath::fromUnknown($srcPath);
-        $destPath = FilePath::fromUnknown($destPath);
+        $srcPath = FilePath::fromFilePathOrString($srcPath);
+        $destPath = FilePath::fromFilePathOrString($destPath);
         $list = parent::copy($srcPath, $destPath);
         $this->exec(['add', $destPath->__toString()]);
 

--- a/lib/Filesystem/Adapter/Simple/SimpleFilesystem.php
+++ b/lib/Filesystem/Adapter/Simple/SimpleFilesystem.php
@@ -35,14 +35,14 @@ class SimpleFilesystem implements Filesystem
 
     public function remove(FilePath|string $path): void
     {
-        $path = FilePath::fromUnknown($path);
+        $path = FilePath::fromFilePathOrString($path);
         $this->filesystem->remove($path);
     }
 
     public function move(FilePath|string $srcLocation, FilePath|string $destPath): void
     {
-        $srcLocation = FilePath::fromUnknown($srcLocation);
-        $destPath = FilePath::fromUnknown($destPath);
+        $srcLocation = FilePath::fromFilePathOrString($srcLocation);
+        $destPath = FilePath::fromFilePathOrString($destPath);
 
         $this->makeDirectoryIfNotExists((string) $destPath);
         $this->filesystem->rename($srcLocation->__toString(), $destPath->__toString());
@@ -50,8 +50,8 @@ class SimpleFilesystem implements Filesystem
 
     public function copy(FilePath|string $srcLocation, FilePath|string $destPath): CopyReport
     {
-        $srcLocation = FilePath::fromUnknown($srcLocation);
-        $destPath = FilePath::fromUnknown($destPath);
+        $srcLocation = FilePath::fromFilePathOrString($srcLocation);
+        $destPath = FilePath::fromFilePathOrString($destPath);
 
         if ($srcLocation->isDirectory()) {
             return $this->copyDirectory($srcLocation, $destPath);
@@ -77,7 +77,7 @@ class SimpleFilesystem implements Filesystem
 
     public function getContents(FilePath|string $path): string
     {
-        $path = FilePath::fromUnknown($path);
+        $path = FilePath::fromFilePathOrString($path);
         $contents = file_get_contents($path->path());
 
         if (false === $contents) {
@@ -89,13 +89,13 @@ class SimpleFilesystem implements Filesystem
 
     public function writeContents(FilePath|string $path, string $contents): void
     {
-        $path = FilePath::fromUnknown($path);
+        $path = FilePath::fromFilePathOrString($path);
         file_put_contents($path->path(), $contents);
     }
 
     public function exists(FilePath|string $path): bool
     {
-        $path = FilePath::fromUnknown($path);
+        $path = FilePath::fromFilePathOrString($path);
         return file_exists($path);
     }
 

--- a/lib/Filesystem/Domain/FileList.php
+++ b/lib/Filesystem/Domain/FileList.php
@@ -26,7 +26,6 @@ class FileList implements Iterator
     {
     }
 
-
     public static function fromIterator(Iterator $iterator): self
     {
         return new self($iterator);

--- a/lib/Filesystem/Domain/FilePath.php
+++ b/lib/Filesystem/Domain/FilePath.php
@@ -48,7 +48,7 @@ final class FilePath
         return self::fromString((string) $fileInfo);
     }
 
-    public static function fromUnknown(FilePath|string $path): FilePath
+    public static function fromFilePathOrString(FilePath|string $path): FilePath
     {
         if ($path instanceof FilePath) {
             return $path;

--- a/lib/Filesystem/Domain/FilePath.php
+++ b/lib/Filesystem/Domain/FilePath.php
@@ -29,6 +29,9 @@ final class FilePath
         return new self($textDocumentUri);
     }
 
+    /**
+     * @param array<string> $parts
+     */
     public static function fromParts(array $parts): FilePath
     {
         $path = Path::join(...$parts);
@@ -45,7 +48,7 @@ final class FilePath
         return self::fromString((string) $fileInfo);
     }
 
-    public static function fromUnknown($path): FilePath
+    public static function fromUnknown(FilePath|string $path): FilePath
     {
         if ($path instanceof FilePath) {
             return $path;
@@ -54,19 +57,6 @@ final class FilePath
         if (is_string($path)) {
             return self::fromString($path);
         }
-
-        if (is_array($path)) {
-            return self::fromParts($path);
-        }
-
-        if ($path instanceof SplFileInfo) {
-            return self::fromSplFileInfo($path);
-        }
-
-        throw new RuntimeException(sprintf(
-            'Do not know how to create FilePath from "%s"',
-            is_object($path) ? get_class($path) : gettype($path)
-        ));
     }
 
     public function isDirectory(): bool

--- a/lib/Filesystem/Domain/FilesystemRegistry.php
+++ b/lib/Filesystem/Domain/FilesystemRegistry.php
@@ -8,5 +8,8 @@ interface FilesystemRegistry
 
     public function has(string $name): bool;
 
+    /**
+     * @return array<string>
+     */
     public function names(): array;
 }

--- a/lib/Filesystem/Domain/MappedFilesystemRegistry.php
+++ b/lib/Filesystem/Domain/MappedFilesystemRegistry.php
@@ -35,7 +35,6 @@ class MappedFilesystemRegistry implements FilesystemRegistry
         return isset($this->filesystems[$name]);
     }
 
-    /** @return array<string> */
     public function names(): array
     {
         return array_keys($this->filesystems);

--- a/lib/Filesystem/Tests/Adapter/AdapterTestCase.php
+++ b/lib/Filesystem/Tests/Adapter/AdapterTestCase.php
@@ -6,8 +6,6 @@ use Phpactor\Filesystem\Domain\Filesystem;
 
 abstract class AdapterTestCase extends IntegrationTestCase
 {
-    private $filesystem;
-
     public function setUp(): void
     {
         $this->initWorkspace();

--- a/lib/Filesystem/Tests/Adapter/IntegrationTestCase.php
+++ b/lib/Filesystem/Tests/Adapter/IntegrationTestCase.php
@@ -17,7 +17,7 @@ abstract class IntegrationTestCase extends TestCase
         $filesystem->mkdir($this->workspacePath());
     }
 
-    protected function workspacePath()
+    protected function workspacePath(): string
     {
         return realpath(__DIR__.'/..') . '/Workspace';
     }
@@ -31,7 +31,7 @@ abstract class IntegrationTestCase extends TestCase
         exec('composer dumpautoload 2> /dev/null');
     }
 
-    protected function getProjectAutoloader()
+    protected function getProjectAutoloader(): string
     {
         return require __DIR__.'/project/vendor/autoload.php';
     }

--- a/lib/Filesystem/Tests/Unit/Domain/FilePathTest.php
+++ b/lib/Filesystem/Tests/Unit/Domain/FilePathTest.php
@@ -30,16 +30,19 @@ class FilePathTest extends TestCase
     }
 
     /**
-     * @dataProvider provideUnknown
+     * @dataProvider provideFilePathOrString
      */
-    public function testFromUnknownWith(FilePath|string $path, string $expectedPath): void
+    public function testFromFilePathOrString(FilePath|string $path, string $expectedPath): void
     {
-        $filePath = FilePath::fromUnknown($path);
+        $filePath = FilePath::fromFilePathOrString($path);
         $this->assertInstanceOf(FilePath::class, $filePath);
         $this->assertEquals($expectedPath, (string) $filePath);
     }
 
-    public function provideUnknown(): Generator
+    /**
+     * @return Generator<string,array{FilePath|string,string}>
+     */
+    public function provideFilePathOrString(): Generator
     {
         yield 'FilePath instance' => [
             FilePath::fromString('/foo.php'),
@@ -77,6 +80,9 @@ class FilePathTest extends TestCase
         FilePath::fromString($input);
     }
 
+    /**
+     * @return Generator<string,array{string,string}>
+     */
     public function provideUnsupportedInput(): Generator
     {
         yield 'unsupported scheme' => [

--- a/lib/Filesystem/Tests/Unit/Domain/MappedFilesystemRegistryTest.php
+++ b/lib/Filesystem/Tests/Unit/Domain/MappedFilesystemRegistryTest.php
@@ -55,7 +55,8 @@ class MappedFilesystemRegistryTest extends TestCase
         $registry->get('barfoo');
     }
 
-    private function createRegistry(array $filesystems)
+    /** @param array<string, Filesystem> $filesystems */
+    private function createRegistry(array $filesystems): MappedFilesystemRegistry
     {
         return new MappedFilesystemRegistry($filesystems);
     }

--- a/lib/TextDocument/Location.php
+++ b/lib/TextDocument/Location.php
@@ -18,17 +18,6 @@ class Location
         );
     }
 
-    /**
-    * @deprecated Use fromPathAndOffsets instead
-    */
-    public static function fromPathAndOffset(string $path, int $offset): self
-    {
-        return new self(
-            TextDocumentUri::fromString($path),
-            ByteOffsetRange::fromInts($offset, $offset),
-        );
-    }
-
     public function uri(): TextDocumentUri
     {
         return $this->uri;

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/AbstractReflectionClass.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/AbstractReflectionClass.php
@@ -11,7 +11,6 @@ use Phpactor\WorseReflection\Core\Exception\NotFound;
 use Phpactor\WorseReflection\Core\Reflection\Collection\ReflectionMethodCollection as PhpactorReflectionMethodCollection;
 use Phpactor\WorseReflection\Core\Reflection\Collection\ReflectionTraitCollection;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionClassLike;
-use Phpactor\WorseReflection\Core\Reflection\ReflectionEnum;
 use Phpactor\WorseReflection\Core\TemplateMap;
 use Phpactor\WorseReflection\Core\TypeFactory;
 use Phpactor\WorseReflection\Core\Type\ReflectedClassType;
@@ -21,21 +20,6 @@ abstract class AbstractReflectionClass extends AbstractReflectedNode implements 
 {
     abstract public function name(): ClassName;
     abstract public function docblock(): DocBlock;
-
-    public function isInterface(): bool
-    {
-        return $this instanceof ReflectionInterface;
-    }
-
-    public function isTrait(): bool
-    {
-        return $this instanceof ReflectionTrait;
-    }
-
-    public function isEnum(): bool
-    {
-        return $this instanceof ReflectionEnum;
-    }
 
     public function isClass(): bool
     {

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionClass.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionClass.php
@@ -300,11 +300,7 @@ class ReflectionClass extends AbstractReflectionClass implements CoreReflectionC
 
     public function isConcrete(): bool
     {
-        if (false === $this->isClass()) {
-            return false;
-        }
-
-        return false === $this->isAbstract();
+        return !$this->isAbstract();
     }
 
     public function docblock(): DocBlock

--- a/lib/WorseReflection/Core/Reflection/ReflectionClassLike.php
+++ b/lib/WorseReflection/Core/Reflection/ReflectionClassLike.php
@@ -32,20 +32,7 @@ interface ReflectionClassLike extends ReflectionNode
 
     public function sourceCode(): TextDocument;
 
-    /**
-     * @deprecated Use instanceof instead
-     */
-    public function isInterface(): bool;
-
     public function isInstanceOf(ClassName $className): bool;
-
-
-    /**
-     * @deprecated Use instanceof instead
-     */
-    public function isClass(): bool;
-
-    public function isEnum(): bool;
 
     public function isConcrete(): bool;
 

--- a/lib/WorseReflection/Core/Reflection/TypeResolver/MethodTypeResolver.php
+++ b/lib/WorseReflection/Core/Reflection/TypeResolver/MethodTypeResolver.php
@@ -7,7 +7,6 @@ use Phpactor\WorseReflection\Core\TypeFactory;
 use Phpactor\WorseReflection\Core\Type;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionClass;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionClassLike;
-use Phpactor\WorseReflection\Core\Reflection\ReflectionInterface;
 
 class MethodTypeResolver
 {
@@ -73,15 +72,11 @@ class MethodTypeResolver
 
     private function getTypesFromInterfaces(ReflectionClassLike $reflectionClassLike): Type
     {
-        if (false === $reflectionClassLike->isClass()) {
+        if (!$reflectionClassLike instanceof ReflectionClass) {
             return TypeFactory::undefined();
         }
 
-        /** @var ReflectionClass $reflectionClass */
-        $reflectionClass = $reflectionClassLike;
-
-        /** @var ReflectionInterface $interface */
-        foreach ($reflectionClass->interfaces() as $interface) {
+        foreach ($reflectionClassLike->interfaces() as $interface) {
             if ($interface->methods()->has($this->method->name())) {
                 return $interface->methods()->get($this->method->name())->inferredType();
             }

--- a/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Reflection/ReflectionClassTest.php
+++ b/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Reflection/ReflectionClassTest.php
@@ -48,7 +48,6 @@ class ReflectionClassTest extends IntegrationTestCase
             function ($class): void {
                 $this->assertEquals('Foobar', (string) $class->name()->short());
                 $this->assertInstanceOf(ReflectionClass::class, $class);
-                $this->assertFalse($class->isInterface());
             },
         ];
 

--- a/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Reflection/ReflectionEnumTest.php
+++ b/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Reflection/ReflectionEnumTest.php
@@ -38,7 +38,6 @@ class ReflectionEnumTest extends IntegrationTestCase
         function ($class): void {
             $this->assertEquals('Barfoo', (string) $class->name()->short());
             $this->assertInstanceOf(ReflectionEnum::class, $class);
-            $this->assertTrue($class->isEnum());
         },
             ];
         yield 'It reflect enum methods' => [

--- a/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Reflection/ReflectionInterfaceTest.php
+++ b/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Reflection/ReflectionInterfaceTest.php
@@ -37,7 +37,6 @@ class ReflectionInterfaceTest extends IntegrationTestCase
             function ($class): void {
                 $this->assertEquals('Barfoo', (string) $class->name()->short());
                 $this->assertInstanceOf(ReflectionInterface::class, $class);
-                $this->assertTrue($class->isInterface());
             },
         ];
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5461,46 +5461,6 @@ parameters:
 			path: lib/Filesystem/Adapter/Simple/SimpleFilesystem.php
 
 		-
-			message: "#^Method Phpactor\\\\Filesystem\\\\Domain\\\\FallbackFilesystemRegistry\\:\\:names\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Filesystem/Domain/FallbackFilesystemRegistry.php
-
-		-
-			message: "#^Method Phpactor\\\\Filesystem\\\\Domain\\\\FilePath\\:\\:fromParts\\(\\) has parameter \\$parts with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Filesystem/Domain/FilePath.php
-
-		-
-			message: "#^Method Phpactor\\\\Filesystem\\\\Domain\\\\FilePath\\:\\:fromUnknown\\(\\) has parameter \\$path with no type specified\\.$#"
-			count: 1
-			path: lib/Filesystem/Domain/FilePath.php
-
-		-
-			message: "#^Method Phpactor\\\\Filesystem\\\\Domain\\\\FilesystemRegistry\\:\\:names\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Filesystem/Domain/FilesystemRegistry.php
-
-		-
-			message: "#^Property Phpactor\\\\Filesystem\\\\Tests\\\\Adapter\\\\AdapterTestCase\\:\\:\\$filesystem has no type specified\\.$#"
-			count: 1
-			path: lib/Filesystem/Tests/Adapter/AdapterTestCase.php
-
-		-
-			message: "#^Property Phpactor\\\\Filesystem\\\\Tests\\\\Adapter\\\\AdapterTestCase\\:\\:\\$filesystem is unused\\.$#"
-			count: 1
-			path: lib/Filesystem/Tests/Adapter/AdapterTestCase.php
-
-		-
-			message: "#^Method Phpactor\\\\Filesystem\\\\Tests\\\\Adapter\\\\IntegrationTestCase\\:\\:getProjectAutoloader\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: lib/Filesystem/Tests/Adapter/IntegrationTestCase.php
-
-		-
-			message: "#^Method Phpactor\\\\Filesystem\\\\Tests\\\\Adapter\\\\IntegrationTestCase\\:\\:workspacePath\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: lib/Filesystem/Tests/Adapter/IntegrationTestCase.php
-
-		-
 			message: "#^Method Phpactor\\\\Filesystem\\\\Tests\\\\Unit\\\\Domain\\\\FilePathTest\\:\\:provideUnknown\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: lib/Filesystem/Tests/Unit/Domain/FilePathTest.php
@@ -5509,26 +5469,6 @@ parameters:
 			message: "#^Method Phpactor\\\\Filesystem\\\\Tests\\\\Unit\\\\Domain\\\\FilePathTest\\:\\:provideUnsupportedInput\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: lib/Filesystem/Tests/Unit/Domain/FilePathTest.php
-
-		-
-			message: "#^Method Phpactor\\\\Filesystem\\\\Tests\\\\Unit\\\\Domain\\\\FilePathTest\\:\\:testFromUnknownWith\\(\\) has parameter \\$path with no type specified\\.$#"
-			count: 1
-			path: lib/Filesystem/Tests/Unit/Domain/FilePathTest.php
-
-		-
-			message: "#^Method Phpactor\\\\Filesystem\\\\Tests\\\\Unit\\\\Domain\\\\FilePathTest\\:\\:testThrowExceptionOnUnknowableType\\(\\) has parameter \\$input with no type specified\\.$#"
-			count: 1
-			path: lib/Filesystem/Tests/Unit/Domain/FilePathTest.php
-
-		-
-			message: "#^Method Phpactor\\\\Filesystem\\\\Tests\\\\Unit\\\\Domain\\\\MappedFilesystemRegistryTest\\:\\:createRegistry\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: lib/Filesystem/Tests/Unit/Domain/MappedFilesystemRegistryTest.php
-
-		-
-			message: "#^Method Phpactor\\\\Filesystem\\\\Tests\\\\Unit\\\\Domain\\\\MappedFilesystemRegistryTest\\:\\:createRegistry\\(\\) has parameter \\$filesystems with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Filesystem/Tests/Unit/Domain/MappedFilesystemRegistryTest.php
 
 		-
 			message: "#^Method Phpactor\\\\Indexer\\\\Adapter\\\\Php\\\\InMemory\\\\InMemoryIndex\\:\\:get\\(\\) should return TRecord of Phpactor\\\\Indexer\\\\Model\\\\Record but returns Phpactor\\\\Indexer\\\\Model\\\\Record\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -621,11 +621,6 @@ parameters:
 			path: lib/CodeTransform/Tests/Adapter/TolerantParser/ClassToFile/Transformer/ClassNameFixerTransformerTest.php
 
 		-
-			message: "#^Method Phpactor\\\\CodeTransform\\\\Tests\\\\Adapter\\\\TolerantParser\\\\Refactor\\\\AbstractTolerantImportNameTest\\:\\:importNameFromTestFile\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: lib/CodeTransform/Tests/Adapter/TolerantParser/Refactor/AbstractTolerantImportNameTest.php
-
-		-
 			message: "#^Method Phpactor\\\\CodeTransform\\\\Tests\\\\Adapter\\\\TolerantParser\\\\Refactor\\\\TolerantChangeVisiblityTest\\:\\:provideChangeVisibility\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: lib/CodeTransform/Tests/Adapter/TolerantParser/Refactor/TolerantChangeVisiblityTest.php
@@ -2976,11 +2971,6 @@ parameters:
 			path: lib/Extension/Core/Application/Status.php
 
 		-
-			message: "#^Method Phpactor\\\\Extension\\\\Core\\\\Application\\\\Status\\:\\:versionInfo\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Extension/Core/Application/Status.php
-
-		-
 			message: "#^Cannot call method path\\(\\) on mixed\\.$#"
 			count: 2
 			path: lib/Extension/Core/Command/ConfigDumpCommand.php
@@ -4054,11 +4044,6 @@ parameters:
 			message: "#^Property Phpactor\\\\LanguageServerProtocol\\\\ServerCapabilities\\:\\:\\$workspace \\(array\\{workspaceFolders\\: Phpactor\\\\LanguageServerProtocol\\\\WorkspaceFoldersServerCapabilities, fileOperations\\: Phpactor\\\\LanguageServerProtocol\\\\FileOperationOptions\\}\\|null\\) does not accept array\\{workspaceFolders\\?\\: Phpactor\\\\LanguageServerProtocol\\\\WorkspaceFoldersServerCapabilities, fileOperations\\: Phpactor\\\\LanguageServerProtocol\\\\FileOperationOptions\\}\\.$#"
 			count: 1
 			path: lib/Extension/LanguageServerRename/Handler/FileRenameHandler.php
-
-		-
-			message: "#^Cannot call method getTraceAsString\\(\\) on Throwable\\|null\\.$#"
-			count: 1
-			path: lib/Extension/LanguageServerRename/Handler/RenameHandler.php
 
 		-
 			message: "#^Method Phpactor\\\\Extension\\\\LanguageServerRename\\\\Handler\\\\RenameHandler\\:\\:prepareRename\\(\\) should return Amp\\\\Promise\\<Phpactor\\\\LanguageServerProtocol\\\\Range\\> but returns Amp\\\\Promise\\<mixed\\>\\.$#"
@@ -5556,47 +5541,12 @@ parameters:
 			path: lib/Indexer/Adapter/Php/InMemory/InMemoryIndex.php
 
 		-
-			message: "#^Cannot call method path\\(\\) on Phpactor\\\\TextDocument\\\\TextDocumentUri\\|null\\.$#"
-			count: 2
-			path: lib/Indexer/Adapter/Tolerant/Indexer/AbstractClassLikeIndexer.php
-
-		-
 			message: "#^Parameter \\#1 \\$name of static method Phpactor\\\\Indexer\\\\Model\\\\Record\\\\ClassRecord\\:\\:fromName\\(\\) expects string, Microsoft\\\\PhpParser\\\\ResolvedName\\|string\\|null given\\.$#"
 			count: 1
 			path: lib/Indexer/Adapter/Tolerant/Indexer/ClassDeclarationIndexer.php
 
 		-
-			message: "#^Cannot call method path\\(\\) on Phpactor\\\\TextDocument\\\\TextDocumentUri\\|null\\.$#"
-			count: 3
-			path: lib/Indexer/Adapter/Tolerant/Indexer/ClassLikeReferenceIndexer.php
-
-		-
-			message: "#^Cannot call method path\\(\\) on Phpactor\\\\TextDocument\\\\TextDocumentUri\\|null\\.$#"
-			count: 2
-			path: lib/Indexer/Adapter/Tolerant/Indexer/ConstantDeclarationIndexer.php
-
-		-
-			message: "#^Cannot call method path\\(\\) on Phpactor\\\\TextDocument\\\\TextDocumentUri\\|null\\.$#"
-			count: 1
-			path: lib/Indexer/Adapter/Tolerant/Indexer/FunctionDeclarationIndexer.php
-
-		-
-			message: "#^Cannot call method path\\(\\) on Phpactor\\\\TextDocument\\\\TextDocumentUri\\|null\\.$#"
-			count: 3
-			path: lib/Indexer/Adapter/Tolerant/Indexer/FunctionReferenceIndexer.php
-
-		-
-			message: "#^Cannot call method path\\(\\) on Phpactor\\\\TextDocument\\\\TextDocumentUri\\|null\\.$#"
-			count: 3
-			path: lib/Indexer/Adapter/Tolerant/Indexer/MemberIndexer.php
-
-		-
 			message: "#^Cannot call method __toString\\(\\) on Phpactor\\\\TextDocument\\\\TextDocumentUri\\|null\\.$#"
-			count: 1
-			path: lib/Indexer/Adapter/Tolerant/TolerantIndexBuilder.php
-
-		-
-			message: "#^Cannot call method path\\(\\) on Phpactor\\\\TextDocument\\\\TextDocumentUri\\|null\\.$#"
 			count: 1
 			path: lib/Indexer/Adapter/Tolerant/TolerantIndexBuilder.php
 
@@ -5997,16 +5947,6 @@ parameters:
 
 		-
 			message: "#^Cannot call method path\\(\\) on Phpactor\\\\TextDocument\\\\TextDocumentUri\\|null\\.$#"
-			count: 1
-			path: lib/Rename/Tests/Adapter/ClassMover/FileRenamerTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$from of method Phpactor\\\\Rename\\\\Adapter\\\\ClassMover\\\\FileRenamer\\:\\:renameFile\\(\\) expects Phpactor\\\\TextDocument\\\\TextDocumentUri, Phpactor\\\\TextDocument\\\\TextDocumentUri\\|null given\\.$#"
-			count: 1
-			path: lib/Rename/Tests/Adapter/ClassMover/FileRenamerTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$to of method Phpactor\\\\Rename\\\\Adapter\\\\ClassMover\\\\FileRenamer\\:\\:renameFile\\(\\) expects Phpactor\\\\TextDocument\\\\TextDocumentUri, Phpactor\\\\TextDocument\\\\TextDocumentUri\\|null given\\.$#"
 			count: 1
 			path: lib/Rename/Tests/Adapter/ClassMover/FileRenamerTest.php
 
@@ -6454,11 +6394,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$items of class Phpactor\\\\WorseReflection\\\\Core\\\\Reflection\\\\Collection\\\\ReflectionConstantCollection constructor expects array\\<Phpactor\\\\WorseReflection\\\\Core\\\\Reflection\\\\ReflectionConstant\\>, array\\<Phpactor\\\\WorseReflection\\\\Core\\\\Reflection\\\\Collection\\\\ReflectionConstant&T of Phpactor\\\\WorseReflection\\\\Core\\\\Reflection\\\\ReflectionMember\\> given\\.$#"
 			count: 1
 			path: lib/WorseReflection/Core/Reflection/Collection/HomogeneousReflectionMemberCollection.php
-
-		-
-			message: "#^Parameter \\#3 \\$node of class Phpactor\\\\WorseReflection\\\\Bridge\\\\TolerantParser\\\\Reflection\\\\ReflectionArgument constructor expects Microsoft\\\\PhpParser\\\\Node\\\\Expression\\\\ArgumentExpression, mixed given\\.$#"
-			count: 1
-			path: lib/WorseReflection/Core/Reflection/Collection/ReflectionArgumentCollection.php
 
 		-
 			message: "#^Cannot call method getName\\(\\) on mixed\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5461,16 +5461,6 @@ parameters:
 			path: lib/Filesystem/Adapter/Simple/SimpleFilesystem.php
 
 		-
-			message: "#^Method Phpactor\\\\Filesystem\\\\Tests\\\\Unit\\\\Domain\\\\FilePathTest\\:\\:provideUnknown\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: lib/Filesystem/Tests/Unit/Domain/FilePathTest.php
-
-		-
-			message: "#^Method Phpactor\\\\Filesystem\\\\Tests\\\\Unit\\\\Domain\\\\FilePathTest\\:\\:provideUnsupportedInput\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: lib/Filesystem/Tests/Unit/Domain/FilePathTest.php
-
-		-
 			message: "#^Method Phpactor\\\\Indexer\\\\Adapter\\\\Php\\\\InMemory\\\\InMemoryIndex\\:\\:get\\(\\) should return TRecord of Phpactor\\\\Indexer\\\\Model\\\\Record but returns Phpactor\\\\Indexer\\\\Model\\\\Record\\.$#"
 			count: 1
 			path: lib/Indexer/Adapter/Php/InMemory/InMemoryIndex.php

--- a/templates/help/markdown/Phpactor/WorseReflection/Core/Reflection/ReflectionMethod.twig
+++ b/templates/help/markdown/Phpactor/WorseReflection/Core/Reflection/ReflectionMethod.twig
@@ -11,7 +11,7 @@
 {%- endif -%}
 {% if object.isVirtual %}[virtual] {% endif -%}
     {% if object.isAbstract -%}abstract {% endif -%}
-{{- object.visibility ~ ' ' -}} 
+{{- object.visibility ~ ' ' -}}
 {%- if object.isStatic %}static {% endif %}
 function {{ object.name }}({{ render(object.parameters) }})
 {%- if typeDefined(object.inferredType) %}: {{ render(object.inferredType) }}{% endif -%}

--- a/tests/Unit/Extension/ClassMover/Application/Finder/FileFinderTest.php
+++ b/tests/Unit/Extension/ClassMover/Application/Finder/FileFinderTest.php
@@ -14,13 +14,20 @@ use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use RuntimeException;
+use Phpactor\TextDocument\TextDocument;
 
 class FileFinderTest extends TestCase
 {
     use ProphecyTrait;
 
+    /**
+     * @var ObjectProphecy<Filesystem>
+     */
     private ObjectProphecy $filesystem;
 
+    /**
+    * @var ObjectProphecy<FileList>
+    */
     private ObjectProphecy $fileList;
 
     public function setUp(): void
@@ -84,7 +91,7 @@ class FileFinderTest extends TestCase
         $this->assertEquals(FileList::fromFilePaths(['barfoo', 'barfoo', 'barfoo', 'barfoo']), $files);
     }
 
-    private function filesFor(ReflectionClassLike $class = null, string $memberName = null)
+    private function filesFor(ReflectionClassLike $class = null, string $memberName = null): FileList
     {
         return (new FileFinder())->filesFor($this->filesystem->reveal(), $class, $memberName);
     }
@@ -96,7 +103,7 @@ class FileFinderTest extends TestCase
         $this->fileList->phpFiles()->willReturn($this->fileList->reveal());
     }
 
-    private function reflectClass($source, string $name)
+    private function reflectClass(string|TextDocument $source, string $name): ReflectionClassLike
     {
         if (is_string($source)) {
             $source = '<?php ' . $source;

--- a/tests/Unit/Extension/ClassMover/Command/Logger/SymfonyConsoleMoveLoggerTest.php
+++ b/tests/Unit/Extension/ClassMover/Command/Logger/SymfonyConsoleMoveLoggerTest.php
@@ -19,9 +19,9 @@ use Phpactor\ClassMover\Domain\Reference\Position;
 
 class SymfonyConsoleMoveLoggerTest extends TestCase
 {
-    private $output;
+    private BufferedOutput $output;
 
-    private $logger;
+    private SymfonyConsoleMoveLogger $logger;
 
     public function setUp(): void
     {

--- a/tests/Unit/Extension/ClassMover/Rpc/ClassCopyHandlerTest.php
+++ b/tests/Unit/Extension/ClassMover/Rpc/ClassCopyHandlerTest.php
@@ -19,6 +19,9 @@ class ClassCopyHandlerTest extends HandlerTestCase
     const SOURCE_PATH = 'souce_path';
     const DEST_PATH = 'souce_path';
 
+    /**
+     * @var ObjectProphecy<ClassCopy>
+     */
     private ObjectProphecy $classCopy;
 
     public function setUp(): void
@@ -38,7 +41,7 @@ class ClassCopyHandlerTest extends HandlerTestCase
      */
     public function testNoDestPath(): void
     {
-        /** @var $action InputCallbackAction */
+        /** @var InputCallbackAction $action */
         $action = $this->handle('copy_class', [
             'source_path' => self::SOURCE_PATH,
             'dest_path' => null,

--- a/tests/Unit/Extension/ClassMover/Rpc/ClassMoveHandlerTest.php
+++ b/tests/Unit/Extension/ClassMover/Rpc/ClassMoveHandlerTest.php
@@ -42,7 +42,7 @@ class ClassMoveHandlerTest extends HandlerTestCase
 
     public function testNotConfirmed(): void
     {
-        /** @var $action InputCallbackAction */
+        /** @var InputCallbackAction $action */
         $action = $this->handle('move_class', [
             'source_path' => self::SOURCE_PATH,
             'dest_path' => null,

--- a/tests/Unit/Extension/ClassMover/Rpc/ReferencesHandlerTest.php
+++ b/tests/Unit/Extension/ClassMover/Rpc/ReferencesHandlerTest.php
@@ -440,7 +440,7 @@ class ReferencesHandlerTest extends HandlerTestCase
         ], $second->parameters());
     }
 
-    private function exampleMemberRiskyResponse()
+    private function exampleMemberRiskyResponse(): array
     {
         return [
             'references' => [
@@ -467,7 +467,7 @@ class ReferencesHandlerTest extends HandlerTestCase
         ];
     }
 
-    private function exampleClassResponse()
+    private function exampleClassResponse(): array
     {
         return [
             'references' => [


### PR DESCRIPTION
Using phpactor to generate return types for phpactor code.

What is in here:
* Specifying types and reducing the amount of "fromUnknown" calls since now we know what types there are.
* Removing deprecated `isClass` and `isInterface` calls from the code and replaced them with instanceof calls.
* Moving one of the tests from array returns to Generator (and include the tests).