### PR TITLE
Only use the snippet formatter if it also can format the snippet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Features:
 
 Bug fixes:
   - Fix parameter type resolution priority @dantleech
+  - Fix completion rendering when snippets are disabled @mamazu
 
 ## 2025.04.17.0
 

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletor.php
@@ -147,9 +147,9 @@ class WorseClassMemberCompletor implements TolerantCompletor, TolerantQualifiabl
                 continue;
             }
 
-            $snippet = [];
+            $snippet = null;
             if ($this->snippetFormatter->canFormat($method)) {
-                $snippet['snippet'] = $completeOnlyName ? $method->name() : $this->snippetFormatter->format($method);
+                $snippet = $completeOnlyName ? $method->name() : $this->snippetFormatter->format($method);
             }
 
             yield Suggestion::createWithOptions($method->name(), [
@@ -162,7 +162,7 @@ class WorseClassMemberCompletor implements TolerantCompletor, TolerantQualifiabl
                         $method->name()
                     ), $method->docblock()->formatted(), $method));
                 },
-                ...$snippet
+                'snippet' => $snippet,
             ]);
         }
 

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletor.php
@@ -147,6 +147,11 @@ class WorseClassMemberCompletor implements TolerantCompletor, TolerantQualifiabl
                 continue;
             }
 
+            $snippet = [];
+            if ($this->snippetFormatter->canFormat($method)) {
+                $snippet['snippet'] = $completeOnlyName ? $method->name() : $this->snippetFormatter->format($method);
+            }
+
             yield Suggestion::createWithOptions($method->name(), [
                 'type' => Suggestion::TYPE_METHOD,
                 'short_description' => fn () => $this->formatter->format($method),
@@ -157,7 +162,7 @@ class WorseClassMemberCompletor implements TolerantCompletor, TolerantQualifiabl
                         $method->name()
                     ), $method->docblock()->formatted(), $method));
                 },
-                'snippet' => $completeOnlyName ? $method->name() : $this->snippetFormatter->format($method),
+                ...$snippet
             ]);
         }
 

--- a/lib/Completion/Core/Suggestion.php
+++ b/lib/Completion/Core/Suggestion.php
@@ -5,6 +5,18 @@ namespace Phpactor\Completion\Core;
 use Closure;
 use RuntimeException;
 
