### PR TITLE
Renaming the reflector method

### DIFF
--- a/lib/CodeBuilder/Adapter/WorseReflection/WorseBuilderFactory.php
+++ b/lib/CodeBuilder/Adapter/WorseReflection/WorseBuilderFactory.php
@@ -37,7 +37,7 @@ class WorseBuilderFactory implements BuilderFactory
                 ->build();
         }
 
-        $classes = $this->reflector->reflectClassesIn($source);
+        $classes = $this->reflector->reflectClassLikesIn($source);
         $builder = SourceCodeBuilder::create();
 
         foreach ($classes as $classLike) {

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseGenerateAccessor.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseGenerateAccessor.php
@@ -99,7 +99,7 @@ class WorseGenerateAccessor implements PropertyAccessGenerator
 
     private function class(SourceCode $source, int $offset): ReflectionClass
     {
-        $classes = $this->reflector->reflectClassesIn($source)->classes();
+        $classes = $this->reflector->reflectClassLikesIn($source)->classes();
 
         if (0 === $classes->count()) {
             throw new InvalidArgumentException(

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseGenerateDecorator.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseGenerateDecorator.php
@@ -23,7 +23,7 @@ class WorseGenerateDecorator implements GenerateDecorator
 
     public function getTextEdits(SourceCode $source, string $interfaceFQN): TextEdits
     {
-        $class = $this->reflector->reflectClassesIn($source)->classes()->first();
+        $class = $this->reflector->reflectClassLikesIn($source)->classes()->first();
 
         $builder = SourceCodeBuilder::create();
         $builder->namespace($class->name()->namespace());

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseGenerateMutator.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseGenerateMutator.php
@@ -109,7 +109,7 @@ class WorseGenerateMutator implements PropertyAccessGenerator
 
     private function class(SourceCode $source, int $offset): ReflectionClass
     {
-        $classes = $this->reflector->reflectClassesIn($source)->classes();
+        $classes = $this->reflector->reflectClassLikesIn($source)->classes();
 
         if (0 === $classes->count()) {
             throw new InvalidArgumentException(

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseOverrideMethod.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseOverrideMethod.php
@@ -45,7 +45,7 @@ class WorseOverrideMethod implements OverrideMethod
             $builder->uri($source->uri());
         }
 
-        $classes = $this->reflector->reflectClassesIn($builder->build())->classes();
+        $classes = $this->reflector->reflectClassLikesIn($builder->build())->classes();
 
         return $classes->get($className);
     }

--- a/lib/CodeTransform/Adapter/WorseReflection/Transformer/CompleteConstructor.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Transformer/CompleteConstructor.php
@@ -176,7 +176,7 @@ class CompleteConstructor implements Transformer
      */
     private function candidateClasses(SourceCode $source): Generator
     {
-        $classes = $this->reflector->reflectClassesIn($source)->classes();
+        $classes = $this->reflector->reflectClassLikesIn($source)->classes();
         foreach ($classes as $class) {
             if ($class instanceof ReflectionInterface) {
                 continue;

--- a/lib/CodeTransform/Adapter/WorseReflection/Transformer/ImplementContracts.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Transformer/ImplementContracts.php
@@ -34,7 +34,7 @@ class ImplementContracts implements Transformer
     {
         return new Success((function () use ($source) {
             $diagnostics = [];
-            $classes = $this->reflector->reflectClassesIn($source);
+            $classes = $this->reflector->reflectClassLikesIn($source);
             foreach ($classes->concrete() as $class) {
                 assert($class instanceof ReflectionClass);
                 $missingMethods = $this->missingClassMethods($class);
@@ -66,7 +66,7 @@ class ImplementContracts implements Transformer
     public function transform(SourceCode $source): Promise
     {
         return new Success((function () use ($source) {
-            $classes = $this->reflector->reflectClassesIn($source);
+            $classes = $this->reflector->reflectClassLikesIn($source);
             $edits = [];
             $sourceCodeBuilder = SourceCodeBuilder::create();
 

--- a/lib/Completion/Tests/Integration/Bridge/WorseReflection/Formatter/ConstantFormatterTest.php
+++ b/lib/Completion/Tests/Integration/Bridge/WorseReflection/Formatter/ConstantFormatterTest.php
@@ -15,7 +15,7 @@ class ConstantFormatterTest extends IntegrationTestCase
     public function testFormatsConstant(string $code, string $expected): void
     {
         $code = TextDocumentBuilder::fromUnknown($code);
-        $constant = ReflectorBuilder::create()->build()->reflectClassesIn($code)->classes()->first()->constants()->first();
+        $constant = ReflectorBuilder::create()->build()->reflectClassLikesIn($code)->classes()->first()->constants()->first();
 
         self::assertTrue($this->formatter()->canFormat($constant));
         self::assertEquals($expected, $this->formatter()->format($constant));

--- a/lib/Completion/Tests/Integration/Bridge/WorseReflection/Formatter/InterfaceFormatterTest.php
+++ b/lib/Completion/Tests/Integration/Bridge/WorseReflection/Formatter/InterfaceFormatterTest.php
@@ -10,7 +10,7 @@ class InterfaceFormatterTest extends IntegrationTestCase
 {
     public function testFormatsInterface(): void
     {
-        $interface = ReflectorBuilder::create()->build()->reflectClassesIn(TextDocumentBuilder::fromUnknown('<?php namespace Bar {interface Foobar {}}'))->first();
+        $interface = ReflectorBuilder::create()->build()->reflectClassLikesIn(TextDocumentBuilder::fromUnknown('<?php namespace Bar {interface Foobar {}}'))->first();
         self::assertTrue($this->formatter()->canFormat($interface));
         self::assertEquals('Bar\\Foobar (interface)', $this->formatter()->format($interface));
     }

--- a/lib/Completion/Tests/Integration/Bridge/WorseReflection/Formatter/MethodFormatterTest.php
+++ b/lib/Completion/Tests/Integration/Bridge/WorseReflection/Formatter/MethodFormatterTest.php
@@ -15,7 +15,7 @@ class MethodFormatterTest extends IntegrationTestCase
     public function testFormatsConstant(string $code, string $expected): void
     {
         $code = TextDocumentBuilder::fromUnknown($code);
-        $constant = ReflectorBuilder::create()->build()->reflectClassesIn(
+        $constant = ReflectorBuilder::create()->build()->reflectClassLikesIn(
             $code
         )->first()->methods()->first();
 

--- a/lib/Completion/Tests/Integration/Bridge/WorseReflection/Formatter/TraitFormatterTest.php
+++ b/lib/Completion/Tests/Integration/Bridge/WorseReflection/Formatter/TraitFormatterTest.php
@@ -10,14 +10,14 @@ class TraitFormatterTest extends IntegrationTestCase
 {
     public function testFormatsTrait(): void
     {
-        $trait = ReflectorBuilder::create()->build()->reflectClassesIn(TextDocumentBuilder::fromUnknown('<?php namespace Bar {trait Foobar {}}'))->first();
+        $trait = ReflectorBuilder::create()->build()->reflectClassLikesIn(TextDocumentBuilder::fromUnknown('<?php namespace Bar {trait Foobar {}}'))->first();
         self::assertTrue($this->formatter()->canFormat($trait));
         self::assertEquals('Bar\\Foobar (trait)', $this->formatter()->format($trait));
     }
 
     public function testFormatsDeprecatedTrait(): void
     {
-        $trait = ReflectorBuilder::create()->build()->reflectClassesIn(TextDocumentBuilder::fromUnknown('<?php namespace Bar {/** @deprecated */trait Foobar {}}'))->first();
+        $trait = ReflectorBuilder::create()->build()->reflectClassLikesIn(TextDocumentBuilder::fromUnknown('<?php namespace Bar {/** @deprecated */trait Foobar {}}'))->first();
         self::assertTrue($this->formatter()->canFormat($trait));
         self::assertEquals('⚠ Bar\\Foobar (trait)', $this->formatter()->format($trait));
     }

--- a/lib/Completion/Tests/Unit/Bridge/WorseReflection/Formatter/FunctionLikeSnippetFormatterTest.php
+++ b/lib/Completion/Tests/Unit/Bridge/WorseReflection/Formatter/FunctionLikeSnippetFormatterTest.php
@@ -89,7 +89,7 @@ final class FunctionLikeSnippetFormatterTest extends TestCase
     {
         return ReflectorBuilder::create()
             ->build()
-            ->reflectClassesIn(TextDocumentBuilder::fromUnknown(\sprintf('<?php class Foo { public function %s {} }', $methodAsString)))
+            ->reflectClassLikesIn(TextDocumentBuilder::fromUnknown(\sprintf('<?php class Foo { public function %s {} }', $methodAsString)))
             ->first()
             ->methods()
             ->first()

--- a/lib/Extension/CodeTransformExtra/Rpc/OverrideMethodHandler.php
+++ b/lib/Extension/CodeTransformExtra/Rpc/OverrideMethodHandler.php
@@ -77,7 +77,7 @@ class OverrideMethodHandler extends AbstractHandler
 
     private function class($source, $className = null)
     {
-        $classes = $this->reflector->reflectClassesIn(TextDocumentBuilder::fromUnknown($source));
+        $classes = $this->reflector->reflectClassLikesIn(TextDocumentBuilder::fromUnknown($source));
 
         if ($classes->count() === 0) {
             throw new InvalidArgumentException(

--- a/lib/Extension/CodeTransformExtra/Rpc/PropertyAccessGeneratorHandler.php
+++ b/lib/Extension/CodeTransformExtra/Rpc/PropertyAccessGeneratorHandler.php
@@ -100,7 +100,7 @@ class PropertyAccessGeneratorHandler extends AbstractHandler
 
     private function class(string $source): ReflectionClass
     {
-        $classes = $this->reflector->reflectClassesIn(TextDocumentBuilder::fromUnknown($source))->classes();
+        $classes = $this->reflector->reflectClassLikesIn(TextDocumentBuilder::fromUnknown($source))->classes();
 
         if ($classes->count() === 0) {
             throw new InvalidArgumentException(

--- a/lib/Extension/LanguageServerCodeTransform/CodeAction/GenerateDecoratorProvider.php
+++ b/lib/Extension/LanguageServerCodeTransform/CodeAction/GenerateDecoratorProvider.php
@@ -33,7 +33,7 @@ class GenerateDecoratorProvider implements CodeActionProvider
     public function provideActionsFor(TextDocumentItem $textDocument, Range $range, CancellationToken $cancel): Promise
     {
         return call(function () use ($textDocument) {
-            $classes = $this->reflector->reflectClassesIn(TextDocumentConverter::fromLspTextItem($textDocument));
+            $classes = $this->reflector->reflectClassLikesIn(TextDocumentConverter::fromLspTextItem($textDocument));
             if (count($classes->classes()) !== 1) {
                 return [];
             }

--- a/lib/Extension/LanguageServerCodeTransform/CodeAction/PropertyAccessGeneratorProvider.php
+++ b/lib/Extension/LanguageServerCodeTransform/CodeAction/PropertyAccessGeneratorProvider.php
@@ -43,7 +43,7 @@ class PropertyAccessGeneratorProvider implements CodeActionProvider
             $startOffset = PositionConverter::positionToByteOffset($range->start, $textDocument->text)->toInt();
             $endOffset = PositionConverter::positionToByteOffset($range->end, $textDocument->text)->toInt();
 
-            $classes = $this->reflector->reflectClassesIn(TextDocumentConverter::fromLspTextItem($textDocument));
+            $classes = $this->reflector->reflectClassLikesIn(TextDocumentConverter::fromLspTextItem($textDocument));
 
             if ($classes->count() === 0) {
                 return [];

--- a/lib/Extension/LanguageServerCompletion/Tests/Integration/MarkdownObjectRendererTest.php
+++ b/lib/Extension/LanguageServerCompletion/Tests/Integration/MarkdownObjectRendererTest.php
@@ -1172,6 +1172,6 @@ class MarkdownObjectRendererTest extends IntegrationTestCase
 
     private function reflectClassesIn(Reflector $reflector, string $textDocument): ReflectionClassLikeCollection
     {
-        return $reflector->reflectClassesIn(TextDocumentBuilder::fromUnknown($textDocument));
+        return $reflector->reflectClassLikesIn(TextDocumentBuilder::fromUnknown($textDocument));
     }
 }

--- a/lib/Extension/LanguageServerWorseReflection/Workspace/WorkspaceIndex.php
+++ b/lib/Extension/LanguageServerWorseReflection/Workspace/WorkspaceIndex.php
@@ -36,9 +36,10 @@ class WorkspaceIndex
      */
     private $waiting = false;
 
-    public function __construct(private SourceCodeReflector $reflector,
- private int $updateInterval = 1000)
-    {
+    public function __construct(
+        private SourceCodeReflector $reflector,
+        private int $updateInterval = 1000
+    ) {
     }
 
     public function documentForName(Name $name): ?TextDocument
@@ -68,7 +69,7 @@ class WorkspaceIndex
         $this->documentToUpdate = null;
 
         $newNames = [];
-        foreach ($this->reflector->reflectClassesIn($textDocument) as $reflectionClass) {
+        foreach ($this->reflector->reflectClassLikesIn($textDocument) as $reflectionClass) {
             $newNames[] = $reflectionClass->name()->full();
         }
 

--- a/lib/Extension/Navigation/Navigator/WorseReflectionNavigator.php
+++ b/lib/Extension/Navigation/Navigator/WorseReflectionNavigator.php
@@ -17,7 +17,7 @@ class WorseReflectionNavigator implements Navigator
     {
         $destinations = [];
         $source = TextDocumentBuilder::fromUri($path)->build();
-        $classes = $this->reflector->reflectClassesIn($source);
+        $classes = $this->reflector->reflectClassLikesIn($source);
 
         foreach ($classes as $class) {
             if ($class instanceof ReflectionClass) {

--- a/lib/Extension/PHPUnit/CodeTransform/GenerateTestMethods.php
+++ b/lib/Extension/PHPUnit/CodeTransform/GenerateTestMethods.php
@@ -30,7 +30,7 @@ class GenerateTestMethods
     /** @return Generator<string> */
     public function getGeneratableTestMethods(SourceCode $source): Generator
     {
-        $classes = $this->reflector->reflectClassesIn($source);
+        $classes = $this->reflector->reflectClassLikesIn($source);
         if (count($classes->classes()) !== 1) {
             return;
         }
@@ -61,7 +61,7 @@ class GenerateTestMethods
             sprintf('%s can not generate "%s" with class', __CLASS__, $methodName),
         );
 
-        $class = $this->reflector->reflectClassesIn($document)->classes()->first();
+        $class = $this->reflector->reflectClassLikesIn($document)->classes()->first();
 
         $builder = SourceCodeBuilder::create();
         $builder->namespace($class->name()->namespace());

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflector/TolerantSourceCodeReflector.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflector/TolerantSourceCodeReflector.php
@@ -41,7 +41,7 @@ class TolerantSourceCodeReflector implements SourceCodeReflector
     /**
      * @param array<string,bool> $visited
      */
-    public function reflectClassesIn(
+    public function reflectClassLikesIn(
         TextDocument $sourceCode,
         array $visited = []
     ): ReflectionClassLikeCollection {

--- a/lib/WorseReflection/Core/Reflector/CompositeReflector.php
+++ b/lib/WorseReflection/Core/Reflector/CompositeReflector.php
@@ -59,9 +59,9 @@ class CompositeReflector implements Reflector
         return $this->classReflector->reflectClassLike($className, $visited);
     }
 
-    public function reflectClassesIn(TextDocument $sourceCode, array $visited = []): ReflectionClassLikeCollection
+    public function reflectClassLikesIn(TextDocument $sourceCode, array $visited = []): ReflectionClassLikeCollection
     {
-        return $this->sourceCodeReflector->reflectClassesIn($sourceCode, $visited);
+        return $this->sourceCodeReflector->reflectClassLikesIn($sourceCode, $visited);
     }
 
     public function reflectOffset(TextDocument $sourceCode, $offset): ReflectionOffset

--- a/lib/WorseReflection/Core/Reflector/CoreReflector.php
+++ b/lib/WorseReflection/Core/Reflector/CoreReflector.php
@@ -148,7 +148,7 @@ class CoreReflector implements ClassReflector, SourceCodeReflector, FunctionRefl
         $visited[$className->__toString()] = true;
 
         $source = $this->sourceLocator->locate($className);
-        $classes = $this->reflectClassesIn($source, $visited);
+        $classes = $this->reflectClassLikesIn($source, $visited);
 
         if (false === $classes->has((string) $className)) {
             throw new ClassNotFound(sprintf(
@@ -165,9 +165,9 @@ class CoreReflector implements ClassReflector, SourceCodeReflector, FunctionRefl
     /**
      * Reflect all classes (or class-likes) in the given source code.
      */
-    public function reflectClassesIn(TextDocument $sourceCode, array $visited = []): ReflectionClassLikeCollection
+    public function reflectClassLikesIn(TextDocument $sourceCode, array $visited = []): ReflectionClassLikeCollection
     {
-        return $this->sourceReflector->reflectClassesIn($sourceCode, $visited);
+        return $this->sourceReflector->reflectClassLikesIn($sourceCode, $visited);
     }
 
     /**

--- a/lib/WorseReflection/Core/Reflector/SourceCode/ContextualSourceCodeReflector.php
+++ b/lib/WorseReflection/Core/Reflector/SourceCode/ContextualSourceCodeReflector.php
@@ -27,11 +27,11 @@ class ContextualSourceCodeReflector implements SourceCodeReflector
     ) {
     }
 
-    public function reflectClassesIn(TextDocument $sourceCode, array $visited = []): ReflectionClassLikeCollection
+    public function reflectClassLikesIn(TextDocument $sourceCode, array $visited = []): ReflectionClassLikeCollection
     {
         $this->locator->pushSourceCode(TextDocumentBuilder::fromUnknown($sourceCode));
 
-        $collection = $this->innerReflector->reflectClassesIn($sourceCode, $visited);
+        $collection = $this->innerReflector->reflectClassLikesIn($sourceCode, $visited);
 
         return $collection;
     }

--- a/lib/WorseReflection/Core/Reflector/SourceCodeReflector.php
+++ b/lib/WorseReflection/Core/Reflector/SourceCodeReflector.php
@@ -28,7 +28,7 @@ interface SourceCodeReflector
      *
      * @param array<string,bool> $visited
      */
-    public function reflectClassesIn(
+    public function reflectClassLikesIn(
         TextDocument $sourceCode,
         array $visited = []
     ): ReflectionClassLikeCollection;

--- a/lib/WorseReflection/Core/SourceCodeLocator/BruteForceSourceLocator.php
+++ b/lib/WorseReflection/Core/SourceCodeLocator/BruteForceSourceLocator.php
@@ -83,7 +83,7 @@ final class BruteForceSourceLocator implements SourceCodeLocator
      */
     private function buildClassMap(SplFileInfo $file, array $map): array
     {
-        $functions = $this->reflector->reflectClassesIn(
+        $functions = $this->reflector->reflectClassLikesIn(
             TextDocumentBuilder::fromUri($file)->build()
         );
 

--- a/lib/WorseReflection/Core/SourceCodeLocator/StubSourceLocator.php
+++ b/lib/WorseReflection/Core/SourceCodeLocator/StubSourceLocator.php
@@ -98,7 +98,7 @@ final class StubSourceLocator implements SourceCodeLocator
      */
     private function buildClassMap(SplFileInfo $file, array $map): array
     {
-        $functions = $this->reflector->reflectClassesIn(
+        $functions = $this->reflector->reflectClassLikesIn(
             TextDocumentBuilder::fromUri($file)->build()
         );
 

--- a/lib/WorseReflection/Core/SourceCodeLocator/TemporarySourceLocator.php
+++ b/lib/WorseReflection/Core/SourceCodeLocator/TemporarySourceLocator.php
@@ -55,7 +55,7 @@ class TemporarySourceLocator implements SourceCodeLocator
     public function locate(Name $name): TextDocument
     {
         foreach ($this->sources as $source) {
-            $classes = $this->reflector->reflectClassesIn($source);
+            $classes = $this->reflector->reflectClassLikesIn($source);
 
             if ($classes->has((string) $name)) {
                 return $source;

--- a/lib/WorseReflection/Tests/Benchmarks/ReflectionStubsBench.php
+++ b/lib/WorseReflection/Tests/Benchmarks/ReflectionStubsBench.php
@@ -25,7 +25,7 @@ class ReflectionStubsBench extends BaseBenchCase
      */
     public function test_classes_and_methods(): void
     {
-        $classes = $this->reflector->reflectClassesIn(TextDocumentBuilder::fromUri(__DIR__ . '/../../../../vendor/jetbrains/phpstorm-stubs/Reflection/Reflection.php')->build());
+        $classes = $this->reflector->reflectClassLikesIn(TextDocumentBuilder::fromUri(__DIR__ . '/../../../../vendor/jetbrains/phpstorm-stubs/Reflection/Reflection.php')->build());
 
         foreach ($classes as $class) {
             foreach ($class->methods() as $method) {

--- a/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Reflection/Collection/ReflectionClassCollectionTest.php
+++ b/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Reflection/Collection/ReflectionClassCollectionTest.php
@@ -15,7 +15,7 @@ class ReflectionClassCollectionTest extends IntegrationTestCase
      */
     public function testCollection(string $source, Closure $assertion): void
     {
-        $collection = $this->createReflector($source)->reflectClassesIn(TextDocumentBuilder::create($source)->build());
+        $collection = $this->createReflector($source)->reflectClassLikesIn(TextDocumentBuilder::create($source)->build());
         $assertion($collection);
     }
 

--- a/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Reflection/Collection/ReflectionParameterCollectionTest.php
+++ b/lib/WorseReflection/Tests/Integration/Bridge/TolerantParser/Reflection/Collection/ReflectionParameterCollectionTest.php
@@ -16,7 +16,7 @@ class ReflectionParameterCollectionTest extends IntegrationTestCase
     public function testCollection(string $source, Closure $assertion): void
     {
         $source = TextDocumentBuilder::fromUnknown($source);
-        $collection = $this->createReflector($source)->reflectClassesIn($source)->first()->methods()->first()->parameters();
+        $collection = $this->createReflector($source)->reflectClassLikesIn($source)->first()->methods()->first()->parameters();
         $assertion($collection);
     }
 

--- a/lib/WorseReflection/Tests/Smoke/smoke_test.php
+++ b/lib/WorseReflection/Tests/Smoke/smoke_test.php
@@ -65,7 +65,7 @@ foreach ($files as $file) {
     $message = $file->getPathname();
     try {
         $source = TextDocumentBuilder::create(file_get_contents($file->getPathname()))->uri($file->getPathname())->build();
-        $classes = $reflector->reflectClassesIn($source);
+        $classes = $reflector->reflectClassLikesIn($source);
 
         /** @var ReflectionClass $class */
         foreach ($classes as $class) {

--- a/lib/WorseReflection/Tests/Unit/Bridge/Phpactor/DocblockParser/DocblockParserFactoryTest.php
+++ b/lib/WorseReflection/Tests/Unit/Bridge/Phpactor/DocblockParser/DocblockParserFactoryTest.php
@@ -284,7 +284,7 @@ class DocblockParserFactoryTest extends IntegrationTestCase
             EOT;
         $reflector = ReflectorBuilder::create()->addSource($source)->build();
         $source = TextDocumentBuilder::fromUnknown($source);
-        $class = $reflector->reflectClassesIn(
+        $class = $reflector->reflectClassLikesIn(
             $source
         )->first();
         $docblock = $this->parseDocblockWithClass($reflector, $class, '/** @return self::BAR */');
@@ -304,7 +304,7 @@ class DocblockParserFactoryTest extends IntegrationTestCase
             EOT;
         $reflector = ReflectorBuilder::create()->addSource($source)->build();
         $source = TextDocumentBuilder::fromUnknown($source);
-        $class = $reflector->reflectClassesIn($source)->first();
+        $class = $reflector->reflectClassLikesIn($source)->first();
         $docblock = $this->parseDocblockWithClass($reflector, $class, '/** @return Foo::BA* */');
         self::assertEquals('Foo::BA*', $docblock->returnType()->__toString());
     }
@@ -322,7 +322,7 @@ class DocblockParserFactoryTest extends IntegrationTestCase
             EOT;
         $reflector = ReflectorBuilder::create()->addSource($source)->build();
         $source = TextDocumentBuilder::fromUnknown($source);
-        $class = $reflector->reflectClassesIn($source)->first();
+        $class = $reflector->reflectClassLikesIn($source)->first();
         $docblock = $this->parseDocblockWithClass($reflector, $class, '/** @return array{string,Foo::*} */');
         self::assertEquals('array{string,Foo::*}', $docblock->returnType()->__toString());
     }

--- a/lib/WorseReflection/Tests/Unit/Core/Reflector/SourceCode/ContextualSourceCodeReflectorTest.php
+++ b/lib/WorseReflection/Tests/Unit/Core/Reflector/SourceCode/ContextualSourceCodeReflectorTest.php
@@ -37,7 +37,7 @@ class ContextualSourceCodeReflectorTest extends TestCase
 
     public function testReflectsClassesIn(): void
     {
-        self::assertEquals(2, $this->reflector->reflectClassesIn(TextDocumentBuilder::fromUnknown('<?php class One{} class Two{}'))->count());
+        self::assertEquals(2, $this->reflector->reflectClassLikesIn(TextDocumentBuilder::fromUnknown('<?php class One{} class Two{}'))->count());
     }
 
     public function testReflectOffset(): void


### PR DESCRIPTION
Renaming: SourceCodeReflector::reflectClassesIn => SourceCodeReflector::reflectClassLikesIn

The old method name would imply that it only returns classes which it doesn't to so renaming makes the intention clearer and opens up the possibility to create a function which only returns classes as well.