### PR TITLE
Docblock: Do not expand unions within a Generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ Improvements:
 
 Bug fix:
 
-  - Handle zero modulo evaluation
+  - Handle zero modulo evaluation @dantleech
+  - Do not use FQNs for imported classes in generated docblocks #2843 @dantleech
 
 Documentation:
 

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionScope.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionScope.php
@@ -60,10 +60,6 @@ class ReflectionScope implements CoreReflectionScope
         return $this->nameImports()->resolveLocalName($name);
     }
 
-    /**
-     * TODO: This is not complete and doesn't work with complex types.
-     *       see: https://github.com/phpactor/phpactor/issues/1453
-     */
     public function resolveLocalType(Type $type): Type
     {
         $union = UnionType::toUnion($type);

--- a/lib/WorseReflection/Core/Type/AggregateType.php
+++ b/lib/WorseReflection/Core/Type/AggregateType.php
@@ -171,7 +171,7 @@ abstract class AggregateType extends Type
 
     public function map(Closure $mapper): Type
     {
-        return $this->withTypes(...array_map($mapper, $this->types));
+        return $this->withTypes(...array_map(fn (Type $type) => $type->map($mapper), $this->types));
     }
 
     public function filter(Closure $closure): AggregateType


### PR DESCRIPTION
When generating docblock tags, do not use fully qualified names within complex types within a union.