### PR TITLE
Fix "Permission denied" errors in Filesystem tests on Windows

### DIFF
--- a/lib/Filesystem/Tests/Adapter/IntegrationTestCase.php
+++ b/lib/Filesystem/Tests/Adapter/IntegrationTestCase.php
@@ -11,6 +11,12 @@ abstract class IntegrationTestCase extends TestCase
     {
         $filesystem = new Filesystem();
         if ($filesystem->exists($this->workspacePath())) {
+            if ('\\' === \DIRECTORY_SEPARATOR) {
+                // On Windows, make files in the workspace writable first (recursively),
+                // because read-only files can't be deleted using the normal filesystem APIs,
+                // and Git marks files in its .git directory as read-only.
+                $filesystem->chmod($this->workspacePath(), 0666, 0, true);
+            }
             $filesystem->remove($this->workspacePath());
         }
 


### PR DESCRIPTION
On Windows, make files in the workspace writable first (recursively), because read-only files can't be deleted using the normal filesystem APIs, and Git marks files in its .git directory as read-only.

For example, note the documentation here:
https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-deletefilea#remarks "To delete a read-only file, first you must remove the read-only attribute."