### PR TITLE
Avoid writing to /dev/null

### DIFF
--- a/lib/ClassMover/Tests/Adapter/AdapterTestCase.php
+++ b/lib/ClassMover/Tests/Adapter/AdapterTestCase.php
@@ -28,7 +28,7 @@ abstract class AdapterTestCase extends TestCase
         $filesystem = new Filesystem();
         $filesystem->mirror($projectPath, $this->workspacePath());
         chdir($this->workspacePath());
-        exec('composer dumpautoload 2> /dev/null');
+        exec('composer dumpautoload --quiet');
     }
 
     protected function getProjectAutoloader(): mixed

--- a/lib/Filesystem/Tests/Adapter/Composer/ComposerFilesystemTest.php
+++ b/lib/Filesystem/Tests/Adapter/Composer/ComposerFilesystemTest.php
@@ -13,7 +13,7 @@ class ComposerFilesystemTest extends AdapterTestCase
     {
         parent::setUp();
         chdir($this->workspacePath());
-        exec('composer dumpautoload  2> /dev/null');
+        exec('composer dumpautoload --quiet');
     }
 
     public function testClassmap(): void

--- a/lib/Filesystem/Tests/Adapter/IntegrationTestCase.php
+++ b/lib/Filesystem/Tests/Adapter/IntegrationTestCase.php
@@ -28,7 +28,7 @@ abstract class IntegrationTestCase extends TestCase
         $filesystem = new Filesystem();
         $filesystem->mirror($projectPath, $this->workspacePath());
         chdir($this->workspacePath());
-        exec('composer dumpautoload 2> /dev/null');
+        exec('composer dumpautoload --quiet');
     }
 
     protected function getProjectAutoloader(): string


### PR DESCRIPTION
On Windows, the null device is called "nul" rather than "/dev/null". But we can avoid having to know that if we instead just pass a flag to the script to tell it to not output anything.