### PR TITLE
Improved inlay hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,17 @@ Changelog
 
 ## master
 
+Improvements:
+
+  - Improved inlay type hints #2825 @dantleech
+
 Security:
 
-  - Ask permission before loading project-level `.phpactor.json`
+  - Ask permission before loading project-level `.phpactor.json` @dantleech
 
 Bug fixes:
 
-  - rename: Do not throw error if there is a reference to a now-non-existing file.
+  - rename: Do not throw error if there is a reference to a now-non-existing file. @dantleech
 
 ## 2025-07-25.0
 

--- a/lib/Extension/LanguageServerWorseReflection/InlayHint/InlayHintWalker.php
+++ b/lib/Extension/LanguageServerWorseReflection/InlayHint/InlayHintWalker.php
@@ -2,11 +2,20 @@
 
 namespace Phpactor\Extension\LanguageServerWorseReflection\InlayHint;
 
+use Microsoft\PhpParser\ClassLike;
+use Microsoft\PhpParser\FunctionLike;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\Expression\ArgumentExpression;
+use Microsoft\PhpParser\Node\Expression\AssignmentExpression;
 use Microsoft\PhpParser\Node\Expression\CallExpression;
 use Microsoft\PhpParser\Node\Expression\ObjectCreationExpression;
 use Microsoft\PhpParser\Node\Expression\Variable;
+use Microsoft\PhpParser\Node\MethodDeclaration;
+use Microsoft\PhpParser\Node\Statement\ClassDeclaration;
+use Microsoft\PhpParser\Node\Statement\EnumDeclaration;
+use Microsoft\PhpParser\Node\Statement\FunctionDeclaration;
+use Microsoft\PhpParser\Node\Statement\InterfaceDeclaration;
+use Microsoft\PhpParser\Node\Statement\TraitDeclaration;
 use Phpactor\Extension\LanguageServerBridge\Converter\PositionConverter;
 use Phpactor\LanguageServerProtocol\InlayHint;
 use Phpactor\LanguageServerProtocol\InlayHintKind;
@@ -20,6 +29,7 @@ use Phpactor\WorseReflection\Core\Inference\NodeContext;
 use Phpactor\WorseReflection\Core\Inference\Walker;
 use Phpactor\WorseReflection\Core\Reflection\Collection\ReflectionParameterCollection;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionMethod;
+use Phpactor\WorseReflection\Core\Util\NodeUtil;
 
 class InlayHintWalker implements Walker
 {
@@ -52,6 +62,12 @@ class InlayHintWalker implements Walker
         }
         if ($this->options->types && $node instanceof Variable) {
             $this->fromVariable($resolver, $frame, $node);
+        }
+        if ($this->options->types && $node instanceof ClassLike) {
+            $this->fromClassLike($resolver, $frame, $node);
+        }
+        if ($this->options->types && $node instanceof FunctionLike) {
+            $this->fromFunctionLike($resolver, $frame, $node);
         }
         if ($this->options->params && $node instanceof CallExpression) {
             $this->fromCall($resolver, $frame, $node);
@@ -97,16 +113,27 @@ class InlayHintWalker implements Walker
             if (!$argument instanceof ArgumentExpression) {
                 continue;
             }
+            if ($argument->name) {
+                continue;
+            }
             $parameter = $parameters->at($index);
             if (null === $parameter) {
                 break;
             }
+
+            if ($argument->expression instanceof Variable) {
+                $name = NodeUtil::nameFromTokenOrNode($argument->expression, $argument->expression->name);
+                if (ltrim($name, '$') === $parameter->name()) {
+                    continue;
+                }
+            }
             $this->hints[] = new InlayHint(
                 position: PositionConverter::intByteOffsetToPosition($argument->getStartPosition(), $node->getFileContents()),
-                label: $parameter->name(),
+                label: sprintf('%s:', $parameter->name()),
                 kind: InlayHintKind::PARAMETER,
                 textEdits: null,
                 tooltip: $parameter->type()->__toString(),
+                paddingRight: true,
             );
         }
     }
