### PR TITLE
Gh 2707: Adding basic support for `@{phpstan,psalm}-assert`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Improvements:
   - Show prose associated with `@throws` tag #2694 @mamazu
   - Support parsing generic variance e.g. `covariant` #2664 @dantleech
 
+Features:
+
+  - Basic support for `@{phpstan,psalm}-assert` #2720 @dantleech
+
 ## 2024-06-30
 
 Features:

--- a/lib/ClassMover/Tests/Unit/Extension/ClassMoverExtensionTest.php
+++ b/lib/ClassMover/Tests/Unit/Extension/ClassMoverExtensionTest.php
@@ -27,6 +27,7 @@ class ClassMoverExtensionTest extends TestCase
             FilePathResolverExtension::PARAM_APPLICATION_ROOT => realpath(__DIR__ .'/..'),
             CodeTransformExtension::PARAM_TEMPLATE_PATHS => [],
         ]);
-        self::assertInstanceOf(ClassMover::class, $container->get(ClassMover::class));
+        $var = $container->get(ClassMover::class);
+        self::assertInstanceOf(ClassMover::class, $var);
     }
 }

--- a/lib/DocblockParser/Ast/Tag/AssertTag.php
+++ b/lib/DocblockParser/Ast/Tag/AssertTag.php
@@ -3,7 +3,6 @@
 namespace Phpactor\DocblockParser\Ast\Tag;
 
 use Phpactor\DocblockParser\Ast\TagNode;
-use Phpactor\DocblockParser\Ast\TextNode;
 use Phpactor\DocblockParser\Ast\Token;
 use Phpactor\DocblockParser\Ast\TypeNode;
 use Phpactor\DocblockParser\Ast\VariableNode;

