### PR TITLE
`$this` type inside object creation

### DIFF
--- a/lib/WorseReflection/Core/Inference/Walker/FunctionLikeWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/FunctionLikeWalker.php
@@ -76,6 +76,17 @@ class FunctionLikeWalker implements Walker
             ObjectCreationExpression::class, // For Inline classes
         );
 
+        while ($classNode instanceof ObjectCreationExpression && $classNode->classTypeDesignator instanceof Node) {
+            // If we are here we found a normal ObjectCreationExpression like: new A(); and this is not useful and we continue traversing
+            $classNode = $classNode->getFirstAncestor(
+                ClassDeclaration::class,
+                InterfaceDeclaration::class,
+                TraitDeclaration::class,
+                EnumDeclaration::class,
+                ObjectCreationExpression::class, // For Inline classes
+            );
+        }
+
         if ($node instanceof AnonymousFunctionCreationExpression) {
             $this->addAnonymousImports($frame, $node);
 
@@ -87,7 +98,7 @@ class FunctionLikeWalker implements Walker
         }
 
         // works for both closure and class method (we currently ignore binding)
-        if ($classNode) {
+        if ($classNode !== null) {
             $classType = $resolver->resolveNode($frame, $classNode)->type();
             $this->addClassContext($node, $classType, $frame);
         }

--- a/lib/WorseReflection/Core/Inference/Walker/FunctionLikeWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/FunctionLikeWalker.php
@@ -68,15 +68,7 @@ class FunctionLikeWalker implements Walker
     private function walkFunctionLike(FrameResolver $resolver, Frame $frame, FunctionLike $node): void
     {
         $namespace = $node->getNamespaceDefinition();
-        $classNode = $node->getFirstAncestor(
-            ClassDeclaration::class,
-            InterfaceDeclaration::class,
-            TraitDeclaration::class,
-            EnumDeclaration::class,
-            ObjectCreationExpression::class, // For Inline classes
-        );
-
-        while ($classNode instanceof ObjectCreationExpression && $classNode->classTypeDesignator instanceof Node) {
+        do {
             // If we are here we found a normal ObjectCreationExpression like: new A(); and this is not useful and we continue traversing
             $classNode = $classNode->getFirstAncestor(
                 ClassDeclaration::class,
@@ -85,7 +77,7 @@ class FunctionLikeWalker implements Walker
                 EnumDeclaration::class,
                 ObjectCreationExpression::class, // For Inline classes
             );
-        }
+        } while ($classNode instanceof ObjectCreationExpression && $classNode->classTypeDesignator instanceof Node);
 
         if ($node instanceof AnonymousFunctionCreationExpression) {
             $this->addAnonymousImports($frame, $node);

--- a/lib/WorseReflection/Core/Inference/Walker/FunctionLikeWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/FunctionLikeWalker.php
@@ -70,7 +70,7 @@ class FunctionLikeWalker implements Walker
         $namespace = $node->getNamespaceDefinition();
         do {
             // If we are here we found a normal ObjectCreationExpression like: new A(); and this is not useful and we continue traversing
-            $classNode = $classNode->getFirstAncestor(
+            $classNode = ($classNode ?? $node)->getFirstAncestor(
                 ClassDeclaration::class,
                 InterfaceDeclaration::class,
                 TraitDeclaration::class,

--- a/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/FunctionLikeWalkerTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/FunctionLikeWalkerTest.php
@@ -34,6 +34,29 @@ class FunctionLikeWalkerTest extends FrameWalkerTestCase
             $this->assertEquals(false, $frame->locals()->byName('this')->first()->isProperty());
         }];
 
+        yield 'It returns this with correct type' => [
+            <<<'EOT'
+                <?php
+
+                namespace Foobar\Barfoo;
+
+                use Acme\Factory;
+
+                class Foobar
+                {
+                    public function hello()
+                    {
+                        new \ReflectionFunction(function() { <> });
+                    }
+                }
+
+                EOT
+        , function (Frame $frame): void {
+            $this->assertCount(1, $frame->locals()->byName('this'));
+            $this->assertEquals('Foobar\Barfoo\Foobar', $frame->locals()->byName('this')->first()->type()->__toString());
+            $this->assertEquals(false, $frame->locals()->byName('this')->first()->isProperty());
+        }];
+
         yield 'It returns method arguments' => [
             <<<'EOT'
                 <?php

--- a/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/FunctionLikeWalkerTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/Inference/FrameWalker/FunctionLikeWalkerTest.php
@@ -34,7 +34,7 @@ class FunctionLikeWalkerTest extends FrameWalkerTestCase
             $this->assertEquals(false, $frame->locals()->byName('this')->first()->isProperty());
         }];
 
-        yield 'It returns this with correct type' => [
+        yield 'It returns this with correct type in an anonymous function' => [
             <<<'EOT'
                 <?php
 


### PR DESCRIPTION
That's an easy fix. If we're inside an `ObjectCreationExpression` and it has a name, then just continue looking up the tree. 