### PR TITLE
Prioritize static patterns over dynamic ones

### DIFF
--- a/lib/Filesystem/Domain/FileList.php
+++ b/lib/Filesystem/Domain/FileList.php
@@ -105,6 +105,12 @@ class FileList implements Iterator
 
         // Sort map by keys so that more specific paths are getting matched first
         uksort($inclusionMap, function (string $a, string $b) {
+            $aIsDynamic = Glob::isDynamic($a);
+            $bIsDynamic = Glob::isDynamic($b);
+            if ($aIsDynamic !== $bIsDynamic) {
+                return $aIsDynamic ? 1 : -1;
+            }
+
             $partsA = explode(DIRECTORY_SEPARATOR, $a);
             $partsB = explode(DIRECTORY_SEPARATOR, $b);
             $countDiff = count($partsA) <=> count($partsB);

--- a/lib/Filesystem/Tests/Unit/Domain/FileListTest.php
+++ b/lib/Filesystem/Tests/Unit/Domain/FileListTest.php
@@ -120,6 +120,7 @@ class FileListTest extends IntegrationTestCase
             FilePath::fromString('/vendor/foo/bar/tests/footest.php'),
             FilePath::fromString('/vendor/foo/bar/src/bar.php'),
             FilePath::fromString('/vendor/foo/bar/src/foo.php'),
+            FilePath::fromString('/resultCache.php'),
         ]);
 
         self::assertEquals(
@@ -129,7 +130,7 @@ class FileListTest extends IntegrationTestCase
             ],
             iterator_to_array($list->includeAndExclude(
                 includePatterns: ['/**/*'],
-                excludePatterns: [ '/vendor/**/tests/*']
+                excludePatterns: ['/vendor/**/tests/*', '/resultCache.php']
             ))
         );
     }


### PR DESCRIPTION
As added in the test case, it is inconvenient that you cannot exclude static files directly under the project root.