### PR TITLE
Completion context: improve recognizing expressions outside class member body

### DIFF
--- a/lib/Completion/Bridge/TolerantParser/CompletionContext.php
+++ b/lib/Completion/Bridge/TolerantParser/CompletionContext.php
@@ -16,6 +16,7 @@ use Microsoft\PhpParser\Node\DelimitedList\MatchArmConditionList;
 use Microsoft\PhpParser\Node\DelimitedList\QualifiedNameList;
 use Microsoft\PhpParser\Node\Expression;
 use Microsoft\PhpParser\Node\Expression\AnonymousFunctionCreationExpression;
+use Microsoft\PhpParser\Node\Expression\ArgumentExpression;
 use Microsoft\PhpParser\Node\Expression\Variable;
 use Microsoft\PhpParser\Node\InterfaceBaseClause;
 use Microsoft\PhpParser\Node\MatchArm;
@@ -46,6 +47,10 @@ class CompletionContext
 
         if (null === $parent) {
             return false;
+        }
+
+        if ($parent instanceof ArgumentExpression) {
+            return true;
         }
 
         if (self::classMembersBody($node)) {

--- a/lib/Completion/Tests/Integration/Bridge/TolerantParser/ReferenceFinder/ExpressionNameCompletorTest.php
+++ b/lib/Completion/Tests/Integration/Bridge/TolerantParser/ReferenceFinder/ExpressionNameCompletorTest.php
@@ -283,5 +283,23 @@ class ExpressionNameCompletorTest extends IntegrationTestCase
                 self::assertCount(0, $suggestions);
             }
         ];
+        yield 'attribute parameter value outside class' => [
+            [
+                NameSearchResult::create('class', 'Xxyz'),
+            ],
+            '<?php class Xxyz {} #[Attribute(flags: Xxy<>)] function foo() {}',
+            function (Suggestions $suggestions): void {
+                self::assertCount(1, $suggestions);
+            },
+        ];
+        yield 'attribute parameter value - property' => [
+            [
+                NameSearchResult::create('class', 'Xxyz'),
+            ],
+            '<?php class Xxyz {} class Foobar { #[Attribute(flags: Xxy<>)] public x; }',
+            function (Suggestions $suggestions): void {
+                self::assertCount(1, $suggestions);
+            },
+        ];
     }
 }


### PR DESCRIPTION
Problem: cannot complete expressions for attribute parameters value when the attribute is attached to some non-promoted property, class or outside class.

The current version does not fix cases when the completed word has zero length.