@@ -114,6 +141,14 @@ class InlayHintWalker implements Walker
     private function fromVariable(FrameResolver $resolver, Frame $frame, Variable $node): void
     {
         $name = $node->getName();
+        if (!$node->parent instanceof AssignmentExpression) {
+            return;
+        }
+
+        if (null === $name) {
+            return;
+        }
+
         $variable = $resolver->resolveNode($frame, $node);
 
         if (false === $variable->type()->isDefined()) {
@@ -121,8 +156,11 @@ class InlayHintWalker implements Walker
         }
 
         $this->hints[] = new InlayHint(
-            position: PositionConverter::intByteOffsetToPosition($node->getStartPosition(), $node->getFileContents()),
-            label: $variable->type()->short(),
+            position: PositionConverter::intByteOffsetToPosition(
+                $node->getEndPosition(),
+                $node->getFileContents()
+            ),
+            label: sprintf(': %s', $variable->type()->short()),
             tooltip: $variable->type()->__toString(),
             kind: InlayHintKind::TYPE,
             textEdits: null,
@@ -135,7 +173,9 @@ class InlayHintWalker implements Walker
         if (!$context instanceof ClassLikeContext) {
             return;
         }
+
         $method = $context->classLike()->methods()->byName('__construct')->firstOrNull();
+
         if (!$method instanceof ReflectionMethod) {
             return;
         }
@@ -145,17 +185,54 @@ class InlayHintWalker implements Walker
             if (!$argument instanceof ArgumentExpression) {
                 continue;
             }
+            if ($argument->name !== null) {
+                continue;
+            }
             $parameter = $parameters->at($index);
             if (null === $parameter) {
                 break;
             }
             $this->hints[] = new InlayHint(
                 position: PositionConverter::intByteOffsetToPosition($argument->getStartPosition(), $node->getFileContents()),
-                label: $parameter->name(),
+                label: sprintf('%s:', $parameter->name()),
                 kind: InlayHintKind::PARAMETER,
                 textEdits: null,
                 tooltip: $parameter->type()->__toString(),
+                paddingRight: true,
             );
         }
+    }
+
+    private function fromClassLike(FrameResolver $resolver, Frame $frame, Node&ClassLike $node): void
+    {
+        if (!$node instanceof ClassDeclaration && !$node instanceof EnumDeclaration && !$node instanceof TraitDeclaration && !$node instanceof InterfaceDeclaration) {
+            return;
+        }
+        $context = $resolver->resolveNode($frame, $node);
+
+        $this->hints[] = new InlayHint(
+            position: PositionConverter::intByteOffsetToPosition($node->getEndPosition(), $node->getFileContents()),
+            label: sprintf('%s %s', $context->symbol()->symbolType(), $context->symbol()->name()),
+            kind: InlayHintKind::TYPE,
+            textEdits: null,
+            paddingLeft: true,
+        );
+    }
+
+    private function fromFunctionLike(FrameResolver $resolver, Frame $frame, Node&FunctionLike $node): void
+    {
+        if (!$node instanceof MethodDeclaration && !$node instanceof FunctionDeclaration) {
+            return;
+        }
+        $name = NodeUtil::nameFromTokenOrNode($node, $node->name);
+        $type = $node instanceof MethodDeclaration ? 'method' : 'function';
+
+        $this->hints[] = new InlayHint(
+            position: PositionConverter::intByteOffsetToPosition($node->getEndPosition(), $node->getFileContents()),
+            label: sprintf('%s %s', $type, $name),
+            kind: InlayHintKind::TYPE,
+            textEdits: null,
+            paddingLeft: true,
+        );
     }
 }

--- a/lib/Extension/LanguageServerWorseReflection/Tests/InlayHint/InlayHintProviderTest.php
+++ b/lib/Extension/LanguageServerWorseReflection/Tests/InlayHint/InlayHintProviderTest.php
@@ -46,53 +46,112 @@ class InlayHintProviderTest extends IntegrationTestCase
         yield 'inlay hint for member' => [
             '<?php class Foo{ function bar(string $bar): void {}} (new Foo())->bar("hello");',
             function (array $hints): void {
-                self::assertCount(1, $hints);
-                $hint = reset($hints);
+                self::assertCount(3, $hints);
+                $hint = $hints[2];
                 assert($hint instanceof InlayHint);
                 self::assertEquals(0, $hint->position->line);
-                self::assertEquals('bar', $hint->label);
+                self::assertEquals('bar:', $hint->label);
                 self::assertEquals('string', $hint->tooltip);
             }
         ];
