### PR TITLE
Remove dead `MethodBody::none` function 

### DIFF
--- a/lib/CodeBuilder/Adapter/TolerantParser/Updater/AbstractMethodUpdater.php
+++ b/lib/CodeBuilder/Adapter/TolerantParser/Updater/AbstractMethodUpdater.php
@@ -73,7 +73,7 @@ abstract class AbstractMethodUpdater
             }
 
             $lines = $methodPrototype->body()->lines();
-            if ($lines !== null && $lines->count()) {
+            if ($lines->count() > 0) {
                 $bodyNode = $methodDeclaration->compoundStatementOrSemicolon;
                 $this->appendLinesToMethod($edits, $methodPrototype, $bodyNode);
             }
@@ -152,7 +152,7 @@ abstract class AbstractMethodUpdater
 
         $lastStatement = end($bodyNode->statements) ?: $bodyNode->openBrace;
 
-        foreach ($method->body()->lines() ?? [] as $line) {
+        foreach ($method->body()->lines() as $line) {
             // do not add duplicate lines
             $bodyNodeLines = explode("\n", $bodyNode->getText());
 

--- a/lib/CodeBuilder/Domain/Prototype/Method.php
+++ b/lib/CodeBuilder/Domain/Prototype/Method.php
@@ -35,13 +35,13 @@ final class Method extends Prototype
         ?UpdatePolicy $updatePolicy = null
     ) {
         parent::__construct($updatePolicy);
-        $this->visibility = $visibility ?: Visibility::public();
-        $this->parameters = $parameters ?: Parameters::empty();
-        $this->returnType = $returnType ?: ReturnType::none();
-        $this->docblock = $docblock ?: Docblock::none();
+        $this->visibility = $visibility ?? Visibility::public();
+        $this->parameters = $parameters ?? Parameters::empty();
+        $this->returnType = $returnType ?? ReturnType::none();
+        $this->docblock = $docblock ?? Docblock::none();
         $this->isStatic = (bool)($modifierFlags & self::IS_STATIC);
         $this->isAbstract = (bool)($modifierFlags & self::IS_ABSTRACT);
-        $this->methodBody = $methodBody ?: MethodBody::empty();
+        $this->methodBody = $methodBody ?? MethodBody::empty();
     }
 
     public function name(): string

--- a/lib/CodeBuilder/Domain/Prototype/MethodBody.php
+++ b/lib/CodeBuilder/Domain/Prototype/MethodBody.php
@@ -4,7 +4,7 @@ namespace Phpactor\CodeBuilder\Domain\Prototype;
 
 final class MethodBody extends Prototype
 {
-    public function __construct(private ?Lines $lines = null)
+    public function __construct(private Lines $lines)
     {
         parent::__construct();
     }
@@ -22,12 +22,7 @@ final class MethodBody extends Prototype
         return new self(Lines::empty());
     }
 
-    public static function none(): self
-    {
-        return new self();
-    }
-
-    public function lines(): ?Lines
+    public function lines(): Lines
     {
         return $this->lines;
     }


### PR DESCRIPTION
You can not have a method body without lines.