### PR TITLE
Support for 1st class callable syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog
 Features:
 
   - Additive stubs #2968 @dantleech
+  - Support for 1st-class callables @dantleech
 
 Improvements:
 

--- a/lib/WorseReflection/Core/Inference/FunctionArguments.php
+++ b/lib/WorseReflection/Core/Inference/FunctionArguments.php
@@ -6,6 +6,8 @@ use Countable;
 use IteratorAggregate;
 use Microsoft\PhpParser\Node\DelimitedList\ArgumentExpressionList;
 use Microsoft\PhpParser\Node\Expression\ArgumentExpression;
+use Phpactor\WorseReflection\Core\Types;
+use Phpactor\WorseReflection\Core\Type;
 use Traversable;
 
 /**
@@ -34,7 +36,7 @@ class FunctionArguments implements IteratorAggregate, Countable
         }
         return new self($resolver, $frame, array_values(array_filter(
             $list->children,
-            fn ($nodeOrToken) => $nodeOrToken instanceof ArgumentExpression
+            fn ($nodeOrToken) => $nodeOrToken instanceof ArgumentExpression,
         )));
     }
 
@@ -57,6 +59,17 @@ class FunctionArguments implements IteratorAggregate, Countable
         foreach ($this->arguments as $argument) {
             yield $this->resolver->resolveNode($this->frame, $argument);
         }
+    }
+
+    /**
+     * @return Types<Type>
+     */
+    public function types(): Types
+    {
+        return new Types(array_map(
+            fn (NodeContext $context) => $context->type(),
+            iterator_to_array($this->getIterator())
+        ));
     }
 
     public function count(): int

--- a/lib/WorseReflection/Core/Inference/Resolver/CallExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/CallExpressionResolver.php
@@ -20,6 +20,7 @@ use Phpactor\WorseReflection\Core\Inference\Symbol;
 use Phpactor\WorseReflection\Core\Inference\TypeCombinator;
 use Phpactor\WorseReflection\Core\Inference\Variable as PhpactorVariable;
 use Phpactor\WorseReflection\Core\Type;
+use Phpactor\WorseReflection\Core\Type\ClosureType;
 use Phpactor\WorseReflection\Core\Type\ConditionalType;
 use Phpactor\WorseReflection\Core\Type\InvokeableType;
 use Phpactor\WorseReflection\Core\Type\ReflectedClassType;
@@ -38,6 +39,14 @@ class CallExpressionResolver implements Resolver
         $context = $resolver->resolveNode($frame, $resolvableNode);
         $returnType = $context->type();
         $containerType = $context->containerType();
