### PR TITLE
Reset workspace to remove generated TestCase.php

### DIFF
--- a/lib/Extension/PHPUnit/Tests/Unit/CodeTransform/GenerateTestMethodsTest.php
+++ b/lib/Extension/PHPUnit/Tests/Unit/CodeTransform/GenerateTestMethodsTest.php
@@ -28,6 +28,11 @@ class GenerateTestMethodsTest extends WorseTestCase
         );
     }
 
+    public function tearDown(): void
+    {
+        $this->workspace()->reset();
+    }
+
     /**
      * @param array<string> $expected
      *


### PR DESCRIPTION
The test [GenerateTestMethodsTest.php](https://github.com/phpactor/phpactor/compare/master...rafalglowacz:cleanup-test-testcase?expand=1#diff-bf54a431596f34d3802e770169e3a2ef61d476491653a472f4df18db11c3754a) creates an example class called `PHPUnit\Framework\TestCase` and its file is left behind after tests. When later browsing Phpactor's test suite, this dummy file can be detected as the base class of the current test and no inherited methods can be found (like `self::assertEquals()` etc.)

To deal with that, I'm proposing to reset the workspace folder after the test, which will delete the generated file.

I guess another solution would be to rename the generated class so that it doesn't conflict with existing classes. Let me know what you think.