### PR TITLE
Skip empty phpstan outputs

### DIFF
--- a/lib/Extension/LanguageServerPhpstan/Model/PhpstanProcess.php
+++ b/lib/Extension/LanguageServerPhpstan/Model/PhpstanProcess.php
@@ -72,6 +72,10 @@ class PhpstanProcess
                 $process->getWorkingDirectory(),
             ));
 
+            if ($stdout === '') {
+                return [];
+            }
+
             return $this->parser->parse($stdout);
         });
     }

--- a/lib/Extension/LanguageServerPhpstan/Model/PhpstanProcess.php
+++ b/lib/Extension/LanguageServerPhpstan/Model/PhpstanProcess.php
@@ -73,6 +73,10 @@ class PhpstanProcess
             ));
 
             if ($stdout === '') {
+                $this->logger->error(sprintf(
+                    'Phpstan exited with code "%s": But the standard output was empty',
+                    $exitCode,
+                ));
                 return [];
             }
 


### PR DESCRIPTION
If phpstan produces an empty stdout we don't need to parse it.

refs #2332