### PR TITLE
Fix performance for local variable references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Features:
 
 Improvements:
 
+  - Refenreces: Do not run Indexed reference finder if references handled by
+    Variable reference finder @dantleech
   - Psalm: add `config` option to specify Psalm config @GDXbsv #2835
   - Completion for `@internal`  tag #2827 @mamazu
   - Add documentation for Nova Language Client #2830 @EmranMR 

--- a/lib/Extension/LanguageServerReferenceFinder/Adapter/Indexer/WorkspaceUpdateReferenceFinder.php
+++ b/lib/Extension/LanguageServerReferenceFinder/Adapter/Indexer/WorkspaceUpdateReferenceFinder.php
@@ -26,7 +26,9 @@ class WorkspaceUpdateReferenceFinder implements ReferenceFinder
     {
         $this->indexWorkspace();
 
-        yield from $this->innerReferenceFinder->findReferences($document, $byteOffset);
+        $generator = $this->innerReferenceFinder->findReferences($document, $byteOffset);
+        yield from $generator;
+        return $generator->getReturn();
     }
 
     private function indexWorkspace(): void

--- a/lib/Indexer/Adapter/ReferenceFinder/IndexedReferenceFinder.php
+++ b/lib/Indexer/Adapter/ReferenceFinder/IndexedReferenceFinder.php
@@ -62,6 +62,8 @@ class IndexedReferenceFinder implements ReferenceFinder
 
             yield PotentialLocation::not($locationConfidence->location());
         }
+
+        return true;
     }
 
     /**

--- a/lib/ReferenceFinder/ChainReferenceFinder.php
+++ b/lib/ReferenceFinder/ChainReferenceFinder.php
@@ -23,8 +23,16 @@ final class ChainReferenceFinder implements ReferenceFinder
     public function findReferences(TextDocument $document, ByteOffset $byteOffset): Generator
     {
         foreach ($this->finders as $finder) {
-            yield from $finder->findReferences($document, $byteOffset);
+            $generator = $finder->findReferences($document, $byteOffset);
+            yield from $generator;
+
+            // stop no more generators should be executed
+            if ($generator->getReturn() === true) {
+                return true;
+            }
         }
+
+        return false;
     }
 
     private function add(ReferenceFinder $finder): void

--- a/lib/ReferenceFinder/DefinitionAndReferenceFinder.php
+++ b/lib/ReferenceFinder/DefinitionAndReferenceFinder.php
@@ -22,8 +22,10 @@ class DefinitionAndReferenceFinder implements ReferenceFinder
         } catch (CouldNotLocateDefinition) {
         }
 
-        foreach ($this->referenceFinder->findReferences($document, $byteOffset) as $reference) {
+        $generator = $this->referenceFinder->findReferences($document, $byteOffset);
+        foreach ($generator as $reference) {
             yield $reference;
         }
+        return $generator->getReturn();
     }
 }

--- a/lib/ReferenceFinder/ReferenceFinder.php
+++ b/lib/ReferenceFinder/ReferenceFinder.php
@@ -11,7 +11,9 @@ interface ReferenceFinder
     /**
      * Find references to the symbol at the given byte offset.
      *
-     * @return Generator<PotentialLocation>
+     * Return true if no more finders should be executed after this finder and false otherwise.
+     *
+     * @return Generator<int, PotentialLocation, null, bool>
      */
     public function findReferences(TextDocument $document, ByteOffset $byteOffset): Generator;
 }

--- a/lib/ReferenceFinder/TestReferenceFinder.php
+++ b/lib/ReferenceFinder/TestReferenceFinder.php
@@ -24,5 +24,6 @@ class TestReferenceFinder implements ReferenceFinder
         foreach ($this->locations as $location) {
             yield $location;
         }
+        return true;
     }
 }

--- a/lib/Rename/Model/ReferenceFinder/PredefinedReferenceFinder.php
+++ b/lib/Rename/Model/ReferenceFinder/PredefinedReferenceFinder.php
@@ -25,5 +25,6 @@ class PredefinedReferenceFinder implements ReferenceFinder
         foreach ($this->locations as $location) {
             yield $location;
         }
+        return true;
     }
 }

--- a/lib/Rename/Model/ReferenceFinder/PredefinedReferenceFinderFoo.php
+++ b/lib/Rename/Model/ReferenceFinder/PredefinedReferenceFinderFoo.php
@@ -25,5 +25,7 @@ class PredefinedReferenceFinderFoo implements ReferenceFinder
         foreach ($this->locations as $location) {
             yield $location;
         }
+
+        return true;
     }
 }

--- a/lib/WorseReferenceFinder/TolerantVariableReferenceFinder.php
+++ b/lib/WorseReferenceFinder/TolerantVariableReferenceFinder.php
@@ -40,7 +40,7 @@ class TolerantVariableReferenceFinder implements ReferenceFinder
         $sourceNode = $this->sourceNode($document->__toString());
         $variable = $this->variableNodeFromSource($sourceNode, $byteOffset->toInt());
         if ($variable === null) {
-            return;
+            return false;
         }
 
         $scopeNode = $this->scopeNode($variable);
@@ -53,6 +53,8 @@ class TolerantVariableReferenceFinder implements ReferenceFinder
         if ($referencesGenerator->valid()) {
             yield from $referencesGenerator;
         }
+
+        return true;
     }
 
     private function sourceNode(string $source): SourceFileNode
@@ -139,8 +141,11 @@ class TolerantVariableReferenceFinder implements ReferenceFinder
     /**
      * @return Generator<PotentialLocation>
      */
-    private function find(Node $scopeNode, string $name, string $uri): Generator
+    private function find(Node $scopeNode, ?string $name, ?string $uri): Generator
     {
+        if (null === $uri || null === $name) {
+            return;
+        }
         if ($scopeNode instanceof CatchClause && $scopeNode->variableName instanceof Token && $name == substr((string)$scopeNode->variableName->getText($scopeNode->getFileContents()), 1)) {
             yield PotentialLocation::surely(
                 Location::fromPathAndOffsets($uri, $scopeNode->variableName->start, $scopeNode->variableName->getEndPosition())


### PR DESCRIPTION
Do not proceed to next reference finder if current reference finder handled the request.