### PR TITLE
Introduce "CacheEntry" and refactor to remove `has`

### DIFF
--- a/lib/WorseReflection/Core/Cache.php
+++ b/lib/WorseReflection/Core/Cache.php
@@ -13,9 +13,7 @@ interface Cache
      */
     public function getOrSet(string $key, Closure $closure);
 
-    public function has(string $key): bool;
-
-    public function get(string $key): mixed;
+    public function get(string $key): ?CacheEntry;
 
     public function set(string $key, mixed $value): void;
 

--- a/lib/WorseReflection/Core/Cache/NullCache.php
+++ b/lib/WorseReflection/Core/Cache/NullCache.php
@@ -4,6 +4,7 @@ namespace Phpactor\WorseReflection\Core\Cache;
 
 use Closure;
 use Phpactor\WorseReflection\Core\Cache;
+use Phpactor\WorseReflection\Core\CacheEntry;
 
 class NullCache implements Cache
 {
@@ -21,7 +22,7 @@ class NullCache implements Cache
         return false;
     }
 
-    public function get(string $key): mixed
+    public function get(string $key): ?CacheEntry
     {
         return null;
     }

--- a/lib/WorseReflection/Core/Cache/StaticCache.php
+++ b/lib/WorseReflection/Core/Cache/StaticCache.php
@@ -4,24 +4,22 @@ namespace Phpactor\WorseReflection\Core\Cache;
 
 use Closure;
 use Phpactor\WorseReflection\Core\Cache;
+use Phpactor\WorseReflection\Core\CacheEntry;
 
 class StaticCache implements Cache
 {
     /**
-     * @var array<string,mixed>
+     * @var array<string,CacheEntry>
      */
     private array $cache = [];
 
-    /**
-     * @return mixed
-     */
     public function getOrSet(string $key, Closure $closure)
     {
         if (isset($this->cache[$key])) {
-            return $this->cache[$key];
+            return $this->cache[$key]->value();
         }
-        $this->cache[$key] = $closure();
-        return $this->cache[$key];
+        $this->cache[$key] = new CacheEntry($closure());
+        return $this->cache[$key]->value();
     }
 
     public function purge(): void
@@ -29,19 +27,14 @@ class StaticCache implements Cache
         $this->cache = [];
     }
 
-    public function has(string $key): bool
-    {
-        return isset($this->cache[$key]);
-    }
-
-    public function get(string $key): mixed
+    public function get(string $key): ?CacheEntry
     {
         return $this->cache[$key] ?? null;
     }
 
     public function set(string $key, mixed $value): void
     {
-        $this->cache[$key] = $value;
+        $this->cache[$key] = new CacheEntry($value);
     }
 
     public function remove(string $key): void

--- a/lib/WorseReflection/Core/CacheEntry.php
+++ b/lib/WorseReflection/Core/CacheEntry.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Phpactor\WorseReflection\Core;
+
+final class CacheEntry
+{
+    public function __construct(private mixed $value)
+    {
+    }
+
+    public function value(): mixed
+    {
+        return $this->value;
+    }
+
+    /**
+     * This method is not safe: it does validate or cast
+     * the value as/to a scalar.
+     *
+     * @return scalar
+     */
+    public function scalar(): mixed
+    {
+        /** @phpstan-ignore-next-line */
+        return $this->value;
+    }
+
+    /**
+     * This method is not safe: it does validate or cast
+     * the value as/to an object.
+     *
+     * @template TObject of object
+     * @param class-string<TObject> $type
+     * @return TObject
+     */
+    public function expect(string $type): object
+    {
+        /** @phpstan-ignore-next-line */
+        return $this->value;
+    }
+}

--- a/lib/WorseReflection/Tests/Unit/Core/Cache/StaticCacheTest.php
+++ b/lib/WorseReflection/Tests/Unit/Core/Cache/StaticCacheTest.php
@@ -13,8 +13,10 @@ class StaticCacheTest extends TestCase
         $counter = 0;
         $value = $cache->getOrSet('foobar', fn () => $counter++);
         self::assertEquals(0, $counter);
+        self::assertEquals(0, $value);
         $value = $cache->getOrSet('foobar', fn () => $counter++);
         self::assertEquals(0, $counter);
+        self::assertEquals(0, $value);
     }
 
     public function testGetHasSet(): void
@@ -22,15 +24,15 @@ class StaticCacheTest extends TestCase
         $cache = new StaticCache();
         $counter = 0;
 
-        self::assertFalse($cache->has('foo'));
+        self::assertNull($cache->get('foo'));
 
         $cache->set('foo', 'bar');
 
-        self::assertTrue($cache->has('foo'));
-        self::assertEquals('bar', $cache->get('foo'));
+        self::assertNotNull($cache->get('foo'));
+        self::assertEquals('bar', $cache->get('foo')->scalar());
 
         $cache->remove('foo');
 
-        self::assertFalse($cache->has('foo'));
+        self::assertNull($cache->get('foo'));
     }
 }

--- a/lib/WorseReflection/Tests/Unit/Core/Cache/TtlCacheTest.php
+++ b/lib/WorseReflection/Tests/Unit/Core/Cache/TtlCacheTest.php
@@ -10,11 +10,11 @@ class TtlCacheTest extends TestCase
     public function testPutsCacheIfNotSet(): void
     {
         $cache = new TtlCache();
-        self::assertFalse($cache->has('foobar'));
+        self::assertNull($cache->get('foobar'));
         self::assertEquals(1234, $cache->getOrSet('foobar', function () {
             return 1234;
         }));
-        self::assertTrue($cache->has('foobar'));
+        self::assertNotNull($cache->get('foobar'));
     }
 
     public function testGetExpire(): void
@@ -37,35 +37,15 @@ class TtlCacheTest extends TestCase
         self::assertLessThanOrEqual(6, $count);
     }
 
-    public function testHasExpire(): void
-    {
-        // 0.5ms
-        $cache = new TtlCache(0.0005);
-        $count = 0;
-
-        // cache should expire on every other iteration
-        for ($i = 0; $i < 10; $i++) {
-            if (false === $cache->has('foobar')) {
-                $cache->set('foobar', ++$count);
-            }
-
-            // 0.25 milliseconds
-            usleep(250);
-        }
-
-        self::assertGreaterThan(4, $count);
-        self::assertLessThanOrEqual(6, $count);
-    }
-
     public function testRemove(): void
     {
         $cache = new TtlCache(1);
         $count = 0;
 
         $cache->set('foobar', 'hello');
-        self::assertTrue($cache->has('foobar'));
+        self::assertNotNull($cache->get('foobar'));
         $cache->remove('foobar');
-        self::assertFalse($cache->has('foobar'));
+        self::assertNull($cache->get('foobar'));
     }
 
     public function testCallbackIsOnlyCalledOnce(): void


### PR DESCRIPTION
Provide a thin wrapper around the cache value to allow "casting" to values and to avoid the necessitty of a `has` method