### PR TITLE
Support for stubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@ Changelog
 
 ## master
 
-Imrprovements:
+Features:
+
+  - Additive stubs #2968 @dantleech
+
+Improvements:
 
   - Restrict attribute completion using targets #2629 @przepompownia
   - Use the Phan fork of the Tolerant Parser as a base #2946 @dantleech

--- a/doc/reference/configuration.rst
+++ b/doc/reference/configuration.rst
@@ -903,6 +903,19 @@ Location of the core PHP stubs - these will be scanned and cached on the first r
 **Default**: ``"%application_root%\/vendor\/jetbrains\/phpstorm-stubs"``
 
 
+.. _param_worse_reflection.additive_stubs:
+
+
+``worse_reflection.additive_stubs``
+"""""""""""""""""""""""""""""""""""
+
+
+Additive stubs files relative to the project root. These stubs augment existing defininitions.
+
+
+**Default**: ``[]``
+
+
 .. _param_worse_reflection.diagnostics.undefined_variable.suggestion_levenshtein_disatance:
 
 
@@ -933,7 +946,7 @@ FilePathResolverExtension
 """""""""""""""""""""""""""""""""""
 
 
-**Default**: ``"\/home\/arctgx\/dev\/arctgx\/php\/phpactor\/phpactor-dev"``
+**Default**: ``"\/home\/daniel\/www\/phpactor\/phpactor"``
 
 
 .. _param_file_path_resolver.app_name:
@@ -1426,7 +1439,7 @@ Amount of time (in milliseconds) to wait before responding to a shutdown notific
 Internal use only - name path to Phpactor binary
 
 
-**Default**: ``"\/home\/arctgx\/dev\/arctgx\/php\/phpactor\/phpactor-dev\/lib\/Extension\/LanguageServer\/..\/..\/..\/bin\/phpactor"``
+**Default**: ``"\/home\/daniel\/www\/phpactor\/phpactor\/lib\/Extension\/LanguageServer\/..\/..\/..\/bin\/phpactor"``
 
 
 .. _param_language_server.self_destruct_timeout:

--- a/doc/reference/stubs.rst
+++ b/doc/reference/stubs.rst
@@ -1,0 +1,34 @@
+.. _stubs:
+
+Stubs
+=====
+
+Phpactor has two types of "stubs":
+
+PHP Core Stubs
+--------------
+
+These stubs fill in for definitions (classes, functions and constants) that are
+defined in the PHP core or in PHP extensions. Phpactor expects the path to be a
+single directory and that directory is configured by default to be the one
+containing the `PHPStorm stubs <https://github.com/JetBrains/phpstorm-stubs/>`_
+that are bundled with Phpactor.
+
+You probably do **not** want to change this setting, but the directory *can* be
+changed at as :ref:`param_worse_reflection.additive_stubs`.
+
+Additive Stubs
+--------------
+
+These stubs **augment** existing classes. For example, in Laravel you may use the `Laravel IDE Helper <https://github.com/barryvdh/laravel-ide-helper>`_ package to provide missing "magic" methods and properties. New definitions cannot be provided with additive stubs.
+
+
+You can specify these stub files with :ref:`param_worse_reflection.additive_stubs` and the stubs will merge onto the existing definitions.
+
+.. note:: 
+
+   Additive stubs should *not* be indexed as Phpactor will be unable to
+   determine which definition is the canonical one. If you use additive stubs
+   ensure that you also manually specify which directories contain your project code (typically `src` and `tests`).
+
+   The indexer include patterns can be specified with :ref:`param_indexer.include_patterns`.

--- a/lib/Extension/LanguageServerWorseReflection/LanguageServerWorseReflectionExtension.php
+++ b/lib/Extension/LanguageServerWorseReflection/LanguageServerWorseReflectionExtension.php
@@ -10,12 +10,14 @@ use Phpactor\Extension\LanguageServerWorseReflection\Handler\InlayHintHandler;
 use Phpactor\Extension\LanguageServerWorseReflection\InlayHint\InlayHintOptions;
 use Phpactor\Extension\LanguageServerWorseReflection\InlayHint\InlayHintProvider;
 use Phpactor\Extension\LanguageServerWorseReflection\Listener\InvalidateDocumentCacheListener;
