### PR TITLE
gh-2761: introduce tolerant code action provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## master
+
+Improvements:
+
+  - Tolerate code action provider failures #2761 @dantleech
+
 ## 2024-11-05
 
 Bug fixes:

--- a/lib/Extension/LanguageServer/CodeAction/TolerantCodeActionProvider.php
+++ b/lib/Extension/LanguageServer/CodeAction/TolerantCodeActionProvider.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServer\CodeAction;
+
+use Amp\CancellationToken;
+use Amp\Promise;
+use Phpactor\LanguageServerProtocol\Range;
+use Phpactor\LanguageServerProtocol\TextDocumentItem;
+use Phpactor\LanguageServer\Core\CodeAction\CodeActionProvider;
+use Phpactor\LanguageServer\Core\Server\ClientApi;
+use function Amp\call;
+use Throwable;
+
+final class TolerantCodeActionProvider implements CodeActionProvider
+{
+    public function __construct(private CodeActionProvider $provider, private ClientApi $client)
+    {
+    }
+
+    public function provideActionsFor(TextDocumentItem $textDocument, Range $range, CancellationToken $cancel): Promise
+    {
+        return call(function () use ($textDocument, $range, $cancel) {
+            try {
+                return yield $this->provider->provideActionsFor($textDocument, $range, $cancel);
+            } catch (Throwable $error) {
+                $this->client->window()->showMessage()->error(sprintf(
+                    'Provider %s (%s) failed: %s',
+                    $this->provider::class,
+                    $this->provider->describe(),
+                    $error->getMessage(),
+                ));
+                return [];
+            }
+        });
+    }
+
+    public function kinds(): array
+    {
+        return $this->provider->kinds();
+    }
+
+    public function describe(): string
+    {
+        return $this->provider->describe();
+    }
+}

--- a/lib/Extension/LanguageServer/LanguageServerExtension.php
+++ b/lib/Extension/LanguageServer/LanguageServerExtension.php
@@ -10,6 +10,7 @@ use Phpactor\Container\Extension;
 use Phpactor\Extension\FilePathResolver\FilePathResolverExtension;
 use Phpactor\Extension\LanguageServerWorseReflection\Workspace\WorkspaceIndex;
 use Phpactor\Extension\LanguageServer\CodeAction\ProfilingCodeActionProvider;
+use Phpactor\Extension\LanguageServer\CodeAction\TolerantCodeActionProvider;
 use Phpactor\Extension\LanguageServer\Command\DiagnosticsCommand;
 use Phpactor\Extension\LanguageServer\DiagnosticProvider\OutsourcedDiagnosticsProvider;
 use Phpactor\Extension\LanguageServer\DiagnosticProvider\PathExcludingDiagnosticsProvider;
@@ -454,6 +455,9 @@ class LanguageServerExtension implements Extension
 
         $container->register(CodeActionHandler::class, function (Container $container) {
             $services = $this->taggedServices($container, self::TAG_CODE_ACTION_PROVIDER, CodeActionProvider::class);
+            $services = array_map(function (CodeActionProvider $provider) use ($container) {
+                return new TolerantCodeActionProvider($provider, $container->get(ClientApi::class));
+            }, $services);
             if ($container->parameter(self::PARAM_PROFILE)->bool()) {
                 $services = array_map(
                     fn (CodeActionProvider $provider) => new ProfilingCodeActionProvider(

--- a/lib/Extension/LanguageServer/Tests/Unit/DiagnosticsProvider/TolerantCodeActionProviderTest.php
+++ b/lib/Extension/LanguageServer/Tests/Unit/DiagnosticsProvider/TolerantCodeActionProviderTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServer\Tests\Unit\DiagnosticsProvider;
+
+use Amp\CancellationTokenSource;
+use PHPUnit\Framework\TestCase;
+use Phpactor\Extension\LanguageServer\CodeAction\TolerantCodeActionProvider;
+use Phpactor\LanguageServer\Core\CodeAction\CodeActionProvider;
+use Phpactor\LanguageServer\Core\Rpc\NotificationMessage;
+use Phpactor\LanguageServer\LanguageServerTesterBuilder;
+use Phpactor\LanguageServer\Test\ProtocolFactory;
+use Exception;
+
+class TolerantCodeActionProviderTest extends TestCase
+{
+    public function testShowErrorWhenProviderFails(): void
+    {
+        $provider = $this->createMock(CodeActionProvider::class);
+        $provider->method('provideActionsFor')->willThrowException(new Exception('Oh no!'));
+        $tester = LanguageServerTesterBuilder::create();
+        (new TolerantCodeActionProvider($provider, $tester->clientApi()))->provideActionsFor(
+            ProtocolFactory::textDocumentItem('', ''),
+            ProtocolFactory::range(1, 1, 1, 1),
+            (new CancellationTokenSource())->getToken(),
+        );
+        $message = $tester->transmitter()->shift();
+        self::assertInstanceOf(NotificationMessage::class, $message);
+        $message = $message->params['message'] ?? null;
+        self::assertIsString($message);
+        self::assertStringContainsString('failed: Oh no!', $message);
+    }
+}

--- a/lib/WorseReflection/Tests/Benchmarks/CarbonReflectBench.php
+++ b/lib/WorseReflection/Tests/Benchmarks/CarbonReflectBench.php
@@ -2,9 +2,7 @@
 
 namespace Phpactor\WorseReflection\Tests\Benchmarks;
 
-use PHPUnit\Framework\TestCase;
 use Phpactor\TextDocument\TextDocumentBuilder;
-use Phpactor\WorseReflection\Core\ClassName;
 
 /**
  * @Iterations(5)
@@ -12,8 +10,6 @@ use Phpactor\WorseReflection\Core\ClassName;
  */
 class CarbonReflectBench extends BaseBenchCase
 {
-    /**
-     */
     public function benchCarbonReflection(): void
     {
         $classes = $this->getReflector()->reflectClassesIn(TextDocumentBuilder::fromUri(__DIR__ . '/fixtures/reflection/carbon.test')->build());


### PR DESCRIPTION
if a single code action provider fails then show an error message to the user and continue to process other code actions.