### PR TITLE
Navigator: Fix attempt to create existing destination

### DIFF
--- a/lib/Extension/Navigation/Application/Navigator.php
+++ b/lib/Extension/Navigation/Application/Navigator.php
@@ -18,6 +18,7 @@ class Navigator
     ) {
     }
 
+    /** @return array<string, string> */
     public function destinationsFor(string $path): array
     {
         return $this->navigator->destinationsFor($path);

--- a/lib/Extension/Navigation/Application/Navigator.php
+++ b/lib/Extension/Navigation/Application/Navigator.php
@@ -3,9 +3,9 @@
 namespace Phpactor\Extension\Navigation\Application;
 
 use Phpactor\Extension\Navigation\Navigator\Navigator as NavigatorInterface;
-use Phpactor\Filesystem\Domain\FilePath;
 use RuntimeException;
 use Phpactor\Extension\CodeTransformExtra\Application\ClassNew;
+use Symfony\Component\Filesystem\Path;
 
 class Navigator
 {
@@ -13,7 +13,7 @@ class Navigator
         private NavigatorInterface $navigator,
         private ClassNew $classNew,
         private array $autoCreateConfig,
-        private FilePath $path
+        private string $absolutePath
     ) {
     }
 
@@ -52,7 +52,7 @@ class Navigator
             ));
         }
 
-        return $this->path->makeAbsoluteFromString($destinations[$destinationName]);
+        return Path::makeAbsolute($destinations[$destinationName], $this->absolutePath);
     }
 
     private function variant(string $destinationName)

--- a/lib/Extension/Navigation/Application/Navigator.php
+++ b/lib/Extension/Navigation/Application/Navigator.php
@@ -3,6 +3,7 @@
 namespace Phpactor\Extension\Navigation\Application;
 
 use Phpactor\Extension\Navigation\Navigator\Navigator as NavigatorInterface;
+use Phpactor\Filesystem\Domain\FilePath;
 use RuntimeException;
 use Phpactor\Extension\CodeTransformExtra\Application\ClassNew;
 
@@ -11,7 +12,8 @@ class Navigator
     public function __construct(
         private NavigatorInterface $navigator,
         private ClassNew $classNew,
-        private array $autoCreateConfig
+        private array $autoCreateConfig,
+        private FilePath $path
     ) {
     }
 
@@ -50,7 +52,7 @@ class Navigator
             ));
         }
 
-        return $destinations[$destinationName];
+        return $this->path->makeAbsoluteFromString($destinations[$destinationName]);
     }
 
     private function variant(string $destinationName)

