### PR TITLE
Making `CallbackExpander` types explict as doctype

### DIFF
--- a/lib/FilePathResolver/Expander/CallbackExpander.php
+++ b/lib/FilePathResolver/Expander/CallbackExpander.php
@@ -1,15 +1,18 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Phpactor\FilePathResolver\Expander;
 
 use Closure;
 use Phpactor\FilePathResolver\Expander;
-use RuntimeException;
 
 class CallbackExpander implements Expander
 {
+    /** @var Closure():string */
     private Closure $callback;
 
+    /**
+     * @param Closure():string $callback
+    */
     public function __construct(private string $tokenName, Closure $callback)
     {
         $this->callback = $callback;
@@ -23,15 +26,6 @@ class CallbackExpander implements Expander
     public function replacementValue(): string
     {
         $closure = $this->callback;
-        $return = $closure();
-
-        if (!is_string($return)) {
-            throw new RuntimeException(sprintf(
-                'Closure in callback expander must return a string, got "%s"',
-                gettype($return)
-            ));
-        }
-
-        return $return;
+        return $closure();
     }
 }

--- a/lib/FilePathResolver/Tests/Unit/Expander/CallbackExpanderTest.php
+++ b/lib/FilePathResolver/Tests/Unit/Expander/CallbackExpanderTest.php
@@ -4,7 +4,6 @@ namespace Phpactor\FilePathResolver\Tests\Unit\Expander;
 
 use Phpactor\FilePathResolver\Expander;
 use Phpactor\FilePathResolver\Expander\CallbackExpander;
-use RuntimeException;
 
 class CallbackExpanderTest extends ExpanderTestCase
 {
@@ -18,15 +17,5 @@ class CallbackExpanderTest extends ExpanderTestCase
     public function testExpandsCallbackValue(): void
     {
         $this->assertEquals('bar', $this->expand('%foo%'));
-    }
-
-    public function testThrowsExeceptionWhenCallbackReturnsNonString(): void
-    {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Closure in callback expander');
-
-        (new CallbackExpander('foo', function () {
-            return 123;
-        }))->replacementValue();
     }
 }


### PR DESCRIPTION
The benefits are:
* Phpstan is yelling at you if you use the wrong return type of your closure at the place you miss used it (preventing runtime errors (and the documentation shows it).
* We don't need to check the type if we make the file type safe then php will crash with a type error
* Less code