### PR TITLE
Allow search results to be filtered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ Changelog
 Improvements:
 
   - Extract document highlighter to own module and add config option to
-    disable it.
+    disable it @dantleech
+
+Features:
+
+  - Search filtering (as applicable to autocomplete, name importing etc)
+    @dantleech
 
 ## 2025.04.17.0
 

--- a/doc/reference/configuration.rst
+++ b/doc/reference/configuration.rst
@@ -1800,6 +1800,22 @@ File extensions (e.g. `php`) for files that should be indexed
 **Default**: ``["php","phar"]``
 
 
+.. _param_indexer.search_include_patterns:
+
+
+``indexer.search_include_patterns``
+"""""""""""""""""""""""""""""""""""
+
+
+Type: array
+
+
+When searching the index exclude records whose fully qualified names match any of these regex patterns (use to exclude suggestions from search results). Namespace separators must be escaped as `\\\\` for example `^Foo\\\\` to include all namespaces whose first segment is `Foo`
+
+
+**Default**: ``[]``
+
+
 .. _ObjectRendererExtension:
 
 

--- a/lib/Indexer/Adapter/Php/InMemory/InMemorySearchIndex.php
+++ b/lib/Indexer/Adapter/Php/InMemory/InMemorySearchIndex.php
@@ -9,12 +9,23 @@ use Phpactor\Indexer\Model\RecordFactory;
 use Phpactor\Indexer\Model\Record\ClassRecord;
 use Phpactor\Indexer\Model\SearchIndex;
 
-class InMemorySearchIndex implements SearchIndex
+final class InMemorySearchIndex implements SearchIndex
 {
     /**
      * @var array<string,array{string,string}>
      */
     private array $buffer = [];
+
+    public static function fromRecords(Record ...$records): self
+    {
+        $instance = new self();
+        foreach ($records as $record) {
+            $instance->write($record);
+        }
+
+        return $instance;
+    }
+
 
     /**
      * @return Generator<Record>

--- a/lib/Indexer/Extension/IndexerExtension.php
+++ b/lib/Indexer/Extension/IndexerExtension.php
@@ -70,6 +70,7 @@ class IndexerExtension implements Extension
     private const SERVICE_INDEXER_EXCLUDE_PATTERNS = 'indexer.exclude_patterns';
     private const SERVICE_INDEXER_INCLUDE_PATTERNS = 'indexer.include_patterns';
     private const PARAM_PROJECT_ROOT = 'indexer.project_root';
+    private const PARAM_SEARCH_INCLUDE_PATTERNS = 'indexer.search_include_patterns';
 
 
     public function configure(Resolver $schema): void
@@ -94,6 +95,7 @@ class IndexerExtension implements Extension
             self::PARAM_REFERENCES_DEEP_REFERENCES => true,
             self::PARAM_IMPLEMENTATIONS_DEEP_REFERENCES => true,
             self::PARAM_SUPPORTED_EXTENSIONS => ['php', 'phar'],
+            self::PARAM_SEARCH_INCLUDE_PATTERNS => [],
         ]);
         $schema->setDescriptions([
             self::PARAM_ENABLED_WATCHERS => 'List of allowed watchers. The first watcher that supports the current system will be used',
@@ -108,6 +110,7 @@ class IndexerExtension implements Extension
             self::PARAM_REFERENCES_DEEP_REFERENCES => 'Recurse over class implementations to resolve all references',
             self::PARAM_IMPLEMENTATIONS_DEEP_REFERENCES => 'Recurse over class implementations to resolve all class implementations (not just the classes directly implementing the subject)',
             self::PARAM_SUPPORTED_EXTENSIONS => 'File extensions (e.g. `php`) for files that should be indexed',
+            self::PARAM_SEARCH_INCLUDE_PATTERNS => 'When searching the index exclude records whose fully qualified names match any of these regex patterns (use to exclude suggestions from search results). Namespace separators must be escaped as `\\\\\\\\` for example `^Foo\\\\\\\\` to include all namespaces whose first segment is `Foo`',
         ]);
         $schema->setTypes([
             self::PARAM_ENABLED_WATCHERS => 'array',
@@ -122,6 +125,7 @@ class IndexerExtension implements Extension
             self::PARAM_REFERENCES_DEEP_REFERENCES => 'boolean',
             self::PARAM_IMPLEMENTATIONS_DEEP_REFERENCES => 'boolean',
             self::PARAM_SUPPORTED_EXTENSIONS => 'array',
+            self::PARAM_SEARCH_INCLUDE_PATTERNS => 'array',
         ]);
     }
 
@@ -228,6 +232,7 @@ class IndexerExtension implements Extension
                 ->setExcludePatterns($container->get(self::SERVICE_INDEXER_EXCLUDE_PATTERNS))
                 /** @phpstan-ignore-next-line */
                 ->setIncludePatterns($container->get(self::SERVICE_INDEXER_INCLUDE_PATTERNS))
+                ->setSearchIncludePatterns($container->parameter(self::PARAM_SEARCH_INCLUDE_PATTERNS)->listOfString())
                 /** @phpstan-ignore-next-line */
                 ->setSupportedExtensions($container->parameter(self::PARAM_SUPPORTED_EXTENSIONS)->value())
                 ->setFollowSymlinks($container->parameter(self::PARAM_INDEXER_FOLLOW_SYMLINKS)->bool())

--- a/lib/Indexer/IndexAgentBuilder.php
+++ b/lib/Indexer/IndexAgentBuilder.php
@@ -31,6 +31,7 @@ use Phpactor\Indexer\Model\Record\FunctionRecord;
 use Phpactor\Indexer\Model\SearchClient\HydratingSearchClient;
 use Phpactor\Indexer\Model\SearchIndex;
 use Phpactor\Indexer\Model\SearchIndex\FilteredSearchIndex;
+use Phpactor\Indexer\Model\SearchIndex\SearchIncludeIndex;
 use Phpactor\Indexer\Model\SearchIndex\ValidatingSearchIndex;
 use Phpactor\Indexer\Model\TestIndexAgent;
 use Psr\Log\LoggerInterface;
@@ -65,6 +66,11 @@ final class IndexAgentBuilder
     private ?array $indexers = null;
 
     private bool $followSymlinks = false;
+
+    /**
+     * @var list<string>
+     */
+    private array $searchIncludePatterns = [];
 
     /**
      * @var list<string>
@@ -152,6 +158,16 @@ final class IndexAgentBuilder
 
         return $this;
     }
+    /**
+     * @param list<string> $searchIncludePatterns
+     */
+    public function setSearchIncludePatterns(array $searchIncludePatterns): self
+    {
+        $this->searchIncludePatterns = $searchIncludePatterns;
+
+        return $this;
+    }
+
 
     /**
      * @param list<string> $supportedExtensions
@@ -208,6 +224,9 @@ final class IndexAgentBuilder
             FunctionRecord::RECORD_TYPE,
             ConstantRecord::RECORD_TYPE,
         ]);
+        if ($this->searchIncludePatterns !== []) {
+            $search = new SearchIncludeIndex($search, $this->searchIncludePatterns);
+        }
 
         return $search;
     }

--- a/lib/Indexer/Model/SearchIndex/FilteredSearchIndex.php
+++ b/lib/Indexer/Model/SearchIndex/FilteredSearchIndex.php
@@ -7,6 +7,9 @@ use Phpactor\Indexer\Model\Query\Criteria;
 use Phpactor\Indexer\Model\Record;
 use Phpactor\Indexer\Model\SearchIndex;
 
+/**
+ * Only writes the given record types to the underlying index.
+ */
 class FilteredSearchIndex implements SearchIndex
 {
     /**

--- a/lib/Indexer/Model/SearchIndex/SearchIncludeIndex.php
+++ b/lib/Indexer/Model/SearchIndex/SearchIncludeIndex.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Phpactor\Indexer\Model\SearchIndex;
+
+use Generator;
+use Phpactor\Indexer\Model\Query\Criteria;
+use Phpactor\Indexer\Model\Record;
+use Phpactor\Indexer\Model\Record\HasFullyQualifiedName;
+use Phpactor\Indexer\Model\SearchIndex;
+
+class SearchIncludeIndex implements SearchIndex
+{
+    /**
+     * @param list<string> $patterns
+     */
+    public function __construct(private SearchIndex $innerIndex, private array $patterns)
+    {
+    }
+
+    public function search(Criteria $criteria): Generator
+    {
+        foreach ($this->innerIndex->search($criteria) as $record) {
+            if (!$record instanceof HasFullyQualifiedName) {
+                continue;
+            }
+            foreach ($this->patterns as $pattern) {
+                if (preg_match('{' . $pattern . '}', $record->fqn())) {
+                    yield $record;
+                    continue 2;
+                }
+            }
+        }
+    }
+
+    public function write(Record $record): void
+    {
+        $this->innerIndex->write($record);
+    }
+
+    public function remove(Record $record): void
+    {
+        $this->innerIndex->remove($record);
+    }
+
+    public function flush(): void
+    {
+        $this->innerIndex->flush();
+    }
+}

--- a/lib/Indexer/Tests/Unit/Model/SearchIndex/SearchIncludeIndexTest.php
+++ b/lib/Indexer/Tests/Unit/Model/SearchIndex/SearchIncludeIndexTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Phpactor\Indexer\Tests\Unit\Model\SearchIndex;
+
+use Phpactor\Indexer\Adapter\Php\InMemory\InMemorySearchIndex;
+use Phpactor\Indexer\Model\Query\Criteria;
+use Phpactor\Indexer\Model\Record\ClassRecord;
+use Phpactor\Indexer\Model\Record\ConstantRecord;
+use Phpactor\Indexer\Model\Record\FunctionRecord;
+use Phpactor\Indexer\Model\SearchIndex\SearchIncludeIndex;
+use Phpactor\TestUtils\PHPUnit\TestCase;
+
+class SearchIncludeIndexTest extends TestCase
+{
+    public function testInclude(): void
+    {
+        $index = new SearchIncludeIndex(InMemorySearchIndex::fromRecords(
+            new ClassRecord('Foo\\Bar\\Baz'),
+            new FunctionRecord('Foo\\Bar\\baz'),
+            new ConstantRecord('Foo\\Bar\\BAZ'),
+            new ClassRecord('Baz\\Bar\\BAZ'),
+        ), ['^Foo\\\\']);
+
+        $records = iterator_to_array($index->search(Criteria::or(
+            Criteria::fqnBeginsWith('Foo'),
+            Criteria::fqnBeginsWith('Baz'),
+        )));
+        self::assertCount(3, $records);
+    }
+}


### PR DESCRIPTION
Allow search results (for classes, functions and constants) to be limited to those results matching any number of given regular expressions.