### PR TITLE
Adding depth information to worse:dump-ast command

### DIFF
--- a/lib/Extension/WorseReflection/Command/DumpAstCommand.php
+++ b/lib/Extension/WorseReflection/Command/DumpAstCommand.php
@@ -54,12 +54,12 @@ class DumpAstCommand extends Command
         return 0;
     }
 
-    private function dump(OutputInterface $output, Node $node, string &$out): void
+    private function dump(OutputInterface $output, Node $node, string &$out, int $depth = 0): void
     {
         foreach ($node->getChildNodesAndTokens() as $child) {
             if ($child instanceof Node) {
-                $out .= sprintf('<info><%s></>', $child->getNodeKindName());
-                $this->dump($output, $child, $out);
+                $out .= sprintf('<info><%s ↓%s></>', $child->getNodeKindName(), $depth);
+                $this->dump($output, $child, $out, $depth + 1);
             }
             if ($child instanceof Token) {
                 $out .= $child->getFullText($node->getFileContents());


### PR DESCRIPTION
When trying to debug why the if completor isn't working I needed to check the AST and what node was a child of what other node. So I added depth information to the debug output:
![image](https://github.com/user-attachments/assets/19e79f0e-5b28-4507-a37e-05232fdc5595)
