### PR TITLE
Support array shapes with string literals in param annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Bug fixes:
   - Take optional parameters into account with conditional types #2700 @dantleech
   - Fix import position when `declare` is present #2698 @dantleech
   - Fix NULL error in Docblock parser #2693 @dantleech
+  - Fix docblock parsing of `array{foo:'quoted',bar:'strings'}` #2730 @nsrosenqvist
 
 Improvements:
 

--- a/lib/DocblockParser/Parser.php
+++ b/lib/DocblockParser/Parser.php
@@ -361,6 +361,9 @@ final class Parser
             if ($this->tokens->ifOneOf(Token::T_LABEL, Token::T_INTEGER)) {
                 $keyValues = $this->parseArrayKeyValues();
             }
+            if ($this->tokens->if(Token::T_QUOTED_STRING)) {
+                $keyValues = $this->parseArrayKeyValues();
+            }
             if ($this->tokens->if(Token::T_BRACKET_CURLY_CLOSE)) {
                 $close = $this->tokens->chomp();
             }
@@ -710,6 +713,9 @@ final class Parser
         }
         $type = null;
         if ($this->tokens->ifOneOf(Token::T_LABEL, Token::T_INTEGER)) {
+            $type = $this->parseTypes();
+        }
+        if ($this->tokens->if(Token::T_QUOTED_STRING)) {
             $type = $this->parseTypes();
         }
 

--- a/lib/DocblockParser/Tests/Unit/Printer/examples/arrayshape6.test
+++ b/lib/DocblockParser/Tests/Unit/Printer/examples/arrayshape6.test
@@ -1,0 +1,20 @@
+/**
+ * @param array{
+ *     foo: 'foo',
+ *     bar: 'bar',
+ * } $config
+ */
+---
+Docblock: = 
+ ElementList: = /**
+ * 
+  ParamTag: = @param
+   ArrayShapeNode: = {
+    ArrayKeyValueList: = 
+     ArrayKeyValueNode: = foo:
+      LiteralStringNode: = 'foo',
+     ArrayKeyValueNode: = bar:
+      LiteralStringNode: = 'bar',}
+   VariableNode: = $config
+   TextNode: = 
+ */

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/DocblockMissingParamProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/DocblockMissingParamProvider.php
@@ -231,6 +231,25 @@ class DocblockMissingParamProvider implements DiagnosticProvider
             }
         );
         yield new DiagnosticExample(
+            title: 'no false positive array shape with string literals',
+            source: <<<'PHP'
+                <?php
+
+                class Foobar
+                {
+                    /**
+                     * @param array{foo: 'foo', bar: 'bar'} $foobar
+                     */
+                    public function foo(array $foobar) {
+                    }
+                }
+                PHP,
+            valid: true,
+            assertion: function (Diagnostics $diagnostics): void {
+                Assert::assertCount(0, $diagnostics);
+            }
+        );
+        yield new DiagnosticExample(
             title: 'no false positive for vardoc on promoted property',
             source: <<<'PHP'
                 <?php


### PR DESCRIPTION
Fixes https://github.com/phpactor/phpactor/issues/2730