--- a/lib/Extension/Navigation/Application/Navigator.php
+++ b/lib/Extension/Navigation/Application/Navigator.php
@@ -9,6 +9,7 @@ use Symfony\Component\Filesystem\Path;
 
 class Navigator
 {
+    /** @param array<string, string> $autoCreateConfig */
     public function __construct(
         private NavigatorInterface $navigator,
         private ClassNew $classNew,
@@ -17,12 +18,12 @@ class Navigator
     ) {
     }
 
-    public function destinationsFor(string $path)
+    public function destinationsFor(string $path): array
     {
         return $this->navigator->destinationsFor($path);
     }
 
-    public function canCreateNew(string $path, string $destinationName)
+    public function canCreateNew(string $path, string $destinationName): bool
     {
         $destination = $this->destination($path, $destinationName);
 
@@ -40,7 +41,7 @@ class Navigator
         $this->classNew->generate($destination, $variant);
     }
 
-    private function destination(string $path, string $destinationName)
+    private function destination(string $path, string $destinationName): string
     {
         $destinations = $this->destinationsFor($path);
 
@@ -55,7 +56,7 @@ class Navigator
         return Path::makeAbsolute($destinations[$destinationName], $this->absolutePath);
     }
 
-    private function variant(string $destinationName)
+    private function variant(string $destinationName): string
     {
         if (!isset($this->autoCreateConfig[$destinationName])) {
             throw new RuntimeException(sprintf(

--- a/lib/Extension/Navigation/NavigationExtension.php
+++ b/lib/Extension/Navigation/NavigationExtension.php
@@ -56,7 +56,7 @@ class NavigationExtension implements Extension
                 $container->get('navigation.navigator.chain'),
                 $container->get('application.class_new'),
                 $container->parameter(self::NAVIGATOR_AUTOCREATE)->value(),
-                FilePath::fromString($this->projectRoot($container))
+                $this->projectRoot($container)
             );
         });
     }

--- a/lib/Extension/Navigation/NavigationExtension.php
+++ b/lib/Extension/Navigation/NavigationExtension.php
@@ -2,16 +2,21 @@
 
 namespace Phpactor\Extension\Navigation;
 
+use Phpactor\Container\Container;
 use Phpactor\Container\ContainerBuilder;
 use Phpactor\Container\Extension;
-use Phpactor\Extension\WorseReflection\WorseReflectionExtension;
-use Phpactor\MapResolver\Resolver;
-use Phpactor\Container\Container;
+use Phpactor\Extension\FilePathResolver\FilePathResolverExtension;
+use Phpactor\Extension\LanguageServer\LanguageServerExtension;
 use Phpactor\Extension\Navigation\Application\Navigator;
-use Phpactor\Extension\Navigation\Navigator\ChainNavigator;
 use Phpactor\Extension\Navigation\Handler\NavigateHandler;
+use Phpactor\Extension\Navigation\Navigator\ChainNavigator;
 use Phpactor\Extension\Navigation\Navigator\PathFinderNavigator;
 use Phpactor\Extension\Navigation\Navigator\WorseReflectionNavigator;
+use Phpactor\Extension\SourceCodeFilesystem\SourceCodeFilesystemExtension;
+use Phpactor\Extension\WorseReflection\WorseReflectionExtension;
+use Phpactor\FilePathResolver\PathResolver;
+use Phpactor\Filesystem\Domain\FilePath;
+use Phpactor\MapResolver\Resolver;
 use Phpactor\PathFinder\PathFinder;
 
 class NavigationExtension implements Extension
@@ -40,16 +45,24 @@ class NavigationExtension implements Extension
     private function registerPathFinder(ContainerBuilder $container): void
     {
         $container->register(self::SERVICE_PATH_FINDER, function (Container $container) {
-            return PathFinder::fromDestinations($container->getParameter(self::PATH_FINDER_DESTINATIONS));
+            return PathFinder::fromAbsoluteDestinations($container->parameter(FilePathResolverExtension::PARAM_PROJECT_ROOT)->string(), $container->parameter(self::PATH_FINDER_DESTINATIONS)->value());
         });
 
         $container->register('application.navigator', function (Container $container) {
             return new Navigator(
                 $container->get('navigation.navigator.chain'),
                 $container->get('application.class_new'),
-                $container->getParameter(self::NAVIGATOR_AUTOCREATE)
+                $container->parameter(self::NAVIGATOR_AUTOCREATE)->value(),
+                FilePath::fromString($this->projectRoot($container))
             );
         });
+    }
+
+    private function projectRoot(Container $container): string
+    {
+        /** @var PathResolver $resolver */
+        $resolver = $container->get(FilePathResolverExtension::SERVICE_FILE_PATH_RESOLVER);
+        return $resolver->resolve($container->parameter(SourceCodeFilesystemExtension::PARAM_PROJECT_ROOT)->string());
     }
 
     private function registerRpc(ContainerBuilder $container): void

--- a/lib/Extension/Navigation/NavigationExtension.php
+++ b/lib/Extension/Navigation/NavigationExtension.php
@@ -6,7 +6,6 @@ use Phpactor\Container\Container;
 use Phpactor\Container\ContainerBuilder;
 use Phpactor\Container\Extension;
 use Phpactor\Extension\FilePathResolver\FilePathResolverExtension;
-use Phpactor\Extension\LanguageServer\LanguageServerExtension;
 use Phpactor\Extension\Navigation\Application\Navigator;
 use Phpactor\Extension\Navigation\Handler\NavigateHandler;
 use Phpactor\Extension\Navigation\Navigator\ChainNavigator;
@@ -44,9 +43,13 @@ class NavigationExtension implements Extension
 
     private function registerPathFinder(ContainerBuilder $container): void
     {
-        $container->register(self::SERVICE_PATH_FINDER, function (Container $container) {
-            return PathFinder::fromAbsoluteDestinations($container->parameter(FilePathResolverExtension::PARAM_PROJECT_ROOT)->string(), $container->parameter(self::PATH_FINDER_DESTINATIONS)->value());
-        });
+        $container->register(
+            self::SERVICE_PATH_FINDER,
+            fn (Container $container) => PathFinder::fromAbsoluteDestinations(
+                $container->parameter(FilePathResolverExtension::PARAM_PROJECT_ROOT)->string(),
+                $container->parameter(self::PATH_FINDER_DESTINATIONS)->value() // @phpstan-ignore argument.type
+            )
+        );
 
         $container->register('application.navigator', function (Container $container) {
             return new Navigator(

--- a/lib/Extension/Navigation/NavigationExtension.php
+++ b/lib/Extension/Navigation/NavigationExtension.php
@@ -11,9 +11,7 @@ use Phpactor\Extension\Navigation\Handler\NavigateHandler;
 use Phpactor\Extension\Navigation\Navigator\ChainNavigator;
 use Phpactor\Extension\Navigation\Navigator\PathFinderNavigator;
 use Phpactor\Extension\Navigation\Navigator\WorseReflectionNavigator;
-use Phpactor\Extension\SourceCodeFilesystem\SourceCodeFilesystemExtension;
 use Phpactor\Extension\WorseReflection\WorseReflectionExtension;
-use Phpactor\FilePathResolver\PathResolver;
 use Phpactor\MapResolver\Resolver;
 use Phpactor\PathFinder\PathFinder;
 
@@ -55,16 +53,9 @@ class NavigationExtension implements Extension
                 $container->get('navigation.navigator.chain'),
                 $container->get('application.class_new'),
                 $container->parameter(self::NAVIGATOR_AUTOCREATE)->value(), // @phpstan-ignore argument.type
-                $this->projectRoot($container)
+                $container->parameter(FilePathResolverExtension::PARAM_PROJECT_ROOT)->string()
             );
         });
-    }
-
-    private function projectRoot(Container $container): string
-    {
-        /** @var PathResolver $resolver */
-        $resolver = $container->get(FilePathResolverExtension::SERVICE_FILE_PATH_RESOLVER);
-        return $resolver->resolve($container->parameter(SourceCodeFilesystemExtension::PARAM_PROJECT_ROOT)->string());
     }
 
     private function registerRpc(ContainerBuilder $container): void

--- a/lib/Extension/Navigation/NavigationExtension.php
+++ b/lib/Extension/Navigation/NavigationExtension.php
@@ -14,7 +14,6 @@ use Phpactor\Extension\Navigation\Navigator\WorseReflectionNavigator;
 use Phpactor\Extension\SourceCodeFilesystem\SourceCodeFilesystemExtension;
 use Phpactor\Extension\WorseReflection\WorseReflectionExtension;
 use Phpactor\FilePathResolver\PathResolver;
-use Phpactor\Filesystem\Domain\FilePath;
 use Phpactor\MapResolver\Resolver;
 use Phpactor\PathFinder\PathFinder;
 
@@ -55,7 +54,7 @@ class NavigationExtension implements Extension
             return new Navigator(
                 $container->get('navigation.navigator.chain'),
                 $container->get('application.class_new'),
-                $container->parameter(self::NAVIGATOR_AUTOCREATE)->value(),
+                $container->parameter(self::NAVIGATOR_AUTOCREATE)->value(), // @phpstan-ignore argument.type
                 $this->projectRoot($container)
             );
         });

