### PR TITLE
gh-2913: avoid infinite loop when resolving constant type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Security:
 Bug fixes:
 
   - rename: Do not throw error if there is a reference to a now-non-existing file. @dantleech
+  - avoid infinite loop when looking up constant type #2913 @dantleech
 
 ## 2025-07-25.0
 

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionDeclaredConstant.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionDeclaredConstant.php
@@ -5,6 +5,7 @@ namespace Phpactor\WorseReflection\Bridge\TolerantParser\Reflection;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\Expression\ArgumentExpression;
 use Microsoft\PhpParser\Node\Expression\CallExpression;
+use Microsoft\PhpParser\Node\QualifiedName;
 use Microsoft\PhpParser\Node\StringLiteral;
 use Phpactor\WorseReflection\Core\DocBlock\DocBlock;
 use Phpactor\WorseReflection\Core\Inference\Frame\ConcreteFrame;
@@ -13,6 +14,7 @@ use Phpactor\WorseReflection\Core\Reflection\ReflectionDeclaredConstant as Phpac
 use Phpactor\TextDocument\TextDocument;
 use Phpactor\WorseReflection\Core\Type;
 use Phpactor\WorseReflection\Core\ServiceLocator;
+use Phpactor\WorseReflection\Core\TypeFactory;
 
 class ReflectionDeclaredConstant extends AbstractReflectedNode implements PhpactorReflectionDeclaredConstant
 {
@@ -35,6 +37,13 @@ class ReflectionDeclaredConstant extends AbstractReflectedNode implements Phpact
 
     public function type(): Type
     {
+        // gh-2913: do not try and lookup constant values in order to avoid
+        // infinite loops.
+        //
+        // @phpstan-ignore instanceof.alwaysFalse
+        if ($this->value->expression instanceof QualifiedName) {
+            return TypeFactory::unknown();
+        }
         return $this->serviceLocator->nodeContextResolver()->resolveNode(new ConcreteFrame(), $this->value)->type();
     }
 

--- a/lib/WorseReflection/Tests/Inference/qualified-name/gh-2913.test
+++ b/lib/WorseReflection/Tests/Inference/qualified-name/gh-2913.test
@@ -1,0 +1,9 @@
+<?php
+
+define('Timer', Timer);
+
+// we do not evaluate possible constant references in constant declarations to avoid
+// inifinite loops
+wrAssertType('<missing>', Timer);
+
+


### PR DESCRIPTION
When we have a cycle such as `declare('Foo', Foo)` PHP will bail at runtime because it will evaluate `Foo` before `declare`. Phpactor will evalute `Foo` lazily - but even if it located it eagerly (bad for performance) the indxer _will find_ the constant, because the indexer doesn't know that the value causes a cycle.

for now we only evaluate literal values.

Fixes #2913 