### PR TITLE
feat(phpstan): support opt-out of using a temporary file for linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Improvements:
     #2695 @przepompownia
   - Show prose associated with `@throws` tag #2694 @mamazu
   - Support parsing generic variance e.g. `covariant` #2664 @dantleech
+  - Support opt-out of using temporary files with phpstan #2764 @tsterker
 
 Features:
 

--- a/lib/Extension/LanguageServerPhpstan/LanguageServerPhpstanExtension.php
+++ b/lib/Extension/LanguageServerPhpstan/LanguageServerPhpstanExtension.php
@@ -24,6 +24,7 @@ class LanguageServerPhpstanExtension implements OptionalExtension
     public const PARAM_CONFIG = 'language_server_phpstan.config';
     public const PARAM_MEM_LIMIT = 'language_server_phpstan.mem_limit';
     public const PARAM_ENABLED = 'language_server_phpstan.enabled';
+    public const PARAM_TMP_FILE_DISABLED = 'language_server_phpstan.tmp_file_disabled';
 
     public function load(ContainerBuilder $container): void
     {
@@ -42,7 +43,10 @@ class LanguageServerPhpstanExtension implements OptionalExtension
         $container->register(
             Linter::class,
             function (Container $container) {
-                return new PhpstanLinter($container->get(PhpstanProcess::class));
+                return new PhpstanLinter(
+                    $container->get(PhpstanProcess::class),
+                    $container->parameter(self::PARAM_TMP_FILE_DISABLED)->value() ?  $container->parameter(self::PARAM_TMP_FILE_DISABLED)->bool() : null,
+                );
             }
         );
 
@@ -85,6 +89,7 @@ class LanguageServerPhpstanExtension implements OptionalExtension
             self::PARAM_LEVEL => null,
             self::PARAM_CONFIG => null,
             self::PARAM_MEM_LIMIT => null,
+            self::PARAM_TMP_FILE_DISABLED => false,
             ]
         );
         $schema->setDescriptions(
@@ -93,6 +98,9 @@ class LanguageServerPhpstanExtension implements OptionalExtension
             self::PARAM_LEVEL => 'Override the PHPStan level',
             self::PARAM_CONFIG => 'Override the PHPStan configuration file',
             self::PARAM_MEM_LIMIT => 'Override the PHPStan memory limit',
+            self::PARAM_TMP_FILE_DISABLED => 'Disable the use of temporary files when.'
+                . ' This prevents as-you-type diagnostics, but ensures paths in phpstan config are respected.'
+                . ' See https://github.com/phpactor/phpactor/issues/2763',
             ]
         );
     }

--- a/lib/Extension/LanguageServerPhpstan/LanguageServerPhpstanExtension.php
+++ b/lib/Extension/LanguageServerPhpstan/LanguageServerPhpstanExtension.php
@@ -45,7 +45,7 @@ class LanguageServerPhpstanExtension implements OptionalExtension
             function (Container $container) {
                 return new PhpstanLinter(
                     $container->get(PhpstanProcess::class),
-                    $container->parameter(self::PARAM_TMP_FILE_DISABLED)->value() ?  $container->parameter(self::PARAM_TMP_FILE_DISABLED)->bool() : null,
+                    $container->parameter(self::PARAM_TMP_FILE_DISABLED)->value() ?  $container->parameter(self::PARAM_TMP_FILE_DISABLED)->bool() : false,
                 );
             }
         );

--- a/lib/Extension/LanguageServerPhpstan/Model/Linter/PhpstanLinter.php
+++ b/lib/Extension/LanguageServerPhpstan/Model/Linter/PhpstanLinter.php
@@ -21,6 +21,11 @@ class PhpstanLinter implements Linter
     ) {
     }
 
