### PR TITLE
Improve method namings

### DIFF
--- a/lib/Extension/LanguageServerCompletion/Handler/CompletionHandler.php
+++ b/lib/Extension/LanguageServerCompletion/Handler/CompletionHandler.php
@@ -150,7 +150,7 @@ class CompletionHandler implements Handler, CanRegisterCapabilities
         });
     }
 
-    public function registerCapabiltiies(ServerCapabilities $capabilities): void
+    public function registerCapabilties(ServerCapabilities $capabilities): void
     {
         $capabilities->completionProvider = new CompletionOptions([
             ':',

--- a/lib/Extension/LanguageServerCompletion/Handler/SignatureHelpHandler.php
+++ b/lib/Extension/LanguageServerCompletion/Handler/SignatureHelpHandler.php
@@ -50,7 +50,7 @@ class SignatureHelpHandler implements Handler, CanRegisterCapabilities
         });
     }
 
-    public function registerCapabiltiies(ServerCapabilities $capabilities): void
+    public function registerCapabilties(ServerCapabilities $capabilities): void
     {
         $options = new SignatureHelpOptions();
         $options->triggerCharacters = [ '(', ',', '@' ];

--- a/lib/Extension/LanguageServerCompletion/Tests/Unit/Handler/HoverHandlerTest.php
+++ b/lib/Extension/LanguageServerCompletion/Tests/Unit/Handler/HoverHandlerTest.php
@@ -33,6 +33,7 @@ class HoverHandlerTest extends IntegrationTestCase
         $this->assertInstanceOf(Hover::class, $result);
     }
 
+    /** @return Generator<array{string}> */
     public function provideHover(): Generator
     {
         yield 'var' => [

--- a/lib/Extension/LanguageServerHover/Handler/HoverHandler.php
+++ b/lib/Extension/LanguageServerHover/Handler/HoverHandler.php
@@ -65,7 +65,7 @@ class HoverHandler implements Handler, CanRegisterCapabilities
             }
 
             $offsetReflection = $this->reflector->reflectOffset($document, $offset);
-            $info = $this->infoFromReflecionOffset($offsetReflection);
+            $info = $this->infoFromReflectionOffset($offsetReflection);
             $string = new MarkupContent('markdown', $info);
             $nodeContext = $offsetReflection->nodeContext();
 
@@ -87,7 +87,7 @@ class HoverHandler implements Handler, CanRegisterCapabilities
         $capabilities->hoverProvider = true;
     }
 
-    private function infoFromReflecionOffset(ReflectionOffset $offset): string
+    private function infoFromReflectionOffset(ReflectionOffset $offset): string
     {
         $nodeContext = $offset->nodeContext();
 

--- a/lib/Extension/LanguageServerIndexer/Handler/WorkspaceSymbolHandler.php
+++ b/lib/Extension/LanguageServerIndexer/Handler/WorkspaceSymbolHandler.php
@@ -34,7 +34,7 @@ class WorkspaceSymbolHandler implements Handler, CanRegisterCapabilities
         });
     }
 
-    public function registerCapabiltiies(ServerCapabilities $capabilities): void
+    public function registerCapabilties(ServerCapabilities $capabilities): void
     {
         $capabilities->workspaceSymbolProvider = true;
     }

--- a/lib/Extension/LanguageServerReferenceFinder/Handler/GotoDefinitionHandler.php
+++ b/lib/Extension/LanguageServerReferenceFinder/Handler/GotoDefinitionHandler.php
@@ -81,7 +81,7 @@ class GotoDefinitionHandler implements Handler, CanRegisterCapabilities
         });
     }
 
-    public function registerCapabiltiies(ServerCapabilities $capabilities): void
+    public function registerCapabilties(ServerCapabilities $capabilities): void
     {
         $capabilities->definitionProvider = true;
     }

--- a/lib/Extension/LanguageServerReferenceFinder/Handler/GotoImplementationHandler.php
+++ b/lib/Extension/LanguageServerReferenceFinder/Handler/GotoImplementationHandler.php
@@ -52,7 +52,7 @@ class GotoImplementationHandler implements Handler, CanRegisterCapabilities
         });
     }
 
-    public function registerCapabiltiies(ServerCapabilities $capabilities): void
+    public function registerCapabilties(ServerCapabilities $capabilities): void
     {
         $capabilities->implementationProvider = true;
     }

--- a/lib/Extension/LanguageServerReferenceFinder/Handler/HighlightHandler.php
+++ b/lib/Extension/LanguageServerReferenceFinder/Handler/HighlightHandler.php
@@ -41,7 +41,7 @@ class HighlightHandler implements Handler, CanRegisterCapabilities
         });
     }
 
-    public function registerCapabiltiies(ServerCapabilities $capabilities): void
+    public function registerCapabilties(ServerCapabilities $capabilities): void
     {
         $capabilities->documentHighlightProvider = true;
     }

