### PR TITLE
gh-2784: fix goto constant in a trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Improvements:
 
 Bug fixes:
 
+  - Fix goto constant within a trait #2784 @dantleech
   - Preserve PHAR scheme when indexing PHAR stubs @dantleech #2754
   - Fix duplicated types when updating methods @mamazu #2779
 

--- a/lib/Extension/Core/Command/DebugContainerCommand.php
+++ b/lib/Extension/Core/Command/DebugContainerCommand.php
@@ -21,6 +21,7 @@ class DebugContainerCommand extends Command
     protected function configure(): void
     {
         $this->addOption('services', null, InputOption::VALUE_NONE, 'List all services');
+        $this->addOption('parameters', null, InputOption::VALUE_NONE, 'List all parameters');
         $this->addOption('tags', null, InputOption::VALUE_NONE, 'List all tags');
         $this->addOption('tag', null, InputOption::VALUE_OPTIONAL|InputOption::VALUE_IS_ARRAY, 'Show specific tag');
     }
@@ -32,6 +33,9 @@ class DebugContainerCommand extends Command
         }
         if ($input->getOption('tags')) {
             $this->renderTags($output);
+        }
+        if ($input->getOption('parameters')) {
+            $this->renderParameters($output);
         }
 
         foreach ((array)$input->getOption('tag') as $tag) {
@@ -92,6 +96,19 @@ class DebugContainerCommand extends Command
         ]);
         foreach ($this->container->getServiceIdsForTag($tag) as $serviceId => $attrs) {
             $table->addRow([$serviceId, json_encode($attrs, JSON_PRETTY_PRINT)]);
+        }
+        $table->render();
+    }
+
+    private function renderParameters(OutputInterface $output): void
+    {
+        $table = new Table($output);
+        $table->setStyle('borderless');
+        $table->setHeaders([
+            'parameter','value',
+        ]);
+        foreach ($this->container->getParameters() as $key => $value) {
+            $table->addRow([$key, json_encode($value, JSON_PRETTY_PRINT)]);
         }
         $table->render();
     }

--- a/lib/WorseReferenceFinder/Tests/Unit/WorseReflectionDefinitionLocatorTest.php
+++ b/lib/WorseReferenceFinder/Tests/Unit/WorseReflectionDefinitionLocatorTest.php
@@ -330,6 +330,19 @@ class WorseReflectionDefinitionLocatorTest extends DefinitionLocatorTestCase
         $this->assertTypeLocation($location->first(), 'FoobarEnum.php', 34, 58);
     }
 
+    public function testLocatesTraitConst(): void
+    {
+        // note this isn't actually valid PHP but I'm too lazy
+        // to test it proeprtly #2784
+        $location = $this->locate(<<<'EOT'
+            // File: FoobarTrait.php
+            <?php trait FoobarTrait { const FOOBAR = 'FOOBAR'; }
+            EOT
+            , '<?php FoobarTrait::FOO<>BAR;');
+
+        $this->assertTypeLocation($location->first(), 'FoobarTrait.php', 26, 50);
+    }
+
     public function testExceptionIfPropertyIsInterface(): void
     {
         $this->expectException(CouldNotLocateDefinition::class);

--- a/lib/WorseReferenceFinder/WorseReflectionDefinitionLocator.php
+++ b/lib/WorseReferenceFinder/WorseReflectionDefinitionLocator.php
@@ -195,11 +195,16 @@ class WorseReflectionDefinitionLocator implements DefinitionLocator
                             break;
                         }
                     }
-                    assert($containingClass instanceof ReflectionClass || $containingClass instanceof ReflectionInterface || $containingClass instanceof ReflectionEnum);
                     $members = $containingClass->constants();
                     break;
                 case Symbol::PROPERTY:
-                    assert($containingClass instanceof ReflectionClass || $containingClass instanceof ReflectionTrait || $containingClass instanceof ReflectionEnum);
+                    if (
+                        !$containingClass instanceof ReflectionClass || $containingClass instanceof ReflectionTrait || $containingClass instanceof ReflectionEnum) {
+                        throw new CouldNotLocateDefinition(sprintf(
+                            'ClassLike "%s" has no properties!',
+                            $containingClass::class
+                        ));
+                    }
                     $members = $containingClass->properties();
                     break;
                 default:

--- a/lib/WorseReflection/Core/Reflection/ReflectionClassLike.php
+++ b/lib/WorseReflection/Core/Reflection/ReflectionClassLike.php
@@ -7,6 +7,7 @@ use Phpactor\TextDocument\ByteOffsetRange;
 use Phpactor\WorseReflection\Core\ClassName;
 use Phpactor\TextDocument\TextDocument;
 use Phpactor\WorseReflection\Core\DocBlock\DocBlock;
+use Phpactor\WorseReflection\Core\Reflection\Collection\ReflectionConstantCollection;
 use Phpactor\WorseReflection\Core\Reflection\Collection\ReflectionMethodCollection;
 use Phpactor\WorseReflection\Core\Reflection\Collection\ReflectionMemberCollection;
 use Phpactor\WorseReflection\Core\TemplateMap;
@@ -45,4 +46,6 @@ interface ReflectionClassLike extends ReflectionNode
     public function type(): ReflectedClassType;
 
     public function classLikeType(): string;
+
+    public function constants(): ReflectionConstantCollection;
 }


### PR DESCRIPTION
- all class-likes support constants, so add it to the class-like interface.
- do not use `assert(` and throw the expected exception if something unexpected happens (e.g. using trying to goto a property in an interface).