--- a/lib/Extension/Navigation/Tests/Application/NavigatorTest.php
+++ b/lib/Extension/Navigation/Tests/Application/NavigatorTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpactor\Extension\Navigation\Tests\Application;
+
+use Phpactor\Extension\Navigation\Tests\IntegrationTestCase;
+use Phpactor\Extension\Navigation\NavigationExtension;
+use Phpactor\Extension\Navigation\Application\Navigator;
+
+class NavigatorTest extends IntegrationTestCase
+{
+    public function testSomething(): void
+    {
+        $navigator = $this->navigator([
+            NavigationExtension::NAVIGATOR_AUTOCREATE => [
+              'source' => 'source',
+              'unit_test' => 'unit_test'
+            ],
+            NavigationExtension::PATH_FINDER_DESTINATIONS => [
+              'source' => 'src/<kernel>.php',
+              'unit_test' => 'tests/Unit/<kernel>Test.php'
+            ]
+        ]);
+
+        $this->workspace->put('src/Kernel.php', '<?php');
+        $result = $navigator->destinationsFor($this->workspace->path('src/Kernel.php'));
+
+        self::assertSame(['unit_test' => 'tests/Unit/KernelTest.php'], $result);
+    }
+
+    public function testCanCreate(): void
+    {
+        $navigator = $this->navigator([
+            NavigationExtension::NAVIGATOR_AUTOCREATE => [
+              'source' => 'source',
+              'unit_test' => 'unit_test'
+            ],
+            NavigationExtension::PATH_FINDER_DESTINATIONS => [
+              'source' => 'src/<kernel>.php',
+              'unit_test' => 'tests/Unit/<kernel>Test.php'
+            ]
+        ]);
+
+        $this->workspace->put('src/Kernel.php', '<?php');
+        $result = $navigator->canCreateNew($this->workspace->path('src/Kernel.php'), 'unit_test');
+
+        self::assertTrue($result);
+    }
+
+    public function testNoNeedToCreate(): void
+    {
+        $navigator = $this->navigator([
+            NavigationExtension::NAVIGATOR_AUTOCREATE => [
+              'source' => 'source',
+              'unit_test' => 'unit_test'
+            ],
+            NavigationExtension::PATH_FINDER_DESTINATIONS => [
+              'source' => 'src/<kernel>.php',
+              'unit_test' => 'tests/Unit/<kernel>Test.php'
+            ]
+        ]);
+
+        $this->workspace->put('src/Kernel.php', '<?php');
+        $this->workspace->put('tests/Unit/KernelTest.php', '<?php');
+        $result = $navigator->canCreateNew($this->workspace->path('src/Kernel.php'), 'unit_test');
+
+        self::assertFalse($result);
+    }
+
+    /**
+     * @param array{
+     * 'navigator.destinations': array<string, string>,
+     * 'navigator.autocreate': array<string, string>,
+     * } $config
+     */
+    private function navigator(array $config): Navigator
+    {
+        $container = $this->container($config);
+        /** @var Navigator */
+        return $container->get('application.navigator');
+    }
+}