+use Phpactor\Extension\LanguageServerWorseReflection\Listener\StubValidationListener;
 use Phpactor\Extension\LanguageServerWorseReflection\SourceLocator\WorkspaceSourceLocator;
 use Phpactor\Extension\LanguageServerWorseReflection\Workspace\WorkspaceIndex;
 use Phpactor\Extension\LanguageServerWorseReflection\Workspace\WorkspaceIndexListener;
 use Phpactor\Extension\LanguageServer\Container\DiagnosticProviderTag;
 use Phpactor\Extension\LanguageServer\LanguageServerExtension;
 use Phpactor\Extension\WorseReflection\WorseReflectionExtension;
+use Phpactor\LanguageServer\Core\Server\ClientApi;
 use Phpactor\LanguageServer\Core\Workspace\Workspace;
 use Phpactor\MapResolver\Resolver;
 use Phpactor\WorseReflection\Core\CacheForDocument;
@@ -34,6 +36,13 @@ class LanguageServerWorseReflectionExtension implements Extension
     public function load(ContainerBuilder $container): void
     {
         $this->registerSourceLocator($container);
+
+        $container->register(StubValidationListener::class, function (Container $container) {
+            return new StubValidationListener(
+                $container->get(ClientApi::class),
+                $container->parameter(WorseReflectionExtension::PARAM_ADDITIVE_STUBS)->listOfString(),
+            );
+        }, [ LanguageServerExtension::TAG_LISTENER_PROVIDER => [] ]);
     }
 
     public function configure(Resolver $schema): void

--- a/lib/Extension/LanguageServerWorseReflection/Listener/StubValidationListener.php
+++ b/lib/Extension/LanguageServerWorseReflection/Listener/StubValidationListener.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerWorseReflection\Listener;
+
+use Phpactor\LanguageServer\Core\Server\ClientApi;
+use Phpactor\LanguageServer\Event\Initialized;
+use Psr\EventDispatcher\ListenerProviderInterface;
+
+class StubValidationListener implements ListenerProviderInterface
+{
+    /**
+     * @param list<string> $stubPaths
+     */
+    public function __construct(private ClientApi $api, private array $stubPaths)
+    {
+    }
+
+    /**
+     * @return iterable<callable>
+     */
+    public function getListenersForEvent($event): iterable
+    {
+        if (!$event instanceof Initialized) {
+            return;
+        }
+
+
+        yield function (): void {
+            $invalidPaths = [];
+            foreach ($this->stubPaths as $stubPath) {
+                if (file_exists($stubPath)) {
+                    continue;
+                }
+
+                $invalidPaths[] = $stubPath;
+            }
+
+            if ([] === $invalidPaths) {
+                return;
+            }
+
+            $this->api->window()->showMessage()->warning(sprintf(
+                'The following stubs could not be found: "%s"',
+                implode('", "', $invalidPaths)
+            ));
+        };
+    }
+}

--- a/lib/Extension/WorseReflection/Tests/Unit/WorseReflectionExtensionTest.php
+++ b/lib/Extension/WorseReflection/Tests/Unit/WorseReflectionExtensionTest.php
@@ -39,6 +39,21 @@ class WorseReflectionExtensionTest extends TestCase
         $this->assertEquals((string) $reflector->reflectClass(__CLASS__)->name(), __CLASS__);
     }
 
