### PR TITLE
Adding support for PHP 8.5's pipe operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Features:
 
   - Additive stubs #2968 @dantleech
   - Support for 1st-class callables @dantleech
+  - Support for the PHP 8.5 pipe operator @dantleech
 
 Improvements:
 

--- a/doc/reference/configuration.rst
+++ b/doc/reference/configuration.rst
@@ -2009,7 +2009,7 @@ Disable the use of temporary files when. This prevents as-you-type diagnostics, 
 """""""""""""""""""""""""""""""""""""""
 
 
-Use the editor mode of Phpstan https://phpstan.org/user-guide/editor-mode (Requires phpstan 2.14 or higher)
+DEPRECATED. Editor mode of Phpstan is used automatically when it's supported.
 
 
 **Default**: ``false``

--- a/lib/WorseReflection/Core/Inference/Resolver/BinaryExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/BinaryExpressionResolver.php
@@ -23,6 +23,7 @@ use Phpactor\WorseReflection\Core\TypeFactory;
 use Phpactor\WorseReflection\Core\Type\ArrayType;
 use Phpactor\WorseReflection\Core\Type\BitwiseOperable;
 use Phpactor\WorseReflection\Core\Type\ClassType;
+use Phpactor\WorseReflection\Core\Type\ClosureType;
 use Phpactor\WorseReflection\Core\Type\Comparable;
 use Phpactor\WorseReflection\Core\Type\Concatable;
 use Phpactor\WorseReflection\Core\Type\MissingType;
@@ -157,6 +158,13 @@ class BinaryExpressionResolver implements Resolver
             TokenKind::SlashToken => TypeUtil::toNumber($left)->divide(TypeUtil::toNumber($right)),
             TokenKind::PercentToken => TypeUtil::toNumber($left)->modulo(TypeUtil::toNumber($right)),
             TokenKind::AsteriskAsteriskToken => TypeUtil::toNumber($left)->exp(TypeUtil::toNumber($right)),
+            TokenKind::PipeToken => (function (Type $left, Type $right) {
+                if ($right instanceof ClosureType) {
+                    return $right->returnType();
+                }
+
+                return $right;
+            })($left, $right),
             default => null,
         };
         if ($value !== null) {

--- a/lib/WorseReflection/Tests/Inference/pipe-operator/pipe-operator.test
+++ b/lib/WorseReflection/Tests/Inference/pipe-operator/pipe-operator.test
@@ -1,0 +1,17 @@
+<?php
+
+$title = ' PHP 8.5 Released ';
+
+$slug = $title
+    |> trim(...)
+    |> strtolower(...)
+    |> (fn ($str) => new \stdClass());
+
+wrAssertType('stdClass', $slug);
+
+function strtolower(): string  {}
+$slug = $title
+    |> trim(...)
+    |> strtolower(...);
+
+wrAssertType('string', $slug);


### PR DESCRIPTION
Thanks to Phan and @rlerdorf the parser already supports the pipe operator.

TODO:

- [x] Make Phpactor understand that the arguments are callables.