--- a/lib/Extension/LanguageServerReferenceFinder/Handler/ReferencesHandler.php
+++ b/lib/Extension/LanguageServerReferenceFinder/Handler/ReferencesHandler.php
@@ -120,7 +120,7 @@ class ReferencesHandler implements Handler, CanRegisterCapabilities
         });
     }
 
-    public function registerCapabiltiies(ServerCapabilities $capabilities): void
+    public function registerCapabilties(ServerCapabilities $capabilities): void
     {
         $capabilities->referencesProvider = true;
     }

--- a/lib/Extension/LanguageServerReferenceFinder/Handler/TypeDefinitionHandler.php
+++ b/lib/Extension/LanguageServerReferenceFinder/Handler/TypeDefinitionHandler.php
@@ -80,7 +80,7 @@ class TypeDefinitionHandler implements Handler, CanRegisterCapabilities
         });
     }
 
-    public function registerCapabiltiies(ServerCapabilities $capabilities): void
+    public function registerCapabilties(ServerCapabilities $capabilities): void
     {
         $capabilities->typeDefinitionProvider = true;
     }

--- a/lib/Extension/LanguageServerRename/Handler/FileRenameHandler.php
+++ b/lib/Extension/LanguageServerRename/Handler/FileRenameHandler.php
@@ -50,7 +50,7 @@ class FileRenameHandler implements Handler, CanRegisterCapabilities
         });
     }
 
-    public function registerCapabiltiies(ServerCapabilities $capabilities): void
+    public function registerCapabilties(ServerCapabilities $capabilities): void
     {
         $capabilities->workspace['fileOperations'] = new FileOperationOptions(willRename: new FileOperationRegistrationOptions(
             filters: [

--- a/lib/Extension/LanguageServerRename/Handler/RenameHandler.php
+++ b/lib/Extension/LanguageServerRename/Handler/RenameHandler.php
@@ -109,7 +109,7 @@ class RenameHandler implements Handler, CanRegisterCapabilities
         });
     }
 
-    public function registerCapabiltiies(ServerCapabilities $capabilities): void
+    public function registerCapabilties(ServerCapabilities $capabilities): void
     {
         $capabilities->renameProvider = new RenameOptions(true);
     }

--- a/lib/Extension/LanguageServerSelectionRange/Handler/SelectionRangeHandler.php
+++ b/lib/Extension/LanguageServerSelectionRange/Handler/SelectionRangeHandler.php
@@ -42,7 +42,7 @@ class SelectionRangeHandler implements Handler, CanRegisterCapabilities
         return new Success($this->provider->provide($textDocument->text, $offsets));
     }
 
-    public function registerCapabiltiies(ServerCapabilities $capabilities): void
+    public function registerCapabilties(ServerCapabilities $capabilities): void
     {
         $capabilities->selectionRangeProvider = true;
     }

--- a/lib/Extension/LanguageServerSymbolProvider/Handler/DocumentSymbolProviderHandler.php
+++ b/lib/Extension/LanguageServerSymbolProvider/Handler/DocumentSymbolProviderHandler.php
@@ -38,7 +38,7 @@ class DocumentSymbolProviderHandler implements Handler, CanRegisterCapabilities
         return new Success($this->provider->provideFor($textDocument->text));
     }
 
-    public function registerCapabiltiies(ServerCapabilities $capabilities): void
+    public function registerCapabilties(ServerCapabilities $capabilities): void
     {
         $capabilities->documentSymbolProvider = true;
     }

--- a/lib/Extension/LanguageServerWorseReflection/Handler/InlayHintHandler.php
+++ b/lib/Extension/LanguageServerWorseReflection/Handler/InlayHintHandler.php
@@ -39,7 +39,7 @@ class InlayHintHandler implements Handler, CanRegisterCapabilities
         );
     }
 
-    public function registerCapabiltiies(ServerCapabilities $capabilities): void
+    public function registerCapabilties(ServerCapabilities $capabilities): void
     {
         $capabilities->inlayHintProvider = true;
     }

--- a/lib/WorseReflection/Core/SourceCodeLocator/StubSourceLocator.php
+++ b/lib/WorseReflection/Core/SourceCodeLocator/StubSourceLocator.php
@@ -98,12 +98,12 @@ final class StubSourceLocator implements SourceCodeLocator
      */
     private function buildClassMap(SplFileInfo $file, array $map): array
     {
-        $functions = $this->reflector->reflectClassesIn(
+        $classes = $this->reflector->reflectClassesIn(
             TextDocumentBuilder::fromUri($file)->build()
         );
 
-        foreach ($functions as $function) {
-            $map[(string) $function->name()] = (string) $file;
+        foreach ($classes as $class) {
+            $map[(string) $class->name()] = (string) $file;
         }
 
         return $map;


### PR DESCRIPTION
Fixing some typos in method names and fixing copy and paste errors in the `StubLocator`