--- a/lib/DocblockParser/Ast/Tag/AssertTag.php
+++ b/lib/DocblockParser/Ast/Tag/AssertTag.php
@@ -12,12 +12,14 @@ class AssertTag extends TagNode
 {
     protected const CHILD_NAMES = [
         'tag',
+        'negationOrEquality',
         'type',
         'paramName',
     ];
 
     public function __construct(
         public Token $tag,
+        public ?Token $negationOrEquality,
         public ?TypeNode $type,
         public ?VariableNode $paramName = null
     ) {

--- a/lib/DocblockParser/Ast/Tag/AssertTag.php
+++ b/lib/DocblockParser/Ast/Tag/AssertTag.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Phpactor\DocblockParser\Ast\Tag;
+
+use Phpactor\DocblockParser\Ast\TagNode;
+use Phpactor\DocblockParser\Ast\TextNode;
+use Phpactor\DocblockParser\Ast\Token;
+use Phpactor\DocblockParser\Ast\TypeNode;
+use Phpactor\DocblockParser\Ast\VariableNode;
+
+class AssertTag extends TagNode
+{
+    protected const CHILD_NAMES = [
+        'tag',
+        'type',
+        'paramName',
+    ];
+
+    public function __construct(
+        public Token $tag,
+        public ?TypeNode $type,
+        public ?VariableNode $paramName = null
+    ) {
+    }
+}

--- a/lib/DocblockParser/Ast/Token.php
+++ b/lib/DocblockParser/Ast/Token.php
@@ -10,6 +10,7 @@ final class Token implements Element
     public const T_PHPDOC_CLOSE = 'PHPDOC_CLOSE';
     public const T_VARIABLE = 'VARIABLE';
     public const T_UNKNOWN = 'UNKNOWN';
+    public const T_BANG = 'BANG';
     public const T_NULLABLE = 'NULLABLE';
     public const T_BAR = 'BAR';
     public const T_TAG = 'TAG';

--- a/lib/DocblockParser/Lexer.php
+++ b/lib/DocblockParser/Lexer.php
@@ -51,6 +51,7 @@ final class Lexer
         '=' => Token::T_EQUALS,
         ':' => Token::T_COLON,
         '::' => Token::T_DOUBLE_COLON,
+        '!' => Token::T_BANG,
     ];
 
     /**

--- a/lib/DocblockParser/Parser.php
+++ b/lib/DocblockParser/Parser.php
@@ -5,6 +5,7 @@ namespace Phpactor\DocblockParser;
 use Phpactor\DocblockParser\Ast\ArrayKeyValueList;
 use Phpactor\DocblockParser\Ast\ArrayKeyValueNode;
 use Phpactor\DocblockParser\Ast\ConditionalNode;
+use Phpactor\DocblockParser\Ast\Tag\AssertTag;
 use Phpactor\DocblockParser\Ast\Tag\DeprecatedTag;
 use Phpactor\DocblockParser\Ast\Docblock;
 use Phpactor\DocblockParser\Ast\Tag\ExtendsTag;
@@ -98,6 +99,7 @@ final class Parser
             '@throws' => $this->parseThrows(),
             '@deprecated' => $this->parseDeprecated(),
             '@method' => $this->parseMethod(),
+            '@assert' => $this->parseAssert(),
             '@type' => $this->parseTypeAlias(),
             '@property', '@property-read' => $this->parseProperty(),
             '@mixin' => $this->parseMixin(),
@@ -763,5 +765,21 @@ final class Parser
         }
 
         return new TypeAliasTag($tag, $alias, $equals, $type);
+    }
+
+    private function parseAssert(): TagNode
+    {
+        $tag = $this->tokens->mustChomp(Token::T_TAG);
+        $paramName = $type = null;
+
+        if ($this->tokens->if(Token::T_LABEL)) {
+            $type = $this->parseType();
+        }
+
+        if ($this->tokens->if(Token::T_VARIABLE)) {
+            $paramName = $this->parseVariable();
+        }
+
+        return new AssertTag($tag, $type, $paramName);
     }
 }

--- a/lib/DocblockParser/Parser.php
+++ b/lib/DocblockParser/Parser.php
@@ -770,7 +770,16 @@ final class Parser
     private function parseAssert(): TagNode
     {
         $tag = $this->tokens->mustChomp(Token::T_TAG);
-        $paramName = $type = null;
+        $paramName = $type = $negOrEquality = null;
+
+        if ($this->tokens->if(Token::T_EQUALS)) {
+            $negOrEquality = $this->tokens->mustChomp(Token::T_EQUALS);
+        }
+
+        if ($this->tokens->if(Token::T_BANG)) {
+            $negation = $this->tokens->mustChomp(Token::T_BANG);
+            $negOrEquality = $negation;
+        }
 
         if ($this->tokens->if(Token::T_LABEL)) {
             $type = $this->parseType();
@@ -780,6 +789,6 @@ final class Parser
             $paramName = $this->parseVariable();
         }
 
-        return new AssertTag($tag, $type, $paramName);
+        return new AssertTag($tag, $negOrEquality, $type, $paramName);
     }
 }

--- a/lib/DocblockParser/Tests/Unit/Printer/examples/assert-equality.test
+++ b/lib/DocblockParser/Tests/Unit/Printer/examples/assert-equality.test
@@ -1,0 +1,11 @@
+/**
+ * @phpstan-assert =Foobar $foobar
+ */
+---
+Docblock: = 
+ ElementList: = /**
+ * 
+  AssertTag: = @phpstan-assert=
+   ClassNode: = Foobar
+   VariableNode: = $foobar
+ */

--- a/lib/DocblockParser/Tests/Unit/Printer/examples/assert-negation.test
+++ b/lib/DocblockParser/Tests/Unit/Printer/examples/assert-negation.test
@@ -1,0 +1,11 @@
+/**
+ * @phpstan-assert !Foobar $foobar
+ */
+---
+Docblock: = 
+ ElementList: = /**
+ * 
+  AssertTag: = @phpstan-assert!
+   ClassNode: = Foobar
+   VariableNode: = $foobar
+ */

--- a/lib/DocblockParser/Tests/Unit/Printer/examples/assert1.test
+++ b/lib/DocblockParser/Tests/Unit/Printer/examples/assert1.test
@@ -1,0 +1,11 @@
+/**
+ * @phpstan-assert Foobar $foobar
+ */
+---
+Docblock: = 
+ ElementList: = /**
+ * 
+  AssertTag: = @phpstan-assert
+   ClassNode: = Foobar
+   VariableNode: = $foobar
+ */

--- a/lib/WorseReflection/Bridge/Phpactor/DocblockParser/DocblockParserFactory.php
+++ b/lib/WorseReflection/Bridge/Phpactor/DocblockParser/DocblockParserFactory.php
@@ -28,6 +28,7 @@ class DocblockParserFactory implements DocBlockFactory
         'template-extends',
         'mixin',
         'throws',
+        'assert',
     ];
 
     private Lexer $lexer;

