### PR TITLE
Fixed Zed's link to PHP support

### DIFF
--- a/doc/lsp/zed.rst
+++ b/doc/lsp/zed.rst
@@ -3,4 +3,4 @@
 Zed
 ===
 
-Phpactor is the default LSP for Zed. Install Zed's `PHP extension <https://github.com/zed-industries/zed/tree/main/extensions/php/>`_.
+Phpactor is the default LSP for Zed. Install Zed's `PHP extension <https://zed.dev/docs/languages/php>`_.


### PR DESCRIPTION
fixes https://github.com/phpactor/phpactor/pull/2836

The [Zed PHP extension](https://github.com/zed-extensions/php) appears to have been extracted into a separate repository [last week](https://github.com/zed-industries/zed/pull/24583).

There is no documentation in the PHP extension repository, so <https://zed.dev/docs/languages/php> is a better reference.

The link from that documentation to the PHP extension is also broken, but I've submitted a [PR](https://github.com/zed-industries/zed/pull/25144) to Zed.