### PR TITLE
Gh 2729: Diagnostic codes and disabling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,21 @@ Changelog
 
 ## master
 
+Features:
+
+  - Show codes for all diagnostics and allow them to be ignored @dantleech
+    #2781
+
 Improvements:
 
   - Tolerate code action provider failures #2761 @dantleech
   - Limit number of methods that are documented on classes to improve
     completion/resolve performance for large classes #2768 @dantleech
+
+Bug fixes:
+
+  - Preserve PHAR scheme when indexing PHAR stubs @dantleech #2754
+  - Fix duplicated types when updating methods @mamazu #2779
 
 ## 2024-11-05
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "php": "^8.1",
         "composer/xdebug-handler": "^3.0",
         "symfony/yaml": "^5.1",
-        "phpactor/container": "^2.2.0",
+        "phpactor/container": "^3.0",
         "phpactor/class-to-file": "~0.5",
         "twig/twig": "^3.4",
         "dnoegel/php-xdg-base-dir": "^0.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3861f1c5f6598168f45d90a7ba674e03",
+    "content-hash": "83ae9b6c653e2bf8527229d2eae617e2",
     "packages": [
         {
             "name": "amphp/amp",
@@ -769,16 +769,16 @@
         },
         {
             "name": "composer/pcre",
-            "version": "3.3.1",
+            "version": "3.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "63aaeac21d7e775ff9bc9d45021e1745c97521c4"
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/63aaeac21d7e775ff9bc9d45021e1745c97521c4",
-                "reference": "63aaeac21d7e775ff9bc9d45021e1745c97521c4",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
                 "shasum": ""
             },
             "require": {
@@ -788,8 +788,8 @@
                 "phpstan/phpstan": "<1.11.10"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.11.10",
-                "phpstan/phpstan-strict-rules": "^1.1",
+                "phpstan/phpstan": "^1.12 || ^2",
+                "phpstan/phpstan-strict-rules": "^1 || ^2",
                 "phpunit/phpunit": "^8 || ^9"
             },
             "type": "library",
@@ -828,7 +828,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.3.1"
+                "source": "https://github.com/composer/pcre/tree/3.3.2"
             },
             "funding": [
                 {
@@ -844,7 +844,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-08-27T18:44:43+00:00"
+            "time": "2024-11-12T16:29:46+00:00"
         },
         {
             "name": "composer/xdebug-handler",
@@ -1149,19 +1149,19 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/JetBrains/phpstorm-stubs.git",
-                "reference": "e0d1af1860e943a0048dce51e210700f8e6af965"
+                "reference": "fda684a4826c1caf59efe1a1bf68d08c11aaddbf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/e0d1af1860e943a0048dce51e210700f8e6af965",
-                "reference": "e0d1af1860e943a0048dce51e210700f8e6af965",
+                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/fda684a4826c1caf59efe1a1bf68d08c11aaddbf",
+                "reference": "fda684a4826c1caf59efe1a1bf68d08c11aaddbf",
                 "shasum": ""
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "v3.61.1",
+                "friendsofphp/php-cs-fixer": "v3.64.0",
                 "nikic/php-parser": "v5.3.1",
-                "phpdocumentor/reflection-docblock": "5.4.1",
-                "phpunit/phpunit": "11.3.0"
+                "phpdocumentor/reflection-docblock": "5.5.1",
+                "phpunit/phpunit": "11.4.3"
             },
             "default-branch": true,
             "type": "library",
@@ -1189,7 +1189,7 @@
             "support": {
                 "source": "https://github.com/JetBrains/phpstorm-stubs/tree/master"
             },
-            "time": "2024-10-09T12:37:55+00:00"
+            "time": "2024-11-15T09:42:33+00:00"
         },
         {
             "name": "kelunik/certificate",
@@ -1522,29 +1522,29 @@
         },
         {
             "name": "phpactor/container",
-            "version": "2.2.1",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpactor/container.git",
-                "reference": "8a9665ec70e654ea100d842f7f77e52ecde5d613"
+                "reference": "143bbd987da798f2d7e5cedafd35b49d5051e167"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpactor/container/zipball/8a9665ec70e654ea100d842f7f77e52ecde5d613",
-                "reference": "8a9665ec70e654ea100d842f7f77e52ecde5d613",
+                "url": "https://api.github.com/repos/phpactor/container/zipball/143bbd987da798f2d7e5cedafd35b49d5051e167",
+                "reference": "143bbd987da798f2d7e5cedafd35b49d5051e167",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.0",
+                "php": "^8.1",
                 "phpactor/map-resolver": "^1.4",
-                "psr/container": "^1.0"
+                "psr/container": "^1.0||^2.0"
             },
             "require-dev": {
                 "ergebnis/composer-normalize": "^2.0",
                 "friendsofphp/php-cs-fixer": "^3.0",
                 "phpspec/prophecy-phpunit": "^2.0",
                 "phpstan/phpstan": "^1.0",
-                "phpunit/phpunit": "^9.0"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
@@ -1570,9 +1570,9 @@
             "description": "Phpactor's DI Container",
             "support": {
                 "issues": "https://github.com/phpactor/container/issues",
-                "source": "https://github.com/phpactor/container/tree/2.2.1"
+                "source": "https://github.com/phpactor/container/tree/3.0.1"
             },
-            "time": "2023-03-19T19:13:59+00:00"
+            "time": "2024-11-16T22:20:43+00:00"
         },
         {
             "name": "phpactor/language-server",
@@ -2253,16 +2253,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.44",
+            "version": "v5.4.47",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "5b5a0aa66e3296e303e22490f90f521551835a83"
+                "reference": "c4ba980ca61a9eb18ee6bcc73f28e475852bb1ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/5b5a0aa66e3296e303e22490f90f521551835a83",
-                "reference": "5b5a0aa66e3296e303e22490f90f521551835a83",
+                "url": "https://api.github.com/repos/symfony/console/zipball/c4ba980ca61a9eb18ee6bcc73f28e475852bb1ed",
+                "reference": "c4ba980ca61a9eb18ee6bcc73f28e475852bb1ed",
                 "shasum": ""
             },
             "require": {
@@ -2332,7 +2332,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.44"
+                "source": "https://github.com/symfony/console/tree/v5.4.47"
             },
             "funding": [
                 {
@@ -2348,7 +2348,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-20T07:56:40+00:00"
+            "time": "2024-11-06T11:30:55+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -2419,16 +2419,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.4.44",
+            "version": "v5.4.45",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "76c3818964e9d32be3862c9318ae3ba9aa280ddc"
+                "reference": "57c8294ed37d4a055b77057827c67f9558c95c54"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/76c3818964e9d32be3862c9318ae3ba9aa280ddc",
-                "reference": "76c3818964e9d32be3862c9318ae3ba9aa280ddc",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/57c8294ed37d4a055b77057827c67f9558c95c54",
+                "reference": "57c8294ed37d4a055b77057827c67f9558c95c54",
                 "shasum": ""
             },
             "require": {
@@ -2466,7 +2466,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.4.44"
+                "source": "https://github.com/symfony/filesystem/tree/v5.4.45"
             },
             "funding": [
                 {
@@ -2482,7 +2482,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-16T14:52:48+00:00"
+            "time": "2024-10-22T13:05:35+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -3036,16 +3036,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v5.4.44",
+            "version": "v5.4.47",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "1b9fa82b5c62cd49da8c9e3952dd8531ada65096"
+                "reference": "5d1662fb32ebc94f17ddb8d635454a776066733d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/1b9fa82b5c62cd49da8c9e3952dd8531ada65096",
-                "reference": "1b9fa82b5c62cd49da8c9e3952dd8531ada65096",
+                "url": "https://api.github.com/repos/symfony/process/zipball/5d1662fb32ebc94f17ddb8d635454a776066733d",
+                "reference": "5d1662fb32ebc94f17ddb8d635454a776066733d",
                 "shasum": ""
             },
             "require": {
@@ -3078,7 +3078,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v5.4.44"
+                "source": "https://github.com/symfony/process/tree/v5.4.47"
             },
             "funding": [
                 {
@@ -3094,7 +3094,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-17T12:46:43+00:00"
+            "time": "2024-11-06T11:36:42+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -3181,16 +3181,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.4.12",
+            "version": "v6.4.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "f8a1ccebd0997e16112dfecfd74220b78e5b284b"
+                "reference": "73a5e66ea2e1677c98d4449177c5a9cf9d8b4c6f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/f8a1ccebd0997e16112dfecfd74220b78e5b284b",
-                "reference": "f8a1ccebd0997e16112dfecfd74220b78e5b284b",
+                "url": "https://api.github.com/repos/symfony/string/zipball/73a5e66ea2e1677c98d4449177c5a9cf9d8b4c6f",
+                "reference": "73a5e66ea2e1677c98d4449177c5a9cf9d8b4c6f",
                 "shasum": ""
             },
             "require": {
@@ -3247,7 +3247,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.4.12"
+                "source": "https://github.com/symfony/string/tree/v6.4.15"
             },
             "funding": [
                 {
@@ -3263,20 +3263,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-20T08:15:52+00:00"
+            "time": "2024-11-13T13:31:12+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v5.4.44",
+            "version": "v5.4.45",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "7025b964f123bbf1896d7563db6ec7f1f63e918a"
+                "reference": "a454d47278cc16a5db371fe73ae66a78a633371e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/7025b964f123bbf1896d7563db6ec7f1f63e918a",
-                "reference": "7025b964f123bbf1896d7563db6ec7f1f63e918a",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/a454d47278cc16a5db371fe73ae66a78a633371e",
+                "reference": "a454d47278cc16a5db371fe73ae66a78a633371e",
                 "shasum": ""
             },
             "require": {
@@ -3322,7 +3322,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v5.4.44"
+                "source": "https://github.com/symfony/yaml/tree/v5.4.45"
             },
             "funding": [
                 {
@@ -3338,7 +3338,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-16T14:36:56+00:00"
+            "time": "2024-09-25T14:11:13+00:00"
         },
         {
             "name": "thecodingmachine/safe",
@@ -3481,16 +3481,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v3.14.0",
+            "version": "v3.14.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "126b2c97818dbff0cdf3fbfc881aedb3d40aae72"
+                "reference": "0b6f9d8370bb3b7f1ce5313ed8feb0fafd6e399a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/126b2c97818dbff0cdf3fbfc881aedb3d40aae72",
-                "reference": "126b2c97818dbff0cdf3fbfc881aedb3d40aae72",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/0b6f9d8370bb3b7f1ce5313ed8feb0fafd6e399a",
+                "reference": "0b6f9d8370bb3b7f1ce5313ed8feb0fafd6e399a",
                 "shasum": ""
             },
             "require": {
@@ -3544,7 +3544,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.14.0"
+                "source": "https://github.com/twigphp/Twig/tree/v3.14.2"
             },
             "funding": [
                 {
@@ -3556,7 +3556,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T17:55:12+00:00"
+            "time": "2024-11-07T12:36:22+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -3811,16 +3811,16 @@
         },
         {
             "name": "composer/ca-bundle",
-            "version": "1.5.2",
+            "version": "1.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "48a792895a2b7a6ee65dd5442c299d7b835b6137"
+                "reference": "3b1fc3f0be055baa7c6258b1467849c3e8204eb2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/48a792895a2b7a6ee65dd5442c299d7b835b6137",
-                "reference": "48a792895a2b7a6ee65dd5442c299d7b835b6137",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/3b1fc3f0be055baa7c6258b1467849c3e8204eb2",
+                "reference": "3b1fc3f0be055baa7c6258b1467849c3e8204eb2",
                 "shasum": ""
             },
             "require": {
@@ -3867,7 +3867,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/ca-bundle/issues",
-                "source": "https://github.com/composer/ca-bundle/tree/1.5.2"
+                "source": "https://github.com/composer/ca-bundle/tree/1.5.3"
             },
             "funding": [
                 {
@@ -3883,7 +3883,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T07:49:53+00:00"
+            "time": "2024-11-04T10:15:26+00:00"
         },
         {
             "name": "composer/semver",
@@ -4612,16 +4612,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.12.0",
+            "version": "1.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c"
+                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
-                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/123267b2c49fbf30d78a7b2d333f6be754b94845",
+                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845",
                 "shasum": ""
             },
             "require": {
@@ -4660,7 +4660,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.0"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.1"
             },
             "funding": [
                 {
@@ -4668,7 +4668,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-12T14:39:25+00:00"
+            "time": "2024-11-08T17:47:46+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -5156,16 +5156,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.4.1",
+            "version": "5.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "9d07b3f7fdcf5efec5d1609cba3c19c5ea2bdc9c"
+                "reference": "f3558a4c23426d12bffeaab463f8a8d8b681193c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/9d07b3f7fdcf5efec5d1609cba3c19c5ea2bdc9c",
-                "reference": "9d07b3f7fdcf5efec5d1609cba3c19c5ea2bdc9c",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/f3558a4c23426d12bffeaab463f8a8d8b681193c",
+                "reference": "f3558a4c23426d12bffeaab463f8a8d8b681193c",
                 "shasum": ""
             },
             "require": {
@@ -5174,17 +5174,17 @@
                 "php": "^7.4 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.2",
                 "phpdocumentor/type-resolver": "^1.7",
-                "phpstan/phpdoc-parser": "^1.7",
+                "phpstan/phpdoc-parser": "^1.7|^2.0",
                 "webmozart/assert": "^1.9.1"
             },
             "require-dev": {
-                "mockery/mockery": "~1.3.5",
+                "mockery/mockery": "~1.3.5 || ~1.6.0",
                 "phpstan/extension-installer": "^1.1",
                 "phpstan/phpstan": "^1.8",
                 "phpstan/phpstan-mockery": "^1.1",
                 "phpstan/phpstan-webmozart-assert": "^1.2",
                 "phpunit/phpunit": "^9.5",
-                "vimeo/psalm": "^5.13"
+                "psalm/phar": "^5.26"
             },
             "type": "library",
             "extra": {
@@ -5214,29 +5214,29 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.4.1"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.0"
             },
-            "time": "2024-05-21T05:55:05+00:00"
+            "time": "2024-11-12T11:25:25+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.8.2",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "153ae662783729388a584b4361f2545e4d841e3c"
+                "reference": "679e3ce485b99e84c775d28e2e96fade9a7fb50a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/153ae662783729388a584b4361f2545e4d841e3c",
-                "reference": "153ae662783729388a584b4361f2545e4d841e3c",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/679e3ce485b99e84c775d28e2e96fade9a7fb50a",
+                "reference": "679e3ce485b99e84c775d28e2e96fade9a7fb50a",
                 "shasum": ""
             },
             "require": {
                 "doctrine/deprecations": "^1.0",
                 "php": "^7.3 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.0",
-                "phpstan/phpdoc-parser": "^1.13"
+                "phpstan/phpdoc-parser": "^1.18|^2.0"
             },
             "require-dev": {
                 "ext-tokenizer": "*",
@@ -5272,9 +5272,9 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.8.2"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.10.0"
             },
-            "time": "2024-02-23T11:10:43+00:00"
+            "time": "2024-11-09T15:12:26+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -5447,30 +5447,30 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.32.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "6ca22b154efdd9e3c68c56f5d94670920a1c19a4"
+                "reference": "c00d78fb6b29658347f9d37ebe104bffadf36299"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/6ca22b154efdd9e3c68c56f5d94670920a1c19a4",
-                "reference": "6ca22b154efdd9e3c68c56f5d94670920a1c19a4",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/c00d78fb6b29658347f9d37ebe104bffadf36299",
+                "reference": "c00d78fb6b29658347f9d37ebe104bffadf36299",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2 || ^8.0"
+                "php": "^7.4 || ^8.0"
             },
             "require-dev": {
                 "doctrine/annotations": "^2.0",
-                "nikic/php-parser": "^4.15",
+                "nikic/php-parser": "^5.3.0",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^1.5",
-                "phpstan/phpstan-phpunit": "^1.1",
-                "phpstan/phpstan-strict-rules": "^1.0",
-                "phpunit/phpunit": "^9.5",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
                 "symfony/process": "^5.2"
             },
             "type": "library",
@@ -5488,22 +5488,22 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.32.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.0.0"
             },
-            "time": "2024-09-26T07:23:32+00:00"
+            "time": "2024-10-13T11:29:49+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.6",
+            "version": "1.12.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "dc4d2f145a88ea7141ae698effd64d9df46527ae"
+                "reference": "fc463b5d0fe906dcf19689be692c65c50406a071"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/dc4d2f145a88ea7141ae698effd64d9df46527ae",
-                "reference": "dc4d2f145a88ea7141ae698effd64d9df46527ae",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/fc463b5d0fe906dcf19689be692c65c50406a071",
+                "reference": "fc463b5d0fe906dcf19689be692c65c50406a071",
                 "shasum": ""
             },
             "require": {
@@ -5548,25 +5548,25 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-10-06T15:03:59+00:00"
+            "time": "2024-11-11T15:37:09+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-phpunit.git",
-                "reference": "f3ea021866f4263f07ca3636bf22c64be9610c11"
+                "reference": "11d4235fbc6313ecbf93708606edfd3222e44949"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/f3ea021866f4263f07ca3636bf22c64be9610c11",
-                "reference": "f3ea021866f4263f07ca3636bf22c64be9610c11",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/11d4235fbc6313ecbf93708606edfd3222e44949",
+                "reference": "11d4235fbc6313ecbf93708606edfd3222e44949",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2 || ^8.0",
-                "phpstan/phpstan": "^1.11"
+                "phpstan/phpstan": "^1.12"
             },
             "conflict": {
                 "phpunit/phpunit": "<7.0"
@@ -5598,9 +5598,9 @@
             "description": "PHPUnit extensions and rules for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-phpunit/issues",
-                "source": "https://github.com/phpstan/phpstan-phpunit/tree/1.4.0"
+                "source": "https://github.com/phpstan/phpstan-phpunit/tree/1.4.1"
             },
-            "time": "2024-04-20T06:39:00+00:00"
+            "time": "2024-11-12T12:43:59+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -6640,16 +6640,16 @@
         },
         {
             "name": "rector/rector",
-            "version": "1.2.7",
+            "version": "1.2.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "5b33bdd871895276e2c18e5410a4a57df9233ee0"
+                "reference": "40f9cf38c05296bd32f444121336a521a293fa61"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/5b33bdd871895276e2c18e5410a4a57df9233ee0",
-                "reference": "5b33bdd871895276e2c18e5410a4a57df9233ee0",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/40f9cf38c05296bd32f444121336a521a293fa61",
+                "reference": "40f9cf38c05296bd32f444121336a521a293fa61",
                 "shasum": ""
             },
             "require": {
@@ -6687,7 +6687,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/1.2.7"
+                "source": "https://github.com/rectorphp/rector/tree/1.2.10"
             },
             "funding": [
                 {
@@ -6695,7 +6695,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-10-12T11:12:46+00:00"
+            "time": "2024-11-08T13:59:10+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -7660,16 +7660,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.10.3",
+            "version": "3.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "62d32998e820bddc40f99f8251958aed187a5c9c"
+                "reference": "19473c30efe4f7b3cd42522d0b2e6e7f243c6f87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/62d32998e820bddc40f99f8251958aed187a5c9c",
-                "reference": "62d32998e820bddc40f99f8251958aed187a5c9c",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/19473c30efe4f7b3cd42522d0b2e6e7f243c6f87",
+                "reference": "19473c30efe4f7b3cd42522d0b2e6e7f243c6f87",
                 "shasum": ""
             },
             "require": {
@@ -7736,20 +7736,20 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-09-18T10:38:58+00:00"
+            "time": "2024-11-16T12:02:36+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v6.4.8",
+            "version": "v6.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "8d7507f02b06e06815e56bb39aa0128e3806208b"
+                "reference": "0ffc48080ab3e9132ea74ef4e09d8dcf26bf897e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/8d7507f02b06e06815e56bb39aa0128e3806208b",
-                "reference": "8d7507f02b06e06815e56bb39aa0128e3806208b",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/0ffc48080ab3e9132ea74ef4e09d8dcf26bf897e",
+                "reference": "0ffc48080ab3e9132ea74ef4e09d8dcf26bf897e",
                 "shasum": ""
             },
             "require": {
@@ -7800,7 +7800,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v6.4.8"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v6.4.13"
             },
             "funding": [
                 {
@@ -7816,7 +7816,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T14:49:08+00:00"
+            "time": "2024-09-25T14:18:03+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -7896,16 +7896,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v6.4.11",
+            "version": "v6.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "d7eb6daf8cd7e9ac4976e9576b32042ef7253453"
+                "reference": "daea9eca0b08d0ed1dc9ab702a46128fd1be4958"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/d7eb6daf8cd7e9ac4976e9576b32042ef7253453",
-                "reference": "d7eb6daf8cd7e9ac4976e9576b32042ef7253453",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/daea9eca0b08d0ed1dc9ab702a46128fd1be4958",
+                "reference": "daea9eca0b08d0ed1dc9ab702a46128fd1be4958",
                 "shasum": ""
             },
             "require": {
@@ -7940,7 +7940,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v6.4.11"
+                "source": "https://github.com/symfony/finder/tree/v6.4.13"
             },
             "funding": [
                 {
@@ -7956,20 +7956,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-08-13T14:27:37+00:00"
+            "time": "2024-10-01T08:30:56+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v6.4.8",
+            "version": "v6.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "22ab9e9101ab18de37839074f8a1197f55590c1b"
+                "reference": "0a62a9f2504a8dd27083f89d21894ceb01cc59db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/22ab9e9101ab18de37839074f8a1197f55590c1b",
-                "reference": "22ab9e9101ab18de37839074f8a1197f55590c1b",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/0a62a9f2504a8dd27083f89d21894ceb01cc59db",
+                "reference": "0a62a9f2504a8dd27083f89d21894ceb01cc59db",
                 "shasum": ""
             },
             "require": {
@@ -8007,7 +8007,7 @@
                 "options"
             ],
             "support": {
-                "source": "https://github.com/symfony/options-resolver/tree/v6.4.8"
+                "source": "https://github.com/symfony/options-resolver/tree/v6.4.13"
             },
             "funding": [
                 {
@@ -8023,20 +8023,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T14:49:08+00:00"
+            "time": "2024-09-25T14:18:03+00:00"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v6.4.8",
+            "version": "v6.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "63e069eb616049632cde9674c46957819454b8aa"
+                "reference": "2cae0a6f8d04937d02f6d19806251e2104d54f92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/63e069eb616049632cde9674c46957819454b8aa",
-                "reference": "63e069eb616049632cde9674c46957819454b8aa",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/2cae0a6f8d04937d02f6d19806251e2104d54f92",
+                "reference": "2cae0a6f8d04937d02f6d19806251e2104d54f92",
                 "shasum": ""
             },
             "require": {
@@ -8069,7 +8069,7 @@
             "description": "Provides a way to profile code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/stopwatch/tree/v6.4.8"
+                "source": "https://github.com/symfony/stopwatch/tree/v6.4.13"
             },
             "funding": [
                 {
@@ -8085,20 +8085,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T14:49:08+00:00"
+            "time": "2024-09-25T14:18:03+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v5.4.43",
+            "version": "v5.4.47",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "6be6a6a8af4818564e3726fc65cf936f34743cef"
+                "reference": "e13e8dfa8eaab2b0536ef365beddc2af723a9ac0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/6be6a6a8af4818564e3726fc65cf936f34743cef",
-                "reference": "6be6a6a8af4818564e3726fc65cf936f34743cef",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/e13e8dfa8eaab2b0536ef365beddc2af723a9ac0",
+                "reference": "e13e8dfa8eaab2b0536ef365beddc2af723a9ac0",
                 "shasum": ""
             },
             "require": {
@@ -8158,7 +8158,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v5.4.43"
+                "source": "https://github.com/symfony/var-dumper/tree/v5.4.47"
             },
             "funding": [
                 {
@@ -8174,7 +8174,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-08-30T16:01:46+00:00"
+            "time": "2024-11-08T15:21:10+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -8244,5 +8244,5 @@
     "platform-overrides": {
         "php": "8.1.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/doc/reference/configuration.rst
+++ b/doc/reference/configuration.rst
@@ -1289,6 +1289,19 @@ List of paths to exclude from diagnostics, e.g. `vendor/**/*`
 **Default**: ``[]``
 
 
+.. _param_language_server.diagnostic_ignore_codes:
+
+
+``language_server.diagnostic_ignore_codes``
+"""""""""""""""""""""""""""""""""""""""""""
+
+
+Ignore diagnostics that have the codes listed here, e.g. ["fix_namespace_class_name"]. The codes match those shown in the LSP client.
+
+
+**Default**: ``[]``
+
+
 .. _param_language_server.file_events:
 
 
@@ -1867,6 +1880,19 @@ Override the PHPStan memory limit
 
 
 **Default**: ``null``
+
+
+.. _param_language_server_phpstan.tmp_file_disabled:
+
+
+``language_server_phpstan.tmp_file_disabled``
+"""""""""""""""""""""""""""""""""""""""""""""
+
+
+Disable the use of temporary files when. This prevents as-you-type diagnostics, but ensures paths in phpstan config are respected. See https://github.com/phpactor/phpactor/issues/2763
+
+
+**Default**: ``false``
 
 
 .. _LanguageServerPsalmExtension:

--- a/doc/reference/diagnostic.rst
+++ b/doc/reference/diagnostic.rst
@@ -13,8 +13,8 @@ Diagnostics
    :local:
 
 
-``missing_method``
-------------------
+MissingMemberProvider
+---------------------
 
 Report if trying to call a class method which does not exist.
 
@@ -135,8 +135,8 @@ Report if trying to call a class method which does not exist.
             $f->foo = 12;
             $f->barfoo = 'string';
         
-``docblock_missing_return``
----------------------------
+DocblockMissingReturnTypeProvider
+---------------------------------
 
 Report when a method has a return type should be augmented by a docblock tag
 
@@ -159,8 +159,8 @@ Report when a method has a return type should be augmented by a docblock tag
         
         - ``WARN``: ``Method "foo" is missing docblock return type: string``
         
-``docblock_missing_param``
---------------------------
+DocblockMissingParamProvider
+----------------------------
 
 Report when a method has a parameter with a type that should be augmented by a docblock tag.
 
@@ -259,8 +259,8 @@ Report when a method has a parameter with a type that should be augmented by a d
         
         - ``WARN``: ``Method "__construct" is missing @param $barfoo``
         
-``assignment_to_missing_property``
-----------------------------------
+AssignmentToMissingPropertyProvider
+-----------------------------------
 
 Report when assigning to a missing property definition.
 
@@ -282,8 +282,8 @@ Report when assigning to a missing property definition.
         
         - ``WARN``: ``Property "bar" has not been defined``
         
-``missing_return_type``
------------------------
+MissingReturnTypeProvider
+-------------------------
 
 Report if a method is missing a return type.
 
@@ -326,8 +326,8 @@ Report if a method is missing a return type.
         
         - ``WARN``: ``Method "foo" is missing return type and the type could not be determined``
         
-``unresolvable_name``
----------------------
+UnresolvableNameProvider
+------------------------
 
 Report if a name (class, function, constant etc) can not be resolved.
 
@@ -420,8 +420,8 @@ Report if a name (class, function, constant etc) can not be resolved.
         
         - ``ERROR``: ``Function "foobar" not found``
         
-``unused_import``
------------------
+UnusedImportProvider
+--------------------
 
 Report if a use statement is not required.
 
@@ -504,8 +504,8 @@ Report if a use statement is not required.
         
         - ``WARN``: ``Name "Foobar" is imported but not used``
         
-``deprecated usage``
---------------------
+DeprecatedUsageDiagnosticProvider
+---------------------------------
 
 Report when a deprecated symbol (class, method, constant, function etc) is used.
 
@@ -673,8 +673,8 @@ Report when a deprecated symbol (class, method, constant, function etc) is used.
         
         - ``WARN``: ``Call to deprecated property "deprecated": This is deprecated``
         
-``undefined_variable``
-----------------------
+UndefinedVariableProvider
+-------------------------
 
 Report if a variable is undefined and suggest variables with similar names.
 
@@ -753,8 +753,8 @@ Report if a variable is undefined and suggest variables with similar names.
             
             return $list;
         
-``docblock_missing_extends_tag``
---------------------------------
+DocblockMissingExtendsTagProvider
+---------------------------------
 
 Report when a class extends a generic class but does not provide an @extends tag.
 
@@ -904,8 +904,8 @@ Report when a class extends a generic class but does not provide an @extends tag
         
         - ``WARN``: ``Generic tag `@extends NeedGeneric<int>` should be compatible with `@extends NeedGeneric<mixed,mixed,mixed>```
         
-``docblock_missing_implements_tag``
------------------------------------
+DocblockMissingImplementsTagProvider
+------------------------------------
 
 Report when a class extends a generic class but does not provide an @extends tag.
 

--- a/lib/Extension/LanguageServer/DiagnosticProvider/AggregateDiagnosticsProvider.php
+++ b/lib/Extension/LanguageServer/DiagnosticProvider/AggregateDiagnosticsProvider.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServer\DiagnosticProvider;
+
+use Amp\CancellationToken;
+use Amp\Promise;
+use Phpactor\LanguageServerProtocol\Diagnostic;
+use Phpactor\LanguageServerProtocol\TextDocumentItem;
+use Phpactor\LanguageServer\Core\Diagnostics\DiagnosticsProvider;
+use Psr\Log\LoggerInterface;
+use function Amp\call;
+use Throwable;
+
+class AggregateDiagnosticsProvider implements DiagnosticsProvider
+{
+    /**
+     * @var array<DiagnosticsProvider>
+     */
+    private array $providers;
+
+    private LoggerInterface $logger;
+
+    public function __construct(LoggerInterface $logger, DiagnosticsProvider ...$providers)
+    {
+        $this->providers = $providers;
+        $this->logger = $logger;
+    }
+
+    public function provideDiagnostics(TextDocumentItem $textDocument, CancellationToken $cancel): Promise
+    {
+        return call(function () use ($textDocument, $cancel) {
+            $diagnostics = [];
+            foreach ($this->providers as $provider) {
+                try {
+                    $start = microtime(true);
+                    $diagnostics = array_merge(
+                        $diagnostics,
+                        // if no code is provided in the diagnostic, set the
+                        // code to be the provider name.
+                        array_map(function (Diagnostic $diagnostic) use ($provider) {
+                            if (null === $diagnostic->code) {
+                                $diagnostic->code = $provider->name();
+                            }
+                            return $diagnostic;
+                        }, yield $provider->provideDiagnostics($textDocument, $cancel))
+                    );
+                    if ($cancel->isRequested()) {
+                        $this->logger->info('Diagnostics cancelled');
+                        return $diagnostics;
+                    }
+                    $this->logger->debug(sprintf(
+                        'Diagnostic finsihed in "%s" (%s)',
+                        number_format(microtime(true) - $start, 2),
+                        get_class($provider)
+                    ));
+                } catch (Throwable $throwable) {
+                    $this->logger->error(sprintf(
+                        'Diagnostic error from provider "%s": %s',
+                        get_class($provider),
+                        $throwable->getMessage()
+                    ), [
+                        'trace' => $throwable->getTraceAsString()
+                    ]);
+                }
+            }
+
+            return $diagnostics;
+        });
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function names(): array
+    {
+        return array_map(
+            fn (DiagnosticsProvider $provider) => $provider->name(),
+            $this->providers
+        );
+    }
+
+    public function name(): string
+    {
+        return implode(', ', $this->names());
+    }
+}

--- a/lib/Extension/LanguageServer/DiagnosticProvider/CodeFilteringDiagnosticProvider.php
+++ b/lib/Extension/LanguageServer/DiagnosticProvider/CodeFilteringDiagnosticProvider.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServer\DiagnosticProvider;
+
+use Amp\CancellationToken;
+use Amp\Promise;
+use Phpactor\LanguageServerProtocol\Diagnostic;
+use Phpactor\LanguageServerProtocol\TextDocumentItem;
+use Phpactor\LanguageServer\Core\Diagnostics\DiagnosticsProvider;
+use function Amp\call;
+
+class CodeFilteringDiagnosticProvider implements DiagnosticsProvider
+{
+    /**
+     * @var array<string,int>
+     */
+    private array $ignoreCodes;
+
+    /**
+     * @param list<string> $ignoreCodes
+     */
+    public function __construct(private DiagnosticsProvider $innerProvider, array $ignoreCodes)
+    {
+        $this->ignoreCodes = array_flip($ignoreCodes);
+    }
+
+    public function provideDiagnostics(TextDocumentItem $textDocument, CancellationToken $cancel): Promise
+    {
+        return call(function () use ($cancel, $textDocument) {
+            return array_values(array_filter(yield $this->innerProvider->provideDiagnostics($textDocument, $cancel), function (Diagnostic $diagnostic) {
+                return null === $diagnostic->code || !array_key_exists(
+                    $diagnostic->code,
+                    $this->ignoreCodes
+                );
+            }));
+        });
+    }
+
+    public function name(): string
+    {
+        return $this->innerProvider->name();
+    }
+}

--- a/lib/Extension/LanguageServer/LanguageServerExtension.php
+++ b/lib/Extension/LanguageServer/LanguageServerExtension.php
@@ -12,6 +12,8 @@ use Phpactor\Extension\LanguageServerWorseReflection\Workspace\WorkspaceIndex;
 use Phpactor\Extension\LanguageServer\CodeAction\ProfilingCodeActionProvider;
 use Phpactor\Extension\LanguageServer\CodeAction\TolerantCodeActionProvider;
 use Phpactor\Extension\LanguageServer\Command\DiagnosticsCommand;
+use Phpactor\Extension\LanguageServer\DiagnosticProvider\AggregateDiagnosticsProvider;
+use Phpactor\Extension\LanguageServer\DiagnosticProvider\CodeFilteringDiagnosticProvider;
 use Phpactor\Extension\LanguageServer\DiagnosticProvider\OutsourcedDiagnosticsProvider;
 use Phpactor\Extension\LanguageServer\DiagnosticProvider\PathExcludingDiagnosticsProvider;
 use Phpactor\Extension\LanguageServer\Dispatcher\PhpactorDispatcherFactory;
@@ -31,7 +33,6 @@ use Phpactor\LanguageServerProtocol\ClientCapabilities;
 use Phpactor\LanguageServer\Core\CodeAction\AggregateCodeActionProvider;
 use Phpactor\LanguageServer\Core\CodeAction\CodeActionProvider;
 use Phpactor\LanguageServer\Core\Command\CommandDispatcher;
-use Phpactor\LanguageServer\Core\Diagnostics\AggregateDiagnosticsProvider;
 use Phpactor\LanguageServer\Core\Diagnostics\DiagnosticsEngine;
 use Phpactor\LanguageServer\Core\Diagnostics\DiagnosticsProvider;
 use Phpactor\LanguageServer\Diagnostics\CodeActionDiagnosticsProvider;
@@ -121,6 +122,7 @@ class LanguageServerExtension implements Extension
     public const PARAM_PHPACTOR_BIN = 'language_server.phpactor_bin';
     public const PARAM_DIAGNOSTIC_OUTSOURCE_TIMEOUT = 'language_server.diagnostic_outsource_timeout';
     public const PARAM_DIAGNOSTIC_EXCLUDE_PATHS = 'language_server.diagnostic_exclude_paths';
+    public const PARAM_DIAGNOSTIC_IGNORE_CODES = 'language_server.diagnostic_ignore_codes';
 
     public function configure(Resolver $schema): void
     {
@@ -136,6 +138,7 @@ class LanguageServerExtension implements Extension
             self::PARAM_DIAGNOSTIC_PROVIDERS => null,
             self::PARAM_DIAGNOSTIC_OUTSOURCE => true,
             self::PARAM_DIAGNOSTIC_EXCLUDE_PATHS => [],
+            self::PARAM_DIAGNOSTIC_IGNORE_CODES => [],
             self::PARAM_FILE_EVENTS => true,
             self::PARAM_FILE_EVENT_GLOBS => ['**/*.php'],
             self::PARAM_PROFILE => false,
@@ -161,6 +164,7 @@ class LanguageServerExtension implements Extension
             self::PARAM_DIAGNOSTIC_PROVIDERS => 'Specify which diagnostic providers should be active (default to all)',
             self::PARAM_DIAGNOSTIC_OUTSOURCE => 'If applicable diagnostics should be "outsourced" to a different process',
             self::PARAM_DIAGNOSTIC_OUTSOURCE_TIMEOUT => 'Kill the diagnostics process if it outlives this timeout',
+            self::PARAM_DIAGNOSTIC_IGNORE_CODES => 'Ignore diagnostics that have the codes listed here, e.g. ["fix_namespace_class_name"]. The codes match those shown in the LSP client.',
             self::PARAM_FILE_EVENTS => 'Register to receive file events',
             self::PARAM_DIAGNOSTIC_EXCLUDE_PATHS => 'List of paths to exclude from diagnostics, e.g. `vendor/**/*`',
             self::PARAM_SHUTDOWN_GRACE_PERIOD => 'Amount of time (in milliseconds) to wait before responding to a shutdown notification',
@@ -538,6 +542,17 @@ class LanguageServerExtension implements Extension
                         $provider,
                         // make all the exclude paths absolute before passing to the provider
                         array_map(fn (string $path) => Path::join($projectRoot, $path), $excludePaths)
+                    );
+                }, $providers);
+            }
+
+            $ignoreCodes = $container->parameter(self::PARAM_DIAGNOSTIC_IGNORE_CODES)->listOfString();
+
+            if (count($ignoreCodes)) {
+                $providers = array_map(function (DiagnosticsProvider $provider) use ($ignoreCodes) {
+                    return new CodeFilteringDiagnosticProvider(
+                        $provider,
+                        $ignoreCodes,
                     );
                 }, $providers);
             }

--- a/lib/Extension/LanguageServer/Tests/Unit/DiagnosticsProvider/AggregateDiagnosticProviderTest.php
+++ b/lib/Extension/LanguageServer/Tests/Unit/DiagnosticsProvider/AggregateDiagnosticProviderTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServer\Tests\Unit\DiagnosticsProvider;
+
+use Amp\CancellationTokenSource;
+use Amp\Success;
+use PHPUnit\Framework\TestCase;
+use Phpactor\Extension\LanguageServer\DiagnosticProvider\AggregateDiagnosticsProvider;
+use Phpactor\LanguageServerProtocol\Diagnostic;
+use Phpactor\LanguageServer\Core\Diagnostics\ClosureDiagnosticsProvider;
+use Phpactor\LanguageServer\Test\ProtocolFactory;
+use Psr\Log\NullLogger;
+use function Amp\Promise\wait;
+
+class AggregateDiagnosticProviderTest extends TestCase
+{
+    public function testProvidesAggregateDiagnostics(): void
+    {
+        $providers = [
+            $this->createProvider([
+                ProtocolFactory::diagnostic(
+                    ProtocolFactory::range(1, 1, 2, 2),
+                    'one'
+                ),
+                ProtocolFactory::diagnostic(
+                    ProtocolFactory::range(1, 1, 2, 2),
+                    'two'
+                )
+            ]),
+            $this->createProvider([
+                ProtocolFactory::diagnostic(
+                    ProtocolFactory::range(1, 1, 2, 2),
+                    'three'
+                ),
+            ]),
+        ];
+
+        $aggregate = $this->createAggregate(...$providers);
+        $cancel = (new CancellationTokenSource())->getToken();
+        $diagnostics = wait($aggregate->provideDiagnostics(ProtocolFactory::textDocumentItem('file:///', 'text'), $cancel));
+        self::assertCount(3, $diagnostics);
+        $diagnostic = $diagnostics[0] ?? null;
+        self::assertInstanceOf(Diagnostic::class, $diagnostic);
+        self::assertEquals('test', $diagnostic->code, 'Uses provider ID as code by default');
+    }
+
+    public function testReturnsAggregateName(): void
+    {
+        $aggregate = $this->createAggregate(...[
+            $this->createProvider([], 'one'),
+            $this->createProvider([], 'two'),
+        ]);
+        self::assertEquals('one, two', $aggregate->name());
+    }
+
+    private function createAggregate(ClosureDiagnosticsProvider ...$providers): AggregateDiagnosticsProvider
+    {
+        return new AggregateDiagnosticsProvider(new NullLogger(), ...$providers);
+    }
+
+    /**
+     * @param Diagnostic[] $diagnostics
+     */
+    private function createProvider(array $diagnostics, string $name = 'test'): ClosureDiagnosticsProvider
+    {
+        return new ClosureDiagnosticsProvider(function () use ($diagnostics) {
+            return new Success($diagnostics);
+        }, $name);
+    }
+}

--- a/lib/Extension/LanguageServer/Tests/Unit/DiagnosticsProvider/CodeFilteringDiagnosticProviderTest.php
+++ b/lib/Extension/LanguageServer/Tests/Unit/DiagnosticsProvider/CodeFilteringDiagnosticProviderTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServer\Tests\Unit\DiagnosticsProvider;
+
+use Amp\CancellationTokenSource;
+use Amp\Success;
+use PHPUnit\Framework\TestCase;
+use Phpactor\Extension\LanguageServer\DiagnosticProvider\CodeFilteringDiagnosticProvider;
+use Phpactor\LanguageServerProtocol\Diagnostic;
+use Phpactor\LanguageServer\Core\Diagnostics\ClosureDiagnosticsProvider;
+use Phpactor\LanguageServer\Test\ProtocolFactory;
+use function Amp\Promise\wait;
+
+class CodeFilteringDiagnosticProviderTest extends TestCase
+{
+    public function testFilter(): void
+    {
+        $provider = new ClosureDiagnosticsProvider(function () {
+            return new Success([
+                new Diagnostic(
+                    range: ProtocolFactory::range(0, 0, 0, 0),
+                    message: 'foobar',
+                    code: 'foo',
+                ),
+                new Diagnostic(
+                    range: ProtocolFactory::range(0, 0, 0, 0),
+                    message: 'foobar',
+                    code: 'bar',
+                ),
+            ]);
+        });
+
+        $provider = new CodeFilteringDiagnosticProvider($provider, ['bar']);
+        $diagnostics = wait($provider->provideDiagnostics(
+            ProtocolFactory::textDocumentItem('file:///foo', ''),
+            (new CancellationTokenSource())->getToken()
+        ));
+        self::assertCount(1, $diagnostics);
+        $diagnostic = $diagnostics[0] ?? null;
+        self::assertInstanceOf(Diagnostic::class, $diagnostic);
+        self::assertEquals('foo', $diagnostic->code);
+    }
+}

--- a/lib/Extension/LanguageServer/Tests/Unit/LanguageServerExtensionTest.php
+++ b/lib/Extension/LanguageServer/Tests/Unit/LanguageServerExtensionTest.php
@@ -2,13 +2,13 @@
 
 namespace Phpactor\Extension\LanguageServer\Tests\Unit;
 
+use Phpactor\Extension\LanguageServer\DiagnosticProvider\AggregateDiagnosticsProvider;
 use Phpactor\Extension\LanguageServer\LanguageServerExtension;
 use Phpactor\LanguageServerProtocol\ClientCapabilities;
 use Phpactor\LanguageServerProtocol\CodeActionRequest;
 use Phpactor\LanguageServerProtocol\DidChangeWatchedFilesClientCapabilities;
 use Phpactor\LanguageServerProtocol\InitializeParams;
 use Phpactor\LanguageServerProtocol\WorkspaceClientCapabilities;
-use Phpactor\LanguageServer\Core\Diagnostics\AggregateDiagnosticsProvider;
 use Phpactor\LanguageServer\Core\Rpc\NotificationMessage;
 use Phpactor\LanguageServer\Core\Rpc\RequestMessage;
 use Phpactor\LanguageServer\Core\Rpc\ResponseMessage;

--- a/lib/Extension/LanguageServerPhpstan/Model/DiagnosticsParser.php
+++ b/lib/Extension/LanguageServerPhpstan/Model/DiagnosticsParser.php
@@ -40,7 +40,6 @@ class DiagnosticsParser
                         codeDescription: $this->resolveCodeDescription($message),
                         code: $message['identifier'] ?? null,
                     );
-
                 }
             }
         }

--- a/lib/Extension/LanguageServerWorseReflection/DiagnosticProvider/WorseDiagnosticProvider.php
+++ b/lib/Extension/LanguageServerWorseReflection/DiagnosticProvider/WorseDiagnosticProvider.php
@@ -37,6 +37,7 @@ class WorseDiagnosticProvider implements DiagnosticsProvider
                 $lspDiagnostic->severity = self::toLspSeverity($diagnostic->severity());
                 $lspDiagnostic->source = 'phpactor';
                 $lspDiagnostic->tags = self::toLspTags($diagnostic->tags());
+                $lspDiagnostic->code = 'worse.'.$diagnostic->code();
 
                 if ($diagnostic instanceof DeprecatedUsageDiagnostic) {
                     $lspDiagnostic->tags[] = DiagnosticTag::DEPRECATED;

--- a/lib/Extension/LanguageServerWorseReflection/LanguageServerWorseReflectionExtension.php
+++ b/lib/Extension/LanguageServerWorseReflection/LanguageServerWorseReflectionExtension.php
@@ -86,7 +86,7 @@ class LanguageServerWorseReflectionExtension implements Extension
                 return null;
             }
             return new WorseDiagnosticProvider(
-                $container->expect(WorseReflectionExtension::SERVICE_REFLECTOR, Reflector::class)
+                $container->expect(WorseReflectionExtension::SERVICE_REFLECTOR, Reflector::class),
             );
         }, [ LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => DiagnosticProviderTag::create('code-action', true) ]);
 

--- a/lib/Extension/LanguageServerWorseReflection/Tests/Unit/DiagnosticProvider/WorseDiagnosticProviderTest.php
+++ b/lib/Extension/LanguageServerWorseReflection/Tests/Unit/DiagnosticProvider/WorseDiagnosticProviderTest.php
@@ -20,7 +20,7 @@ class WorseDiagnosticProviderTest extends TestCase
     public function testDiagnostics(): void
     {
         $reflector = ReflectorBuilder::create()->addDiagnosticProvider(new InMemoryDiagnosticProvider([
-            new BareDiagnostic(ByteOffsetRange::fromInts(1, 1), DiagnosticSeverity::WARNING(), 'Foo')
+            new BareDiagnostic(ByteOffsetRange::fromInts(1, 1), DiagnosticSeverity::WARNING(), 'Foo', 'foo')
         ]))->build();
 
         $cancel = (new CancellationTokenSource())->getToken();
@@ -35,6 +35,7 @@ class WorseDiagnosticProviderTest extends TestCase
         self::assertCount(1, $lspDiagnostics);
         self::assertInstanceOf(Diagnostic::class, $lspDiagnostics[0]);
         self::assertEquals('Foo', $lspDiagnostics[0]->message);
+        self::assertEquals('worse.foo', $lspDiagnostics[0]->code);
         self::assertEquals(PhpactorDiagnosticSeverity::WARNING, $lspDiagnostics[0]->severity);
     }
 }

--- a/lib/Extension/WorseReflection/Documentor/DiagnosticDocumentor.php
+++ b/lib/Extension/WorseReflection/Documentor/DiagnosticDocumentor.php
@@ -52,7 +52,7 @@ class DiagnosticDocumentor implements Documentor
     {
         $reflection = new ReflectionClass($provider);
         $docs = [];
-        $docs[] = DocHelper::title('-', sprintf('``%s``', $provider->name()));
+        $docs[] = DocHelper::title('-', sprintf('%s', $reflection->getShortName()));
         $docs[] = '';
         $docs[] = trim((string)preg_replace('{(^/\*\*)|(\s+\*\s)|(\s+\*/$)}m', ' ', trim((string)$reflection->getDocComment())));
         $docs[] = '';

--- a/lib/Name/NameUtil.php
+++ b/lib/Name/NameUtil.php
@@ -86,6 +86,15 @@ final class NameUtil
         return '\\' . $name;
     }
 
+    public static function namespace(string $fqn): string
+    {
+        $shortNamePos = strrpos($fqn, '\\');
+        if (false === $shortNamePos) {
+            return $fqn;
+        }
+        return substr($fqn, 0, $shortNamePos);
+    }
+
     private static function normalize(string $name): string
     {
         // trim?

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/AssignmentToMissingPropertyDiagnostic.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/AssignmentToMissingPropertyDiagnostic.php
@@ -56,4 +56,9 @@ class AssignmentToMissingPropertyDiagnostic implements Diagnostic
     {
         return [];
     }
+
+    public function code(): string
+    {
+        return 'assignment_to_missing_property';
+    }
 }

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/DeprecatedUsageDiagnostic.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/DeprecatedUsageDiagnostic.php
@@ -36,4 +36,9 @@ class DeprecatedUsageDiagnostic implements Diagnostic
     {
         return [DiagnosticTag::DEPRECATED];
     }
+
+    public function code(): string
+    {
+        return 'deprecated_usage';
+    }
 }

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/DeprecatedUsageDiagnosticProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/DeprecatedUsageDiagnosticProvider.php
@@ -222,11 +222,6 @@ class DeprecatedUsageDiagnosticProvider implements DiagnosticProvider
         );
     }
 
-    public function name(): string
-    {
-        return 'deprecated usage';
-    }
-
     /**
      * @param MemberAccessContext<ReflectionMember> $resolved
      * @return Generator<DeprecatedUsageDiagnostic>

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/DocblockIncorrectClassGenericDiagnostic.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/DocblockIncorrectClassGenericDiagnostic.php
@@ -43,4 +43,9 @@ class DocblockIncorrectClassGenericDiagnostic implements Diagnostic
     {
         return [];
     }
+
+    public function code(): string
+    {
+        return 'docblock_incorrect_class_generic';
+    }
 }

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/DocblockMissingClassGenericDiagnostic.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/DocblockMissingClassGenericDiagnostic.php
@@ -57,4 +57,9 @@ class DocblockMissingClassGenericDiagnostic implements Diagnostic
     {
         return [];
     }
+
+    public function code(): string
+    {
+        return 'doblock_missing_class_generic';
+    }
 }

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/DocblockMissingExtendsTagProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/DocblockMissingExtendsTagProvider.php
@@ -353,9 +353,4 @@ class DocblockMissingExtendsTagProvider implements DiagnosticProvider
             }
         );
     }
-
-    public function name(): string
-    {
-        return 'docblock_missing_extends_tag';
-    }
 }

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/DocblockMissingImplementsTagProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/DocblockMissingImplementsTagProvider.php
@@ -186,9 +186,4 @@ class DocblockMissingImplementsTagProvider implements DiagnosticProvider
             }
         );
     }
-
-    public function name(): string
-    {
-        return 'docblock_missing_implements_tag';
-    }
 }

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/DocblockMissingParamDiagnostic.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/DocblockMissingParamDiagnostic.php
@@ -59,4 +59,9 @@ class DocblockMissingParamDiagnostic implements Diagnostic
     {
         return [];
     }
+
+    public function code(): string
+    {
+        return 'docblock_missing_param';
+    }
 }

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/DocblockMissingParamProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/DocblockMissingParamProvider.php
@@ -309,11 +309,6 @@ class DocblockMissingParamProvider implements DiagnosticProvider
         );
     }
 
-    public function name(): string
-    {
-        return 'docblock_missing_param';
-    }
-
     private function upcastType(Type $type, NodeContextResolver $resolver): Type
     {
         if (!$type instanceof ReflectedClassType) {

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/DocblockMissingReturnTypeDiagnostic.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/DocblockMissingReturnTypeDiagnostic.php
@@ -52,4 +52,9 @@ class DocblockMissingReturnTypeDiagnostic implements Diagnostic
     {
         return [];
     }
+
+    public function code(): string
+    {
+        return 'docblock_missing_return_type';
+    }
 }

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/DocblockMissingReturnTypeProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/DocblockMissingReturnTypeProvider.php
@@ -152,9 +152,4 @@ class DocblockMissingReturnTypeProvider implements DiagnosticProvider
             }
         );
     }
-
-    public function name(): string
-    {
-        return 'docblock_missing_return';
-    }
 }

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/MissingMemberDiagnostic.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/MissingMemberDiagnostic.php
@@ -52,4 +52,9 @@ class MissingMemberDiagnostic implements Diagnostic
     {
         return [];
     }
+
+    public function code(): string
+    {
+        return 'missing_member';
+    }
 }

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/MissingMemberProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/MissingMemberProvider.php
@@ -313,9 +313,4 @@ class MissingMemberProvider implements DiagnosticProvider
             }
         );
     }
-
-    public function name(): string
-    {
-        return 'missing_method';
-    }
 }

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/MissingReturnTypeDiagnostic.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/MissingReturnTypeDiagnostic.php
@@ -60,4 +60,9 @@ class MissingReturnTypeDiagnostic implements Diagnostic
     {
         return [];
     }
+
+    public function code(): string
+    {
+        return 'missing_return_type';
+    }
 }

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/MissingReturnTypeProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/MissingReturnTypeProvider.php
@@ -166,9 +166,4 @@ class MissingReturnTypeProvider implements DiagnosticProvider
     {
         return [];
     }
-
-    public function name(): string
-    {
-        return 'missing_return_type';
-    }
 }

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UndefinedVariableDiagnostic.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UndefinedVariableDiagnostic.php
@@ -64,4 +64,9 @@ class UndefinedVariableDiagnostic implements Diagnostic
     {
         return [];
     }
+
+    public function code(): string
+    {
+        return 'undefined_variable';
+    }
 }

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UndefinedVariableProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UndefinedVariableProvider.php
@@ -514,9 +514,4 @@ class UndefinedVariableProvider implements DiagnosticProvider
             })
         );
     }
-
-    public function name(): string
-    {
-        return 'undefined_variable';
-    }
 }

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UnresolvableNameDiagnostic.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UnresolvableNameDiagnostic.php
@@ -61,4 +61,9 @@ class UnresolvableNameDiagnostic implements Diagnostic
     {
         return [];
     }
+
+    public function code(): string
+    {
+        return 'unresolved_name';
+    }
 }

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UnresolvableNameProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UnresolvableNameProvider.php
@@ -293,11 +293,6 @@ class UnresolvableNameProvider implements DiagnosticProvider
         );
     }
 
-    public function name(): string
-    {
-        return 'unresolvable_name';
-    }
-
     /**
      * @return iterable<UnresolvableNameDiagnostic>
      */

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UnusedImportDiagnostic.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UnusedImportDiagnostic.php
@@ -42,4 +42,9 @@ class UnusedImportDiagnostic implements Diagnostic
     {
         return [DiagnosticTag::UNNECESSARY];
     }
+
+    public function code(): string
+    {
+        return 'unused_import';
+    }
 }

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UnusedImportProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UnusedImportProvider.php
@@ -457,11 +457,6 @@ class UnusedImportProvider implements DiagnosticProvider
         );
     }
 
-    public function name(): string
-    {
-        return 'unused_import';
-    }
-
     private function extractDocblockNames(Docblock $docblock, NodeContextResolver $resolver, Node $node): void
     {
         $prefix = sprintf('%s:', $this->getNamespaceName($node));

--- a/lib/WorseReflection/Core/Diagnostic.php
+++ b/lib/WorseReflection/Core/Diagnostic.php
@@ -6,6 +6,8 @@ use Phpactor\TextDocument\ByteOffsetRange;
 
 interface Diagnostic
 {
+    public function code(): string;
+
     public function range(): ByteOffsetRange;
 
     public function severity(): DiagnosticSeverity;

--- a/lib/WorseReflection/Core/DiagnosticProvider.php
+++ b/lib/WorseReflection/Core/DiagnosticProvider.php
@@ -22,6 +22,4 @@ interface DiagnosticProvider
      * @return iterable<DiagnosticExample>
      */
     public function examples(): iterable;
-
-    public function name(): string;
 }

--- a/lib/WorseReflection/Core/DiagnosticProvider/BareDiagnostic.php
+++ b/lib/WorseReflection/Core/DiagnosticProvider/BareDiagnostic.php
@@ -11,7 +11,8 @@ class BareDiagnostic implements Diagnostic
     public function __construct(
         private ByteOffsetRange $range,
         private DiagnosticSeverity $severity,
-        private string $message
+        private string $message,
+        private string $code,
     ) {
     }
 
@@ -33,5 +34,10 @@ class BareDiagnostic implements Diagnostic
     public function tags(): array
     {
         return [];
+    }
+
+    public function code(): string
+    {
+        return $this->code;
     }
 }

--- a/lib/WorseReflection/Core/DiagnosticProvider/InMemoryDiagnosticProvider.php
+++ b/lib/WorseReflection/Core/DiagnosticProvider/InMemoryDiagnosticProvider.php
@@ -36,9 +36,4 @@ class InMemoryDiagnosticProvider implements DiagnosticProvider
     {
         return [];
     }
-
-    public function name(): string
-    {
-        return 'in_memory';
-    }
 }


### PR DESCRIPTION
gh-2781: show diagnostic codes and allow them to be ignored

- Show provider ID as code if no code present
- Add diagnostic codes to all WR diagnostics
- Always show a diagnostic code
- Remove redundant `name` method on diagnostic provider
- Add `language_server.diagnostic_ignore_cores` option.

![image](https://github.com/user-attachments/assets/84a51584-2832-48eb-bfcb-76f23d62a149)
![image](https://github.com/user-attachments/assets/7fc78a21-6dc5-47a4-bbe3-53d686f2b2a5)