--- a/lib/WorseReflection/Bridge/Phpactor/DocblockParser/ParsedDocblock.php
+++ b/lib/WorseReflection/Bridge/Phpactor/DocblockParser/ParsedDocblock.php
@@ -311,7 +311,8 @@ class ParsedDocblock implements DocBlock
             }
             $assertions[] = new DocBlockTypeAssertion(
                 ltrim($assert->paramName->toString(), '$'),
-                $this->convertType($assert->type)
+                $this->convertType($assert->type),
+                $assert->negationOrEquality?->value === '!',
             );
         }
         return $assertions;

--- a/lib/WorseReflection/Bridge/Phpactor/DocblockParser/ParsedDocblock.php
+++ b/lib/WorseReflection/Bridge/Phpactor/DocblockParser/ParsedDocblock.php
@@ -4,6 +4,7 @@ namespace Phpactor\WorseReflection\Bridge\Phpactor\DocblockParser;
 
 use Phpactor\DocblockParser\Ast\Docblock as ParserDocblock;
 use Phpactor\DocblockParser\Ast\ParameterList;
+use Phpactor\DocblockParser\Ast\Tag\AssertTag;
 use Phpactor\DocblockParser\Ast\Tag\DeprecatedTag;
 use Phpactor\DocblockParser\Ast\Tag\ExtendsTag;
 use Phpactor\DocblockParser\Ast\Tag\ImplementsTag;
@@ -24,6 +25,7 @@ use Phpactor\WorseReflection\Core\DocBlock\DocBlockParam;
 use Phpactor\WorseReflection\Core\DocBlock\DocBlockParams;
 use Phpactor\WorseReflection\Core\DocBlock\DocBlockTypeAlias;
 use Phpactor\WorseReflection\Core\DocBlock\DocBlockTypeAliases;
+use Phpactor\WorseReflection\Core\DocBlock\DocBlockTypeAssertion;
 use Phpactor\WorseReflection\Core\DocBlock\DocBlockVar;
 use Phpactor\WorseReflection\Core\Inference\Frame;
 use Phpactor\WorseReflection\Core\NodeText;
@@ -298,6 +300,21 @@ class ParsedDocblock implements DocBlock
     public function node(): ParserDocblock
     {
         return $this->node;
+    }
+
+    public function assertions(): array
+    {
+        $assertions = [];
+        foreach ($this->node->tags(AssertTag::class) as $assert) {
+            if (!$assert->paramName) {
+                continue;
+            }
+            $assertions[] = new DocBlockTypeAssertion(
+                ltrim($assert->paramName->toString(), '$'),
+                $this->convertType($assert->type)
+            );
+        }
+        return $assertions;
     }
 
     private function addParameters(VirtualReflectionMethod $method, ReflectionParameterCollection $collection, ?ParameterList $parameterList): void

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/Docblock/ClassGenericDiagnosticHelper.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/Docblock/ClassGenericDiagnosticHelper.php
@@ -11,7 +11,6 @@ use Phpactor\WorseReflection\Core\Reflection\ReflectionClass;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionClassLike;
 use Phpactor\WorseReflection\Core\Reflector\ClassReflector;
 use Phpactor\WorseReflection\Core\Type;
-use Phpactor\WorseReflection\Core\Type\ClassType;
 use Phpactor\WorseReflection\Core\Type\MixedType;
 use Phpactor\WorseReflection\Core\Type\MissingType;
 use Phpactor\WorseReflection\Core\Type\GenericClassType;

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/Docblock/ClassGenericDiagnosticHelper.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/Docblock/ClassGenericDiagnosticHelper.php
@@ -104,13 +104,7 @@ final class ClassGenericDiagnosticHelper
         if ($extendTagType instanceof GenericClassType) {
             $classTemplateMap = $class->templateMap();
             $extendTagType = $extendTagType->withArguments(array_map(function (Type $type) use ($classTemplateMap) {
-                if (!$type instanceof ClassType) {
-                    return $type;
-                }
-                if (!$classTemplateMap->has($type->__toString())) {
-                    return $type;
-                }
-                return $classTemplateMap->get($type->__toString());
+                return $classTemplateMap->getOrGiven($type);
             }, $extendTagType->arguments()));
         }
 

--- a/lib/WorseReflection/Core/DefaultResolverFactory.php
+++ b/lib/WorseReflection/Core/DefaultResolverFactory.php
@@ -133,7 +133,7 @@ final class DefaultResolverFactory
             Variable::class => new VariableResolver(),
             MemberAccessExpression::class => new MemberAccessExpressionResolver($this->nodeContextFromMemberAccess),
             ScopedPropertyAccessExpression::class => new ScopedPropertyAccessResolver($this->nodeContextFromMemberAccess),
