### PR TITLE
Optimise renaming private methods and properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Features:
 
 Improvements:
 
+  - Do not use indexer when renaming private properties/methods #2672 @dantleech
   - Fix contextual completion in constructor agrument position #2504
   - Basic support for `array_reduce` stub #2576
   - Support variadics in contextual completion #2603

--- a/lib/Extension/LanguageServerRename/LanguageServerRenameWorseExtension.php
+++ b/lib/Extension/LanguageServerRename/LanguageServerRenameWorseExtension.php
@@ -15,6 +15,7 @@ use Phpactor\Rename\Adapter\ClassToFile\ClassToFileUriToNameConverter;
 use Phpactor\Rename\Adapter\ReferenceFinder\ClassMover\ClassRenamer;
 use Phpactor\Rename\Adapter\ReferenceFinder\MemberRenamer;
 use Phpactor\Rename\Adapter\ReferenceFinder\VariableRenamer;
+use Phpactor\Rename\Adapter\WorseReflection\WorseReflectionMemberRenamer;
 use Phpactor\Rename\Model\FileRenamer;
 use Phpactor\Rename\Model\FileRenamer\LoggingFileRenamer;
 use Phpactor\Extension\LanguageServer\LanguageServerExtension;
@@ -29,6 +30,7 @@ use Phpactor\ReferenceFinder\DefinitionAndReferenceFinder;
 use Phpactor\ReferenceFinder\ReferenceFinder;
 use Phpactor\TextDocument\TextDocumentLocator;
 use Phpactor\WorseReferenceFinder\TolerantVariableReferenceFinder;
+use Phpactor\WorseReflection\Reflector;
 
 class LanguageServerRenameWorseExtension implements Extension
 {
@@ -45,6 +47,14 @@ class LanguageServerRenameWorseExtension implements Extension
                 ),
                 $container->get(TextDocumentLocator::class),
                 $container->get('worse_reflection.tolerant_parser')
