### PR TITLE
Fix renaming scoped property access variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Improvements:
 
 Bug fixes:
 
+  - Fix scoped property access variable renaming #2968 @dantleech
   - Fix display of configuration warnings #2971 @dantleech
 
 ## 2025.10.17.0

--- a/lib/Rename/Adapter/ReferenceFinder/VariableRenamer.php
+++ b/lib/Rename/Adapter/ReferenceFinder/VariableRenamer.php
@@ -16,7 +16,10 @@ class VariableRenamer extends AbstractReferenceRenamer
     public function getRenameRangeForNode(Node $node): ?ByteOffsetRange
     {
         // do not try and rename static property names
-        if ($node->parent instanceof ScopedPropertyAccessExpression) {
+        if (
+            $node->parent instanceof ScopedPropertyAccessExpression
+            && $node->parent->scopeResolutionQualifier !== $node
+        ) {
             return null;
         }
 

--- a/lib/Rename/Tests/Adapter/ReferenceFinder/VariableRenamerTest.php
+++ b/lib/Rename/Tests/Adapter/ReferenceFinder/VariableRenamerTest.php
@@ -91,6 +91,7 @@ class VariableRenamerTest extends TestCase
         yield 'NULL: Rename property (multiple definition)' => [
             '<?php class Class1 { public $prop1, $pr<>op2; } }'
         ];
+
     }
 
     #[DataProvider('provideRename')]
@@ -202,6 +203,10 @@ class VariableRenamerTest extends TestCase
 
         yield 'Rename foreach variable' => [
             '<?php $var1 = 0; foreach($array as <d>${{value}}) { echo <r>${{val<>ue}}; }'
+        ];
+
+        yield 'Rename variable on ::class' => [
+            '<?php class Class1 { function method1(){ <d>${{va<>r1}}::class; $var2 = <r>${{var1}}; } }'
         ];
     }
 

--- a/lib/WorseReferenceFinder/Tests/Unit/TolerantVariableReferenceFinderTest.php
+++ b/lib/WorseReferenceFinder/Tests/Unit/TolerantVariableReferenceFinderTest.php
@@ -117,6 +117,10 @@ class TolerantVariableReferenceFinderTest extends TestCase
             '<?php $v<>ar1 = 5; $func = function() use (<sr>$var1) { };',
         ];
 
+        yield 'static var::' => [
+            '<?php class C1 { function m1() { $v<>ar4::prop1; <sr>$var4 = 12; } }',
+        ];
+
         yield 'scope: anonymous function: inside' => [
             '<?php $v<>ar1 = 5; $func = function() use (<sr>$var1) { $var2 = <sr>$var1; };',
         ];

--- a/lib/WorseReferenceFinder/TolerantVariableReferenceFinder.php
+++ b/lib/WorseReferenceFinder/TolerantVariableReferenceFinder.php
@@ -82,9 +82,13 @@ class TolerantVariableReferenceFinder implements ReferenceFinder
         }
 
         if (
-            ($node instanceof Variable && $node->parent instanceof ScopedPropertyAccessExpression)
-            || ($node instanceof Variable && $node->getFirstAncestor(PropertyDeclaration::class))
+            $node instanceof Variable && $node->parent instanceof ScopedPropertyAccessExpression
+            && $node->parent->scopeResolutionQualifier !== $node
         ) {
+            return null;
+        }
+
+        if ($node instanceof Variable && $node->getFirstAncestor(PropertyDeclaration::class)) {
             return null;
         }
 


### PR DESCRIPTION
Fixes bug where by it's impssible to rename variable
references if the definition or any subsequent reference
is a scoped property access `$f<>oo::bar`.
