### PR TITLE
Fix parameter type resolution to take the most specific type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Features:
   - Search filtering (as applicable to autocomplete, name importing etc)
     @dantleech
 
+Bug fixes:
+  - Fix parameter type resolution priority @dantleech
+
 ## 2025.04.17.0
 
 Improvements:

--- a/lib/WorseReflection/Core/ClassHierarchyResolver.php
+++ b/lib/WorseReflection/Core/ClassHierarchyResolver.php
@@ -24,6 +24,9 @@ final class ClassHierarchyResolver
     }
 
     /**
+     * Returns an ordered list of all classes in the heierarchy with the base
+     * class being first and the provided class being last.
+     *
      * @param array<string,ReflectionClassLike> $resolved
      * @return ReflectionClassLike[]
      */

--- a/lib/WorseReflection/Core/Reflection/TypeResolver/ParameterTypeResolver.php
+++ b/lib/WorseReflection/Core/Reflection/TypeResolver/ParameterTypeResolver.php
@@ -39,7 +39,7 @@ class ParameterTypeResolver
             ClassHierarchyResolver::INCLUDE_PARENT | ClassHierarchyResolver::INCLUDE_INTERFACE
         ))->resolve($functionLike->class());
 
-        foreach ($hierarchy as $classLike) {
+        foreach (array_reverse($hierarchy) as $classLike) {
             // find declaring class
             if (!$classLike->methods()->has($functionLike->name())) {
                 continue;
@@ -50,7 +50,9 @@ class ParameterTypeResolver
             if (!$type->isDefined()) {
                 continue;
             }
+
             $aliased = $classLike->docblock()->typeAliases()->forType($type);
+
             if ($aliased) {
                 return $aliased;
             }

--- a/lib/WorseReflection/Tests/Inference/type/conditional-type-container.test
+++ b/lib/WorseReflection/Tests/Inference/type/conditional-type-container.test
@@ -1,0 +1,35 @@
+<?php
+
+namespace Bar;
+
+use Bang\Foobar;
+
+interface ContainerInterface
+{
+    /**
+     * @param string $id Identifier of the entry to look for.
+     *
+     * @throws NotFoundExceptionInterface  No entry was found for **this** identifier.
+     * @throws ContainerExceptionInterface Error while retrieving the entry.
+     *
+     * @return mixed Entry.
+     */
+    public function get(string $id);
+}
+
+interface Container extends ContainerInterface
+{
+    /**
+     * @template T of object
+     * @param class-string<T>|string $id
+     * @return ($id is class-string<T> ? T : mixed)
+     */
+    public function get($id);
+}
+
+function foo(Container $container): void
+{
+    $map = $container->get(Foobar::class);
+
+    wrAssertType('Bang\Foobar', $map);
+}

--- a/lib/WorseReflection/Tests/Unit/Core/ClassHierarchyResolverTest.php
+++ b/lib/WorseReflection/Tests/Unit/Core/ClassHierarchyResolverTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Phpactor\WorseReflection\Tests\Unit\Core;
+
+use Generator;
+use Phpactor\TestUtils\PHPUnit\TestCase;
+use Phpactor\WorseReflection\Core\ClassHierarchyResolver;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionClassLike;
+use Phpactor\WorseReflection\ReflectorBuilder;
+
+final class ClassHierarchyResolverTest extends TestCase
+{
+    /**
+     * @param list<string> $definitions
+     * @param list<string> $expected
+     * @dataProvider provideClassHierarchy
+     */
+    public function testClassHierarchy(array $definitions, array $expected): void
+    {
+        $reflector = ReflectorBuilder::create()->addSource(implode("\n", $definitions))->build();
+        $resolver = new ClassHierarchyResolver();
+        $hierarchy  =$resolver->resolve($reflector->reflectClassLike('Foobar'));
+        $names = array_map(fn (ReflectionClassLike $class) => $class->name()->__toString(), $hierarchy);
+
+        self::assertEquals($expected, array_values($names));
+    }
+
+    public static function provideClassHierarchy(): Generator
+    {
+        yield [
+            [
+                '<?php class Foobar {}',
+            ],
+            [
+                'Foobar'
+            ],
+        ];
+
+        yield [
+            [
+                '<?php class Barfoo {}',
+                '<?php class Foobar extends Barfoo {}',
+            ],
+            [
+                'Barfoo',
+                'Foobar',
+            ],
+        ];
+        yield [
+            [
+                '<?php interface Barfoo {}',
+                '<?php interface Foobar extends Barfoo {}',
+            ],
+            [
+                'Barfoo',
+                'Foobar',
+            ],
+        ];
+        yield [
+            [
+                '<?php interface Barfoo {}',
+                '<?php interface Foobar extends Barfoo {}',
+            ],
+            [
+                'Barfoo',
+                'Foobar',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Fixes issue whereby a generic type was not being resolved because it was "overridden" by a parent definition.