### PR TITLE
chore: add `ext-tokenizer` in the `require` section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "require": {
         "php": "^8.1",
         "ext-mbstring": "*",
+        "ext-tokenizer": "*",
         "composer/xdebug-handler": "^3.0",
         "symfony/yaml": "^5.1",
         "phpactor/container": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f32073d073d39d0c0dd3ba931c19e989",
+    "content-hash": "952d55f44d4102e9ce74d3fd0db44c03",
     "packages": [
         {
             "name": "amphp/amp",
@@ -7953,19 +7953,20 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "dms/phpunit-arraysubset-asserts": 20,
         "jetbrains/phpstorm-stubs": 20,
-        "phpactor/tolerant-php-parser": 20,
-        "dms/phpunit-arraysubset-asserts": 20
+        "phpactor/tolerant-php-parser": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.1",
-        "ext-mbstring": "*"
+        "ext-mbstring": "*",
+        "ext-tokenizer": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.1.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
This should fix issue like: https://github.com/NixOS/nixpkgs/pull/427092

The `composer.lock` has been updated by doing: `composer update --lock`.