### PR TITLE
Fixing method updating when return type is nullable.

### DIFF
--- a/lib/CodeBuilder/Adapter/TolerantParser/Edits.php
+++ b/lib/CodeBuilder/Adapter/TolerantParser/Edits.php
@@ -55,6 +55,18 @@ class Edits
         $this->edits[] = TextEdit::create($node->getFullStartPosition(), $node->getFullWidth(), $text);
     }
 
+    public function replaceMultiple(
+        Node|Token|QualifiedName $firstNodeToReplace,
+        Node|Token|QualifiedName $lastToReplace,
+        string $text,
+    ): void {
+        $this->edits[] = TextEdit::create(
+            $firstNodeToReplace->getStartPosition(),
+            $lastToReplace->getEndPosition() - $firstNodeToReplace->getStartPosition(),
+            $text
+        );
+    }
+
     public function textEdits(): TextEdits
     {
         return TextEdits::fromTextEdits($this->edits);

--- a/lib/CodeTransform/Tests/Adapter/WorseReflection/Transformer/UpdateReturnTypeTransformerTest.php
+++ b/lib/CodeTransform/Tests/Adapter/WorseReflection/Transformer/UpdateReturnTypeTransformerTest.php
@@ -111,6 +111,54 @@ class UpdateReturnTypeTransformerTest extends WorseTestCase
                 EOT
         ];
 
+        yield 'update nullable type' => [
+            <<<'EOT'
+                <?php
+
+                use Arg\Foo;
+
+                interface Animal
+                {
+                    public function jump(): ?Arg\Foo;
+                }
+                EOT
+            ,
+            <<<'EOT'
+                <?php
+
+                use Arg\Foo;
+
+                interface Animal
+                {
+                    public function jump(): ?Foo;
+                }
+                EOT
+        ];
+
+        yield 'update nullable type unions' => [
+            <<<'EOT'
+                <?php
+
+                use Arg\Foo;
+
+                interface Animal
+                {
+                    public function jump(): ?Arg\Foo|int;
+                }
+                EOT
+            ,
+            <<<'EOT'
+                <?php
+
+                use Arg\Foo;
+
+                interface Animal
+                {
+                    public function jump(): ?Foo|int;
+                }
+                EOT
+        ];
+
         yield 'add multipe return types' => [
             <<<'EOT'
                 <?php


### PR DESCRIPTION
Replaces #2778

When updating a method's return type the `TextEdit` updates only the type list which is correct unless there is a nullable token at the beginning:

```
public function test() ?Testing;
                        ^     ^
```
This is the part that was being replaced. This PR will also include the question mark operator.