### PR TITLE
Moving the `RecordReferenceEnhancer`

### DIFF
--- a/lib/Indexer/Adapter/Worse/WorseRecordReferenceEnhancer.php
+++ b/lib/Indexer/Adapter/Worse/WorseRecordReferenceEnhancer.php
@@ -3,7 +3,7 @@
 namespace Phpactor\Indexer\Adapter\Worse;
 
 use Phpactor\Indexer\Model\RecordReference;
-use Phpactor\Indexer\Model\RecordReferenceEnhancer;
+use Phpactor\Indexer\Model\RecordReferenceEnhancer\RecordReferenceEnhancer;
 use Phpactor\Indexer\Model\Record\FileRecord;
 use Phpactor\Indexer\Model\Record\MemberRecord;
 use Phpactor\TextDocument\Exception\TextDocumentNotFound;
@@ -16,8 +16,11 @@ use Psr\Log\LoggerInterface;
 
 class WorseRecordReferenceEnhancer implements RecordReferenceEnhancer
 {
-    public function __construct(private SourceCodeReflector $reflector, private LoggerInterface $logger, private TextDocumentLocator $locator)
-    {
+    public function __construct(
+        private SourceCodeReflector $reflector,
+        private LoggerInterface $logger,
+        private TextDocumentLocator $locator
+    ) {
     }
 
     public function enhance(FileRecord $record, RecordReference $reference): RecordReference

--- a/lib/Indexer/IndexAgentBuilder.php
+++ b/lib/Indexer/IndexAgentBuilder.php
@@ -21,7 +21,7 @@ use Phpactor\Indexer\Model\RealIndexAgent;
 use Phpactor\Indexer\Model\IndexBuilder;
 use Phpactor\Indexer\Model\QueryClient;
 use Phpactor\Indexer\Model\Indexer;
-use Phpactor\Indexer\Model\RecordReferenceEnhancer;
+use Phpactor\Indexer\Model\RecordReferenceEnhancer\RecordReferenceEnhancer;
 use Phpactor\Indexer\Model\RecordReferenceEnhancer\NullRecordReferenceEnhancer;
 use Phpactor\Indexer\Model\RecordSerializer;
 use Phpactor\Indexer\Model\RecordSerializer\PhpSerializer;

--- a/lib/Indexer/Model/Query/MemberQuery.php
+++ b/lib/Indexer/Model/Query/MemberQuery.php
@@ -6,7 +6,7 @@ use Generator;
 use Phpactor\Indexer\Model\Index;
 use Phpactor\Indexer\Model\IndexQuery;
 use Phpactor\Indexer\Model\LocationConfidence;
-use Phpactor\Indexer\Model\RecordReferenceEnhancer;
+use Phpactor\Indexer\Model\RecordReferenceEnhancer\RecordReferenceEnhancer;
 use Phpactor\Indexer\Model\Record\FileRecord;
 use Phpactor\TextDocument\Location;
 use Phpactor\Indexer\Model\Record\MemberRecord;

--- a/lib/Indexer/Model/QueryClient.php
+++ b/lib/Indexer/Model/QueryClient.php
@@ -8,6 +8,7 @@ use Phpactor\Indexer\Model\Query\FileQuery;
 use Phpactor\Indexer\Model\Query\FunctionQuery;
 use Phpactor\Indexer\Model\Query\MemberQuery;
 use Phpactor\Indexer\Model\RecordReferenceEnhancer\NullRecordReferenceEnhancer;
+use Phpactor\Indexer\Model\RecordReferenceEnhancer\RecordReferenceEnhancer;
 
 class QueryClient
 {

--- a/lib/Indexer/Model/RecordReferenceEnhancer/NullRecordReferenceEnhancer.php
+++ b/lib/Indexer/Model/RecordReferenceEnhancer/NullRecordReferenceEnhancer.php
@@ -3,7 +3,6 @@
 namespace Phpactor\Indexer\Model\RecordReferenceEnhancer;
 
 use Phpactor\Indexer\Model\RecordReference;
-use Phpactor\Indexer\Model\RecordReferenceEnhancer;
 use Phpactor\Indexer\Model\Record\FileRecord;
 
 class NullRecordReferenceEnhancer implements RecordReferenceEnhancer

--- a/lib/Indexer/Model/RecordReferenceEnhancer/RecordReferenceEnhancer.php
+++ b/lib/Indexer/Model/RecordReferenceEnhancer/RecordReferenceEnhancer.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Phpactor\Indexer\Model;
+namespace Phpactor\Indexer\Model\RecordReferenceEnhancer;
 
 use Phpactor\Indexer\Model\Record\FileRecord;
+use Phpactor\Indexer\Model\RecordReference;
 
 interface RecordReferenceEnhancer
 {


### PR DESCRIPTION
Moving the `RecordReferenceEnhancer (interface)` next to the implementation (NullEnhancer):

```php
//From
use Phpactor\Indexer\Model\RecordReferenceEnhancer;
// To
use Phpactor\Indexer\Model\RecordReferenceEnhancer\RecordReferenceEnhancer;
```

Or was that supposed to be all the interfaces in the `Model` directory? And the folders are just for the implementations?