### PR TITLE
Add doc for zed code editor

### DIFF
--- a/doc/lsp/clients.rst
+++ b/doc/lsp/clients.rst
@@ -12,6 +12,7 @@ Clients
    emacs
    helix
    nova
+   zed
 
 .. toctree::
    :hidden:

--- a/doc/lsp/zed.rst
+++ b/doc/lsp/zed.rst
@@ -3,4 +3,4 @@
 Zed
 ===
 
-Phpactor is default LSP for Zed. Install Zed's `PHP extension <https://github.com/zed-industries/zed/tree/main/extensions/php/>`_.
+Phpactor is the default LSP for Zed. Install Zed's `PHP extension <https://github.com/zed-industries/zed/tree/main/extensions/php/>`_.

--- a/doc/lsp/zed.rst
+++ b/doc/lsp/zed.rst
@@ -3,4 +3,4 @@
 Zed
 ===
 
-phpactor is default LSP for zed. Install zed's `Php extension <https://github.com/zed-industries/zed/tree/main/extensions/php/>`_.
+Phpactor is default LSP for Zed. Install Zed's `PHP extension <https://github.com/zed-industries/zed/tree/main/extensions/php/>`_.

--- a/doc/lsp/zed.rst
+++ b/doc/lsp/zed.rst
@@ -1,6 +1,6 @@
 .. _lsp_client_zed:
 
 Zed
-================
+===
 
 phpactor is default LSP for zed. Install zed's `Php extension <https://github.com/zed-industries/zed/tree/main/extensions/php/>`_.

--- a/doc/lsp/zed.rst
+++ b/doc/lsp/zed.rst
@@ -1,0 +1,6 @@
+.. _lsp_client_zed:
+
+Zed
+================
+
+phpactor is default LSP for zed. Install zed's `Php extension <https://github.com/zed-industries/zed/tree/main/extensions/php/>`_.


### PR DESCRIPTION
This PR adds documentation for Zed code editor. It supports phpactor by default as it's PHP LSP