-            CallExpression::class => new CallExpressionResolver(),
+            CallExpression::class => new CallExpressionResolver($this->genericResolver),
             ParenthesizedExpression::class => new ParenthesizedExpressionResolver(),
             BinaryExpression::class => new BinaryExpressionResolver(),
             UnaryOpExpression::class => new UnaryOpExpressionResolver(),

--- a/lib/WorseReflection/Core/DocBlock/DocBlock.php
+++ b/lib/WorseReflection/Core/DocBlock/DocBlock.php
@@ -3,6 +3,7 @@
 namespace Phpactor\WorseReflection\Core\DocBlock;
 
 use Phpactor\WorseReflection\Core\Deprecation;
+use Phpactor\WorseReflection\Core\Inference\TypeAssertion;
 use Phpactor\WorseReflection\Core\Reflection\Collection\ReflectionMethodCollection;
 use Phpactor\WorseReflection\Core\Reflection\Collection\ReflectionPropertyCollection;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionClassLike;
@@ -55,4 +56,9 @@ interface DocBlock
      * @return Type[]
      */
     public function mixins(): array;
+
+    /**
+     * @return DocBlockTypeAssertion[]
+     */
+    public function assertions(): array;
 }

--- a/lib/WorseReflection/Core/DocBlock/DocBlock.php
+++ b/lib/WorseReflection/Core/DocBlock/DocBlock.php
@@ -3,7 +3,6 @@
 namespace Phpactor\WorseReflection\Core\DocBlock;
 
 use Phpactor\WorseReflection\Core\Deprecation;
-use Phpactor\WorseReflection\Core\Inference\TypeAssertion;
 use Phpactor\WorseReflection\Core\Reflection\Collection\ReflectionMethodCollection;
 use Phpactor\WorseReflection\Core\Reflection\Collection\ReflectionPropertyCollection;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionClassLike;

--- a/lib/WorseReflection/Core/DocBlock/DocBlockTypeAssertion.php
+++ b/lib/WorseReflection/Core/DocBlock/DocBlockTypeAssertion.php
@@ -6,7 +6,7 @@ use Phpactor\WorseReflection\Core\Type;
 
 final class DocBlockTypeAssertion
 {
-    public function __construct(public string $variableName, public Type $type)
+    public function __construct(public string $variableName, public Type $type, public bool $negated)
     {
     }
 }

--- a/lib/WorseReflection/Core/DocBlock/DocBlockTypeAssertion.php
+++ b/lib/WorseReflection/Core/DocBlock/DocBlockTypeAssertion.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Phpactor\WorseReflection\Core\DocBlock;
+
+use Phpactor\WorseReflection\Core\Type;
+
+final class DocBlockTypeAssertion
+{
+    public function __construct(public string $variableName, public Type $type)
+    {
+    }
+}

--- a/lib/WorseReflection/Core/DocBlock/PlainDocblock.php
+++ b/lib/WorseReflection/Core/DocBlock/PlainDocblock.php
@@ -179,4 +179,9 @@ class PlainDocblock implements DocBlock
     {
         return new DocBlockTypeAliases([]);
     }
+
+    public function assertions(): array
+    {
+        return [];
+    }
 }

--- a/lib/WorseReflection/Core/Inference/Context/CallContext.php
+++ b/lib/WorseReflection/Core/Inference/Context/CallContext.php
@@ -4,7 +4,6 @@ namespace Phpactor\WorseReflection\Core\Inference\Context;
 
 use Phpactor\WorseReflection\Core\Inference\FunctionArguments;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionFunction;
-use Phpactor\WorseReflection\Core\Reflection\ReflectionMember;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionMethod;
 
 interface CallContext

--- a/lib/WorseReflection/Core/Inference/Context/CallContext.php
+++ b/lib/WorseReflection/Core/Inference/Context/CallContext.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Phpactor\WorseReflection\Core\Inference\Context;
+
+use Phpactor\WorseReflection\Core\Inference\FunctionArguments;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionFunction;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionMember;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionMethod;
+
+interface CallContext
+{
+    public function callable(): ReflectionMethod|ReflectionFunction;
+    public function arguments(): ?FunctionArguments;
+}