+    public function testAdditiveStubPaths(): void
+    {
+        $reflector = $this->createReflector([
+            WorseReflectionExtension::PARAM_ADDITIVE_STUBS => [
+                'example/stub.stub',
+            ],
+            FilePathResolverExtension::PARAM_APPLICATION_ROOT => __DIR__ . '/../../../../..',
+            FilePathResolverExtension::PARAM_PROJECT_ROOT => __DIR__
+        ]);
+
+        $reflection = $reflector->reflectClass(__CLASS__);
+        $method = $reflection->methods()->byName('testAdditiveStubPaths')->first();
+        self::assertEquals('string', $method->inferredType()->__toString());
+    }
+
     public function testProvideReflectorWithStubsAndCustomCacheDir(): void
     {
         $reflector = $this->createReflector([

--- a/lib/Extension/WorseReflection/Tests/Unit/example/stub.stub
+++ b/lib/Extension/WorseReflection/Tests/Unit/example/stub.stub
@@ -1,0 +1,14 @@
+<?php
+
+namespace Phpactor\Extension\WorseReflection\Tests\Unit;
+
+class WorseReflectionExtensionTest extends TestCase
+{
+    /**
+     * @return string
+     */
+    public function testAdditiveStubPaths(): void
+    {
+    }
+}
+

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionClass.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionClass.php
@@ -83,9 +83,11 @@ class ReflectionClass extends AbstractReflectionClass implements CoreReflectionC
             return $this->members;
         }
         $members = ClassLikeReflectionMemberCollection::empty();
+        $providedMembers = ClassLikeReflectionMemberCollection::empty();
         foreach ($this->hierarchy() as $reflectionClassLike) {
             $classLikeMembers = $reflectionClassLike->ownMembers();
-            $classLikeMembers = $classLikeMembers->merge($this->serviceLocator->methodProviders()->provideMembers(
+            /** @phpstan-ignore-next-line collection IS compatible */
+            $providedMembers = $providedMembers->merge($this->serviceLocator->methodProviders()->provideMembers(
                 $this->serviceLocator,
                 $reflectionClassLike
             ));
@@ -115,6 +117,7 @@ class ReflectionClass extends AbstractReflectionClass implements CoreReflectionC
                 continue;
             }
         }
+        $members = $members->merge($providedMembers);
         $this->members = $members->map(fn (ReflectionMember $member) => $member->withClass($this));
 
         return $this->members;

--- a/lib/WorseReflection/Core/ServiceLocator.php
+++ b/lib/WorseReflection/Core/ServiceLocator.php
@@ -4,6 +4,7 @@ namespace Phpactor\WorseReflection\Core;
 
 use Phpactor\WorseReflection\Bridge\Phpactor\DocblockParser\CachedParserFactory;
 use Phpactor\WorseReflection\Bridge\Phpactor\DocblockParser\DocblockParserFactory;
+use Phpactor\WorseReflection\Bridge\Phpactor\MemberProvider\DocblockMemberProvider;
 use Phpactor\WorseReflection\Core\Cache\NullCache;
 use Phpactor\WorseReflection\Core\Cache\StaticCache;
 use Phpactor\WorseReflection\Core\Inference\GenericMapResolver;
@@ -28,6 +29,7 @@ use Phpactor\WorseReflection\Core\SourceCodeLocator\ChainSourceLocator;
 use Phpactor\WorseReflection\Core\SourceCodeLocator\TemporarySourceLocator;
 use Phpactor\WorseReflection\Core\DocBlock\DocBlockFactory;
 use Phpactor\WorseReflection\Core\Reflector\SourceCodeReflectorFactory;
+use Phpactor\WorseReflection\ReflectorBuilder;
 use Psr\Log\LoggerInterface;
 
 class ServiceLocator
@@ -169,5 +171,13 @@ class ServiceLocator
     public function newDiagnosticsWalker(): DiagnosticsWalker
     {
         return new DiagnosticsWalker($this->diagnosticProviders);
+    }
+
+    public function stubReflector(): Reflector
+    {
+        return ReflectorBuilder::create()
+            ->addLocator($this->sourceLocator)
+            ->addMemberProvider(new DocblockMemberProvider())
+            ->build();
     }
 }

--- a/lib/WorseReflection/Core/Virtual/StubFileMemberProvider.php
+++ b/lib/WorseReflection/Core/Virtual/StubFileMemberProvider.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Phpactor\WorseReflection\Core\Virtual;
+
+use Phpactor\TextDocument\TextDocumentBuilder;
+use Phpactor\WorseReflection\Core\Reflection\Collection\ChainReflectionMemberCollection;
+use Phpactor\WorseReflection\Core\Reflection\Collection\ReflectionMemberCollection;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionClassLike;
+use Phpactor\WorseReflection\Core\ServiceLocator;
+use RuntimeException;
+
+class StubFileMemberProvider implements ReflectionMemberProvider
+{
+    /**
+     * @var array<string,ReflectionClassLike>
+     */
+    private array $stubClasses = [];
+
+    private bool $initialized = false;
+
+    /**
+     * @param list<string> $stubFiles
+     */
+    public function __construct(private array $stubFiles)
+    {
+    }
+
+    public function provideMembers(ServiceLocator $locator, ReflectionClassLike $class): ReflectionMemberCollection
+    {
+        $this->buildMap($locator);
+
+        if (!isset($this->stubClasses[$class->name()->__toString()])) {
+            return ChainReflectionMemberCollection::fromCollections([]);
+        }
+
+        $stubClass = $this->stubClasses[$class->name()->__toString()];
+        return $stubClass->members();
+    }
+
+    private function buildMap(ServiceLocator $locator): void
+    {
+        if ($this->initialized === true) {
+            return;
+        }
+
+        $classes = [];
+        foreach ($this->stubFiles as $stubFile) {
+            try {
+                $document = TextDocumentBuilder::fromUri($stubFile)->language('php')->build();
+            } catch (RuntimeException) {
+                // depend on validation on startup rather than break everything
+                continue;
+            }
+            foreach ($locator->stubReflector()->reflectClassesIn(
+                $document,
+            ) as $class) {
+                $classes[$class->name()->__toString()] = $class;
+            }
+        }
+
+        $this->stubClasses = $classes;
+        $this->initialized = true;
+    }
+}

--- a/lib/WorseReflection/Tests/Unit/Core/Virtual/StubMemberProviderTest.php
+++ b/lib/WorseReflection/Tests/Unit/Core/Virtual/StubMemberProviderTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Phpactor\WorseReflection\Tests\Unit\Core\Virtual;
+
+use PHPUnit\Framework\TestCase;
+use Phpactor\TextDocument\TextDocumentBuilder;
+use Phpactor\WorseReflection\Core\Virtual\StubFileMemberProvider;
+use Phpactor\WorseReflection\Reflector;
+use Phpactor\WorseReflection\ReflectorBuilder;
+
+class StubMemberProviderTest extends TestCase
+{
+    public function testProvider(): void
+    {
+        $stubs = [__DIR__ . '/example/model.stub'];
+        $reflector = $this->createReflector($stubs);
+
+        $classes = $reflector->reflectClassesIn(
+            TextDocumentBuilder::fromUri(__DIR__ . '/example/model.php.test')->build()
+        );
+
+        $reflection = $classes->get('Example\Model');
+        self::assertEquals('static(Example\Model)|false', $reflection->methods()->get('findOne')->inferredType()->__toString());
+    }
+
+    public function testProviderExtended(): void
+    {
+        $stubs = [__DIR__ . '/example/model.stub'];
+        $reflector = $this->createReflector($stubs);
+
+        $classes = $reflector->reflectClassesIn(
+            TextDocumentBuilder::fromUri(__DIR__ . '/example/model.php.test')->build()
+        );
+
+        $reflection = $classes->get('Example\Blog');
+        self::assertEquals(
+            'static(Example\Blog)|false',
+            $reflection->methods()->get(
+                'findOne'
+            )->inferredType()->__toString()
+        );
+    }
+
+    public function testProvideVirtualMethodsFromStubs(): void
+    {
+        $stubs = [__DIR__ . '/example/model.stub'];
+        $reflector = $this->createReflector($stubs);
+
+        $classes = $reflector->reflectClassesIn(
+            TextDocumentBuilder::fromUri(__DIR__ . '/example/model.php.test')->build()
+        );
+
+        $reflection = $classes->get('Example\Blog');
+        self::assertEquals(
+            'string',
+            $reflection->properties()->get('virtualString')->inferredType()->__toString()
+        );
+    }
+
+    /**
+     * @param string[]  $stubs
+     */
+    private function createReflector(array $stubs): Reflector
+    {
+        $reflector = ReflectorBuilder::create()
+            ->enableContextualSourceLocation()
+            ->addMemberProvider(
+                new StubFileMemberProvider($stubs)
+            )
+            ->build();
+        return $reflector;
+    }
+}

--- a/lib/WorseReflection/Tests/Unit/Core/Virtual/example/model.php.test
+++ b/lib/WorseReflection/Tests/Unit/Core/Virtual/example/model.php.test
@@ -1,0 +1,20 @@
+<?php
+
+namespace Example;
+
+/**
+ * @property string $virtualString
+ * @method \stdClass foobar(string $bar)
+ */
+interface ModelInterface {
+    public static function findOne();
+}
+
+class Model implements ModelInterface {
+    public static function query($dependencyInjector = null)
+    {
+    }
+}
+
+
+class Blog extends Model {}

--- a/lib/WorseReflection/Tests/Unit/Core/Virtual/example/model.stub
+++ b/lib/WorseReflection/Tests/Unit/Core/Virtual/example/model.stub
@@ -1,0 +1,21 @@
+<?php
+
+namespace Example;
+
+/**
+ * @property string $virtualString
+ * @method \stdClass foobar(string $bar)
+ */
+interface ModelInterface {
+    /**
+     * @return \Phalcon\Mvc\Model\Criteria<static>
+     */
+    public static function query(\Phalcon\DiInterface $dependencyInjector = null);
+    /**
+     * @return static|false
+     */
+    public static function findOne()
+    {
+    }
+}
+


### PR DESCRIPTION
This PR aims to introduce a way to introduce _additive_ stubs. i.e. a way to overlay stubs to augment existing classes (for example Laravel)

- Additive stubs are provided through the `MemberProvder` mechanism.
- Provided members always override members in the class hierarchy.
- Stubs are validated for existence on LS initialization.