--- a/lib/Extension/Navigation/Tests/Application/NavigatorTest.php
+++ b/lib/Extension/Navigation/Tests/Application/NavigatorTest.php
@@ -5,23 +5,14 @@ declare(strict_types=1);
 namespace Phpactor\Extension\Navigation\Tests\Application;
 
 use Phpactor\Extension\Navigation\Tests\IntegrationTestCase;
-use Phpactor\Extension\Navigation\NavigationExtension;
 use Phpactor\Extension\Navigation\Application\Navigator;
+use Phpactor\Extension\Navigation\NavigationExtension;
 
 class NavigatorTest extends IntegrationTestCase
 {
-    public function testSomething(): void
+    public function testProvidesCorrectDestination(): void
     {
-        $navigator = $this->navigator([
-            NavigationExtension::NAVIGATOR_AUTOCREATE => [
-              'source' => 'source',
-              'unit_test' => 'unit_test'
-            ],
-            NavigationExtension::PATH_FINDER_DESTINATIONS => [
-              'source' => 'src/<kernel>.php',
-              'unit_test' => 'tests/Unit/<kernel>Test.php'
-            ]
-        ]);
+        $navigator = $this->navigator();
 
         $this->workspace->put('src/Kernel.php', '<?php');
         $result = $navigator->destinationsFor($this->workspace->path('src/Kernel.php'));
@@ -31,16 +22,7 @@ class NavigatorTest extends IntegrationTestCase
 
     public function testCanCreate(): void
     {
-        $navigator = $this->navigator([
-            NavigationExtension::NAVIGATOR_AUTOCREATE => [
-              'source' => 'source',
-              'unit_test' => 'unit_test'
-            ],
-            NavigationExtension::PATH_FINDER_DESTINATIONS => [
-              'source' => 'src/<kernel>.php',
-              'unit_test' => 'tests/Unit/<kernel>Test.php'
-            ]
-        ]);
+        $navigator = $this->navigator();
 
         $this->workspace->put('src/Kernel.php', '<?php');
         $result = $navigator->canCreateNew($this->workspace->path('src/Kernel.php'), 'unit_test');
@@ -50,16 +32,7 @@ class NavigatorTest extends IntegrationTestCase
 
     public function testNoNeedToCreate(): void
     {
-        $navigator = $this->navigator([
-            NavigationExtension::NAVIGATOR_AUTOCREATE => [
-              'source' => 'source',
-              'unit_test' => 'unit_test'
-            ],
-            NavigationExtension::PATH_FINDER_DESTINATIONS => [
-              'source' => 'src/<kernel>.php',
-              'unit_test' => 'tests/Unit/<kernel>Test.php'
-            ]
-        ]);
+        $navigator = $this->navigator();
 
         $this->workspace->put('src/Kernel.php', '<?php');
         $this->workspace->put('tests/Unit/KernelTest.php', '<?php');
@@ -69,14 +42,17 @@ class NavigatorTest extends IntegrationTestCase
     }
 
     /**
-     * @param array{
-     * 'navigator.destinations': array<string, string>,
-     * 'navigator.autocreate': array<string, string>,
-     * } $config
+     * @param array<string,string> $destinations
+     * @param array<string,string> $autocreate
      */
-    private function navigator(array $config): Navigator
-    {
-        $container = $this->container($config);
+    private function navigator(
+        array $destinations = ['source' => 'src/<kernel>.php', 'unit_test' => 'tests/Unit/<kernel>Test.php'],
+        array $autocreate = ['source' => 'source', 'unit_test' => 'unit_test'],
+    ): Navigator {
+        $container = $this->container([
+          NavigationExtension::PATH_FINDER_DESTINATIONS => $destinations,
+          NavigationExtension::NAVIGATOR_AUTOCREATE  => $autocreate
+        ]);
         /** @var Navigator */
         return $container->get('application.navigator');
     }

--- a/lib/Extension/Navigation/Tests/IntegrationTestCase.php
+++ b/lib/Extension/Navigation/Tests/IntegrationTestCase.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Phpactor\Extension\Navigation\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Phpactor\Container\Container;
+use Phpactor\Container\PhpactorContainer;
+use Phpactor\Extension\ClassToFile\ClassToFileExtension;
+use Phpactor\Extension\CodeTransformExtra\CodeTransformExtraExtension;
+use Phpactor\Extension\CodeTransform\CodeTransformExtension;
+use Phpactor\Extension\ComposerAutoloader\ComposerAutoloaderExtension;
+use Phpactor\Extension\Core\CoreExtension;
+use Phpactor\Extension\FilePathResolver\FilePathResolverExtension;
+use Phpactor\Extension\Logger\LoggingExtension;
+use Phpactor\Extension\Navigation\NavigationExtension;
+use Phpactor\Extension\Php\PhpExtension;
+use Phpactor\Extension\SourceCodeFilesystem\SourceCodeFilesystemExtension;
+use Phpactor\Extension\WorseReflection\WorseReflectionExtension;
+use Phpactor\TestUtils\Workspace;
+
+abstract class IntegrationTestCase extends TestCase
+{
+    protected Workspace $workspace;
+
+    public function setUp(): void
+    {
+        $this->workspace = $this->workspace();
+        $this->workspace->reset();
+    }
+
+    /**
+     * @param array{
+     * 'navigator.destinations': array<string, string>,
+     * 'navigator.autocreate': array<string, string>,
+     * } $config
+     */
+    protected function container(array $config): Container
+    {
+        $key = serialize($config);
+        static $container = [];
+
+        if (isset($container[$key])) {
+            return $container[$key];
+        }
+
+        $container[$key] = PhpactorContainer::fromExtensions([
+            CodeTransformExtension::class,
+            CodeTransformExtraExtension::class,
+            PhpExtension::class,
+            CoreExtension::class,
+            NavigationExtension::class,
+            LoggingExtension::class,
+            SourceCodeFilesystemExtension::class,
+            ClassToFileExtension::class,
+            ComposerAutoloaderExtension::class,
+            FilePathResolverExtension::class,
+            WorseReflectionExtension::class,
+        ], array_merge([
+            LoggingExtension::PARAM_ENABLED=> true,
+            LoggingExtension::PARAM_PATH=> 'php://stderr',
+            WorseReflectionExtension::PARAM_ENABLE_CACHE=> false,
+            WorseReflectionExtension::PARAM_STUB_DIR => $this->workspace()->path(),
+            FilePathResolverExtension::PARAM_APPLICATION_ROOT => __DIR__ . '/../',
+            FilePathResolverExtension::PARAM_PROJECT_ROOT => $this->workspace()->path(),
+        ], $config));
+
+        return $container[$key];
+    }
+
+    protected function workspace(): Workspace
+    {
+        return Workspace::create(__DIR__ . '/Workspace');
+    }
+}

--- a/lib/Extension/Navigation/Tests/IntegrationTestCase.php
+++ b/lib/Extension/Navigation/Tests/IntegrationTestCase.php
@@ -59,6 +59,7 @@ abstract class IntegrationTestCase extends TestCase
             LoggingExtension::PARAM_ENABLED=> true,
             LoggingExtension::PARAM_PATH=> 'php://stderr',
             WorseReflectionExtension::PARAM_ENABLE_CACHE=> false,
+            ComposerAutoloaderExtension::PARAM_COMPOSER_ENABLE => false,
             WorseReflectionExtension::PARAM_STUB_DIR => $this->workspace()->path(),
             FilePathResolverExtension::PARAM_APPLICATION_ROOT => __DIR__ . '/../',
             FilePathResolverExtension::PARAM_PROJECT_ROOT => $this->workspace()->path(),

--- a/lib/Extension/Navigation/Tests/Navigator/PathFinderNavigatorTest.php
+++ b/lib/Extension/Navigation/Tests/Navigator/PathFinderNavigatorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpactor\Extension\Navigation\Tests\Navigator;
+
+use Phpactor\Extension\Navigation\Navigator\PathFinderNavigator;
+use Phpactor\PathFinder\PathFinder;
+use PHPUnit\Framework\TestCase;
+
+class PathFinderNavigatorTest extends TestCase
+{
+    private PathFinder $pathFinder;
+
+    public function setUp(): void
+    {
+        $this->pathFinder = PathFinder::fromDestinations([
+        'source' => 'src/<kernel>.php',
+        'unit_test' => 'tests/Unit/<kernel>Test.php'
+        ]);
+    }
+
+    public function testSomething(): void
+    {
+        $navigator = new PathFinderNavigator($this->pathFinder);
+        $result = $navigator->destinationsFor('src/Kernel.php');
+
+        self::assertSame(['unit_test' => 'tests/Unit/KernelTest.php'], $result);
+    }
+
+}


### PR DESCRIPTION
Remove false-positive file creation attempt by resolving absolute path of destination. Introduce a rough set of tests for that, for further refinement.

Fix #2758