+/** @phpstan-type SuggestionOptions array{
+ *   short_description?:string|null|Closure,
+ *   documentation?:string|null|Closure,
+ *   type?:string|null,
+ *   class_import?:string|null,
+ *   name_import?:string|null,
+ *   fqn?:string|null,
+ *   label?:string|null,
+ *   range?:Range|null,
+ *   snippet?:string|null,
+ *   priority?:int|null
+ * } */
 class Suggestion
 {
     /**
@@ -66,18 +78,7 @@ class Suggestion
     }
 
     /**
-     * @param array{
-     *   short_description?:string|null|Closure,
-     *   documentation?:string|null|Closure,
-     *   type?:string|null,
-     *   class_import?:string|null,
-     *   name_import?:string|null,
-     *   fqn?:string|null,
-     *   label?:string|null,
-     *   range?:Range|null,
-     *   snippet?:string|null,
-     *   priority?:int|null
-     * } $options
+     * @param SuggestionOptions $options
      */
     public static function createWithOptions(string $name, array $options): self
     {

--- a/lib/Completion/Tests/Integration/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletorTest.php
+++ b/lib/Completion/Tests/Integration/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletorTest.php
@@ -12,10 +12,12 @@ use Phpactor\WorseReflection\ReflectorBuilder;
 use Phpactor\Completion\Bridge\TolerantParser\WorseReflection\WorseClassMemberCompletor;
 use Generator;
 
+/** @phpstan-import-type SuggestionOptions from Suggestion */
 class WorseClassMemberCompletorTest extends TolerantCompletorTestCase
 {
     /**
      * @dataProvider provideComplete
+     * @param array<SuggestionOptions> $expected
      */
     public function testComplete(string $source, array $expected): void
     {
@@ -23,7 +25,7 @@ class WorseClassMemberCompletorTest extends TolerantCompletorTestCase
     }
 
     /**
-     * @return Generator<string,array{string,array<int,array<string,string>>}>
+     * @return Generator<string,array{string,array<SuggestionOptions>}>
      */
     public function provideComplete(): Generator
     {

--- a/lib/Completion/Tests/Integration/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletorTestWithoutSnippetFormatter.php
+++ b/lib/Completion/Tests/Integration/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletorTestWithoutSnippetFormatter.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Phpactor\Completion\Tests\Integration\Bridge\TolerantParser\WorseReflection;
+
+use Phpactor\Completion\Bridge\TolerantParser\TolerantCompletor;
+use Phpactor\Completion\Core\Formatter\ObjectFormatter;
+use Phpactor\ObjectRenderer\ObjectRendererBuilder;
+use Phpactor\TextDocument\TextDocument;
+use Phpactor\WorseReflection\Bridge\Phpactor\MemberProvider\DocblockMemberProvider;
+use Phpactor\WorseReflection\ReflectorBuilder;
+use Phpactor\Completion\Bridge\TolerantParser\WorseReflection\WorseClassMemberCompletor;
+
+class WorseClassMemberCompletorTestWithoutSnippetFormatter extends WorseClassMemberCompletorTest
+{
+    /**
+     * @dataProvider provideComplete
+     */
+    public function testComplete(string $source, array $expected): void
+    {
+        // Expect all snippets to be null
+        foreach ($expected as &$suggestion) {
+            if (array_key_exists('snippet', $suggestion)) {
+                $suggestion['snippet'] = null;
+            }
+        }
+
+        $this->assertComplete($source, $expected);
+    }
+
+    protected function createTolerantCompletor(TextDocument $source): TolerantCompletor
+    {
+        $reflector = ReflectorBuilder::create()
+            ->addMemberProvider(new DocblockMemberProvider())
+            ->addSource($source)->build();
+
+        return new WorseClassMemberCompletor(
+            $reflector,
+            $this->formatter(),
+            new ObjectFormatter(),
+            ObjectRendererBuilder::create()->renderEmptyOnNotFound()->build()
+        );
+    }
+}

--- a/lib/Completion/Tests/Integration/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletorTestWithoutSnippetFormatter.php
+++ b/lib/Completion/Tests/Integration/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletorTestWithoutSnippetFormatter.php
@@ -9,11 +9,14 @@ use Phpactor\TextDocument\TextDocument;
 use Phpactor\WorseReflection\Bridge\Phpactor\MemberProvider\DocblockMemberProvider;
 use Phpactor\WorseReflection\ReflectorBuilder;
 use Phpactor\Completion\Bridge\TolerantParser\WorseReflection\WorseClassMemberCompletor;
+use Phpactor\Completion\Core\Suggestion;
 
+/** @phpstan-import-type SuggestionOptions from Suggestion */
 class WorseClassMemberCompletorTestWithoutSnippetFormatter extends WorseClassMemberCompletorTest
 {
     /**
      * @dataProvider provideComplete
+     * @param array<SuggestionOptions> $expected
      */
     public function testComplete(string $source, array $expected): void
     {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -796,11 +796,6 @@ parameters:
 			path: lib/Completion/Tests/Integration/Bridge/TolerantParser/SourceCodeFilesystem/ScfClassCompletorTest.php
 
 		-
-			message: "#^Method Phpactor\\\\Completion\\\\Tests\\\\Integration\\\\Bridge\\\\TolerantParser\\\\WorseReflection\\\\WorseClassMemberCompletorTest\\:\\:testComplete\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Completion/Tests/Integration/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletorTest.php
-
-		-
 			message: "#^Class Phpactor\\\\Completion\\\\Bridge\\\\TolerantParser\\\\WorseReflection\\\\WorseConstantCompletor does not have a constructor and must be instantiated without any parameters\\.$#"
 			count: 1
 			path: lib/Completion/Tests/Integration/Bridge/TolerantParser/WorseReflection/WorseConstantCompletorTest.php
@@ -3802,11 +3797,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$workspace of class Phpactor\\\\Extension\\\\LanguageServerReferenceFinder\\\\Handler\\\\GotoImplementationHandler constructor expects Phpactor\\\\LanguageServer\\\\Core\\\\Workspace\\\\Workspace, mixed given\\.$#"
-			count: 1
-			path: lib/Extension/LanguageServerReferenceFinder/LanguageServerReferenceFinderExtension.php
-
-		-
-			message: "#^Parameter \\#1 \\$workspace of class Phpactor\\\\Extension\\\\LanguageServerReferenceFinder\\\\Handler\\\\HighlightHandler constructor expects Phpactor\\\\LanguageServer\\\\Core\\\\Workspace\\\\Workspace, mixed given\\.$#"
 			count: 1
 			path: lib/Extension/LanguageServerReferenceFinder/LanguageServerReferenceFinderExtension.php
 


### PR DESCRIPTION
Fixes #2896 

When the snippet completions is disabled the snippetformatter has no formatters attached. So it crashes when trying to format a method. Now we just don't provide any snippets for the user if the formatter does not support it.