--- a/lib/WorseReflection/Core/Inference/Context/FunctionCallContext.php
+++ b/lib/WorseReflection/Core/Inference/Context/FunctionCallContext.php
@@ -8,7 +8,6 @@ use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\Symbol;
 use Phpactor\WorseReflection\Core\Name;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionFunction;
-use Phpactor\WorseReflection\Core\Reflection\ReflectionMember;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionMethod;
 
 final class FunctionCallContext extends NodeContext implements CallContext

--- a/lib/WorseReflection/Core/Inference/Context/FunctionCallContext.php
+++ b/lib/WorseReflection/Core/Inference/Context/FunctionCallContext.php
@@ -8,8 +8,10 @@ use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\Symbol;
 use Phpactor\WorseReflection\Core\Name;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionFunction;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionMember;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionMethod;
 
-final class FunctionCallContext extends NodeContext
+final class FunctionCallContext extends NodeContext implements CallContext
 {
     public function __construct(
         Symbol $symbol,
@@ -33,7 +35,7 @@ final class FunctionCallContext extends NodeContext
         return $this->function;
     }
 
-    public function arguments(): FunctionArguments
+    public function arguments(): ?FunctionArguments
     {
         return $this->arguments;
     }
@@ -50,5 +52,10 @@ final class FunctionCallContext extends NodeContext
             $function,
             $arguments,
         );
+    }
+
+    public function callable(): ReflectionMethod|ReflectionFunction
+    {
+        return $this->function;
     }
 }

--- a/lib/WorseReflection/Core/Inference/Context/MemberAccessContext.php
+++ b/lib/WorseReflection/Core/Inference/Context/MemberAccessContext.php
@@ -22,7 +22,7 @@ class MemberAccessContext extends NodeContext
         Type $type,
         Type $containerType,
         private ByteOffsetRange $memberNameRange,
-        private ReflectionMember $member,
+        protected  ReflectionMember $member,
         private ?FunctionArguments $arguments,
     ) {
         parent::__construct($symbol, $type, $containerType);

--- a/lib/WorseReflection/Core/Inference/Context/MemberAccessContext.php
+++ b/lib/WorseReflection/Core/Inference/Context/MemberAccessContext.php
@@ -3,6 +3,7 @@
 namespace Phpactor\WorseReflection\Core\Inference\Context;
 
 use Phpactor\TextDocument\ByteOffsetRange;
+use Phpactor\WorseReflection\Core\Inference\FunctionArguments;
 use Phpactor\WorseReflection\Core\Inference\Symbol;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionMember;
 use Phpactor\WorseReflection\Core\Inference\NodeContext;
@@ -21,7 +22,8 @@ class MemberAccessContext extends NodeContext
         Type $type,
         Type $containerType,
         private ByteOffsetRange $memberNameRange,
-        private ReflectionMember $member
+        private ReflectionMember $member,
+        private ?FunctionArguments $arguments,
     ) {
         parent::__construct($symbol, $type, $containerType);
     }
@@ -37,5 +39,10 @@ class MemberAccessContext extends NodeContext
     public function memberNameRange(): ByteOffsetRange
     {
         return $this->memberNameRange;
+    }
+
+    public function arguments(): ?FunctionArguments
+    {
+        return $this->arguments;
     }
 }

--- a/lib/WorseReflection/Core/Inference/Context/MethodCallContext.php
+++ b/lib/WorseReflection/Core/Inference/Context/MethodCallContext.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Phpactor\WorseReflection\Core\Inference\Context;
+
+use Phpactor\WorseReflection\Core\Reflection\ReflectionFunction;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionMethod;
+
+/**
+ * @extends MemberAccessContext<ReflectionMethod>
+ */
+class MethodCallContext extends MemberAccessContext implements CallContext
+{
+    public function callable(): ReflectionMethod|ReflectionFunction
+    {
+        return $this->member;
+    }
+}

--- a/lib/WorseReflection/Core/Inference/FunctionArguments.php
+++ b/lib/WorseReflection/Core/Inference/FunctionArguments.php
@@ -76,12 +76,4 @@ class FunctionArguments implements IteratorAggregate, Countable
 
         return new self($this->resolver, $this->frame, $newArgs);
     }
-
-    /**
-     * @return list<Type>
-     */
-    public function toList(): array
-    {
-        return iterator_to_array($this->getIterator(), false);
-    }
 }

