### PR TITLE
fix: fix render of nullable type

### DIFF
--- a/lib/CodeBuilder/Adapter/WorseReflection/TypeRenderer/WorseTypeRenderer74.php
+++ b/lib/CodeBuilder/Adapter/WorseReflection/TypeRenderer/WorseTypeRenderer74.php
@@ -21,6 +21,10 @@ class WorseTypeRenderer74 implements WorseTypeRenderer
     public function render(Type $type): ?string
     {
         if ($type instanceof NullableType) {
+            if ($type->type instanceof ClassType) {
+                return $this->render($type->type);
+            }
+
             return '?' . $this->render($type->type);
         }
 

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Transformer/UpdateReturnTypeTransformerTest.php
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Transformer/UpdateReturnTypeTransformerTest.php
@@ -243,6 +243,29 @@ class UpdateReturnTypeTransformerTest extends WorseTestCase
                 }
                 EOT
         ];
+        yield 'on interface nullable type' => [
+            <<<'EOT'
+                <?php
+
+                use Arg\Foo;
+
+                interface Animal
+                {
+                    public function jump(): ?Arg\Foo;
+                }
+                EOT
+            ,
+            <<<'EOT'
+                <?php
+
+                use Arg\Foo;
+
+                interface Animal
+                {
+                    public function jump(): ?Arg\Foo;
+                }
+                EOT
+        ];
     }
 
     /**


### PR DESCRIPTION
I've noticed that strange behavior when running the `class:transform` cli on interfaces:

```
 interface Animal
 {
-    public function jump(): ?Foo;
+    public function jump(): ? ?Foo;
 }
 ```
 
 That PR should fix that.