+    public function isTmpFileDisabled(): bool
+    {
+        return $this->disableTmpFile;
+    }
+
     public function lint(string $url, ?string $text): Promise
     {
         return call(function () use ($url, $text) {

--- a/lib/Extension/LanguageServerPhpstan/Model/Linter/PhpstanLinter.php
+++ b/lib/Extension/LanguageServerPhpstan/Model/Linter/PhpstanLinter.php
@@ -17,7 +17,7 @@ class PhpstanLinter implements Linter
 {
     public function __construct(
         private PhpstanProcess $process,
-        private ?bool $disableTmpFile = null,
+        private bool $disableTmpFile = false,
     ) {
     }
 

--- a/lib/Extension/LanguageServerPhpstan/Model/Linter/PhpstanLinter.php
+++ b/lib/Extension/LanguageServerPhpstan/Model/Linter/PhpstanLinter.php
@@ -9,13 +9,16 @@ use Phpactor\Extension\LanguageServerPhpstan\Model\Linter;
 use Phpactor\Extension\LanguageServerPhpstan\Model\PhpstanProcess;
 use Phpactor\LanguageServerProtocol\Diagnostic;
 use Phpactor\TextDocument\TextDocumentUri;
+
 use function Safe\tempnam;
 use function Safe\file_put_contents;
 
 class PhpstanLinter implements Linter
 {
-    public function __construct(private PhpstanProcess $process)
-    {
+    public function __construct(
+        private PhpstanProcess $process,
+        private ?bool $disableTmpFile = null,
+    ) {
     }
 
     public function lint(string $url, ?string $text): Promise
@@ -32,14 +35,17 @@ class PhpstanLinter implements Linter
      */
     private function doLint(string $url, ?string $text): Generator
     {
-        if (null === $text) {
+        if (null === $text || $this->disableTmpFile) {
             return yield $this->process->analyse(TextDocumentUri::fromString($url)->path());
         }
 
         $name = tempnam(sys_get_temp_dir(), 'phpstanls');
         file_put_contents($name, $text);
-        $diagnostics = yield $this->process->analyse($name);
-        unlink($name);
+        try {
+            $diagnostics = yield $this->process->analyse($name);
+        } finally {
+            @unlink($name);
+        }
         return $diagnostics;
     }
 }

--- a/lib/Extension/LanguageServerPhpstan/Tests/LanguageServerPhpstanExtensionTest.php
+++ b/lib/Extension/LanguageServerPhpstan/Tests/LanguageServerPhpstanExtensionTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerPhpstan\Tests;
+
+use Phpactor\Container\Container;
+use Phpactor\Container\PhpactorContainer;
+use Phpactor\Extension\LanguageServerPhpstan\Model\Linter;
+use Phpactor\Extension\LanguageServerPhpstan\Model\Linter\PhpstanLinter;
+use Phpactor\Extension\Logger\LoggingExtension;
+use Phpactor\Extension\FilePathResolver\FilePathResolverExtension;
+use Phpactor\Extension\LanguageServerPhpstan\LanguageServerPhpstanExtension;
+use PHPUnit\Framework\TestCase;
+
+class LanguageServerPhpstanExtensionTest extends TestCase
+{
+    public function testParam_tmp_file_disabled(): void
+    {
+        // Case: Enabled by default
+        $linter = $this->getLinter([]);
+        $this->assertFalse($linter->isTmpFileDisabled());
+
+        // Case: Enable via param
+        $linter = $this->getLinter([LanguageServerPhpstanExtension::PARAM_TMP_FILE_DISABLED => false]);
+        $this->assertFalse($linter->isTmpFileDisabled());
+
+        // Case: Disable via param
+        $linter = $this->getLinter([LanguageServerPhpstanExtension::PARAM_TMP_FILE_DISABLED => true]);
+        $this->assertTrue($linter->isTmpFileDisabled());
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function getLinter(array $params = []): PhpstanLinter
+    {
+        $container = $this->getContainer($params);
+
+        $linter = $container->get(Linter::class);
+
+        $this->assertInstanceOf(PhpstanLinter::class, $linter);
+
+        return $linter;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function getContainer(array $params = []): Container
+    {
+        return PhpactorContainer::fromExtensions(
+            [
+                FilePathResolverExtension::class,
+                LoggingExtension::class,
+                LanguageServerPhpstanExtension::class
+            ],
+            $params
+        );
+    }
+}

--- a/lib/Extension/LanguageServerPhpstan/Tests/Model/PhpstanLinterTest.php
+++ b/lib/Extension/LanguageServerPhpstan/Tests/Model/PhpstanLinterTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerPhpstan\Tests\Model;
+
+use PHPUnit\Framework\TestCase;
+use Phpactor\Extension\LanguageServerPhpstan\Model\Linter\PhpstanLinter;
+use Phpactor\Extension\LanguageServerPhpstan\Model\PhpstanProcess;
+
+class PhpstanLinterTest extends TestCase
+{
+    public function testLinterUsesTmpFileByDefault(): void
+    {
+        $originalFilePath = '/foo';
+        $expectedFileContent = '<file content that will be written to tmp file>';
+
+        $phpstanProcess = $this->createMock(PhpstanProcess::class);
+        $phpstanProcess->expects($this->once())
+            ->method('analyse')
+            // ->with($this->stringContains(sys_get_temp_dir() . '/phpstanls'));
+            ->with($this->callback(function ($analyzedFilePath) use ($originalFilePath, $expectedFileContent) {
+
+                // Infer that a temporary file was used by confirming that the PHPStan
+                // does not get the original file path passed.
+                $this->assertNotEquals($originalFilePath, $analyzedFilePath);
+
+                // Confirm the file content was written to the temporary file.
+                $this->assertStringEqualsFile($analyzedFilePath, $expectedFileContent);
+
+                // Explicitly confirm a temporary file is used.
+                //
+                // NOTE: We use implementation detail knowledge here on how the tempnam is created.
+                //       This might not be necessary but provides an extra layer of safety and makes
+                //       the test more declarative.
+                //
+                // NOTE: It is not guaranteed that the sys_get_temp_dir() will be the *actual* directory
+                //       that is used. MacOs for example will create a directory prefixed with /private:
+                //       /private/<sys_get_temp_dir>/<prefix>...
+                //
+                $expectedPathSegment = sys_get_temp_dir() . '/phpstanls';
+                $this->assertStringContainsString($expectedPathSegment, $analyzedFilePath);
+
+                return true;
+            }));
+
+        $linter = new PhpstanLinter($phpstanProcess);
+
+        $linter->lint($originalFilePath, $expectedFileContent);
+    }
+
+    public function testLinterUsesOriginalFilePathWhenTmpFileDisabled(): void
+    {
+        $originalFilePath = '/foo';
+
+        $phpstanProcess = $this->createMock(PhpstanProcess::class);
+        $phpstanProcess->expects($this->once())
+            ->method('analyse')
+            ->with($originalFilePath);
+
+        $linter = new PhpstanLinter(
+            process: $phpstanProcess,
+            disableTmpFile: true,
+        );
+
+        $linter->lint($originalFilePath, '<file content that will be ignored and not used for a tmp file>');
+    }
+}

--- a/lib/Extension/LanguageServerPhpstan/Tests/Model/PhpstanLinterTest.php
+++ b/lib/Extension/LanguageServerPhpstan/Tests/Model/PhpstanLinterTest.php
@@ -16,7 +16,6 @@ class PhpstanLinterTest extends TestCase
         $phpstanProcess = $this->createMock(PhpstanProcess::class);
         $phpstanProcess->expects($this->once())
             ->method('analyse')
-            // ->with($this->stringContains(sys_get_temp_dir() . '/phpstanls'));
             ->with($this->callback(function ($analyzedFilePath) use ($originalFilePath, $expectedFileContent) {
 
                 // Infer that a temporary file was used by confirming that the PHPStan


### PR DESCRIPTION
Add support for a new `language_server_phpstan.tmp_file_disabled` parameter which defaults to `false`.

Disabling the use of temporary files ensures paths in phpstan config are respected. When using temporary files, PHPStan will not be able to relate the

Note that this prevents as-you-type diagnostics, because only saved changes can be checked with PHPStan.

Ref https://github.com/phpactor/phpactor/issues/2763