--- a/lib/WorseReflection/Core/Inference/FunctionArguments.php
+++ b/lib/WorseReflection/Core/Inference/FunctionArguments.php
@@ -76,4 +76,12 @@ class FunctionArguments implements IteratorAggregate, Countable
 
         return new self($this->resolver, $this->frame, $newArgs);
     }
+
+    /**
+     * @return list<Type>
+     */
+    public function toList(): array
+    {
+        return iterator_to_array($this->getIterator(), false);
+    }
 }

--- a/lib/WorseReflection/Core/Inference/GenericMapResolver.php
+++ b/lib/WorseReflection/Core/Inference/GenericMapResolver.php
@@ -3,7 +3,9 @@
 namespace Phpactor\WorseReflection\Core\Inference;
 
 use Phpactor\WorseReflection\Core\ClassName;
+use Phpactor\WorseReflection\Core\Inference\Context\MemberAccessContext;
 use Phpactor\WorseReflection\Core\Reflection\Collection\ReflectionParameterCollection;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionMember;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionParameter;
 use Phpactor\WorseReflection\Core\Reflector\ClassReflector;
 use Phpactor\WorseReflection\Core\TemplateMap;
@@ -72,6 +74,7 @@ class GenericMapResolver
     {
         foreach ($parameters as $parameter) {
             $parameterType = $parameter->inferredType();
+
 
             if ($parameterType instanceof ClassStringType && $parameterType->className()) {
                 $this->mapClassString($parameterType, $templateMap, $arguments, $parameter);

--- a/lib/WorseReflection/Core/Inference/GenericMapResolver.php
+++ b/lib/WorseReflection/Core/Inference/GenericMapResolver.php
@@ -3,9 +3,7 @@
 namespace Phpactor\WorseReflection\Core\Inference;
 
 use Phpactor\WorseReflection\Core\ClassName;
-use Phpactor\WorseReflection\Core\Inference\Context\MemberAccessContext;
 use Phpactor\WorseReflection\Core\Reflection\Collection\ReflectionParameterCollection;
-use Phpactor\WorseReflection\Core\Reflection\ReflectionMember;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionParameter;
 use Phpactor\WorseReflection\Core\Reflector\ClassReflector;
 use Phpactor\WorseReflection\Core\TemplateMap;

--- a/lib/WorseReflection/Core/Inference/Resolver/CallExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/CallExpressionResolver.php
@@ -17,10 +17,12 @@ use Phpactor\WorseReflection\Core\Inference\NodeContextFactory;
 use Phpactor\WorseReflection\Core\Inference\Resolver;
 use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
 use Phpactor\WorseReflection\Core\Inference\Symbol;
+use Phpactor\WorseReflection\Core\Inference\TypeCombinator;
 use Phpactor\WorseReflection\Core\Inference\Variable as PhpactorVariable;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionMember;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionMethod;
 use Phpactor\WorseReflection\Core\Type;
+use Phpactor\WorseReflection\Core\Type\AggregateType;
 use Phpactor\WorseReflection\Core\Type\ConditionalType;
 use Phpactor\WorseReflection\Core\Type\InvokeableType;
 use Phpactor\WorseReflection\Core\Type\ReflectedClassType;
@@ -146,10 +148,15 @@ class CallExpressionResolver implements Resolver
             }
             $param = $parameters->get($assertion->variableName);
             $arg = $arguments->at($param->index());
+            $type = $assertion->type;
+            if ($assertion->negated) {
+                $type = TypeCombinator::subtract($assertion->type, $arg->type());
+            }
+
             $frame->locals()->set(new PhpactorVariable(
                 $arg->symbol()->name(),
                 $node->getStartPosition(),
-                $map->has($assertion->type->short()) ? $map->get($assertion->type->short()) : $assertion->type,
+                $map->has($type->short()) ? $map->get($type->short()) : $type,
             ));
         }
     }

--- a/lib/WorseReflection/Core/Inference/Resolver/CallExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/CallExpressionResolver.php
@@ -156,7 +156,7 @@ class CallExpressionResolver implements Resolver
             $frame->locals()->set(new PhpactorVariable(
                 $arg->symbol()->name(),
                 $node->getStartPosition(),
-                $map->has($type->short()) ? $map->get($type->short()) : $type,
+                $map->getOrGiven($type),
             ));
         }
     }