+
+        // if this is a closure type then this _was_ a first-class callable
+        // and the "retutn type" is just the Closure type
+        if ($returnType instanceof ClosureType) {
+            if (NodeUtil::isFirstClassCallable($node)) {
+                return $context;
+            }
+        }
 
         if (
             $context instanceof CallContext && $context->arguments()

--- a/lib/WorseReflection/Core/Inference/Resolver/MemberAccess/NodeContextFromMemberAccess.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/MemberAccess/NodeContextFromMemberAccess.php
@@ -28,6 +28,7 @@ use Phpactor\WorseReflection\Core\Reflection\ReflectionMethod;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionProperty;
 use Phpactor\WorseReflection\Core\TemplateMap;
 use Phpactor\WorseReflection\Core\Type\ClassType;
+use Phpactor\WorseReflection\Core\Type\ClosureType;
 use Phpactor\WorseReflection\Core\Type\GenericClassType;
 use Phpactor\WorseReflection\Core\Type\GlobbedConstantUnionType;
 use Phpactor\WorseReflection\Core\Type\SelfType;
@@ -116,6 +117,14 @@ class NodeContextFromMemberAccess
 
         if ($member instanceof ReflectionMember) {
             if ($member instanceof ReflectionMethod) {
+                if (NodeUtil::isFirstClassCallable($node->parent)) {
+                    return $context->withType(new ClosureType(
+                        $resolver->reflector(),
+                        $member->parameters()->types()->toArray(),
+                        $member->type(),
+                    ));
+                }
+
                 return new MethodCallContext(
                     $context->symbol(),
                     $memberType->reduce(),

--- a/lib/WorseReflection/Core/Reflection/Collection/ReflectionParameterCollection.php
+++ b/lib/WorseReflection/Core/Reflection/Collection/ReflectionParameterCollection.php
@@ -10,6 +10,8 @@ use Phpactor\WorseReflection\Core\ServiceLocator;
 use Microsoft\PhpParser\Node\MethodDeclaration;
 use Phpactor\WorseReflection\Bridge\TolerantParser\Reflection\ReflectionParameter;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionMethod;
+use Phpactor\WorseReflection\Core\Type;
+use Phpactor\WorseReflection\Core\Types;
 
 /**
  * @extends AbstractReflectionCollection<PhpactorReflectionParameter>
@@ -102,6 +104,16 @@ final class ReflectionParameterCollection extends AbstractReflectionCollection
         }
 
         return null;
+    }
+    /**
+     * @return Types<Type>
+     */
+    public function types(): Types
+    {
+        return new Types(array_map(
+            static fn (PhpactorReflectionParameter $parameter) => $parameter->type(),
+            $this->items
+        ));
     }
 
     public function passedByReference(): PhpactorReflectionParameterCollection

--- a/lib/WorseReflection/Core/Types.php
+++ b/lib/WorseReflection/Core/Types.php
@@ -81,4 +81,12 @@ final class Types implements IteratorAggregate
     {
         return $this->types[$index] ?? new MissingType();
     }
+
+    /**
+     * @return list<Type>
+     */
+    public function toArray(): array
+    {
+        return array_values($this->types);
+    }
 }

--- a/lib/WorseReflection/Core/Util/NodeUtil.php
+++ b/lib/WorseReflection/Core/Util/NodeUtil.php
@@ -9,6 +9,7 @@ use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\DelimitedList\ArgumentExpressionList;
 use Microsoft\PhpParser\Node\DelimitedList\QualifiedNameList;
 use Microsoft\PhpParser\Node\Expression\ArgumentExpression;
+use Microsoft\PhpParser\Node\Expression\CallExpression;
 use Microsoft\PhpParser\Node\Expression\MemberAccessExpression;
 use Microsoft\PhpParser\Node\Expression\ObjectCreationExpression;
 use Microsoft\PhpParser\Node\Expression\UnaryExpression;
@@ -387,5 +388,26 @@ class NodeUtil
         }
 
         return null;
+    }
+
+    public static function isFirstClassCallable(?Node $node): bool
+    {
+        if (!$node instanceof CallExpression) {
+            return false;
+        }
+
+        foreach ($node?->argumentExpressionList->children ?? [] as $child) {
+            if (!$child instanceof ArgumentExpression) {
+                continue;
+            }
+
+            if ($child->dotDotDotToken !== null) {
+                return true;
+            }
+
+            break;
+        }
+
+        return false;
     }
 }

--- a/lib/WorseReflection/Tests/Inference/call-expression/1st-class-callable.test
+++ b/lib/WorseReflection/Tests/Inference/call-expression/1st-class-callable.test
@@ -1,0 +1,30 @@
+<?php
+
+$callable = foobar(...);
+wrAssertType('Closure(): string', $callable);
+
+function foobar(): string
+{
+}
+
+$callable = foobar_with_params(...);
+wrAssertType('Closure(string,int): string', $callable);
+wrAssertType('string', $callable());
+
+function foobar_with_params(string $p1, int $p2): string
+{
+}
+
+class Foobar {
+    public function baz(string $foo): bool {}
+    public static function boo(string $foo): bool {}
+}
+
+
+$callable = (new Foobar())->baz(...);
+wrAssertType('Closure(string): bool', $callable);
+wrAssertType('bool', $callable());
+
+$callable = Foobar::boo(...);
+wrAssertType('Closure(string): bool', $callable);
+wrAssertType('bool', $callable());

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     colors="true" 
     bootstrap="vendor/autoload.php" 
-    displayDetailsOnPhpunitDeprecations="true"
+    displayDetailsOnPhpunitDeprecations="false"
     displayDetailsOnTestsThatTriggerDeprecations="true"
 
     xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"


### PR DESCRIPTION
To better support the 8.5 pipe operator.

```php
<?php

$callable = foobar(...);
wrAssertType('Closure(): string', $callable);

function foobar(): string
{
}

$callable = foobar_with_params(...);
wrAssertType('Closure(string,int): string', $callable);
wrAssertType('string', $callable());

function foobar_with_params(string $p1, int $p2): string
{
}

class Foobar {
    public function baz(string $foo): bool {}
    public static function boo(string $foo): bool {}
}


$callable = (new Foobar())->baz(...);
wrAssertType('Closure(string): bool', $callable);
wrAssertType('bool', $callable());

$callable = Foobar::boo(...);
wrAssertType('Closure(string): bool', $callable);
wrAssertType('bool', $callable());
```