### PR TITLE
Adding support for explanatory text in throw

### DIFF
--- a/lib/DocblockParser/Ast/Tag/ThrowsTag.php
+++ b/lib/DocblockParser/Ast/Tag/ThrowsTag.php
@@ -3,6 +3,7 @@
 namespace Phpactor\DocblockParser\Ast\Tag;
 
 use Phpactor\DocblockParser\Ast\TagNode;
+use Phpactor\DocblockParser\Ast\TextNode;
 use Phpactor\DocblockParser\Ast\Token;
 use Phpactor\DocblockParser\Ast\TypeNode;
 
@@ -10,10 +11,11 @@ class ThrowsTag extends TagNode
 {
     protected const CHILD_NAMES = [
         'tag',
-        'exceptionClass'
+        'exceptionClass',
+        'text',
     ];
 
-    public function __construct(public Token $tag, public ?TypeNode $exceptionClass)
+    public function __construct(public Token $tag, public ?TypeNode $exceptionClass, public ?TextNode $text)
     {
     }
 }

--- a/lib/DocblockParser/Parser.php
+++ b/lib/DocblockParser/Parser.php
@@ -147,9 +147,12 @@ final class Parser
 
         if ($this->tokens->if(Token::T_LABEL)) {
             $type = $this->parseTypes();
+            $this->tokens->chompWhitespace();
         }
 
-        return new ThrowsTag($tag, $type);
+        $text = $this->parseText();
+
+        return new ThrowsTag($tag, $type, $text);
     }
 
     private function parseMethod(): MethodTag

--- a/lib/DocblockParser/Tests/Unit/Ast/NodeTestCase.php
+++ b/lib/DocblockParser/Tests/Unit/Ast/NodeTestCase.php
@@ -21,6 +21,7 @@ class NodeTestCase extends TestCase
         self::assertIsIterable($nodes);
         self::assertEquals(0, $node->start(), 'Start offset');
         self::assertEquals(strlen($doc), $node->end(), 'End offset');
+        self::assertGreaterThanOrEqual(0, $node->length(), 'Length is negative');
 
         if ($assertion) {
             $assertion($node);

--- a/lib/DocblockParser/Tests/Unit/Printer/examples/throw1.test
+++ b/lib/DocblockParser/Tests/Unit/Printer/examples/throw1.test
@@ -6,5 +6,4 @@ Docblock: =
  ElementList: = /**
  * 
   ThrowsTag: = @throws
-   ClassNode: = RuntimeException
- */
+   ClassNode: = RuntimeException*/

--- a/lib/DocblockParser/Tests/Unit/Printer/examples/throw2.test
+++ b/lib/DocblockParser/Tests/Unit/Printer/examples/throw2.test
@@ -1,0 +1,12 @@
+/**
+ * @throws RuntimeException This happens if something breaks
+ */
+---
+Docblock: = 
+ ElementList: = /**
+ * 
+  ThrowsTag: = @throws
+   ClassNode: = RuntimeException
+   TextNode: = This happens if something breaks
+ */
+

--- a/templates/help/markdown/Phpactor/DocblockParser/Ast/Tag/ThrowsTag.twig
+++ b/templates/help/markdown/Phpactor/DocblockParser/Ast/Tag/ThrowsTag.twig
@@ -1,1 +1,1 @@
-**Throws** `{{ object.exceptionClass ? object.exceptionClass.toString : '?' }}`
+**Throws** `{{ object.exceptionClass ? object.exceptionClass.toString : '?' }}`{{ object.text ? (' ' ~ object.text.toString) : '' }}


### PR DESCRIPTION
Before when a method had this signiture the help text after the throw was not visible in the hover overlay:
![image](https://github.com/user-attachments/assets/f645af8f-dcc4-4fc8-b3f2-bdc83735f248)

Now:
![image](https://github.com/user-attachments/assets/5a059017-7fc6-4e05-af69-5695a5504f0e)