-        yield 'inlay hint for variable' => [
+        yield 'inlay hint for variable only definitions' => [
             '<?php $foo = "foo"; $foo;',
             function (array $hints): void {
-                self::assertCount(2, $hints);
-                $hint = $hints[1];
+                self::assertCount(1, $hints);
+                $hint = $hints[0];
                 assert($hint instanceof InlayHint);
                 self::assertEquals(0, $hint->position->line);
-                self::assertEquals('string', $hint->label);
+                self::assertEquals(': string', $hint->label);
                 self::assertEquals('"foo"', $hint->tooltip);
+            }
+        ];
+        yield 'inlay hint for variable only definitions 2' => [
+            '<?php $foo = "foo"; $foo->bar();',
+            function (array $hints): void {
+                self::assertCount(1, $hints);
+                $hint = $hints[0];
+                assert($hint instanceof InlayHint);
+                self::assertEquals(0, $hint->position->line);
+                self::assertEquals(': string', $hint->label);
+                self::assertEquals('"foo"', $hint->tooltip);
+            }
+        ];
+        yield 'inlay hint for variable only definitions 3' => [
+            '<?php class Fo {function bar():string {}}; $foo = new Fo(); $foo->bar(); $bar = $foo->bar();',
+            function (array $hints): void {
+                self::assertCount(4, $hints);
+                $hint = $hints[2];
+                assert($hint instanceof InlayHint);
+                self::assertEquals(0, $hint->position->line);
+                self::assertEquals(': Fo', $hint->label);
+            }
+        ];
+        yield 'inlay hint for variable only definitions 4' => [
+            '<?php class Fo {function bar():string { if ($this->bar() == "bar") {}; }};',
+            function (array $hints): void {
+                self::assertCount(2, $hints);
             }
         ];
         yield 'inlay hint for class instantiation' => [
             '<?php class A { function __construct($a, $b) {}} new A(1, 2)',
             function (array $hints): void {
-                self::assertCount(2, $hints);
-                $hint = $hints[1];
+                self::assertCount(4, $hints);
+                $hint = $hints[3];
                 assert($hint instanceof InlayHint);
                 self::assertEquals(0, $hint->position->line);
-                self::assertEquals('b', $hint->label);
+                self::assertEquals('b:', $hint->label);
             }
         ];
         yield 'inlay hint for function call' => [
             '<?php function foobar($a, $b) {} foobar(1, 2);',
             function (array $hints): void {
-                self::assertCount(2, $hints);
-                $hint = $hints[1];
+                self::assertCount(3, $hints);
+                $hint = $hints[2];
                 assert($hint instanceof InlayHint);
                 self::assertEquals(0, $hint->position->line);
-                self::assertEquals('b', $hint->label);
+                self::assertEquals('b:', $hint->label);
+            }
+        ];
+        yield 'inlay hint for function call ignore named' => [
+            '<?php function foobar($a, $b) {} foobar(1, b: 2);',
+            function (array $hints): void {
+                self::assertCount(2, $hints);
+            }
+        ];
+        yield 'inlay hint for function call ignore if variable name same' => [
+            '<?php function foobar($a, $b) {} foobar(1, $b);',
+            function (array $hints): void {
+                self::assertCount(2, $hints);
             }
         ];
         yield 'inlay hint for stub function' => [
             '<?php function array_map($func, $arr){}array_map("trim", []);',
             function (array $hints): void {
+                self::assertCount(3, $hints);
+                $hint = $hints[2];
+                assert($hint instanceof InlayHint);
+                self::assertEquals(0, $hint->position->line);
+                self::assertEquals('arr:', $hint->label);
+            }
+        ];
+        yield 'inlay hint for class' => [
+            '<?php class Foobar {}',
+            function (array $hints): void {
+                self::assertCount(1, $hints);
+                $hint = $hints[0];
+                assert($hint instanceof InlayHint);
+                self::assertEquals(0, $hint->position->line);
+                self::assertEquals('class Foobar', $hint->label);
+            }
+        ];
+        yield 'inlay hint for method' => [
+            '<?php class Foobar { public function bar(): string {}}',
+            function (array $hints): void {
                 self::assertCount(2, $hints);
                 $hint = $hints[1];
                 assert($hint instanceof InlayHint);
                 self::assertEquals(0, $hint->position->line);
-                self::assertEquals('arr', $hint->label);
+                self::assertEquals('class Foobar', $hint->label);
             }
         ];
     }


### PR DESCRIPTION
- Format inlay hints after Rust Analyzer
- Do not show hints for named parameters
- Do not show hints if variable name is same as parameter name
- Show type hint for class body
- Show type hint for method body