+            );
+        }, [
+            LanguageServerRenameExtension::TAG_RENAMER => []
+        ]);
+
+        $container->register(WorseReflectionMemberRenamer::class, function (Container $container) {
+            return new WorseReflectionMemberRenamer(
+                $container->expect(WorseReflectionExtension::SERVICE_REFLECTOR, Reflector::class),
             );
         }, [
             LanguageServerRenameExtension::TAG_RENAMER => []

--- a/lib/Rename/Adapter/WorseReflection/WorseReflectionMemberRenamer.php
+++ b/lib/Rename/Adapter/WorseReflection/WorseReflectionMemberRenamer.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Phpactor\Rename\Adapter\WorseReflection;
+
+use Generator;
+use Phpactor\Rename\Model\LocatedTextEdit;
+use Phpactor\Rename\Model\Renamer;
+use Phpactor\TextDocument\ByteOffset;
+use Phpactor\TextDocument\ByteOffsetRange;
+use Phpactor\TextDocument\TextDocument;
+use Phpactor\TextDocument\TextEdit as PhpactorTextEdit;
+use Phpactor\WorseReflection\Core\Inference\Symbol;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionMember;
+use Phpactor\WorseReflection\Core\Type\ClassLikeType;
+use Phpactor\WorseReflection\Reflector;
+
+class WorseReflectionMemberRenamer implements Renamer
+{
+    public function __construct(
+        private Reflector $reflector,
+    ) {
+    }
+
+    public function getRenameRange(TextDocument $textDocument, ByteOffset $offset): ?ByteOffsetRange
+    {
+        $member = $this->resolveMember($textDocument, $offset);
+
+        if (null === $member) {
+            return null;
+        }
+
+        return $member->nameRange();
+    }
+
+    public function rename(TextDocument $textDocument, ByteOffset $offset, string $newName): Generator
+    {
+        $member = $this->resolveMember($textDocument, $offset);
+
+        if (null === $member) {
+            return;
+        }
+
+        $uri = $member->class()->sourceCode()->uri();
+
+        if (null === $uri) {
+            return;
+        }
+
+        $rangeStart = $member->nameRange()->start();
+        yield new LocatedTextEdit(
+            $uri,
+            PhpactorTextEdit::create(
+                $rangeStart,
+                $member->nameRange()->length(),
+                $newName,
+            )
+        );
+
+        $accesses = match ($member->memberType()) {
+            ReflectionMember::TYPE_METHOD => $this->reflector->navigate($textDocument)->methodCalls(),
+            ReflectionMember::TYPE_PROPERTY => $this->reflector->navigate($textDocument)->propertyAccesses(),
+            default => [],
+        };
+
+        foreach ($accesses as $access) {
+            if ($access->name() !== $member->name()) {
+                continue;
+            }
+            yield new LocatedTextEdit(
+                $uri,
+                PhpactorTextEdit::create($access->nameRange()->start(), $access->nameRange()->length(), $newName)
+            );
+        }
+    }
+
+    private function resolveMember(TextDocument $textDocument, ByteOffset $offset): ?ReflectionMember
+    {
+        $context = $this->reflector->reflectOffset($textDocument, $offset)->nodeContext();
+
+        $symbolType = $context->symbol()->symbolType();
+        if (!in_array($symbolType, [
+            Symbol::METHOD,
+            Symbol::PROPERTY,
+            Symbol::VARIABLE, // promoted properties 🙃
+        ])) {
+            return null;
+        }
+
+        $containerType = $context->containerType();
+
+        if (!$containerType instanceof ClassLikeType) {
+            return null;
+        }
+
+        $class = $this->reflector->reflectClassLike($containerType->name());
+
+        $memberType = $symbolType === Symbol::VARIABLE ? 'property' : $symbolType;
+        $members = $class->members()->byMemberType($memberType)->byName($context->symbol()->name());
+
+        foreach ($members as $member) {
+            if (!$member->visibility()->isPrivate()) {
+                return null;
+            }
+            return $member;
+        }
+
+        return null;
+    }
+}

--- a/lib/Rename/Tests/Adapter/WorseReflection/WorseReflectionMemberRenamerTest.php
+++ b/lib/Rename/Tests/Adapter/WorseReflection/WorseReflectionMemberRenamerTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Phpactor\Rename\Tests\Adapter\WorseReflection;
+
+use Generator;
+use Phpactor\Rename\Adapter\WorseReflection\WorseReflectionMemberRenamer;
+use Phpactor\Rename\Model\Renamer;
+use Phpactor\Rename\Tests\RenamerTestCase;
+use Phpactor\WorseReflection\Reflector;
+
+class WorseReflectionMemberRenamerTest extends RenamerTestCase
+{
+    /**
+     * @return Generator<string,array<mixed>>
+     */
+    public function provideRename(): Generator
+    {
+        yield from $this->renames();
+    }
+
+    protected function createRenamer(): Renamer
+    {
+        return new WorseReflectionMemberRenamer(
+            $this->reflector,
+        );
+    }
+
+    /**
+     * @return Generator<string,array<mixed>>
+     */
+    private function renames(): Generator
+    {
+        yield 'private method declaration' => [
+            'member_renamer/method_declaration_private',
+            function (Reflector $reflector, Renamer $renamer): Generator {
+                $reflection = $reflector->reflectClass('Foo\ClassOne');
+                $method = $reflection->methods()->get('foobar');
+
+                return $renamer->rename(
+                    $reflection->sourceCode(),
+                    $method->nameRange()->start(),
+                    'newName'
+                );
+            },
+            function (Reflector $reflector): void {
+                $reflection = $reflector->reflectClass('Foo\ClassOne');
+                self::assertTrue($reflection->methods()->has('newName'));
+            }
+        ];
+        yield 'private property declaration' => [
+            'member_renamer/property_declaration_private',
+            function (Reflector $reflector, Renamer $renamer): Generator {
+                $reflection = $reflector->reflectClass('ClassOne');
+                $method = $reflection->properties()->get('foobar');
+
+                return $renamer->rename(
+                    $reflection->sourceCode(),
+                    $method->nameRange()->start(),
+                    'newName'
+                );
+            },
+            function (Reflector $reflector): void {
+                $reflection = $reflector->reflectClass('ClassOne');
+                self::assertTrue($reflection->properties()->has('newName'));
+            }
+        ];
+        yield 'private promoted property declaration' => [
+            'member_renamer/property_promoted_private',
+            function (Reflector $reflector, Renamer $renamer): Generator {
+                $reflection = $reflector->reflectClass('ClassOne');
+                $method = $reflection->properties()->get('foobar');
+
+                return $renamer->rename(
+                    $reflection->sourceCode(),
+                    $method->nameRange()->start(),
+                    'newName'
+                );
+            },
+            function (Reflector $reflector): void {
+                $reflection = $reflector->reflectClass('ClassOne');
+                self::assertTrue($reflection->properties()->has('newName'));
+            }
+        ];
+    }
+}

--- a/lib/Rename/Tests/Cases/member_renamer/constant_declaration_private/ClassTwo.ph
+++ b/lib/Rename/Tests/Cases/member_renamer/constant_declaration_private/ClassTwo.ph
@@ -1,0 +1,9 @@
+<?php
+
+class ClassTwo
+{
+    public function hello(): string
+    {
+        return (new ClassOne())->foobar();
+    }
+}

--- a/lib/Rename/Tests/Cases/member_renamer/method_declaration_private/ClassOne.ph
+++ b/lib/Rename/Tests/Cases/member_renamer/method_declaration_private/ClassOne.ph
@@ -1,0 +1,16 @@
+<?php
+
+namespace Foo;
+
+class ClassOne
+{
+    private function foobar(): string
+    {
+        return 'foobar';
+    }
+
+    public function hello(): string
+    {
+        return $this->foobar();
+    }
+}

--- a/lib/Rename/Tests/Cases/member_renamer/method_declaration_private/test.ph
+++ b/lib/Rename/Tests/Cases/member_renamer/method_declaration_private/test.ph
@@ -1,0 +1,10 @@
+<?php
+
+require __DIR__ . '/ClassOne.php';
+
+$one = new Foo\ClassOne();
+if (!$one->hello() === 'foobar') {
+    echo 'expected "foobar" but didn\'t get it';
+    exit(127);
+}
+

--- a/lib/Rename/Tests/Cases/member_renamer/property_promoted_private/ClassOne.ph
+++ b/lib/Rename/Tests/Cases/member_renamer/property_promoted_private/ClassOne.ph
@@ -1,0 +1,22 @@
+<?php
+
+class ClassOne
+{
+    private string $barfoo;
+
+    public function __construct(
+        private string $foobar,
+    ) {
+        $this->barfoo = 'barfoo';
+    }
+
+    public function bar(): string
+    {
+        return $this->foobar;
+    }
+
+    public function foo(): string
+    {
+        return $this->barfoo;
+    }
+}

--- a/lib/Rename/Tests/Cases/member_renamer/property_promoted_private/test.ph
+++ b/lib/Rename/Tests/Cases/member_renamer/property_promoted_private/test.ph
@@ -1,0 +1,19 @@
+<?php
+
+require __DIR__ . '/ClassOne.php';
+
+$two = new ClassOne('foobar', 'foobar');
+
+// ensure that the method call will still work
+// after the renaming
+if (!$two->bar() === 'foobar') {
+    echo 'expected "foobar" but didn\'t get it';
+    exit(127);
+}
+
+// this method call ensure that we did not replace
+// all property names
+if (!$two->foo() === 'barfoo') {
+    echo 'expected "foobar" but didn\'t get it';
+    exit(127);
+}

--- a/lib/Rename/Tests/RenamerTestCase.php
+++ b/lib/Rename/Tests/RenamerTestCase.php
@@ -29,6 +29,7 @@ abstract class RenamerTestCase extends TestCase
     protected function setUp(): void
     {
         $this->workspace()->reset();
+        $this->workspace()->mkdir('project');
         $this->reflector = ReflectorBuilder::create()
             ->addLocator(new BruteForceSourceLocator(ReflectorBuilder::create()->build(), $this->workspace()->path('project')))
             ->build();

--- a/lib/TextDocument/ByteOffsetRange.php
+++ b/lib/TextDocument/ByteOffsetRange.php
@@ -31,6 +31,11 @@ class ByteOffsetRange
         return $this->start;
     }
 
+    public function length(): int
+    {
+        return $this->end->toInt() - $this->start->toInt();
+    }
+
     public function end(): ByteOffset
     {
         return $this->end;

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionPromotedProperty.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionPromotedProperty.php
@@ -68,7 +68,7 @@ class ReflectionPromotedProperty extends AbstractReflectionClassMember implement
     public function nameRange(): ByteOffsetRange
     {
         return ByteOffsetRange::fromInts(
-            $this->parameter->variableName->getStartPosition(),
+            $this->parameter->variableName->getStartPosition() + 1, // return the range after the `$`
             $this->parameter->variableName->getEndPosition(),
         );
     }

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionProperty.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionProperty.php
@@ -65,7 +65,7 @@ class ReflectionProperty extends AbstractReflectionClassMember implements CoreRe
     public function nameRange(): ByteOffsetRange
     {
         return ByteOffsetRange::fromInts(
-            $this->variable->getStartPosition(),
+            $this->variable->getStartPosition() + 1, // do not return the $
             $this->variable->getEndPosition(),
         );
     }


### PR DESCRIPTION
This PR avoids the use of the indexer when:

- Renaming private properties
- Renaming private methods

Note that:

- Constants are not supported due to the fact we can't parse constant
  visiblity currently.
- Enums are always public.

**Protected** could also be dramatically optimised by using the indexer to find any leaf classes (i.e. only analysing leaf classes and not any property in the entire project that happens to have the same name), but we can leave that for another day.

---

note this PR makes a risky change to reflection property `nameRange()` to only return the range after the `$`. The tests pass :shrug: 