### PR TITLE
Use get_debug_type() instead of get_class() and gettype()

### DIFF
--- a/lib/CodeBuilder/Domain/Builder/AbstractBuilder.php
+++ b/lib/CodeBuilder/Domain/Builder/AbstractBuilder.php
@@ -4,6 +4,9 @@ namespace Phpactor\CodeBuilder\Domain\Builder;
 
 use Generator;
 use RuntimeException;
+use function is_object;
+use function sprintf;
+use function get_debug_type;
 
 abstract class AbstractBuilder implements Builder
 {
@@ -60,7 +63,7 @@ abstract class AbstractBuilder implements Builder
                     throw new RuntimeException(sprintf(
                         'Child "%s" is not a builder instance, it is a "%s"',
                         $childName,
-                        is_object($child) ? get_class($child) : gettype($child)
+                        get_debug_type($child),
                     ));
                 }
 

--- a/lib/CodeBuilder/Domain/TemplatePathResolver/FilterPhpVersionDirectoryIterator.php
+++ b/lib/CodeBuilder/Domain/TemplatePathResolver/FilterPhpVersionDirectoryIterator.php
@@ -6,6 +6,10 @@ use Iterator;
 use FilterIterator;
 use RuntimeException;
 use SplFileInfo;
+use function get_debug_type;
+use function preg_match;
+use function sprintf;
+use function version_compare;
 
 class FilterPhpVersionDirectoryIterator extends FilterIterator
 {
@@ -25,7 +29,7 @@ class FilterPhpVersionDirectoryIterator extends FilterIterator
             throw new RuntimeException(
                 sprintf(
                     'Expected instance of "\SplFileInfo", got "%s".',
-                    \is_object($file) ? \get_class($file) : \gettype($file)
+                    get_debug_type($file)
                 )
             );
         }

--- a/lib/Extension/Core/Command/DebugContainerCommand.php
+++ b/lib/Extension/Core/Command/DebugContainerCommand.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use function get_debug_type;
 
 class DebugContainerCommand extends Command
 {
@@ -53,12 +54,12 @@ class DebugContainerCommand extends Command
 
             try {
                 $value = $this->container->get($serviceId);
-                $type = is_object($value) ? get_class($value) : gettype($value);
+                $type = get_debug_type($value);
             } catch (RuntimeException $exception) {
                 $table->addRow(['<error>Error: '.$serviceId.'</>', $exception->getMessage()]);
             }
 
-            $table->addRow([$serviceId, $type ]);
+            $table->addRow([$serviceId, $type]);
         }
         $table->render();
         return $table;

--- a/lib/Extension/LanguageServer/LanguageServerExtension.php
+++ b/lib/Extension/LanguageServer/LanguageServerExtension.php
@@ -73,6 +73,13 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Webmozart\Assert\Assert;
+use function array_filter;
+use function array_keys;
+use function array_values;
+use function get_debug_type;
+use function implode;
+use function is_string;
+use function sprintf;
 
 class LanguageServerExtension implements Extension
 {
@@ -336,7 +343,7 @@ class LanguageServerExtension implements Extension
                     throw new RuntimeException(sprintf(
                         'Tagged service provider "%s" does not implement ServiceProvider interface, is a "%s"',
                         $serviceId,
-                        is_object($provider) ? get_class($provider) : gettype($provider)
+                        get_debug_type($provider),
                     ));
                 }
                 $providers[] = $provider;

--- a/lib/WorseReflection/Core/Name.php
+++ b/lib/WorseReflection/Core/Name.php
@@ -3,6 +3,12 @@
 namespace Phpactor\WorseReflection\Core;
 
 use InvalidArgumentException;
+use function explode;
+use function get_debug_type;
+use function implode;
+use function sprintf;
+use function str_starts_with;
+use function trim;
 
 class Name
 {
@@ -46,7 +52,7 @@ class Name
         /** @phpstan-ignore-next-line */
         throw new InvalidArgumentException(sprintf(
             'Do not know how to create class from type "%s"',
-            is_object($value) ? get_class($value) : gettype($value)
+            get_debug_type($value)
         ));
     }
 


### PR DESCRIPTION
With PHP 8's addition of [`get_debug_type()`](https://www.php.net/get_debug_type), there's no longer a need to distinguish between `get_class()` and `gettype()`.