### PR TITLE
Fixing typo in missing_class_generic diagnostic

### DIFF
--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/DocblockMissingClassGenericDiagnostic.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/DocblockMissingClassGenericDiagnostic.php
@@ -60,6 +60,6 @@ class DocblockMissingClassGenericDiagnostic implements Diagnostic
 
     public function code(): string
     {
-        return 'doblock_missing_class_generic';
+        return 'docblock_missing_class_generic';
     }
 }


### PR DESCRIPTION
A small typo in the diagnostic name 