### PR TITLE
Rendering the `object` type in the TypeRenderer

### DIFF
--- a/lib/CodeBuilder/Adapter/WorseReflection/TypeRenderer/WorseTypeRenderer74.php
+++ b/lib/CodeBuilder/Adapter/WorseReflection/TypeRenderer/WorseTypeRenderer74.php
@@ -14,6 +14,7 @@ use Phpactor\WorseReflection\Core\Type\PseudoIterableType;
 use Phpactor\WorseReflection\Core\Type\ScalarType;
 use Phpactor\WorseReflection\Core\Type\SelfType;
 use Phpactor\WorseReflection\Core\Type\VoidType;
+use Phpactor\WorseReflection\Core\Type\ObjectType;
 
 class WorseTypeRenderer74 implements WorseTypeRenderer
 {
@@ -21,6 +22,10 @@ class WorseTypeRenderer74 implements WorseTypeRenderer
     {
         if ($type instanceof NullableType) {
             return '?' . $this->render($type->type);
+        }
+
+        if ($type instanceof ObjectType) {
+            return $type->toPhpString();
         }
 
         if ($type instanceof AggregateType) {

--- a/lib/CodeBuilder/Tests/Unit/Adapter/WorseReflection/TypeRenderer/WorseTypeRenderer74Test.php
+++ b/lib/CodeBuilder/Tests/Unit/Adapter/WorseReflection/TypeRenderer/WorseTypeRenderer74Test.php
@@ -9,6 +9,7 @@ use Phpactor\WorseReflection\Core\Type\CallableType;
 use Phpactor\WorseReflection\Core\Type\ClosureType;
 use Phpactor\WorseReflection\Core\Type\FalseType;
 use Phpactor\WorseReflection\Core\Type\MixedType;
+use Phpactor\WorseReflection\Core\Type\ObjectType;
 use Phpactor\WorseReflection\Core\Type\PseudoIterableType;
 use Phpactor\WorseReflection\Core\Type\StringType;
 use Phpactor\WorseReflection\Core\Type\UnionType;
@@ -45,6 +46,10 @@ class WorseTypeRenderer74Test extends TypeRendererTestCase
         yield [
             new UnionType(new StringType(), new FalseType()),
             '',
+        ];
+        yield [
+            new ObjectType(),
+            'object',
         ];
     }
 

--- a/lib/CodeBuilder/Tests/Unit/Adapter/WorseReflection/TypeRenderer/WorseTypeRenderer81Test.php
+++ b/lib/CodeBuilder/Tests/Unit/Adapter/WorseReflection/TypeRenderer/WorseTypeRenderer81Test.php
@@ -35,7 +35,5 @@ class WorseTypeRenderer81Test extends TypeRendererTestCase
     protected function createRenderer(): WorseTypeRenderer
     {
         return new WorseTypeRenderer81();
-
-        //$this->foobar(file_get_contents('asd'));
     }
 }

--- a/lib/CodeBuilder/Tests/Unit/Adapter/WorseReflection/TypeRenderer/WorseTypeRenderer82Test.php
+++ b/lib/CodeBuilder/Tests/Unit/Adapter/WorseReflection/TypeRenderer/WorseTypeRenderer82Test.php
@@ -7,6 +7,7 @@ use Phpactor\CodeBuilder\Adapter\WorseReflection\TypeRenderer\WorseTypeRenderer;
 use Phpactor\CodeBuilder\Adapter\WorseReflection\TypeRenderer\WorseTypeRenderer82;
 use Phpactor\WorseReflection\Core\Type\FalseType;
 use Phpactor\WorseReflection\Core\Type\MixedType;
+use Phpactor\WorseReflection\Core\Type\ObjectType;
 use Phpactor\WorseReflection\Core\Type\StringType;
 use Phpactor\WorseReflection\Core\Type\UnionType;
 
@@ -29,6 +30,10 @@ class WorseTypeRenderer82Test extends TypeRendererTestCase
         yield [
             new UnionType(new StringType(), new FalseType()),
             'string|false',
+        ];
+        yield [
+            new UnionType(new StringType(), new ObjectType()),
+            'string|object',
         ];
     }
 


### PR DESCRIPTION
Fixes #2658

`object` wasn't rendered in the type renderer.