### PR TITLE
POC to import previously local references after class move

### DIFF
--- a/lib/ClassMover/ClassMover.php
+++ b/lib/ClassMover/ClassMover.php
@@ -33,6 +33,14 @@ class ClassMover
         return new FoundReferences($source, $name, $references);
     }
 
+    public function findLocalReferences(FullyQualifiedName $sourceName, string $sourceCode): FoundReferences
+    {
+        $sourceCode = TextDocumentBuilder::create($sourceCode)->build();
+        $references = $this->finder->findIn($sourceCode)->filterLocal($sourceName)->filterLocal($sourceName);
+
+        return new FoundReferences($sourceCode, $sourceName, $references);
+    }
+
     public function replaceReferences(FoundReferences $foundReferences, string $newFullyQualifiedName): TextEdits
     {
         $newName = FullyQualifiedName::fromString($newFullyQualifiedName);

--- a/lib/ClassMover/Domain/Reference/NamespacedClassReferences.php
+++ b/lib/ClassMover/Domain/Reference/NamespacedClassReferences.php
@@ -47,6 +47,14 @@ final class NamespacedClassReferences implements IteratorAggregate
         }));
     }
 
+    public function filterLocal(FullyQualifiedName $name): NamespacedClassReferences
+    {
+        return new self($this->namespaceRef, array_filter($this->classRefs, function (ClassReference $classRef) use ($name) {
+            return $classRef->fullName()->parentNamespace()->equals($name->parentNamespace())
+                && false === $classRef->fullName()->equals($name); // skip self reference
+        }));
+    }
+
     public function isEmpty(): bool
     {
         return $this->classRefs === [];

--- a/lib/Extension/ClassMover/Command/Logger/SymfonyConsoleMoveLogger.php
+++ b/lib/Extension/ClassMover/Command/Logger/SymfonyConsoleMoveLogger.php
@@ -40,4 +40,21 @@ class SymfonyConsoleMoveLogger implements ClassMoverLogger
             ));
         }
     }
+
+    public function import(FilePath $path, FoundReferences $references): void
+    {
+        if ($references->references()->isEmpty()) {
+            return;
+        }
+        $this->output->writeln('<info>[USE]</> <comment>'.$path.'</>');
+
+        foreach ($references->references() as $reference) {
+            $this->output->writeln(sprintf(
+                '       %s:%s <comment>=></> use %s',
+                $reference->position()->start(),
+                $reference->position()->end(),
+                (string) $reference->fullName()
+            ));
+        }
+    }
 }


### PR DESCRIPTION
Work in progress as it needs some cleaning up and needs tests. 

Currently I'm restructuring a project, so a lot of classes and namespaces being moved. In the past I often just used PHPStorm as a fallback for this, but I decided to figure out how to use phpactor for it. 
I'm honestly not sure what the best approach would be, as looking at it per file/class not always the most useful when doing big refactors. But for now this resolves one of my issues :sweat_smile:  