--- a/lib/WorseReflection/Core/Inference/Resolver/CallExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/CallExpressionResolver.php
@@ -9,7 +9,6 @@ use Microsoft\PhpParser\Node\Expression\Variable;
 use Phpactor\TextDocument\ByteOffsetRange;
 use Phpactor\WorseReflection\Core\Inference\Context\CallContext;
 use Phpactor\WorseReflection\Core\Inference\Context\FunctionCallContext;
-use Phpactor\WorseReflection\Core\Inference\Context\MemberAccessContext;
 use Phpactor\WorseReflection\Core\Inference\Frame;
 use Phpactor\WorseReflection\Core\Inference\FunctionArguments;
 use Phpactor\WorseReflection\Core\Inference\GenericMapResolver;
@@ -20,10 +19,7 @@ use Phpactor\WorseReflection\Core\Inference\NodeContextResolver;
 use Phpactor\WorseReflection\Core\Inference\Symbol;
 use Phpactor\WorseReflection\Core\Inference\TypeCombinator;
 use Phpactor\WorseReflection\Core\Inference\Variable as PhpactorVariable;
-use Phpactor\WorseReflection\Core\Reflection\ReflectionMember;
-use Phpactor\WorseReflection\Core\Reflection\ReflectionMethod;
 use Phpactor\WorseReflection\Core\Type;
-use Phpactor\WorseReflection\Core\Type\AggregateType;
 use Phpactor\WorseReflection\Core\Type\ConditionalType;
 use Phpactor\WorseReflection\Core\Type\InvokeableType;
 use Phpactor\WorseReflection\Core\Type\ReflectedClassType;
@@ -44,9 +40,7 @@ class CallExpressionResolver implements Resolver
         $containerType = $context->containerType();
 
         if (
-            ($context instanceof MemberAccessContext ||
-            $context instanceof FunctionCallContext)
-            && $context->arguments()
+            $context instanceof CallContext && $context->arguments()
         ) {
             $this->applyAssertions($context, $frame, $node);
         }

--- a/lib/WorseReflection/Core/Inference/Resolver/MemberAccess/NodeContextFromMemberAccess.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/MemberAccess/NodeContextFromMemberAccess.php
@@ -141,7 +141,7 @@ class NodeContextFromMemberAccess
     }
 
     /**
-     * @return array{Type,Type,?ReflectionMember}
+     * @return array{Type,Type,?ReflectionMember,?FunctionArguments}
      */
     private function resolveContainerMemberType(
         NodeContextResolver $resolver,

--- a/lib/WorseReflection/Core/Inference/Resolver/MemberAccess/NodeContextFromMemberAccess.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/MemberAccess/NodeContextFromMemberAccess.php
@@ -10,6 +10,7 @@ use Microsoft\PhpParser\Node\Expression\ScopedPropertyAccessExpression;
 use Phpactor\TextDocument\ByteOffsetRange;
 use Phpactor\WorseReflection\Core\Exception\NotFound;
 use Phpactor\WorseReflection\Core\Inference\Context\MemberAccessContext;
+use Phpactor\WorseReflection\Core\Inference\Context\MethodCallContext;
 use Phpactor\WorseReflection\Core\Inference\Frame;
 use Phpactor\WorseReflection\Core\Inference\FunctionArguments;
 use Phpactor\WorseReflection\Core\Inference\GenericMapResolver;
@@ -114,6 +115,16 @@ class NodeContextFromMemberAccess
         }
 
         if ($member instanceof ReflectionMember) {
+            if ($member instanceof ReflectionMethod) {
+                return new MethodCallContext(
+                    $context->symbol(),
+                    $memberType->reduce(),
+                    $containerType,
+                    ByteOffsetRange::fromInts($node->memberName->getStartPosition(), $node->memberName->getEndPosition()),
+                    $member,
+                    $arguments,
+                );
+            }
             return new MemberAccessContext(
                 $context->symbol(),
                 $memberType->reduce(),

--- a/lib/WorseReflection/Core/Inference/Resolver/MemberAccess/NodeContextFromMemberAccess.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/MemberAccess/NodeContextFromMemberAccess.php
@@ -333,10 +333,7 @@ class NodeContextFromMemberAccess
     {
         $templateMap = $this->resolver->mergeParameters($templateMap, $member->parameters(), $arguments);
         $type = $type->map(function (Type $type) use ($templateMap): Type {
-            if ($templateMap->has($type->short())) {
-                return $templateMap->get($type->short());
-            }
-            return $type;
+            return $templateMap->getOrGiven($type);
         });
 
         return $type;

--- a/lib/WorseReflection/Core/Inference/Resolver/MemberAccess/NodeContextFromMemberAccess.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/MemberAccess/NodeContextFromMemberAccess.php
@@ -100,7 +100,7 @@ class NodeContextFromMemberAccess
             }
         }
 
-        [ $containerType, $memberType, $member ] = $this->resolveContainerMemberType(
+        [ $containerType, $memberType, $member, $arguments ] = $this->resolveContainerMemberType(
             $resolver,
             $frame,
             $node,
@@ -120,6 +120,7 @@ class NodeContextFromMemberAccess
                 $containerType,
                 ByteOffsetRange::fromInts($node->memberName->getStartPosition(), $node->memberName->getEndPosition()),
                 $member,
+                $arguments,
             );
         }
 
@@ -197,7 +198,7 @@ class NodeContextFromMemberAccess
         }
 
         $containerType = UnionType::fromTypes(...$types)->reduce();
-        return [$containerType, $memberType, $member];
+        return [$containerType, $memberType, $member, $arguments];
     }
 
     private function resolveMemberType(NodeContextResolver $resolver, Frame $frame, ReflectionMember $member, ?FunctionArguments $arguments, Node $node, Type $subType): Type

--- a/lib/WorseReflection/Core/TemplateMap.php
+++ b/lib/WorseReflection/Core/TemplateMap.php
@@ -3,6 +3,7 @@
 namespace Phpactor\WorseReflection\Core;
 
 use Countable;
+use Phpactor\WorseReflection\Core\Type\ClassType;
 use Phpactor\WorseReflection\Core\Type\MissingType;
 
 final class TemplateMap implements Countable
@@ -105,5 +106,17 @@ final class TemplateMap implements Countable
     public function toArguments(): array
     {
         return array_values($this->map);
+    }
+
+    public function getOrGiven(Type $type): Type
+    {
+        if (!$type instanceof ClassType) {
+            return $type;
+        }
+        $templateType = $this->map[$type->short()] ?? null;
+        if ($templateType) {
+            return $templateType;
+        }
+        return $type;
     }
 }

--- a/lib/WorseReflection/Tests/Inference/narrowing/function-narrow.test
+++ b/lib/WorseReflection/Tests/Inference/narrowing/function-narrow.test
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @phpstan-assert Foobar $class
+ */
+function assertFoobar(string $class): void
+{
+}
+
+function foo(object $obj): void
+{
+    assertFoobar($obj);
+    wrAssertType('Foobar', $obj);
+}

--- a/lib/WorseReflection/Tests/Inference/narrowing/narrow-generic.test
+++ b/lib/WorseReflection/Tests/Inference/narrowing/narrow-generic.test
@@ -1,0 +1,19 @@
+<?php
+
+final class Assert
+{
+    /**
+     * @psalm-template ExpectedType of object
+     * @psalm-param class-string<ExpectedType> $expected
+     * @psalm-assert ExpectedType $actual
+     */
+    public static function assertFoobar(string $expected, object $actual): void
+    {
+    }
+}
+
+function foo(object $obj): void
+{
+    Assert::assertFoobar('Foobar', $obj);
+    wrAssertType('Foobar', $obj);
+}

--- a/lib/WorseReflection/Tests/Inference/narrowing/narrow-negate.test
+++ b/lib/WorseReflection/Tests/Inference/narrowing/narrow-negate.test
@@ -1,0 +1,17 @@
+<?php
+
+final class Assert
+{
+    /**
+     * @phpstan-assert !Foobar $class
+     */
+    public static function assertFoobar(string $class): void
+    {
+    }
+}
+
+function foo(Foobar|Barfoo $obj): void
+{
+    Assert::assertFoobar($obj);
+    wrAssertType('Barfoo', $obj);
+}

--- a/lib/WorseReflection/Tests/Inference/narrowing/narrow.test
+++ b/lib/WorseReflection/Tests/Inference/narrowing/narrow.test
@@ -1,0 +1,17 @@
+<?php
+
+final class Assert
+{
+    /**
+     * @phpstan-assert Foobar $class
+     */
+    public static function assertFoobar(string $class): void
+    {
+    }
+}
+
+function foo(object $obj): void
+{
+    Assert::assertFoobar($obj);
+    wrAssertType('Foobar', $obj);
+}


### PR DESCRIPTION
Support narrowing types:

- [x] Narrow types without generics on classes
- [x] Narrow types with generics
- [x] Support (or explicitly not support) negation
- [x] Support on function calls 