### PR TITLE
Introducing a rule to split up constructor parameters

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -48,6 +48,9 @@ return (new Config())
             'anonymous_class' => true,
             'named_class' => true,
         ],
+        'multiline_promoted_properties' => [
+            'minimum_number_of_parameters' => 2
+        ],
     ])
     ->setFinder($finder)
 ;

--- a/lib/Application.php
+++ b/lib/Application.php
@@ -23,8 +23,10 @@ class Application extends SymfonyApplication
 {
     private Container $container;
 
-    public function __construct(private string $vendorDir, private ?string $phpactorBin = null)
-    {
+    public function __construct(
+        private string $vendorDir,
+        private ?string $phpactorBin = null
+    ) {
         parent::__construct('Phpactor', Cast::toString(InstalledVersions::getVersion('phpactor/phpactor')));
     }
 

--- a/lib/ClassMover/Adapter/WorseTolerant/WorseTolerantMemberFinder.php
+++ b/lib/ClassMover/Adapter/WorseTolerant/WorseTolerantMemberFinder.php
@@ -48,7 +48,7 @@ class WorseTolerantMemberFinder implements MemberFinder
     public function __construct(
         ?Reflector $reflector = null,
         private Parser $parser = new Parser(),
-        private LoggerInterface $logger = new NullLogger()
+        private LoggerInterface $logger = new NullLogger(),
     ) {
         $this->reflector = $reflector ?: ReflectorBuilder::create()->addSource(TextDocumentBuilder::empty());
     }

--- a/lib/ClassMover/Domain/Name/NameImportTable.php
+++ b/lib/ClassMover/Domain/Name/NameImportTable.php
@@ -11,8 +11,10 @@ class NameImportTable
     private array $importedNameRefs = [];
 
     /** @param ImportedNameReference[] $importedNamespaceNames */
-    private function __construct(private Namespace_ $namespace, array $importedNamespaceNames)
-    {
+    private function __construct(
+        private Namespace_ $namespace,
+        array $importedNamespaceNames
+    ) {
         foreach ($importedNamespaceNames as $importedNamespaceName) {
             $this->addImportedName($importedNamespaceName);
         }

--- a/lib/ClassMover/Domain/Reference/ImportedNameReference.php
+++ b/lib/ClassMover/Domain/Reference/ImportedNameReference.php
@@ -8,8 +8,10 @@ final class ImportedNameReference
 {
     private bool $exists;
 
-    private function __construct(private ?Position $position = null, private ?ImportedName $importedName = null)
-    {
+    private function __construct(
+        private ?Position $position = null,
+        private ?ImportedName $importedName = null
+    ) {
     }
 
     public function __toString(): string

--- a/lib/ClassMover/Domain/Reference/NamespacedClassReferences.php
+++ b/lib/ClassMover/Domain/Reference/NamespacedClassReferences.php
@@ -20,8 +20,10 @@ final class NamespacedClassReferences implements IteratorAggregate
     /**
      * @param ClassReference[] $classRefs
      */
-    private function __construct(private NamespaceReference $namespaceRef, array $classRefs)
-    {
+    private function __construct(
+        private NamespaceReference $namespaceRef,
+        array $classRefs
+    ) {
         foreach ($classRefs as $classRef) {
             $this->add($classRef);
         }

--- a/lib/ClassMover/Domain/Reference/Position.php
+++ b/lib/ClassMover/Domain/Reference/Position.php
@@ -4,8 +4,10 @@ namespace Phpactor\ClassMover\Domain\Reference;
 
 class Position
 {
-    private function __construct(private int $start, private int $end)
-    {
+    private function __construct(
+        private int $start,
+        private int $end
+    ) {
     }
 
     public static function fromStartAndEnd(int $start, int $end): self

--- a/lib/ClassMover/FoundReferences.php
+++ b/lib/ClassMover/FoundReferences.php
@@ -8,8 +8,11 @@ use Phpactor\TextDocument\TextDocument;
 
 final class FoundReferences
 {
-    public function __construct(private TextDocument $source, private FullyQualifiedName $name, private NamespacedClassReferences $references)
-    {
+    public function __construct(
+        private TextDocument $source,
+        private FullyQualifiedName $name,
+        private NamespacedClassReferences $references
+    ) {
     }
 
     public function source(): TextDocument

--- a/lib/CodeBuilder/Adapter/TolerantParser/TolerantUpdater.php
+++ b/lib/CodeBuilder/Adapter/TolerantParser/TolerantUpdater.php
@@ -38,7 +38,7 @@ class TolerantUpdater implements Updater
     public function __construct(
         private Renderer $renderer,
         private TextFormat $textFormat = new TextFormat(),
-        private Parser $parser = new Parser()
+        private Parser $parser = new Parser(),
     ) {
         $this->classUpdater = new ClassUpdater($renderer);
         $this->interfaceUpdater = new InterfaceUpdater($renderer);

--- a/lib/CodeBuilder/Domain/Builder/ClassLikeBuilder.php
+++ b/lib/CodeBuilder/Domain/Builder/ClassLikeBuilder.php
@@ -14,8 +14,10 @@ abstract class ClassLikeBuilder extends AbstractBuilder implements Builder
 
     protected ?Docblock $docblock = null;
 
-    public function __construct(private SourceCodeBuilder $parent, protected string $name)
-    {
+    public function __construct(
+        private SourceCodeBuilder $parent,
+        protected string $name
+    ) {
         $this->docblock = null;
     }
 

--- a/lib/CodeBuilder/Domain/Builder/ConstantBuilder.php
+++ b/lib/CodeBuilder/Domain/Builder/ConstantBuilder.php
@@ -13,8 +13,11 @@ class ConstantBuilder extends AbstractBuilder implements NamedBuilder
 
     private ?Visibility $visibility = null;
 
-    public function __construct(private ClassLikeBuilder $parent, protected string $name, mixed $value)
-    {
+    public function __construct(
+        private ClassLikeBuilder $parent,
+        protected string $name,
+        mixed $value
+    ) {
         $this->value = Value::fromValue($value);
     }
 

--- a/lib/CodeBuilder/Domain/Builder/MethodBuilder.php
+++ b/lib/CodeBuilder/Domain/Builder/MethodBuilder.php
@@ -30,8 +30,10 @@ class MethodBuilder extends AbstractBuilder implements NamedBuilder
 
     protected MethodBodyBuilder $bodyBuilder;
 
-    public function __construct(private ClassLikeBuilder $parent, protected string $name)
-    {
+    public function __construct(
+        private ClassLikeBuilder $parent,
+        protected string $name
+    ) {
         $this->bodyBuilder = new MethodBodyBuilder($this);
     }
 

--- a/lib/CodeBuilder/Domain/Builder/ParameterBuilder.php
+++ b/lib/CodeBuilder/Domain/Builder/ParameterBuilder.php
@@ -21,8 +21,10 @@ class ParameterBuilder extends AbstractBuilder
 
     protected ?Visibility $visibility = null;
 
-    public function __construct(private MethodBuilder $parent, protected string $name)
-    {
+    public function __construct(
+        private MethodBuilder $parent,
+        protected string $name
+    ) {
     }
 
     /**

--- a/lib/CodeBuilder/Domain/Builder/PropertyBuilder.php
+++ b/lib/CodeBuilder/Domain/Builder/PropertyBuilder.php
@@ -18,8 +18,10 @@ class PropertyBuilder extends AbstractBuilder implements NamedBuilder
 
     private ?Type $docType = null;
 
-    public function __construct(private ClassLikeBuilder $parent, protected string $name)
-    {
+    public function __construct(
+        private ClassLikeBuilder $parent,
+        protected string $name
+    ) {
     }
 
     public static function childNames(): array

--- a/lib/CodeBuilder/Domain/Prototype/Case_.php
+++ b/lib/CodeBuilder/Domain/Prototype/Case_.php
@@ -6,8 +6,11 @@ namespace Phpactor\CodeBuilder\Domain\Prototype;
 
 class Case_ extends Prototype
 {
-    public function __construct(private string $name, private ?Value $value = null, ?UpdatePolicy $updatePolicy = null)
-    {
+    public function __construct(
+        private string $name,
+        private ?Value $value = null,
+        ?UpdatePolicy $updatePolicy = null
+    ) {
         parent::__construct($updatePolicy);
     }
 

--- a/lib/CodeBuilder/Domain/Prototype/Type.php
+++ b/lib/CodeBuilder/Domain/Prototype/Type.php
@@ -6,8 +6,10 @@ final class Type extends Prototype
 {
     private bool $none = false;
 
-    public function __construct(private ?string $type = null, private mixed $originalType = null)
-    {
+    public function __construct(
+        private ?string $type = null,
+        private mixed $originalType = null
+    ) {
         parent::__construct();
     }
 

--- a/lib/CodeBuilder/Domain/TemplatePathResolver/FilterPhpVersionDirectoryIterator.php
+++ b/lib/CodeBuilder/Domain/TemplatePathResolver/FilterPhpVersionDirectoryIterator.php
@@ -16,8 +16,10 @@ class FilterPhpVersionDirectoryIterator extends FilterIterator
     /**
      *      @see https://www.php.net/manual/en/reserved.constants.php#reserved.constants.core
      */
-    public function __construct(Iterator $iterator, private string $phpVersion)
-    {
+    public function __construct(
+        Iterator $iterator,
+        private string $phpVersion
+    ) {
         parent::__construct($iterator);
     }
 

--- a/lib/CodeBuilder/SourceBuilder.php
+++ b/lib/CodeBuilder/SourceBuilder.php
@@ -9,8 +9,10 @@ use Phpactor\CodeBuilder\Domain\Code;
 
 class SourceBuilder
 {
-    public function __construct(private Renderer $generator, private Updater $updater)
-    {
+    public function __construct(
+        private Renderer $generator,
+        private Updater $updater
+    ) {
     }
 
     public function render(Prototype\Prototype $prototype): Code

--- a/lib/CodeBuilder/Util/TextFormat.php
+++ b/lib/CodeBuilder/Util/TextFormat.php
@@ -6,8 +6,10 @@ use RuntimeException;
 
 class TextFormat
 {
-    public function __construct(private string $indentation = '    ', private string $newLineChar = "\n")
-    {
+    public function __construct(
+        private string $indentation = '    ',
+        private string $newLineChar = "\n"
+    ) {
     }
 
     public function indent(string $string, int $level = 0): string

--- a/lib/CodeTransform/Adapter/DocblockParser/ParserDocblockUpdater.php
+++ b/lib/CodeTransform/Adapter/DocblockParser/ParserDocblockUpdater.php
@@ -20,8 +20,10 @@ use RuntimeException;
  */
 class ParserDocblockUpdater implements DocBlockUpdater
 {
-    public function __construct(private DocblockParser $parser, private TextFormat $textFormat)
-    {
+    public function __construct(
+        private DocblockParser $parser,
+        private TextFormat $textFormat
+    ) {
     }
 
     public function set(string $docblockText, TagPrototype $prototype): string

--- a/lib/CodeTransform/Adapter/Native/GenerateNew/ClassGenerator.php
+++ b/lib/CodeTransform/Adapter/Native/GenerateNew/ClassGenerator.php
@@ -10,8 +10,10 @@ use Phpactor\CodeBuilder\Domain\Renderer;
 
 class ClassGenerator implements GenerateNew
 {
-    public function __construct(private Renderer $renderer, private ?string $variant = null)
-    {
+    public function __construct(
+        private Renderer $renderer,
+        private ?string $variant = null
+    ) {
     }
 
 

--- a/lib/CodeTransform/Adapter/TolerantParser/ClassToFile/Transformer/ClassNameFixerTransformer.php
+++ b/lib/CodeTransform/Adapter/TolerantParser/ClassToFile/Transformer/ClassNameFixerTransformer.php
@@ -31,8 +31,10 @@ use RuntimeException;
 
 class ClassNameFixerTransformer implements Transformer
 {
-    public function __construct(private FileToClass $fileToClass, private Parser $parser = new Parser())
-    {
+    public function __construct(
+        private FileToClass $fileToClass,
+        private Parser $parser = new Parser(),
+    ) {
     }
 
     /**

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseExtractConstant.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseExtractConstant.php
@@ -23,8 +23,11 @@ use Phpactor\WorseReflection\TypeUtil;
 
 class WorseExtractConstant implements ExtractConstant
 {
-    public function __construct(private Reflector $reflector, private Updater $updater, private Parser $parser = new Parser())
-    {
+    public function __construct(
+        private Reflector $reflector,
+        private Updater $updater,
+        private Parser $parser = new Parser(),
+    ) {
     }
 
     public function extractConstant(SourceCode $sourceCode, int $offset, string $constantName): TextDocumentEdits

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseGenerateDecorator.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseGenerateDecorator.php
@@ -17,8 +17,10 @@ use Phpactor\WorseReflection\Reflector;
 
 class WorseGenerateDecorator implements GenerateDecorator
 {
-    public function __construct(private Reflector $reflector, private Updater $updater)
-    {
+    public function __construct(
+        private Reflector $reflector,
+        private Updater $updater
+    ) {
     }
 
     public function getTextEdits(SourceCode $source, string $interfaceFQN): TextEdits

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseReplaceQualifierWithImport.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseReplaceQualifierWithImport.php
@@ -17,8 +17,12 @@ use Phpactor\WorseReflection\Reflector;
 
 class WorseReplaceQualifierWithImport implements ReplaceQualifierWithImport
 {
-    public function __construct(private Reflector $reflector, private BuilderFactory $factory, private Updater $updater, private Parser $parser = new Parser())
-    {
+    public function __construct(
+        private Reflector $reflector,
+        private BuilderFactory $factory,
+        private Updater $updater,
+        private Parser $parser = new Parser(),
+    ) {
     }
 
     public function getTextEdits(SourceCode $sourceCode, int $offset): TextDocumentEdits

--- a/lib/CodeTransform/Adapter/WorseReflection/Transformer/AddMissingProperties.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Transformer/AddMissingProperties.php
@@ -25,8 +25,11 @@ class AddMissingProperties implements Transformer
 {
     private const LENGTH_OF_THIS_PREFIX = 7;
 
-    public function __construct(private Reflector $reflector, private Updater $updater, private Parser $parser = new Parser())
-    {
+    public function __construct(
+        private Reflector $reflector,
+        private Updater $updater,
+        private Parser $parser = new Parser(),
+    ) {
     }
 
     /**

--- a/lib/CodeTransform/Adapter/WorseReflection/Transformer/RemoveUnusedImportsTransformer.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Transformer/RemoveUnusedImportsTransformer.php
@@ -25,8 +25,10 @@ class RemoveUnusedImportsTransformer implements Transformer
      */
     private array $fixed = [];
 
-    public function __construct(private Reflector $reflector, private Parser $parser)
-    {
+    public function __construct(
+        private Reflector $reflector,
+        private Parser $parser
+    ) {
     }
 
     /**

--- a/lib/CodeTransform/Domain/Diagnostic.php
+++ b/lib/CodeTransform/Domain/Diagnostic.php
@@ -11,8 +11,11 @@ class Diagnostic
     public const INFORMATION = 3;
     public const HINT = 4;
 
-    public function __construct(private ByteOffsetRange $range, private string $message, private int $severity)
-    {
+    public function __construct(
+        private ByteOffsetRange $range,
+        private string $message,
+        private int $severity
+    ) {
     }
 
     public function range(): ByteOffsetRange

--- a/lib/CodeTransform/Domain/DocBlockUpdater/ParamTagPrototype.php
+++ b/lib/CodeTransform/Domain/DocBlockUpdater/ParamTagPrototype.php
@@ -8,8 +8,10 @@ use Phpactor\WorseReflection\Core\Type;
 
 class ParamTagPrototype implements TagPrototype
 {
-    public function __construct(public string $name, public Type $type)
-    {
+    public function __construct(
+        public string $name,
+        public Type $type
+    ) {
     }
 
     public function matches(TagNode $tag): bool

--- a/lib/CodeTransform/Domain/Helper/MissingMemberFinder/MissingMember.php
+++ b/lib/CodeTransform/Domain/Helper/MissingMemberFinder/MissingMember.php
@@ -6,8 +6,11 @@ use Phpactor\TextDocument\ByteOffsetRange;
 
 class MissingMember
 {
-    public function __construct(private string $name, public ByteOffsetRange $range, private string $memberType)
-    {
+    public function __construct(
+        private string $name,
+        public ByteOffsetRange $range,
+        private string $memberType
+    ) {
     }
 
     public function range(): ByteOffsetRange

--- a/lib/CodeTransform/Domain/NameWithByteOffset.php
+++ b/lib/CodeTransform/Domain/NameWithByteOffset.php
@@ -17,8 +17,11 @@ final class NameWithByteOffset
 
     private string $type;
 
-    public function __construct(private Name $name, private ByteOffset $byteOffset, string $type = self::TYPE_CLASS)
-    {
+    public function __construct(
+        private Name $name,
+        private ByteOffset $byteOffset,
+        string $type = self::TYPE_CLASS
+    ) {
         if (!in_array($type, self::VALID_TYPES)) {
             throw new RuntimeException(sprintf(
                 'Invalid type "%s", valid types "%s"',

--- a/lib/CodeTransform/Domain/Refactor/ImportClass/NameImport.php
+++ b/lib/CodeTransform/Domain/Refactor/ImportClass/NameImport.php
@@ -9,8 +9,11 @@ class NameImport
     private const TYPE_CLASS = 'class';
     private const TYPE_FUNCTION = 'function';
 
-    private function __construct(private string $type, private FullyQualifiedName $name, private ?string $alias = null)
-    {
+    private function __construct(
+        private string $type,
+        private FullyQualifiedName $name,
+        private ?string $alias = null
+    ) {
     }
 
     public static function forClass(string $name, ?string $alias = null): self

--- a/lib/CodeTransform/Domain/SourceCode.php
+++ b/lib/CodeTransform/Domain/SourceCode.php
@@ -9,8 +9,10 @@ use RuntimeException;
 
 final class SourceCode implements TextDocument
 {
-    private function __construct(private string $code, private TextDocumentUri $uri)
-    {
+    private function __construct(
+        private string $code,
+        private TextDocumentUri $uri
+    ) {
     }
 
     public function __toString(): string

--- a/lib/Completion/Bridge/ObjectRenderer/ItemDocumentation.php
+++ b/lib/Completion/Bridge/ObjectRenderer/ItemDocumentation.php
@@ -4,8 +4,11 @@ namespace Phpactor\Completion\Bridge\ObjectRenderer;
 
 class ItemDocumentation
 {
-    public function __construct(private string $name, private string $docs, private object $object)
-    {
+    public function __construct(
+        private string $name,
+        private string $docs,
+        private object $object
+    ) {
     }
 
     public function docs(): string

--- a/lib/Completion/Bridge/TolerantParser/LimitingCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/LimitingCompletor.php
@@ -10,8 +10,10 @@ use Phpactor\TextDocument\TextDocument;
 
 class LimitingCompletor implements TolerantCompletor, TolerantQualifiable
 {
-    public function __construct(private TolerantCompletor $completor, private int $limit = 50)
-    {
+    public function __construct(
+        private TolerantCompletor $completor,
+        private int $limit = 50
+    ) {
     }
 
 

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/DoctrineAnnotationCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/DoctrineAnnotationCompletor.php
@@ -25,7 +25,7 @@ class DoctrineAnnotationCompletor extends NameSearcherCompletor implements Compl
     public function __construct(
         NameSearcher $nameSearcher,
         private Reflector $reflector,
-        private Parser $parser = new Parser()
+        private Parser $parser = new Parser(),
     ) {
         parent::__construct($nameSearcher);
     }

--- a/lib/Completion/Bridge/WorseReflection/Completor/ContextSensitiveCompletor.php
+++ b/lib/Completion/Bridge/WorseReflection/Completor/ContextSensitiveCompletor.php
@@ -28,8 +28,10 @@ use Phpactor\WorseReflection\Reflector;
 
 class ContextSensitiveCompletor implements TolerantCompletor, TolerantQualifiable
 {
-    public function __construct(private TolerantCompletor $inner, private Reflector $reflector)
-    {
+    public function __construct(
+        private TolerantCompletor $inner,
+        private Reflector $reflector
+    ) {
     }
 
     public function complete(Node $node, TextDocument $source, ByteOffset $offset): Generator

--- a/lib/Completion/Core/ChainSignatureHelper.php
+++ b/lib/Completion/Core/ChainSignatureHelper.php
@@ -14,8 +14,10 @@ class ChainSignatureHelper implements SignatureHelper
      */
     private array $helpers = [];
 
-    public function __construct(private LoggerInterface $logger, array $helpers)
-    {
+    public function __construct(
+        private LoggerInterface $logger,
+        array $helpers
+    ) {
         foreach ($helpers as $helper) {
             $this->add($helper);
         }

--- a/lib/Completion/Core/Completor/DedupeCompletor.php
+++ b/lib/Completion/Core/Completor/DedupeCompletor.php
@@ -9,8 +9,10 @@ use Phpactor\TextDocument\TextDocument;
 
 class DedupeCompletor implements Completor
 {
-    public function __construct(private Completor $innerCompletor, private bool $matchNameImport = false)
-    {
+    public function __construct(
+        private Completor $innerCompletor,
+        private bool $matchNameImport = false
+    ) {
     }
 
 

--- a/lib/Completion/Core/Completor/DocumentingCompletor.php
+++ b/lib/Completion/Core/Completor/DocumentingCompletor.php
@@ -10,8 +10,10 @@ use Phpactor\TextDocument\TextDocument;
 
 class DocumentingCompletor implements Completor
 {
-    public function __construct(private Completor $innerCompletor, private SuggestionDocumentor $documentor)
-    {
+    public function __construct(
+        private Completor $innerCompletor,
+        private SuggestionDocumentor $documentor
+    ) {
     }
 
     public function complete(TextDocument $source, ByteOffset $byteOffset): Generator

--- a/lib/Completion/Core/Completor/LabelFormattingCompletor.php
+++ b/lib/Completion/Core/Completor/LabelFormattingCompletor.php
@@ -11,8 +11,10 @@ use Phpactor\TextDocument\TextDocument;
 
 class LabelFormattingCompletor implements Completor
 {
-    public function __construct(private Completor $completor, private LabelFormatter $labelFormatter)
-    {
+    public function __construct(
+        private Completor $completor,
+        private LabelFormatter $labelFormatter
+    ) {
     }
 
     public function complete(

--- a/lib/Completion/Core/Completor/LimitingCompletor.php
+++ b/lib/Completion/Core/Completor/LimitingCompletor.php
@@ -10,8 +10,10 @@ use RuntimeException;
 
 class LimitingCompletor implements Completor
 {
-    public function __construct(private Completor $innerCompletor, private int $limit = 32)
-    {
+    public function __construct(
+        private Completor $innerCompletor,
+        private int $limit = 32
+    ) {
         if ($limit < 0) {
             throw new RuntimeException(sprintf(
                 'Limit cannot be less than 0, got %d',

--- a/lib/Completion/Core/Range.php
+++ b/lib/Completion/Core/Range.php
@@ -6,8 +6,10 @@ use Phpactor\TextDocument\ByteOffset;
 
 class Range
 {
-    public function __construct(private ByteOffset $byteStart, private ByteOffset $byteEnd)
-    {
+    public function __construct(
+        private ByteOffset $byteStart,
+        private ByteOffset $byteEnd
+    ) {
     }
 
     public static function fromStartAndEnd(int $byteStart, int $byteEnd): self

--- a/lib/Completion/Core/SignatureInformation.php
+++ b/lib/Completion/Core/SignatureInformation.php
@@ -14,8 +14,11 @@ class SignatureInformation
      */
     private array $parameters = [];
 
-    public function __construct(private string $label, array $parameters, private ?string $documentation = null)
-    {
+    public function __construct(
+        private string $label,
+        array $parameters,
+        private ?string $documentation = null
+    ) {
         foreach ($parameters as $parameter) {
             $this->add($parameter);
         }

--- a/lib/ComposerInspector/Package.php
+++ b/lib/ComposerInspector/Package.php
@@ -4,7 +4,10 @@ namespace Phpactor\ComposerInspector;
 
 class Package
 {
-    public function __construct(public string $name, public string $version, public bool $isDev)
-    {
+    public function __construct(
+        public string $name,
+        public string $version,
+        public bool $isDev
+    ) {
     }
 }

--- a/lib/ConfigLoader/Adapter/PathCandidate/AbsolutePathCandidate.php
+++ b/lib/ConfigLoader/Adapter/PathCandidate/AbsolutePathCandidate.php
@@ -10,8 +10,10 @@ class AbsolutePathCandidate implements PathCandidate
 {
     private string $absolutePath;
 
-    public function __construct(string $absolutePath, private string $loader)
-    {
+    public function __construct(
+        string $absolutePath,
+        private string $loader
+    ) {
         $absolutePath = Path::canonicalize($absolutePath);
         $this->absolutePath = $absolutePath;
 

--- a/lib/ConfigLoader/Core/ConfigLoader.php
+++ b/lib/ConfigLoader/Core/ConfigLoader.php
@@ -6,8 +6,10 @@ use RuntimeException;
 
 class ConfigLoader
 {
-    public function __construct(private Deserializers $deserializers, private PathCandidates $candidates)
-    {
+    public function __construct(
+        private Deserializers $deserializers,
+        private PathCandidates $candidates
+    ) {
     }
 
     public function load(): array

--- a/lib/Configurator/Adapter/Phpactor/PhpactorConfigChange.php
+++ b/lib/Configurator/Adapter/Phpactor/PhpactorConfigChange.php
@@ -10,8 +10,10 @@ class PhpactorConfigChange implements Change
     /**
      * @param Closure(bool):array<string,mixed> $keyValues
      */
-    public function __construct(private string $prompt, private Closure $keyValues)
-    {
+    public function __construct(
+        private string $prompt,
+        private Closure $keyValues
+    ) {
     }
 
     public function prompt(): string

--- a/lib/Configurator/Configurator.php
+++ b/lib/Configurator/Configurator.php
@@ -14,8 +14,10 @@ class Configurator
      * @param list<ChangeSuggestor> $suggestors
      * @param list<ChangeApplicator> $applicators
      */
-    public function __construct(private array $suggestors, private array $applicators)
-    {
+    public function __construct(
+        private array $suggestors,
+        private array $applicators
+    ) {
     }
 
     public function suggestChanges(): Changes

--- a/lib/Configurator/Model/ConfigManipulator.php
+++ b/lib/Configurator/Model/ConfigManipulator.php
@@ -18,8 +18,10 @@ final class ConfigManipulator
     public const ACTION_CREATED = 'created';
     public const ACTION_UPDATED = 'updated';
 
-    public function __construct(private string $schemaPath, private string $configPath)
-    {
+    public function __construct(
+        private string $schemaPath,
+        private string $configPath
+    ) {
     }
 
     public function configPath(): string

--- a/lib/DocblockParser/Ast/Tag/DeprecatedTag.php
+++ b/lib/DocblockParser/Ast/Tag/DeprecatedTag.php
@@ -13,8 +13,10 @@ class DeprecatedTag extends TagNode
         'text',
     ];
 
-    public function __construct(public Token $token, public ?TextNode $text)
-    {
+    public function __construct(
+        public Token $token,
+        public ?TextNode $text
+    ) {
     }
 
     public function text(): ?string

--- a/lib/DocblockParser/Ast/Tag/ExtendsTag.php
+++ b/lib/DocblockParser/Ast/Tag/ExtendsTag.php
@@ -13,7 +13,9 @@ class ExtendsTag extends TagNode
         'type',
     ];
 
-    public function __construct(public Token $tag, public ?TypeNode $type = null)
-    {
+    public function __construct(
+        public Token $tag,
+        public ?TypeNode $type = null
+    ) {
     }
 }

--- a/lib/DocblockParser/Ast/Tag/ImplementsTag.php
+++ b/lib/DocblockParser/Ast/Tag/ImplementsTag.php
@@ -16,8 +16,10 @@ class ImplementsTag extends TagNode
     /**
      * @param array<array-key, Token|TypeNode> $tokensAndTypes
      */
-    public function __construct(public Token $tag, public array $tokensAndTypes = [])
-    {
+    public function __construct(
+        public Token $tag,
+        public array $tokensAndTypes = []
+    ) {
     }
 
     /**

--- a/lib/DocblockParser/Ast/Tag/MixinTag.php
+++ b/lib/DocblockParser/Ast/Tag/MixinTag.php
@@ -13,8 +13,10 @@ class MixinTag extends TagNode
         'class'
     ];
 
-    public function __construct(public Token $tag, public ?TypeNode $class)
-    {
+    public function __construct(
+        public Token $tag,
+        public ?TypeNode $class
+    ) {
     }
 
     public function class(): ?TypeNode

--- a/lib/DocblockParser/Ast/Tag/ParameterTag.php
+++ b/lib/DocblockParser/Ast/Tag/ParameterTag.php
@@ -15,8 +15,11 @@ class ParameterTag extends TagNode
         'default',
     ];
 
-    public function __construct(public ?TypeNode $type, public ?VariableNode $name, public ?ValueNode $default)
-    {
+    public function __construct(
+        public ?TypeNode $type,
+        public ?VariableNode $name,
+        public ?ValueNode $default
+    ) {
     }
 
     public function parameterName(): ?string

--- a/lib/DocblockParser/Ast/Tag/PropertyTag.php
+++ b/lib/DocblockParser/Ast/Tag/PropertyTag.php
@@ -14,8 +14,11 @@ class PropertyTag extends TagNode
         'name',
     ];
 
-    public function __construct(public Token $tag, public ?TypeNode $type, public ?Token $name)
-    {
+    public function __construct(
+        public Token $tag,
+        public ?TypeNode $type,
+        public ?Token $name
+    ) {
     }
 
     public function propertyName(): ?string

--- a/lib/DocblockParser/Ast/Tag/ReturnTag.php
+++ b/lib/DocblockParser/Ast/Tag/ReturnTag.php
@@ -15,8 +15,11 @@ class ReturnTag extends TagNode
         'text',
     ];
 
-    public function __construct(public Token $tag, public ?TypeNode $type, public ?TextNode $text = null)
-    {
+    public function __construct(
+        public Token $tag,
+        public ?TypeNode $type,
+        public ?TextNode $text = null
+    ) {
     }
 
     public function type(): ?TypeNode

--- a/lib/DocblockParser/Ast/Tag/ThrowsTag.php
+++ b/lib/DocblockParser/Ast/Tag/ThrowsTag.php
@@ -15,7 +15,10 @@ class ThrowsTag extends TagNode
         'text',
     ];
 
-    public function __construct(public Token $tag, public ?TypeNode $exceptionClass, public ?TextNode $text)
-    {
+    public function __construct(
+        public Token $tag,
+        public ?TypeNode $exceptionClass,
+        public ?TextNode $text
+    ) {
     }
 }

--- a/lib/DocblockParser/Ast/Tag/TypeAliasTag.php
+++ b/lib/DocblockParser/Ast/Tag/TypeAliasTag.php
@@ -15,7 +15,11 @@ class TypeAliasTag extends TagNode
         'type',
     ];
 
-    public function __construct(public Token $tag, public ?TypeNode $alias, public ?Token $equals, public ?TypeNode $type)
-    {
+    public function __construct(
+        public Token $tag,
+        public ?TypeNode $alias,
+        public ?Token $equals,
+        public ?TypeNode $type
+    ) {
     }
 }

--- a/lib/DocblockParser/Ast/Tag/VarTag.php
+++ b/lib/DocblockParser/Ast/Tag/VarTag.php
@@ -15,8 +15,11 @@ class VarTag extends TagNode
         'variable',
     ];
 
-    public function __construct(public Token $tag, public ?TypeNode $type, public ?VariableNode $variable)
-    {
+    public function __construct(
+        public Token $tag,
+        public ?TypeNode $type,
+        public ?VariableNode $variable
+    ) {
     }
 
     public function type(): ?TypeNode

--- a/lib/DocblockParser/Ast/Token.php
+++ b/lib/DocblockParser/Ast/Token.php
@@ -35,8 +35,11 @@ final class Token implements Element
     public const T_INVALID = 'INVALID';
     public const T_IS = 'IS';
 
-    public function __construct(public int $byteOffset, public string $type, public string $value)
-    {
+    public function __construct(
+        public int $byteOffset,
+        public string $type,
+        public string $value
+    ) {
     }
 
     public function toString(): string

--- a/lib/DocblockParser/Ast/Type/ArrayShapeNode.php
+++ b/lib/DocblockParser/Ast/Type/ArrayShapeNode.php
@@ -14,7 +14,10 @@ class ArrayShapeNode extends TypeNode
         'close',
     ];
 
-    public function __construct(public Token $open, public ArrayKeyValueList $arrayKeyValueList, public ?Token $close)
-    {
+    public function __construct(
+        public Token $open,
+        public ArrayKeyValueList $arrayKeyValueList,
+        public ?Token $close
+    ) {
     }
 }

--- a/lib/DocblockParser/Ast/Type/ConstantNode.php
+++ b/lib/DocblockParser/Ast/Type/ConstantNode.php
@@ -13,7 +13,10 @@ class ConstantNode extends TypeNode
         'constant'
     ];
 
-    public function __construct(public TypeNode $name, public Token $doubleColon, public Token $constant)
-    {
+    public function __construct(
+        public TypeNode $name,
+        public Token $doubleColon,
+        public Token $constant
+    ) {
     }
 }

--- a/lib/DocblockParser/Ast/Type/GenericNode.php
+++ b/lib/DocblockParser/Ast/Type/GenericNode.php
@@ -19,8 +19,12 @@ class GenericNode extends TypeNode
     /**
      * @param TypeList<Element> $parameters
      */
-    public function __construct(public Token $open, public TypeNode $type, public TypeList $parameters, public Token $close)
-    {
+    public function __construct(
+        public Token $open,
+        public TypeNode $type,
+        public TypeList $parameters,
+        public Token $close
+    ) {
     }
 
     public function close(): Token

--- a/lib/DocblockParser/Ast/Type/ListBracketsNode.php
+++ b/lib/DocblockParser/Ast/Type/ListBracketsNode.php
@@ -12,8 +12,10 @@ class ListBracketsNode extends TypeNode
         'listChars',
     ];
 
-    public function __construct(public TypeNode $type, public Token $listChars)
-    {
+    public function __construct(
+        public TypeNode $type,
+        public Token $listChars
+    ) {
     }
 
     public function type(): TypeNode

--- a/lib/DocblockParser/Ast/Type/NullableNode.php
+++ b/lib/DocblockParser/Ast/Type/NullableNode.php
@@ -12,8 +12,10 @@ class NullableNode extends TypeNode
         'type',
     ];
 
-    public function __construct(public Token $nullable, public TypeNode $type)
-    {
+    public function __construct(
+        public Token $nullable,
+        public TypeNode $type
+    ) {
     }
 
     public function nullable(): Token

--- a/lib/DocblockParser/Ast/Type/ParenthesizedType.php
+++ b/lib/DocblockParser/Ast/Type/ParenthesizedType.php
@@ -13,7 +13,10 @@ class ParenthesizedType extends TypeNode
         'closed',
     ];
 
-    public function __construct(public Token $open, public ?TypeNode $node, public ?Token $closed)
-    {
+    public function __construct(
+        public Token $open,
+        public ?TypeNode $node,
+        public ?Token $closed
+    ) {
     }
 }

--- a/lib/DocblockParser/DocblockParser.php
+++ b/lib/DocblockParser/DocblockParser.php
@@ -7,8 +7,10 @@ use RuntimeException;
 
 final class DocblockParser
 {
-    public function __construct(private Lexer $lexer, private Parser $parser)
-    {
+    public function __construct(
+        private Lexer $lexer,
+        private Parser $parser
+    ) {
     }
 
     public static function create(): self

--- a/lib/Extension/Behat/Adapter/Worse/WorseStepFactory.php
+++ b/lib/Extension/Behat/Adapter/Worse/WorseStepFactory.php
@@ -14,8 +14,10 @@ use Phpactor\WorseReflection\Core\Reflector\ClassReflector;
 
 class WorseStepFactory implements StepFactory
 {
-    public function __construct(private ClassReflector $reflector, private ContextClassResolver $contextClassResolver)
-    {
+    public function __construct(
+        private ClassReflector $reflector,
+        private ContextClassResolver $contextClassResolver
+    ) {
     }
 
     /**

--- a/lib/Extension/Behat/Behat/Context.php
+++ b/lib/Extension/Behat/Behat/Context.php
@@ -4,8 +4,10 @@ namespace Phpactor\Extension\Behat\Behat;
 
 class Context
 {
-    public function __construct(private string $suite, private string $class)
-    {
+    public function __construct(
+        private string $suite,
+        private string $class
+    ) {
     }
 
     public function class(): string

--- a/lib/Extension/Behat/Behat/StepGenerator.php
+++ b/lib/Extension/Behat/Behat/StepGenerator.php
@@ -10,8 +10,11 @@ use IteratorAggregate;
  */
 class StepGenerator implements IteratorAggregate
 {
-    public function __construct(private BehatConfig $config, private StepFactory $factory, private StepParser $parser)
-    {
+    public function __construct(
+        private BehatConfig $config,
+        private StepFactory $factory,
+        private StepParser $parser
+    ) {
     }
 
     public function getIterator(): Generator

--- a/lib/Extension/Behat/ReferenceFinder/StepDefinitionLocator.php
+++ b/lib/Extension/Behat/ReferenceFinder/StepDefinitionLocator.php
@@ -17,8 +17,10 @@ use Phpactor\WorseReflection\Core\TypeFactory;
 
 class StepDefinitionLocator implements DefinitionLocator
 {
-    public function __construct(private StepGenerator $generator, private StepParser $parser)
-    {
+    public function __construct(
+        private StepGenerator $generator,
+        private StepParser $parser
+    ) {
     }
 
 

--- a/lib/Extension/ClassMover/Rpc/ClassMoveHandler.php
+++ b/lib/Extension/ClassMover/Rpc/ClassMoveHandler.php
@@ -21,8 +21,10 @@ class ClassMoveHandler extends AbstractHandler
     private const PARAM_CONFIRMED = 'confirmed';
     private const PARAM_ADDITIONAL_MOVE_CONFIRM = 'move_related';
 
-    public function __construct(private ClassMover $classMove, private string $defaultFilesystem)
-    {
+    public function __construct(
+        private ClassMover $classMove,
+        private string $defaultFilesystem
+    ) {
     }
 
     public function name(): string

--- a/lib/Extension/ClassToFileExtra/Application/FileInfo.php
+++ b/lib/Extension/ClassToFileExtra/Application/FileInfo.php
@@ -8,8 +8,10 @@ use Phpactor\ClassFileConverter\Domain\FileToClass;
 
 class FileInfo
 {
-    public function __construct(private FileToClass $classToFileConverter, private Filesystem $filesystem)
-    {
+    public function __construct(
+        private FileToClass $classToFileConverter,
+        private Filesystem $filesystem
+    ) {
     }
 
     public function infoForFile(string $sourcePath)

--- a/lib/Extension/CodeTransform/Rpc/AbstractClassGenerateHandler.php
+++ b/lib/Extension/CodeTransform/Rpc/AbstractClassGenerateHandler.php
@@ -23,8 +23,10 @@ abstract class AbstractClassGenerateHandler extends AbstractHandler
     public const PARAM_VARIANT = 'variant';
     public const PARAM_OVERWRITE_EXISTING = 'overwrite_existing';
 
-    public function __construct(protected Generators $generators, protected FileToClass $fileToClass)
-    {
+    public function __construct(
+        protected Generators $generators,
+        protected FileToClass $fileToClass
+    ) {
     }
 
     public function configure(Resolver $resolver): void

--- a/lib/Extension/CodeTransformExtra/Application/AbstractClassGenerator.php
+++ b/lib/Extension/CodeTransformExtra/Application/AbstractClassGenerator.php
@@ -14,7 +14,7 @@ class AbstractClassGenerator
     public function __construct(
         protected ClassFileNormalizer $normalizer,
         protected Generators $generators,
-        private LoggerInterface $logger = new NullLogger()
+        private LoggerInterface $logger = new NullLogger(),
     ) {
     }
 

--- a/lib/Extension/CodeTransformExtra/Rpc/ImportMissingClassesHandler.php
+++ b/lib/Extension/CodeTransformExtra/Rpc/ImportMissingClassesHandler.php
@@ -19,8 +19,10 @@ class ImportMissingClassesHandler implements Handler
     public const PARAM_SOURCE = 'source';
     public const PARAM_PATH = 'path';
 
-    public function __construct(private RequestHandler $handler, private Reflector $reflector)
-    {
+    public function __construct(
+        private RequestHandler $handler,
+        private Reflector $reflector
+    ) {
     }
 
     public function configure(Resolver $resolver): void

--- a/lib/Extension/CodeTransformExtra/Rpc/OverrideMethodHandler.php
+++ b/lib/Extension/CodeTransformExtra/Rpc/OverrideMethodHandler.php
@@ -23,8 +23,10 @@ class OverrideMethodHandler extends AbstractHandler
     const PARAM_METHOD_NAME = 'method_name';
     const PARAM_PATH = 'path';
 
-    public function __construct(private Reflector $reflector, private OverrideMethod $overrideMethod)
-    {
+    public function __construct(
+        private Reflector $reflector,
+        private OverrideMethod $overrideMethod
+    ) {
     }
 
     public function name(): string

--- a/lib/Extension/CompletionExtra/Rpc/HoverHandler.php
+++ b/lib/Extension/CompletionExtra/Rpc/HoverHandler.php
@@ -23,8 +23,10 @@ class HoverHandler implements Handler
     const PARAM_OFFSET = 'offset';
     const NAME = 'hover';
 
-    public function __construct(private Reflector $reflector, private ObjectFormatter $formatter)
-    {
+    public function __construct(
+        private Reflector $reflector,
+        private ObjectFormatter $formatter
+    ) {
     }
 
     public function name(): string

--- a/lib/Extension/ComposerAutoloader/ClassLoaderFactory.php
+++ b/lib/Extension/ComposerAutoloader/ClassLoaderFactory.php
@@ -7,8 +7,10 @@ use Psr\Log\LoggerInterface;
 
 class ClassLoaderFactory
 {
-    public function __construct(private string $composerDir, private LoggerInterface $logger)
-    {
+    public function __construct(
+        private string $composerDir,
+        private LoggerInterface $logger
+    ) {
     }
 
     public function getLoader(): ClassLoader

--- a/lib/Extension/Configuration/Model/JsonSchemaBuilder.php
+++ b/lib/Extension/Configuration/Model/JsonSchemaBuilder.php
@@ -12,8 +12,10 @@ class JsonSchemaBuilder
     /**
      * @param class-string[] $extensions
      */
-    public function __construct(private string $title, private array $extensions)
-    {
+    public function __construct(
+        private string $title,
+        private array $extensions
+    ) {
     }
 
     public function dump(): string

--- a/lib/Extension/ContextMenu/Model/Action.php
+++ b/lib/Extension/ContextMenu/Model/Action.php
@@ -4,8 +4,11 @@ namespace Phpactor\Extension\ContextMenu\Model;
 
 class Action
 {
-    public function __construct(private string $action, private ?string $key = null, private array $parameters = [])
-    {
+    public function __construct(
+        private string $action,
+        private ?string $key = null,
+        private array $parameters = []
+    ) {
     }
 
     public function action(): string

--- a/lib/Extension/ContextMenu/Model/ContextMenu.php
+++ b/lib/Extension/ContextMenu/Model/ContextMenu.php
@@ -9,8 +9,10 @@ class ContextMenu
 {
     private array $actions = [];
 
-    public function __construct(array $actions, private array $contexts)
-    {
+    public function __construct(
+        array $actions,
+        private array $contexts
+    ) {
         foreach ($actions as $name => $action) {
             $this->actions[$name] = Invoke::new(Action::class, $action);
         }

--- a/lib/Extension/Core/Application/Status.php
+++ b/lib/Extension/Core/Application/Status.php
@@ -21,7 +21,7 @@ class Status
         private string $workingDirectory,
         private PhpVersionResolver $phpVersionResolver,
         private Trust $trust,
-        private ExecutableFinder $executableFinder = new ExecutableFinder()
+        private ExecutableFinder $executableFinder = new ExecutableFinder(),
     ) {
     }
 

--- a/lib/Extension/Core/Command/TrustCommand.php
+++ b/lib/Extension/Core/Command/TrustCommand.php
@@ -14,8 +14,10 @@ class TrustCommand extends Command
 {
     const OPT_TRUST = 'trust';
 
-    public function __construct(private Trust $status, private string $projectDir)
-    {
+    public function __construct(
+        private Trust $status,
+        private string $projectDir
+    ) {
         parent::__construct();
     }
 

--- a/lib/Extension/Core/Console/Dumper/DumperRegistry.php
+++ b/lib/Extension/Core/Console/Dumper/DumperRegistry.php
@@ -8,8 +8,10 @@ final class DumperRegistry
 {
     private $dumpers = [];
 
-    public function __construct(array $dumpers, private string $default)
-    {
+    public function __construct(
+        array $dumpers,
+        private string $default
+    ) {
         foreach ($dumpers as $name => $dumper) {
             $this->add($name, $dumper);
         }

--- a/lib/Extension/Core/Rpc/StatusHandler.php
+++ b/lib/Extension/Core/Rpc/StatusHandler.php
@@ -17,8 +17,10 @@ class StatusHandler implements Handler
     const TYPE_FORMATTED = 'formatted';
     const TYPE_DETAILED = 'detailed';
 
-    public function __construct(private Status $status, private PathCandidates $paths)
-    {
+    public function __construct(
+        private Status $status,
+        private PathCandidates $paths
+    ) {
     }
 
     public function name(): string

--- a/lib/Extension/Core/Rpc/TrustHandler.php
+++ b/lib/Extension/Core/Rpc/TrustHandler.php
@@ -13,8 +13,10 @@ final class TrustHandler implements Handler
     const NAME = 'trust';
     const PARAM_TRUST = 'trust';
 
-    public function __construct(private Trust $status, private string $projectDir)
-    {
+    public function __construct(
+        private Trust $status,
+        private string $projectDir
+    ) {
     }
 
     public function configure(Resolver $resolver): void

--- a/lib/Extension/Core/Trust/Trust.php
+++ b/lib/Extension/Core/Trust/Trust.php
@@ -11,8 +11,10 @@ class Trust
     /**
      * @param array<string,bool> $trust
      */
-    public function __construct(public array $trust, public readonly ?string $path)
-    {
+    public function __construct(
+        public array $trust,
+        public readonly ?string $path
+    ) {
         $this->unconditionalTrust = (bool)getenv('PHPACTOR_UNCONDITIONAL_TRUST');
     }
 

--- a/lib/Extension/Debug/Model/DocumentorRegistry.php
+++ b/lib/Extension/Debug/Model/DocumentorRegistry.php
@@ -10,8 +10,10 @@ class DocumentorRegistry
     /**
      * @param array<string> $documentors
      */
-    public function __construct(private Container $container, private array $documentors)
-    {
+    public function __construct(
+        private Container $container,
+        private array $documentors
+    ) {
     }
 
     public function get(string $string): Documentor

--- a/lib/Extension/Debug/Model/ExtensionDocumentor.php
+++ b/lib/Extension/Debug/Model/ExtensionDocumentor.php
@@ -12,8 +12,10 @@ class ExtensionDocumentor implements Documentor
     /**
      * @param array<string> $extensionFqns
      */
-    public function __construct(private array $extensionFqns, private DefinitionDocumentor $definitionDocumentor)
-    {
+    public function __construct(
+        private array $extensionFqns,
+        private DefinitionDocumentor $definitionDocumentor
+    ) {
     }
 
     public function document(string $commandName=''): string

--- a/lib/Extension/LanguageServer/CodeAction/ProfilingCodeActionProvider.php
+++ b/lib/Extension/LanguageServer/CodeAction/ProfilingCodeActionProvider.php
@@ -14,8 +14,10 @@ use function Amp\call;
 
 class ProfilingCodeActionProvider implements CodeActionProvider
 {
-    public function __construct(private CodeActionProvider $innerProvider, private LoggerInterface $logger)
-    {
+    public function __construct(
+        private CodeActionProvider $innerProvider,
+        private LoggerInterface $logger
+    ) {
     }
 
     public function provideActionsFor(TextDocumentItem $textDocument, Range $range, CancellationToken $cancel): Promise

--- a/lib/Extension/LanguageServer/CodeAction/TolerantCodeActionProvider.php
+++ b/lib/Extension/LanguageServer/CodeAction/TolerantCodeActionProvider.php
@@ -13,8 +13,10 @@ use Throwable;
 
 final class TolerantCodeActionProvider implements CodeActionProvider
 {
-    public function __construct(private CodeActionProvider $provider, private ClientApi $client)
-    {
+    public function __construct(
+        private CodeActionProvider $provider,
+        private ClientApi $client
+    ) {
     }
 
     public function provideActionsFor(TextDocumentItem $textDocument, Range $range, CancellationToken $cancel): Promise

--- a/lib/Extension/LanguageServer/DiagnosticProvider/CodeFilteringDiagnosticProvider.php
+++ b/lib/Extension/LanguageServer/DiagnosticProvider/CodeFilteringDiagnosticProvider.php
@@ -19,8 +19,10 @@ class CodeFilteringDiagnosticProvider implements DiagnosticsProvider
     /**
      * @param list<string> $ignoreCodes
      */
-    public function __construct(private DiagnosticsProvider $innerProvider, array $ignoreCodes)
-    {
+    public function __construct(
+        private DiagnosticsProvider $innerProvider,
+        array $ignoreCodes
+    ) {
         $this->ignoreCodes = array_flip($ignoreCodes);
     }
 

--- a/lib/Extension/LanguageServer/DiagnosticProvider/PathExcludingDiagnosticsProvider.php
+++ b/lib/Extension/LanguageServer/DiagnosticProvider/PathExcludingDiagnosticsProvider.php
@@ -15,8 +15,10 @@ class PathExcludingDiagnosticsProvider implements DiagnosticsProvider
     /**
      * @param list<string> $paths
      */
-    public function __construct(private DiagnosticsProvider $innerProvider, private array $paths)
-    {
+    public function __construct(
+        private DiagnosticsProvider $innerProvider,
+        private array $paths
+    ) {
     }
 
     public function provideDiagnostics(TextDocumentItem $textDocument, CancellationToken $cancel): Promise

--- a/lib/Extension/LanguageServer/EventDispatcher/LazyAggregateProvider.php
+++ b/lib/Extension/LanguageServer/EventDispatcher/LazyAggregateProvider.php
@@ -14,8 +14,10 @@ class LazyAggregateProvider implements ListenerProviderInterface
     /**
      * @param list<string> $serviceIds
      */
-    public function __construct(private ContainerInterface $container, private array $serviceIds)
-    {
+    public function __construct(
+        private ContainerInterface $container,
+        private array $serviceIds
+    ) {
     }
 
     /**

--- a/lib/Extension/LanguageServer/Listener/InvalidConfigListener.php
+++ b/lib/Extension/LanguageServer/Listener/InvalidConfigListener.php
@@ -13,8 +13,10 @@ use Psr\EventDispatcher\ListenerProviderInterface;
 
 class InvalidConfigListener implements ListenerProviderInterface
 {
-    public function __construct(private ClientApi $clientApi, private ResolverErrors $errors)
-    {
+    public function __construct(
+        private ClientApi $clientApi,
+        private ResolverErrors $errors
+    ) {
     }
 
     /**

--- a/lib/Extension/LanguageServer/Logger/ClientLogger.php
+++ b/lib/Extension/LanguageServer/Logger/ClientLogger.php
@@ -7,8 +7,10 @@ use Psr\Log\LoggerInterface;
 
 class ClientLogger implements LoggerInterface
 {
-    public function __construct(private ClientApi $client, private LoggerInterface $innerLogger)
-    {
+    public function __construct(
+        private ClientApi $client,
+        private LoggerInterface $innerLogger
+    ) {
     }
 
 

--- a/lib/Extension/LanguageServer/Middleware/ProfilerMiddleware.php
+++ b/lib/Extension/LanguageServer/Middleware/ProfilerMiddleware.php
@@ -13,8 +13,10 @@ use function Amp\call;
 
 class ProfilerMiddleware implements Middleware
 {
-    public function __construct(private LoggerInterface $logger, private bool $trace = false)
-    {
+    public function __construct(
+        private LoggerInterface $logger,
+        private bool $trace = false
+    ) {
     }
 
     public function process(Message $request, RequestHandler $handler): Promise

--- a/lib/Extension/LanguageServerBlackfire/Handler/BlackfireHandler.php
+++ b/lib/Extension/LanguageServerBlackfire/Handler/BlackfireHandler.php
@@ -10,8 +10,10 @@ use Phpactor\LanguageServer\Core\Server\ClientApi;
 
 class BlackfireHandler implements Handler
 {
-    public function __construct(private BlackfireProfiler $profiler, private ClientApi $client)
-    {
+    public function __construct(
+        private BlackfireProfiler $profiler,
+        private ClientApi $client
+    ) {
     }
 
     public function methods(): array

--- a/lib/Extension/LanguageServerCodeTransform/Model/NameImport/CandidateFinder.php
+++ b/lib/Extension/LanguageServerCodeTransform/Model/NameImport/CandidateFinder.php
@@ -20,8 +20,10 @@ use function Amp\call;
 
 class CandidateFinder
 {
-    public function __construct(private Reflector $reflector, private SearchClient $client)
-    {
+    public function __construct(
+        private Reflector $reflector,
+        private SearchClient $client
+    ) {
     }
 
     /**

--- a/lib/Extension/LanguageServerCompletion/Handler/SignatureHelpHandler.php
+++ b/lib/Extension/LanguageServerCompletion/Handler/SignatureHelpHandler.php
@@ -19,8 +19,10 @@ use Phpactor\TextDocument\TextDocumentBuilder;
 
 class SignatureHelpHandler implements Handler, CanRegisterCapabilities
 {
-    public function __construct(private Workspace $workspace, private SignatureHelper $helper)
-    {
+    public function __construct(
+        private Workspace $workspace,
+        private SignatureHelper $helper
+    ) {
     }
 
 

--- a/lib/Extension/LanguageServerConfiguration/Listener/AutoConfigListener.php
+++ b/lib/Extension/LanguageServerConfiguration/Listener/AutoConfigListener.php
@@ -17,8 +17,11 @@ class AutoConfigListener implements ListenerProviderInterface
     const NO = 'no';
 
 
-    public function __construct(private Configurator $configurator, private ClientApi $clientApi, private bool $trusted)
-    {
+    public function __construct(
+        private Configurator $configurator,
+        private ClientApi $clientApi,
+        private bool $trusted
+    ) {
     }
 
 

--- a/lib/Extension/LanguageServerDiagnostics/Provider/PhpLintDiagnosticProvider.php
+++ b/lib/Extension/LanguageServerDiagnostics/Provider/PhpLintDiagnosticProvider.php
@@ -13,8 +13,10 @@ use function Amp\call;
 
 class PhpLintDiagnosticProvider implements DiagnosticsProvider
 {
-    public function __construct(private PhpLinter $linter, private TextDocumentLocator $locator)
-    {
+    public function __construct(
+        private PhpLinter $linter,
+        private TextDocumentLocator $locator
+    ) {
     }
 
 

--- a/lib/Extension/LanguageServerHover/Renderer/HoverInformation.php
+++ b/lib/Extension/LanguageServerHover/Renderer/HoverInformation.php
@@ -4,8 +4,11 @@ namespace Phpactor\Extension\LanguageServerHover\Renderer;
 
 class HoverInformation
 {
-    public function __construct(private string $name, private string $docs, private object $object)
-    {
+    public function __construct(
+        private string $name,
+        private string $docs,
+        private object $object
+    ) {
     }
 
     public function docs(): string

--- a/lib/Extension/LanguageServerIndexer/Listener/IndexOnSaveListener.php
+++ b/lib/Extension/LanguageServerIndexer/Listener/IndexOnSaveListener.php
@@ -11,8 +11,10 @@ use Psr\EventDispatcher\ListenerProviderInterface;
 
 class IndexOnSaveListener implements ListenerProviderInterface
 {
-    public function __construct(private Indexer $indexer, private TextDocumentLocator $locator)
-    {
+    public function __construct(
+        private Indexer $indexer,
+        private TextDocumentLocator $locator
+    ) {
     }
 
     /**

--- a/lib/Extension/LanguageServerPhpstan/Model/Linter/TestLinter.php
+++ b/lib/Extension/LanguageServerPhpstan/Model/Linter/TestLinter.php
@@ -13,8 +13,10 @@ class TestLinter implements Linter
     /**
      * @param array<Diagnostic> $diagnostics
      */
-    public function __construct(private array $diagnostics, private int $delay)
-    {
+    public function __construct(
+        private array $diagnostics,
+        private int $delay
+    ) {
     }
 
     public function lint(string $url, ?string $text): Promise

--- a/lib/Extension/LanguageServerPhpstan/Model/PhpstanConfig.php
+++ b/lib/Extension/LanguageServerPhpstan/Model/PhpstanConfig.php
@@ -9,8 +9,13 @@ final class PhpstanConfig
     /**
      * @param DiagnosticSeverity::* $severity
      */
-    public function __construct(private string $phpstanBin, private int $severity, private ?string $level = null, private ?string $config = null, private ?string $memLimit = null)
-    {
+    public function __construct(
+        private string $phpstanBin,
+        private int $severity,
+        private ?string $level = null,
+        private ?string $config = null,
+        private ?string $memLimit = null
+    ) {
     }
 
     public function level(): ?string

--- a/lib/Extension/LanguageServerPsalm/Model/Linter/TestLinter.php
+++ b/lib/Extension/LanguageServerPsalm/Model/Linter/TestLinter.php
@@ -13,8 +13,10 @@ class TestLinter implements Linter
     /**
      * @param array<Diagnostic> $diagnostics
      */
-    public function __construct(private array $diagnostics, private int $delay)
-    {
+    public function __construct(
+        private array $diagnostics,
+        private int $delay
+    ) {
     }
 
     public function lint(string $url, ?string $text): Promise

--- a/lib/Extension/LanguageServerReferenceFinder/Handler/HighlightHandler.php
+++ b/lib/Extension/LanguageServerReferenceFinder/Handler/HighlightHandler.php
@@ -17,8 +17,10 @@ use function Amp\call;
 
 class HighlightHandler implements Handler, CanRegisterCapabilities
 {
-    public function __construct(private Workspace $workspace, private Highlighter $highlighter)
-    {
+    public function __construct(
+        private Workspace $workspace,
+        private Highlighter $highlighter
+    ) {
     }
 
 

--- a/lib/Extension/LanguageServerReferenceFinder/Model/Highlight.php
+++ b/lib/Extension/LanguageServerReferenceFinder/Model/Highlight.php
@@ -9,7 +9,10 @@ class Highlight
     /**
      * @param DocumentHighlightKind::* $kind
      */
-    public function __construct(public int $start, public int $end, public int $kind)
-    {
+    public function __construct(
+        public int $start,
+        public int $end,
+        public int $kind
+    ) {
     }
 }

--- a/lib/Extension/LanguageServerRename/Handler/FileRenameHandler.php
+++ b/lib/Extension/LanguageServerRename/Handler/FileRenameHandler.php
@@ -21,8 +21,10 @@ use function Amp\call;
 
 class FileRenameHandler implements Handler, CanRegisterCapabilities
 {
-    public function __construct(private FileRenamer $renamer, private LocatedTextEditConverter $converter)
-    {
+    public function __construct(
+        private FileRenamer $renamer,
+        private LocatedTextEditConverter $converter
+    ) {
     }
 
 

--- a/lib/Extension/LanguageServerRename/Tests/Util/OffsetExtractorResult.php
+++ b/lib/Extension/LanguageServerRename/Tests/Util/OffsetExtractorResult.php
@@ -13,8 +13,11 @@ final class OffsetExtractorResult
      * @param array<string, ByteOffset[]> $offsets
      * @param array<string, ByteOffsetRange[]> $ranges
      */
-    public function __construct(private string $source, private array $offsets, private array $ranges)
-    {
+    public function __construct(
+        private string $source,
+        private array $offsets,
+        private array $ranges
+    ) {
     }
 
     public function source(): string

--- a/lib/Extension/LanguageServerRename/Util/LocatedTextEditConverter.php
+++ b/lib/Extension/LanguageServerRename/Util/LocatedTextEditConverter.php
@@ -14,8 +14,10 @@ use Phpactor\TextDocument\TextDocumentLocator;
 
 final class LocatedTextEditConverter
 {
-    public function __construct(private Workspace $workspace, private TextDocumentLocator $locator)
-    {
+    public function __construct(
+        private Workspace $workspace,
+        private TextDocumentLocator $locator
+    ) {
     }
 
     public function toWorkspaceEdit(LocatedTextEditsMap $map, ?RenameResult $renameResult = null): WorkspaceEdit

--- a/lib/Extension/LanguageServerSelectionRange/Handler/SelectionRangeHandler.php
+++ b/lib/Extension/LanguageServerSelectionRange/Handler/SelectionRangeHandler.php
@@ -17,8 +17,10 @@ use Phpactor\LanguageServer\Core\Workspace\Workspace;
 
 class SelectionRangeHandler implements Handler, CanRegisterCapabilities
 {
-    public function __construct(private Workspace $workspace, private RangeProvider $provider)
-    {
+    public function __construct(
+        private Workspace $workspace,
+        private RangeProvider $provider
+    ) {
     }
 
 

--- a/lib/Extension/LanguageServerWorseReflection/Handler/InlayHintHandler.php
+++ b/lib/Extension/LanguageServerWorseReflection/Handler/InlayHintHandler.php
@@ -16,8 +16,10 @@ use Phpactor\LanguageServer\Core\Workspace\Workspace;
 
 class InlayHintHandler implements Handler, CanRegisterCapabilities
 {
-    public function __construct(private InlayHintProvider $provider, private Workspace $workspace)
-    {
+    public function __construct(
+        private InlayHintProvider $provider,
+        private Workspace $workspace
+    ) {
     }
     public function methods(): array
     {

--- a/lib/Extension/LanguageServerWorseReflection/InlayHint/InlayHintOptions.php
+++ b/lib/Extension/LanguageServerWorseReflection/InlayHint/InlayHintOptions.php
@@ -4,7 +4,9 @@ namespace Phpactor\Extension\LanguageServerWorseReflection\InlayHint;
 
 class InlayHintOptions
 {
-    public function __construct(public bool $types, public bool $params)
-    {
+    public function __construct(
+        public bool $types,
+        public bool $params
+    ) {
     }
 }

--- a/lib/Extension/LanguageServerWorseReflection/InlayHint/InlayHintProvider.php
+++ b/lib/Extension/LanguageServerWorseReflection/InlayHint/InlayHintProvider.php
@@ -15,8 +15,10 @@ class InlayHintProvider
 {
     private ?CancellationTokenSource $previousCancellationSource = null;
 
-    public function __construct(private SourceCodeReflector $reflector, private InlayHintOptions $options)
-    {
+    public function __construct(
+        private SourceCodeReflector $reflector,
+        private InlayHintOptions $options
+    ) {
     }
 
     /**

--- a/lib/Extension/LanguageServerWorseReflection/InlayHint/InlayHintWalker.php
+++ b/lib/Extension/LanguageServerWorseReflection/InlayHint/InlayHintWalker.php
@@ -38,8 +38,10 @@ class InlayHintWalker implements Walker
      */
     private array $hints = [];
 
-    public function __construct(private ByteOffsetRange $range, private InlayHintOptions $options)
-    {
+    public function __construct(
+        private ByteOffsetRange $range,
+        private InlayHintOptions $options
+    ) {
     }
 
     public function nodeFqns(): array

--- a/lib/Extension/LanguageServerWorseReflection/Listener/StubValidationListener.php
+++ b/lib/Extension/LanguageServerWorseReflection/Listener/StubValidationListener.php
@@ -11,8 +11,10 @@ class StubValidationListener implements ListenerProviderInterface
     /**
      * @param list<string> $stubPaths
      */
-    public function __construct(private ClientApi $api, private array $stubPaths)
-    {
+    public function __construct(
+        private ClientApi $api,
+        private array $stubPaths
+    ) {
     }
 
     /**

--- a/lib/Extension/Logger/Formatter/FormatterRegistry.php
+++ b/lib/Extension/Logger/Formatter/FormatterRegistry.php
@@ -8,8 +8,10 @@ use RuntimeException;
 
 class FormatterRegistry
 {
-    public function __construct(private ContainerInterface $container, private array $serviceMap)
-    {
+    public function __construct(
+        private ContainerInterface $container,
+        private array $serviceMap
+    ) {
     }
 
     public function get(string $alias): FormatterInterface

--- a/lib/Extension/Logger/Logger/ChannelLogger.php
+++ b/lib/Extension/Logger/Logger/ChannelLogger.php
@@ -7,8 +7,10 @@ use Psr\Log\LoggerInterface;
 
 class ChannelLogger extends AbstractLogger
 {
-    public function __construct(private string $name, private LoggerInterface $innerLogger)
-    {
+    public function __construct(
+        private string $name,
+        private LoggerInterface $innerLogger
+    ) {
     }
 
     public function log($level, $message, array $context = []): void

--- a/lib/Extension/OpenTelemetry/Model/PostContext.php
+++ b/lib/Extension/OpenTelemetry/Model/PostContext.php
@@ -9,8 +9,12 @@ class PostContext
     /**
      * @param array<int,mixed> $params
      */
-    public function __construct(public object $object, public array $params, public mixed $returnValue, public ?Throwable $exception)
-    {
+    public function __construct(
+        public object $object,
+        public array $params,
+        public mixed $returnValue,
+        public ?Throwable $exception
+    ) {
     }
 
 }

--- a/lib/Extension/OpenTelemetry/Model/PreContext.php
+++ b/lib/Extension/OpenTelemetry/Model/PreContext.php
@@ -11,8 +11,14 @@ final class PreContext
     /**
      * @param array<int,mixed> $params
      */
-    public function __construct(public object $object, public array $params, public string $class, public string $function, public ?string $filename, public ?int $lineno)
-    {
+    public function __construct(
+        public object $object,
+        public array $params,
+        public string $class,
+        public string $function,
+        public ?string $filename,
+        public ?int $lineno
+    ) {
     }
 
     public function context(): ContextInterface

--- a/lib/Extension/Rpc/Registry/LazyContainerHandlerRegistry.php
+++ b/lib/Extension/Rpc/Registry/LazyContainerHandlerRegistry.php
@@ -9,8 +9,10 @@ use Psr\Container\ContainerInterface;
 
 class LazyContainerHandlerRegistry implements HandlerRegistry
 {
-    public function __construct(private ContainerInterface $container, private array $serviceMap)
-    {
+    public function __construct(
+        private ContainerInterface $container,
+        private array $serviceMap
+    ) {
     }
 
     public function get($handlerName): Handler

--- a/lib/Extension/Rpc/Request.php
+++ b/lib/Extension/Rpc/Request.php
@@ -9,8 +9,10 @@ class Request
     const KEY_ACTION = 'action';
     const KEY_PARAMETERS = 'parameters';
 
-    private function __construct(private string $name, private array $parameters)
-    {
+    private function __construct(
+        private string $name,
+        private array $parameters
+    ) {
     }
 
     public static function fromNameAndParameters(string $name, array $parameters)

--- a/lib/Extension/Rpc/RequestHandler/LoggingHandler.php
+++ b/lib/Extension/Rpc/RequestHandler/LoggingHandler.php
@@ -11,8 +11,10 @@ use Phpactor\Extension\Rpc\Response\ErrorResponse;
 
 class LoggingHandler implements RequestHandler
 {
-    public function __construct(private RequestHandler $requestHandler, private LoggerInterface $logger)
-    {
+    public function __construct(
+        private RequestHandler $requestHandler,
+        private LoggerInterface $logger
+    ) {
     }
 
     public function handle(Request $request): Response

--- a/lib/Extension/Rpc/Response/ErrorResponse.php
+++ b/lib/Extension/Rpc/Response/ErrorResponse.php
@@ -7,8 +7,10 @@ use Exception;
 
 class ErrorResponse implements Response
 {
-    private function __construct(private string $message, private string $details)
-    {
+    private function __construct(
+        private string $message,
+        private string $details
+    ) {
     }
 
     public static function fromMessageAndDetails(string $message, string $details): ErrorResponse

--- a/lib/Extension/Rpc/Response/Input/ConfirmInput.php
+++ b/lib/Extension/Rpc/Response/Input/ConfirmInput.php
@@ -4,8 +4,10 @@ namespace Phpactor\Extension\Rpc\Response\Input;
 
 class ConfirmInput implements Input
 {
-    private function __construct(private string $name, private string $label)
-    {
+    private function __construct(
+        private string $name,
+        private string $label
+    ) {
     }
 
     public static function fromNameAndLabel(string $name, string $label)

--- a/lib/Extension/Rpc/Response/Input/TextInput.php
+++ b/lib/Extension/Rpc/Response/Input/TextInput.php
@@ -4,8 +4,12 @@ namespace Phpactor\Extension\Rpc\Response\Input;
 
 class TextInput implements Input
 {
-    private function __construct(private string $name, private string $label, private ?string $default = null, private ?string $type = null)
-    {
+    private function __construct(
+        private string $name,
+        private string $label,
+        private ?string $default = null,
+        private ?string $type = null
+    ) {
     }
 
     public static function fromNameLabelAndDefault(string $name, string $label, ?string $default = null, ?string $type = null)

--- a/lib/Extension/Rpc/Response/InputCallbackResponse.php
+++ b/lib/Extension/Rpc/Response/InputCallbackResponse.php
@@ -10,8 +10,10 @@ class InputCallbackResponse implements Response
 {
     private array $inputs = [];
 
-    private function __construct(private Request $callbackAction, array $inputs)
-    {
+    private function __construct(
+        private Request $callbackAction,
+        array $inputs
+    ) {
         foreach ($inputs as $input) {
             $this->add($input);
         }

--- a/lib/Extension/Rpc/Response/Reference/FileReferences.php
+++ b/lib/Extension/Rpc/Response/Reference/FileReferences.php
@@ -6,8 +6,10 @@ class FileReferences
 {
     private array $references = [];
 
-    private function __construct(private string $filePath, array $references)
-    {
+    private function __construct(
+        private string $filePath,
+        array $references
+    ) {
         foreach ($references as $reference) {
             $this->addReference($reference);
         }

--- a/lib/Extension/Rpc/Response/ReplaceFileSourceResponse.php
+++ b/lib/Extension/Rpc/Response/ReplaceFileSourceResponse.php
@@ -6,8 +6,10 @@ use Phpactor\Extension\Rpc\Response;
 
 class ReplaceFileSourceResponse implements Response
 {
-    private function __construct(private string $path, private string $replacementSource)
-    {
+    private function __construct(
+        private string $path,
+        private string $replacementSource
+    ) {
     }
 
     public static function fromPathAndSource(string $path, string $replacementSource)

--- a/lib/Extension/Rpc/Response/ReturnOption.php
+++ b/lib/Extension/Rpc/Response/ReturnOption.php
@@ -4,8 +4,10 @@ namespace Phpactor\Extension\Rpc\Response;
 
 class ReturnOption
 {
-    private function __construct(private string $name, private $value)
-    {
+    private function __construct(
+        private string $name,
+        private $value
+    ) {
     }
 
     public static function fromNameAndValue(string $name, $value)

--- a/lib/Extension/Rpc/Response/UpdateFileSourceResponse.php
+++ b/lib/Extension/Rpc/Response/UpdateFileSourceResponse.php
@@ -9,8 +9,11 @@ class UpdateFileSourceResponse implements Response
 {
     private TextEditBuilder $textEditBuilder;
 
-    private function __construct(private string $path, private string $oldSource, private string $newSource)
-    {
+    private function __construct(
+        private string $path,
+        private string $oldSource,
+        private string $newSource
+    ) {
         // TODO: This should be a service
         $this->textEditBuilder = new TextEditBuilder();
     }

--- a/lib/Extension/Rpc/RpcCommandDocumentor.php
+++ b/lib/Extension/Rpc/RpcCommandDocumentor.php
@@ -9,8 +9,10 @@ use RuntimeException;
 
 class RpcCommandDocumentor implements Documentor
 {
-    public function __construct(private HandlerRegistry $handlerRegistry, private DefinitionDocumentor $definitionDocumentor)
-    {
+    public function __construct(
+        private HandlerRegistry $handlerRegistry,
+        private DefinitionDocumentor $definitionDocumentor
+    ) {
     }
 
     public function document(string $commandName=''): string

--- a/lib/Extension/Symfony/Adapter/Symfony/XmlSymfonyContainerInspector.php
+++ b/lib/Extension/Symfony/Adapter/Symfony/XmlSymfonyContainerInspector.php
@@ -17,8 +17,10 @@ class XmlSymfonyContainerInspector implements SymfonyContainerInspector
 
     private ?DOMXPath $cache = null;
 
-    public function __construct(private string $xmlPath, private bool $publicOnly = false)
-    {
+    public function __construct(
+        private string $xmlPath,
+        private bool $publicOnly = false
+    ) {
     }
 
     public function services(): array

--- a/lib/Extension/Symfony/Completor/SymfonyContainerCompletor.php
+++ b/lib/Extension/Symfony/Completor/SymfonyContainerCompletor.php
@@ -22,8 +22,10 @@ class SymfonyContainerCompletor implements TolerantCompletor
 {
     const CONTAINER_CLASS = 'Symfony\\Component\\DependencyInjection\\ContainerInterface';
 
-    public function __construct(private Reflector $reflector, private SymfonyContainerInspector $inspector)
-    {
+    public function __construct(
+        private Reflector $reflector,
+        private SymfonyContainerInspector $inspector
+    ) {
     }
 
     public function complete(Node $node, TextDocument $source, ByteOffset $offset): Generator

--- a/lib/Extension/Symfony/Model/InMemorySymfonyContainerInspector.php
+++ b/lib/Extension/Symfony/Model/InMemorySymfonyContainerInspector.php
@@ -8,8 +8,10 @@ class InMemorySymfonyContainerInspector implements SymfonyContainerInspector
      * @param SymfonyContainerService[] $services
      * @param SymfonyContainerParameter[] $parameters
      */
-    public function __construct(private array $services, private array $parameters)
-    {
+    public function __construct(
+        private array $services,
+        private array $parameters
+    ) {
     }
 
     public function services(): array

--- a/lib/Extension/Symfony/Model/SymfonyContainerParameter.php
+++ b/lib/Extension/Symfony/Model/SymfonyContainerParameter.php
@@ -6,7 +6,9 @@ use Phpactor\WorseReflection\Core\Type;
 
 class SymfonyContainerParameter
 {
-    public function __construct(public string $id, public Type $type)
-    {
+    public function __construct(
+        public string $id,
+        public Type $type
+    ) {
     }
 }

--- a/lib/Extension/Symfony/Model/SymfonyContainerService.php
+++ b/lib/Extension/Symfony/Model/SymfonyContainerService.php
@@ -6,7 +6,9 @@ use Phpactor\WorseReflection\Core\Type;
 
 class SymfonyContainerService
 {
-    public function __construct(public string $id, public Type $type)
-    {
+    public function __construct(
+        public string $id,
+        public Type $type
+    ) {
     }
 }

--- a/lib/Extension/WorseReflectionAnalyse/Model/Analyser.php
+++ b/lib/Extension/WorseReflectionAnalyse/Model/Analyser.php
@@ -17,8 +17,10 @@ use function Amp\Promise\wait;
 
 class Analyser
 {
-    public function __construct(private FilesystemRegistry $filesystem, private SourceCodeReflector $reflector)
-    {
+    public function __construct(
+        private FilesystemRegistry $filesystem,
+        private SourceCodeReflector $reflector
+    ) {
     }
 
     /**

--- a/lib/Extension/WorseReflectionExtra/Application/ClassReflector.php
+++ b/lib/Extension/WorseReflectionExtra/Application/ClassReflector.php
@@ -14,8 +14,10 @@ class ClassReflector
     const FOOBAR = 'foo';
 
     // rename compositetransformer => classToFileConverter
-    public function __construct(private ClassFileNormalizer $classFileNormalizer, private Reflector $reflector)
-    {
+    public function __construct(
+        private ClassFileNormalizer $classFileNormalizer,
+        private Reflector $reflector
+    ) {
     }
 
     /**

--- a/lib/FilePathResolver/Expander/CallbackExpander.php
+++ b/lib/FilePathResolver/Expander/CallbackExpander.php
@@ -13,8 +13,10 @@ class CallbackExpander implements Expander
     /**
      * @param Closure():string $callback
     */
-    public function __construct(private string $tokenName, Closure $callback)
-    {
+    public function __construct(
+        private string $tokenName,
+        Closure $callback
+    ) {
         $this->callback = $callback;
     }
 

--- a/lib/FilePathResolver/Expander/ValueExpander.php
+++ b/lib/FilePathResolver/Expander/ValueExpander.php
@@ -6,8 +6,10 @@ use Phpactor\FilePathResolver\Expander;
 
 class ValueExpander implements Expander
 {
-    public function __construct(private string $tokenName, private string $value)
-    {
+    public function __construct(
+        private string $tokenName,
+        private string $value
+    ) {
     }
 
     public function tokenName(): string

--- a/lib/FilePathResolver/Expander/Xdg/AbstractXdgExpander.php
+++ b/lib/FilePathResolver/Expander/Xdg/AbstractXdgExpander.php
@@ -7,8 +7,10 @@ use XdgBaseDir\Xdg;
 
 abstract class AbstractXdgExpander implements Expander
 {
-    public function __construct(private string $name, protected Xdg $xdg = new Xdg())
-    {
+    public function __construct(
+        private string $name,
+        protected Xdg $xdg = new Xdg(),
+    ) {
     }
 
     public function tokenName(): string

--- a/lib/FilePathResolver/Expander/Xdg/SuffixExpanderDecorator.php
+++ b/lib/FilePathResolver/Expander/Xdg/SuffixExpanderDecorator.php
@@ -6,8 +6,10 @@ use Phpactor\FilePathResolver\Expander;
 
 class SuffixExpanderDecorator implements Expander
 {
-    public function __construct(private Expander $innerExpander, private string $suffix)
-    {
+    public function __construct(
+        private Expander $innerExpander,
+        private string $suffix
+    ) {
     }
 
     public function tokenName(): string

--- a/lib/Filesystem/Adapter/Composer/ComposerFileListProvider.php
+++ b/lib/Filesystem/Adapter/Composer/ComposerFileListProvider.php
@@ -16,8 +16,10 @@ use Symfony\Component\Filesystem\Path;
 
 class ComposerFileListProvider implements FileListProvider
 {
-    public function __construct(private FilePath $path, private ClassLoader $classLoader)
-    {
+    public function __construct(
+        private FilePath $path,
+        private ClassLoader $classLoader
+    ) {
     }
 
     public function fileList(): FileList

--- a/lib/Filesystem/Adapter/Simple/SimpleFileListProvider.php
+++ b/lib/Filesystem/Adapter/Simple/SimpleFileListProvider.php
@@ -12,8 +12,10 @@ use RecursiveIteratorIterator;
 
 final class SimpleFileListProvider implements FileListProvider
 {
-    public function __construct(private FilePath $path, private bool $followSymlinks = false)
-    {
+    public function __construct(
+        private FilePath $path,
+        private bool $followSymlinks = false
+    ) {
     }
 
     public function fileList(): FileList

--- a/lib/Filesystem/Adapter/Simple/SimpleFilesystem.php
+++ b/lib/Filesystem/Adapter/Simple/SimpleFilesystem.php
@@ -20,7 +20,7 @@ class SimpleFilesystem implements Filesystem
     public function __construct(
         private FilePath $path,
         ?FileListProvider $fileListProvider = null,
-        private SymfonyFilesystem $filesystem = new SymfonyFilesystem()
+        private SymfonyFilesystem $filesystem = new SymfonyFilesystem(),
     ) {
         $this->fileListProvider = $fileListProvider ?? new SimpleFileListProvider($this->path);
     }

--- a/lib/Filesystem/Domain/CopyReport.php
+++ b/lib/Filesystem/Domain/CopyReport.php
@@ -4,8 +4,10 @@ namespace Phpactor\Filesystem\Domain;
 
 final class CopyReport
 {
-    private function __construct(private FileList $srcFiles, private FileList $destFiles)
-    {
+    private function __construct(
+        private FileList $srcFiles,
+        private FileList $destFiles
+    ) {
     }
 
     public static function fromSrcAndDestFiles(FileList $srcFiles, FileList $destFiles): CopyReport

--- a/lib/Filesystem/Domain/FallbackFilesystemRegistry.php
+++ b/lib/Filesystem/Domain/FallbackFilesystemRegistry.php
@@ -4,8 +4,10 @@ namespace Phpactor\Filesystem\Domain;
 
 class FallbackFilesystemRegistry implements FilesystemRegistry
 {
-    public function __construct(private FilesystemRegistry $registry, private string $fallback)
-    {
+    public function __construct(
+        private FilesystemRegistry $registry,
+        private string $fallback
+    ) {
     }
 
     public function get(string $name): Filesystem

--- a/lib/Indexer/Adapter/Php/FileInfoPharExpandingIterator.php
+++ b/lib/Indexer/Adapter/Php/FileInfoPharExpandingIterator.php
@@ -19,8 +19,10 @@ class FileInfoPharExpandingIterator implements IteratorAggregate
      * @param Iterator<SplFileInfo> $innerIterator
      * @param list<string> $supportedExtensions
      */
-    public function __construct(private Iterator $innerIterator, private array $supportedExtensions = ['php'])
-    {
+    public function __construct(
+        private Iterator $innerIterator,
+        private array $supportedExtensions = ['php']
+    ) {
     }
 
     public function getIterator(): Traversable

--- a/lib/Indexer/Adapter/Php/Serialized/FileRepository.php
+++ b/lib/Indexer/Adapter/Php/Serialized/FileRepository.php
@@ -33,7 +33,7 @@ class FileRepository
     public function __construct(
         private string $path,
         private RecordSerializer $serializer,
-        private LoggerInterface $logger = new NullLogger()
+        private LoggerInterface $logger = new NullLogger(),
     ) {
         $this->initializeLastUpdate();
     }

--- a/lib/Indexer/Adapter/Worse/WorseRecordReferenceEnhancer.php
+++ b/lib/Indexer/Adapter/Worse/WorseRecordReferenceEnhancer.php
@@ -16,8 +16,11 @@ use Psr\Log\LoggerInterface;
 
 class WorseRecordReferenceEnhancer implements RecordReferenceEnhancer
 {
-    public function __construct(private SourceCodeReflector $reflector, private LoggerInterface $logger, private TextDocumentLocator $locator)
-    {
+    public function __construct(
+        private SourceCodeReflector $reflector,
+        private LoggerInterface $logger,
+        private TextDocumentLocator $locator
+    ) {
     }
 
     public function enhance(FileRecord $record, RecordReference $reference): RecordReference

--- a/lib/Indexer/Extension/Command/IndexBuildCommand.php
+++ b/lib/Indexer/Extension/Command/IndexBuildCommand.php
@@ -23,8 +23,10 @@ class IndexBuildCommand extends Command
 
     private MemoryUsage $usage;
 
-    public function __construct(private Indexer $indexer, private Watcher $watcher)
-    {
+    public function __construct(
+        private Indexer $indexer,
+        private Watcher $watcher
+    ) {
         parent::__construct();
         $this->usage = MemoryUsage::create();
     }

--- a/lib/Indexer/Extension/Command/IndexCleanCommand.php
+++ b/lib/Indexer/Extension/Command/IndexCleanCommand.php
@@ -25,8 +25,10 @@ class IndexCleanCommand extends Command
     public const ARG_INDEX_NAME = 'name';
     public const OPT_CLEAN_ALL = 'all';
 
-    public function __construct(private IndexLister $indexLister, private Filesystem $filesystem)
-    {
+    public function __construct(
+        private IndexLister $indexLister,
+        private Filesystem $filesystem
+    ) {
         parent::__construct();
     }
 

--- a/lib/Indexer/Extension/Rpc/IndexHandler.php
+++ b/lib/Indexer/Extension/Rpc/IndexHandler.php
@@ -18,8 +18,10 @@ class IndexHandler implements Handler
     const PARAM_WATCH = 'watch';
     const PARAM_INTERVAL = 'interval';
 
-    public function __construct(private Indexer $indexer, private Watcher $watcher)
-    {
+    public function __construct(
+        private Indexer $indexer,
+        private Watcher $watcher
+    ) {
     }
 
     public function configure(Resolver $resolver): void

--- a/lib/Indexer/Model/Index/SearchAwareIndex.php
+++ b/lib/Indexer/Model/Index/SearchAwareIndex.php
@@ -9,8 +9,10 @@ use SplFileInfo;
 
 class SearchAwareIndex implements Index
 {
-    public function __construct(private Index $innerIndex, private SearchIndex $search)
-    {
+    public function __construct(
+        private Index $innerIndex,
+        private SearchIndex $search
+    ) {
     }
 
     public function lastUpdate(): int

--- a/lib/Indexer/Model/LocationConfidence.php
+++ b/lib/Indexer/Model/LocationConfidence.php
@@ -10,8 +10,10 @@ class LocationConfidence
     public const CONFIDENCE_NOT = 'not';
     public const CONFIDENCE_MAYBE = 'maybe';
 
-    public function __construct(private Location $location, private string $confidence)
-    {
+    public function __construct(
+        private Location $location,
+        private string $confidence
+    ) {
     }
 
     public function __toString(): string

--- a/lib/Indexer/Model/MemberReference.php
+++ b/lib/Indexer/Model/MemberReference.php
@@ -10,8 +10,11 @@ class MemberReference
     /**
      * @param MemberRecord::TYPE_* $type
      */
-    public function __construct(private string $type, private ?FullyQualifiedName $name, private ?string $memberName)
-    {
+    public function __construct(
+        private string $type,
+        private ?FullyQualifiedName $name,
+        private ?string $memberName
+    ) {
     }
 
     /**

--- a/lib/Indexer/Model/MemoryUsage.php
+++ b/lib/Indexer/Model/MemoryUsage.php
@@ -8,8 +8,11 @@ use function memory_get_usage;
 
 final class MemoryUsage
 {
-    private function __construct(private ?int $memoryLimit, private int $memoryUsage, private int $precision = 0)
-    {
+    private function __construct(
+        private ?int $memoryLimit,
+        private int $memoryUsage,
+        private int $precision = 0
+    ) {
     }
 
     public static function create(): self

--- a/lib/Indexer/Model/Query/MemberQuery.php
+++ b/lib/Indexer/Model/Query/MemberQuery.php
@@ -13,8 +13,10 @@ use Phpactor\Indexer\Model\Record\MemberRecord;
 
 class MemberQuery implements IndexQuery
 {
-    public function __construct(private Index $index, private RecordReferenceEnhancer $enhancer)
-    {
+    public function __construct(
+        private Index $index,
+        private RecordReferenceEnhancer $enhancer
+    ) {
     }
 
     public function get(string $identifier): ?MemberRecord

--- a/lib/Indexer/Model/RealIndexAgent.php
+++ b/lib/Indexer/Model/RealIndexAgent.php
@@ -6,8 +6,12 @@ use Phpactor\Indexer\IndexAgent;
 
 class RealIndexAgent implements IndexAgent, TestIndexAgent
 {
-    public function __construct(private Index $index, private QueryClient $query, private SearchClient $search, private Indexer $indexer)
-    {
+    public function __construct(
+        private Index $index,
+        private QueryClient $query,
+        private SearchClient $search,
+        private Indexer $indexer
+    ) {
     }
 
     public function search(): SearchClient

--- a/lib/Indexer/Model/Record/MemberRecord.php
+++ b/lib/Indexer/Model/Record/MemberRecord.php
@@ -23,8 +23,11 @@ class MemberRecord implements HasFileReferences, Record, HasShortName
     /**
      * @param MemberRecord::TYPE_* $type
      */
-    public function __construct(string $type, private string $memberName, private ?string $containerType = null)
-    {
+    public function __construct(
+        string $type,
+        private string $memberName,
+        private ?string $containerType = null
+    ) {
         if (!in_array($type, [
             self::TYPE_PROPERTY,
             self::TYPE_CONSTANT,

--- a/lib/Indexer/Model/RecordReferences.php
+++ b/lib/Indexer/Model/RecordReferences.php
@@ -20,8 +20,10 @@ class RecordReferences implements IteratorAggregate
     /**
      * @param array<RecordReference> $references
      */
-    public function __construct(private FileRecord $file, array $references)
-    {
+    public function __construct(
+        private FileRecord $file,
+        array $references
+    ) {
         foreach ($references as $reference) {
             $this->add($reference);
         }

--- a/lib/Indexer/Model/SearchClient/HydratingSearchClient.php
+++ b/lib/Indexer/Model/SearchClient/HydratingSearchClient.php
@@ -9,8 +9,10 @@ use Phpactor\Indexer\Model\SearchClient;
 
 class HydratingSearchClient implements SearchClient
 {
-    public function __construct(private Index $index, private SearchClient $innerClient)
-    {
+    public function __construct(
+        private Index $index,
+        private SearchClient $innerClient
+    ) {
     }
 
 

--- a/lib/Indexer/Model/SearchIndex/FilteredSearchIndex.php
+++ b/lib/Indexer/Model/SearchIndex/FilteredSearchIndex.php
@@ -15,8 +15,10 @@ class FilteredSearchIndex implements SearchIndex
     /**
      * @param array<string> $recordTypes
      */
-    public function __construct(private SearchIndex $innerIndex, private array $recordTypes)
-    {
+    public function __construct(
+        private SearchIndex $innerIndex,
+        private array $recordTypes
+    ) {
     }
 
 

--- a/lib/Indexer/Model/SearchIndex/SearchIncludeIndex.php
+++ b/lib/Indexer/Model/SearchIndex/SearchIncludeIndex.php
@@ -13,8 +13,10 @@ class SearchIncludeIndex implements SearchIndex
     /**
      * @param list<string> $patterns
      */
-    public function __construct(private SearchIndex $innerIndex, private array $patterns)
-    {
+    public function __construct(
+        private SearchIndex $innerIndex,
+        private array $patterns
+    ) {
     }
 
     public function search(Criteria $criteria): Generator

--- a/lib/PathFinder/PathFinder.php
+++ b/lib/PathFinder/PathFinder.php
@@ -10,8 +10,10 @@ class PathFinder
     /**
      * @param array<string, Pattern> $destinations
      */
-    private function __construct(private string $basePath, private array $destinations)
-    {
+    private function __construct(
+        private string $basePath,
+        private array $destinations
+    ) {
     }
 
     /**

--- a/lib/PathFinder/Pattern.php
+++ b/lib/PathFinder/Pattern.php
@@ -13,8 +13,11 @@ class Pattern
     /**
      * @param array<string> $tokenNames
      */
-    public function __construct(private string $regex, private string $pattern, private array $tokenNames)
-    {
+    public function __construct(
+        private string $regex,
+        private string $pattern,
+        private array $tokenNames
+    ) {
     }
 
     public static function fromPattern(string $pattern): self

--- a/lib/ReferenceFinder/DefinitionAndReferenceFinder.php
+++ b/lib/ReferenceFinder/DefinitionAndReferenceFinder.php
@@ -9,8 +9,10 @@ use Phpactor\TextDocument\TextDocument;
 
 class DefinitionAndReferenceFinder implements ReferenceFinder
 {
-    public function __construct(private DefinitionLocator $locator, private ReferenceFinder $referenceFinder)
-    {
+    public function __construct(
+        private DefinitionLocator $locator,
+        private ReferenceFinder $referenceFinder
+    ) {
     }
 
 

--- a/lib/ReferenceFinder/PotentialLocation.php
+++ b/lib/ReferenceFinder/PotentialLocation.php
@@ -10,8 +10,10 @@ final class PotentialLocation
     private const CONFIDENCE_NOT = 'not';
     private const CONFIDENCE_MAYBE = 'maybe';
 
-    public function __construct(private Location $location, private string $confidence)
-    {
+    public function __construct(
+        private Location $location,
+        private string $confidence
+    ) {
     }
 
     public static function maybe(Location $location): self

--- a/lib/ReferenceFinder/TypeLocation.php
+++ b/lib/ReferenceFinder/TypeLocation.php
@@ -7,8 +7,10 @@ use Phpactor\WorseReflection\Core\Type;
 
 class TypeLocation
 {
-    public function __construct(private Type $type, private Location $location)
-    {
+    public function __construct(
+        private Type $type,
+        private Location $location
+    ) {
     }
 
     public function type(): Type

--- a/lib/Rename/Model/FileRenamer/LoggingFileRenamer.php
+++ b/lib/Rename/Model/FileRenamer/LoggingFileRenamer.php
@@ -10,8 +10,10 @@ use function Amp\call;
 
 class LoggingFileRenamer implements FileRenamer
 {
-    public function __construct(private FileRenamer $innerRenamer, private LoggerInterface $logger)
-    {
+    public function __construct(
+        private FileRenamer $innerRenamer,
+        private LoggerInterface $logger
+    ) {
     }
 
 

--- a/lib/Rename/Model/FileRenamer/TestFileRenamer.php
+++ b/lib/Rename/Model/FileRenamer/TestFileRenamer.php
@@ -14,8 +14,10 @@ class TestFileRenamer implements FileRenamer
 {
     private LocatedTextEditsMap $workspaceEdits;
 
-    public function __construct(private bool $throw = false, ?LocatedTextEditsMap $workspaceEdits = null)
-    {
+    public function __construct(
+        private bool $throw = false,
+        ?LocatedTextEditsMap $workspaceEdits = null
+    ) {
         $this->workspaceEdits = $workspaceEdits ?: LocatedTextEditsMap::create();
     }
 

--- a/lib/Rename/Model/LocatedTextEdit.php
+++ b/lib/Rename/Model/LocatedTextEdit.php
@@ -7,8 +7,10 @@ use Phpactor\TextDocument\TextEdit;
 
 final class LocatedTextEdit
 {
-    public function __construct(private TextDocumentUri $documentUri, private TextEdit $textEdit)
-    {
+    public function __construct(
+        private TextDocumentUri $documentUri,
+        private TextEdit $textEdit
+    ) {
     }
 
     public function textEdit(): TextEdit

--- a/lib/Rename/Model/LocatedTextEdits.php
+++ b/lib/Rename/Model/LocatedTextEdits.php
@@ -7,8 +7,10 @@ use Phpactor\TextDocument\TextEdits;
 
 class LocatedTextEdits
 {
-    public function __construct(private TextEdits $textEdits, private TextDocumentUri $documentUri)
-    {
+    public function __construct(
+        private TextEdits $textEdits,
+        private TextDocumentUri $documentUri
+    ) {
     }
 
     public function textEdits(): TextEdits

--- a/lib/Rename/Model/RenameResult.php
+++ b/lib/Rename/Model/RenameResult.php
@@ -6,8 +6,10 @@ use Phpactor\TextDocument\TextDocumentUri;
 
 class RenameResult
 {
-    public function __construct(private TextDocumentUri $oldUri, private TextDocumentUri $newUri)
-    {
+    public function __construct(
+        private TextDocumentUri $oldUri,
+        private TextDocumentUri $newUri
+    ) {
     }
 
     public function oldUri(): TextDocumentUri

--- a/lib/Rename/Model/Renamer/InMemoryRenamer.php
+++ b/lib/Rename/Model/Renamer/InMemoryRenamer.php
@@ -14,8 +14,10 @@ class InMemoryRenamer implements Renamer
     /**
      * @param LocatedTextEdit[] $results
      */
-    public function __construct(private ?ByteOffsetRange $range, private array $results = [])
-    {
+    public function __construct(
+        private ?ByteOffsetRange $range,
+        private array $results = []
+    ) {
     }
 
     public function getRenameRange(TextDocument $textDocument, ByteOffset $offset): ?ByteOffsetRange

--- a/lib/TextDocument/ByteOffsetRange.php
+++ b/lib/TextDocument/ByteOffsetRange.php
@@ -4,8 +4,10 @@ namespace Phpactor\TextDocument;
 
 class ByteOffsetRange
 {
-    public function __construct(private ByteOffset $start, private ByteOffset $end)
-    {
+    public function __construct(
+        private ByteOffset $start,
+        private ByteOffset $end
+    ) {
     }
 
     public static function fromInts(int $start, int $end): self

--- a/lib/TextDocument/LineColRange.php
+++ b/lib/TextDocument/LineColRange.php
@@ -4,8 +4,10 @@ namespace Phpactor\TextDocument;
 
 final class LineColRange
 {
-    public function __construct(private LineCol $start, private LineCol $end)
-    {
+    public function __construct(
+        private LineCol $start,
+        private LineCol $end
+    ) {
     }
 
     public function start(): LineCol

--- a/lib/TextDocument/TextDocumentEdits.php
+++ b/lib/TextDocument/TextDocumentEdits.php
@@ -12,8 +12,10 @@ use IteratorAggregate;
  */
 class TextDocumentEdits implements IteratorAggregate
 {
-    public function __construct(private TextDocumentUri $uri, private TextEdits $textEdits)
-    {
+    public function __construct(
+        private TextDocumentUri $uri,
+        private TextEdits $textEdits
+    ) {
     }
 
     public static function fromTextDocument(TextDocument $textDocument, TextEdits $edits): self

--- a/lib/TextDocument/TextDocumentUri.php
+++ b/lib/TextDocument/TextDocumentUri.php
@@ -12,8 +12,10 @@ class TextDocumentUri
     public const SCHEME_PHAR = 'phar';
     public const SCHEMES = [self::SCHEME_FILE, self::SCHEME_UNTITLED, self::SCHEME_PHAR];
 
-    final private function __construct(private string $scheme, private string $path)
-    {
+    final private function __construct(
+        private string $scheme,
+        private string $path
+    ) {
     }
 
     public function __toString(): string

--- a/lib/WorseReferenceFinder/TolerantVariableReferenceFinder.php
+++ b/lib/WorseReferenceFinder/TolerantVariableReferenceFinder.php
@@ -28,8 +28,10 @@ use Exception;
 
 class TolerantVariableReferenceFinder implements ReferenceFinder
 {
-    public function __construct(private Parser $parser, private bool $includeDefinition = false)
-    {
+    public function __construct(
+        private Parser $parser,
+        private bool $includeDefinition = false
+    ) {
     }
 
     /**

--- a/lib/WorseReferenceFinder/WorseReflectionDefinitionLocator.php
+++ b/lib/WorseReferenceFinder/WorseReflectionDefinitionLocator.php
@@ -26,8 +26,10 @@ use Phpactor\WorseReflection\Reflector;
 
 class WorseReflectionDefinitionLocator implements DefinitionLocator
 {
-    public function __construct(private Reflector $reflector, private Cache $cache)
-    {
+    public function __construct(
+        private Reflector $reflector,
+        private Cache $cache
+    ) {
     }
 
 

--- a/lib/WorseReflection/Bridge/Phpactor/DocblockParser/CachedParserFactory.php
+++ b/lib/WorseReflection/Bridge/Phpactor/DocblockParser/CachedParserFactory.php
@@ -10,8 +10,10 @@ use Phpactor\WorseReflection\Core\Reflection\ReflectionScope;
 
 class CachedParserFactory implements DocBlockFactory
 {
-    public function __construct(private DocBlockFactory $innerFactory, private Cache $cache)
-    {
+    public function __construct(
+        private DocBlockFactory $innerFactory,
+        private Cache $cache
+    ) {
     }
 
     public function create(string $docblock, ReflectionScope $scope): DocBlock

--- a/lib/WorseReflection/Bridge/Phpactor/DocblockParser/ParsedDocblock.php
+++ b/lib/WorseReflection/Bridge/Phpactor/DocblockParser/ParsedDocblock.php
@@ -46,8 +46,11 @@ use function array_map;
 
 class ParsedDocblock implements DocBlock
 {
-    public function __construct(private ParserDocblock $node, private TypeConverter $typeConverter, private string $raw)
-    {
+    public function __construct(
+        private ParserDocblock $node,
+        private TypeConverter $typeConverter,
+        private string $raw
+    ) {
     }
 
     public function rawNode(): ParserDocblock

--- a/lib/WorseReflection/Bridge/Phpactor/DocblockParser/TypeConverter.php
+++ b/lib/WorseReflection/Bridge/Phpactor/DocblockParser/TypeConverter.php
@@ -70,8 +70,10 @@ use Phpactor\WorseReflection\Reflector;
 
 class TypeConverter
 {
-    public function __construct(private Reflector $reflector, private ?ReflectionScope $scope)
-    {
+    public function __construct(
+        private Reflector $reflector,
+        private ?ReflectionScope $scope
+    ) {
     }
 
     public function convert(?TypeNode $type): Type

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/DeprecatedUsageDiagnostic.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/DeprecatedUsageDiagnostic.php
@@ -9,8 +9,12 @@ use Phpactor\WorseReflection\Core\DiagnosticTag;
 
 class DeprecatedUsageDiagnostic implements Diagnostic
 {
-    public function __construct(private ByteOffsetRange $range, private string $memberName, private string $message, private string $memberType)
-    {
+    public function __construct(
+        private ByteOffsetRange $range,
+        private string $memberName,
+        private string $message,
+        private string $memberType
+    ) {
     }
 
     public function range(): ByteOffsetRange

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UndefinedVariableDiagnostic.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UndefinedVariableDiagnostic.php
@@ -11,8 +11,11 @@ class UndefinedVariableDiagnostic implements Diagnostic
     /**
      * @param list<string> $suggestions
      */
-    public function __construct(private ByteOffsetRange $byteOffsetRange, private string $varName, private array $suggestions)
-    {
+    public function __construct(
+        private ByteOffsetRange $byteOffsetRange,
+        private string $varName,
+        private array $suggestions
+    ) {
     }
 
     public function range(): ByteOffsetRange

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UnresolvableNameDiagnostic.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UnresolvableNameDiagnostic.php
@@ -15,8 +15,11 @@ class UnresolvableNameDiagnostic implements Diagnostic
     /**
      * @param self::TYPE_* $type
      */
-    private function __construct(private ByteOffsetRange $range, private string $type, private Name $name)
-    {
+    private function __construct(
+        private ByteOffsetRange $range,
+        private string $type,
+        private Name $name
+    ) {
     }
 
     public static function forFunction(ByteOffsetRange $range, Name $name): self

--- a/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UnusedImportDiagnostic.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Diagnostics/UnusedImportDiagnostic.php
@@ -9,8 +9,10 @@ use Phpactor\WorseReflection\Core\DiagnosticTag;
 
 class UnusedImportDiagnostic implements Diagnostic
 {
-    private function __construct(private ByteOffsetRange $range, private string $name)
-    {
+    private function __construct(
+        private ByteOffsetRange $range,
+        private string $name
+    ) {
     }
 
     public static function for(ByteOffsetRange $range, string $name): self

--- a/lib/WorseReflection/Bridge/TolerantParser/Parser/CachedParser.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Parser/CachedParser.php
@@ -13,8 +13,10 @@ class CachedParser extends Parser
 {
     private CacheForDocument $cacheForDocument;
 
-    public function __construct(private Cache $cache = new TtlCache(), ?CacheForDocument $cacheForDocument = null)
-    {
+    public function __construct(
+        private Cache $cache = new TtlCache(),
+        ?CacheForDocument $cacheForDocument = null
+    ) {
         parent::__construct();
         $this->cacheForDocument = $cacheForDocument ?? CacheForDocument::none();
     }

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionNavigation.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionNavigation.php
@@ -13,8 +13,10 @@ use Phpactor\WorseReflection\Core\ServiceLocator;
 
 class ReflectionNavigation
 {
-    public function __construct(private ServiceLocator $locator, private Node $node)
-    {
+    public function __construct(
+        private ServiceLocator $locator,
+        private Node $node
+    ) {
     }
 
     /**

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionOffset.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionOffset.php
@@ -8,8 +8,10 @@ use Phpactor\WorseReflection\Core\Reflection\ReflectionOffset as CoreReflectionO
 
 final class ReflectionOffset implements CoreReflectionOffset
 {
-    private function __construct(private Frame $frame, private NodeContext $nodeContext)
-    {
+    private function __construct(
+        private Frame $frame,
+        private NodeContext $nodeContext
+    ) {
     }
 
     public static function fromFrameAndSymbolContext(Frame $frame, NodeContext $nodeContext): CoreReflectionOffset

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionScope.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/ReflectionScope.php
@@ -19,8 +19,10 @@ use Phpactor\WorseReflection\Reflector;
 
 class ReflectionScope implements CoreReflectionScope
 {
-    public function __construct(private Reflector $reflector, private Node $node)
-    {
+    public function __construct(
+        private Reflector $reflector,
+        private Node $node
+    ) {
     }
 
     /**

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflection/TraitImport/TraitImport.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflection/TraitImport/TraitImport.php
@@ -4,8 +4,10 @@ namespace Phpactor\WorseReflection\Bridge\TolerantParser\Reflection\TraitImport;
 
 class TraitImport
 {
-    public function __construct(private string $traitName, private array $traitAliases = [])
-    {
+    public function __construct(
+        private string $traitName,
+        private array $traitAliases = []
+    ) {
     }
 
     public function name(): string

--- a/lib/WorseReflection/Core/Deprecation.php
+++ b/lib/WorseReflection/Core/Deprecation.php
@@ -4,8 +4,10 @@ namespace Phpactor\WorseReflection\Core;
 
 class Deprecation
 {
-    public function __construct(private bool $isDefined, private ?string $message = null)
-    {
+    public function __construct(
+        private bool $isDefined,
+        private ?string $message = null
+    ) {
     }
 
     public function isDefined(): bool

--- a/lib/WorseReflection/Core/DocBlock/DocBlockParam.php
+++ b/lib/WorseReflection/Core/DocBlock/DocBlockParam.php
@@ -6,8 +6,10 @@ use Phpactor\WorseReflection\Core\Type;
 
 class DocBlockParam
 {
-    public function __construct(private string $name, private Type $type)
-    {
+    public function __construct(
+        private string $name,
+        private Type $type
+    ) {
     }
 
     public function name(): string

--- a/lib/WorseReflection/Core/DocBlock/DocBlockTypeAlias.php
+++ b/lib/WorseReflection/Core/DocBlock/DocBlockTypeAlias.php
@@ -6,8 +6,10 @@ use Phpactor\WorseReflection\Core\Type;
 
 final class DocBlockTypeAlias
 {
-    public function __construct(private string $alias, private Type $type)
-    {
+    public function __construct(
+        private string $alias,
+        private Type $type
+    ) {
     }
 
     public function alias(): string

--- a/lib/WorseReflection/Core/DocBlock/DocBlockTypeAssertion.php
+++ b/lib/WorseReflection/Core/DocBlock/DocBlockTypeAssertion.php
@@ -6,7 +6,10 @@ use Phpactor\WorseReflection\Core\Type;
 
 final class DocBlockTypeAssertion
 {
-    public function __construct(public string $variableName, public Type $type, public bool $negated)
-    {
+    public function __construct(
+        public string $variableName,
+        public Type $type,
+        public bool $negated
+    ) {
     }
 }

--- a/lib/WorseReflection/Core/DocBlock/DocBlockVar.php
+++ b/lib/WorseReflection/Core/DocBlock/DocBlockVar.php
@@ -6,8 +6,10 @@ use Phpactor\WorseReflection\Core\Type;
 
 class DocBlockVar
 {
-    public function __construct(private string $name, private Type $type)
-    {
+    public function __construct(
+        private string $name,
+        private Type $type
+    ) {
     }
 
     public function name(): string

--- a/lib/WorseReflection/Core/Inference/Context/ClassLikeContext.php
+++ b/lib/WorseReflection/Core/Inference/Context/ClassLikeContext.php
@@ -9,8 +9,11 @@ use Phpactor\WorseReflection\Core\Reflection\ReflectionClassLike;
 
 class ClassLikeContext extends NodeContext
 {
-    public function __construct(Symbol $symbol, private ByteOffsetRange $byteOffsetRange, private ReflectionClassLike $class)
-    {
+    public function __construct(
+        Symbol $symbol,
+        private ByteOffsetRange $byteOffsetRange,
+        private ReflectionClassLike $class
+    ) {
         parent::__construct($symbol, $class->type());
     }
 

--- a/lib/WorseReflection/Core/Inference/Frame/LazyFrame.php
+++ b/lib/WorseReflection/Core/Inference/Frame/LazyFrame.php
@@ -15,8 +15,10 @@ class LazyFrame implements Frame
 {
     private ?Frame $frame = null;
 
-    public function __construct(private FrameResolver $frameResolver, private Node $node)
-    {
+    public function __construct(
+        private FrameResolver $frameResolver,
+        private Node $node
+    ) {
     }
 
     public function __toString(): string

--- a/lib/WorseReflection/Core/Inference/FunctionArguments.php
+++ b/lib/WorseReflection/Core/Inference/FunctionArguments.php
@@ -18,8 +18,11 @@ class FunctionArguments implements IteratorAggregate, Countable
     /**
      * @param ArgumentExpression[] $arguments
      */
-    public function __construct(private NodeContextResolver $resolver, private Frame $frame, private array $arguments)
-    {
+    public function __construct(
+        private NodeContextResolver $resolver,
+        private Frame $frame,
+        private array $arguments
+    ) {
     }
 
     public function __toString(): string

--- a/lib/WorseReflection/Core/Inference/NodeToTypeConverter.php
+++ b/lib/WorseReflection/Core/Inference/NodeToTypeConverter.php
@@ -31,8 +31,10 @@ use Psr\Log\NullLogger;
  */
 class NodeToTypeConverter
 {
-    public function __construct(private Reflector $reflector, private LoggerInterface $logger = new NullLogger())
-    {
+    public function __construct(
+        private Reflector $reflector,
+        private LoggerInterface $logger = new NullLogger(),
+    ) {
     }
 
     /**

--- a/lib/WorseReflection/Core/Inference/Symbol.php
+++ b/lib/WorseReflection/Core/Inference/Symbol.php
@@ -26,8 +26,11 @@ final class Symbol
     /**
      * @param Symbol::* $symbolType
      */
-    private function __construct(private string $symbolType, string $name, private ByteOffsetRange $position)
-    {
+    private function __construct(
+        private string $symbolType,
+        string $name,
+        private ByteOffsetRange $position
+    ) {
         $this->name = ltrim($name, '$');
     }
 

--- a/lib/WorseReflection/Core/Inference/Walker/IncludeWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/IncludeWalker.php
@@ -23,8 +23,11 @@ use Symfony\Component\Filesystem\Path;
  */
 class IncludeWalker implements Walker
 {
-    public function __construct(private LoggerInterface $logger, private FrameResolver $resolver, private Parser $parser = new Parser())
-    {
+    public function __construct(
+        private LoggerInterface $logger,
+        private FrameResolver $resolver,
+        private Parser $parser = new Parser(),
+    ) {
     }
 
 

--- a/lib/WorseReflection/Core/Name.php
+++ b/lib/WorseReflection/Core/Name.php
@@ -13,8 +13,10 @@ use function trim;
 class Name
 {
     /** @param array<string> $parts */
-    final public function __construct(protected array $parts, private bool $wasFullyQualified)
-    {
+    final public function __construct(
+        protected array $parts,
+        private bool $wasFullyQualified
+    ) {
     }
 
     public function __toString(): string

--- a/lib/WorseReflection/Core/Reflection/TypeResolver/ParameterTypeResolver.php
+++ b/lib/WorseReflection/Core/Reflection/TypeResolver/ParameterTypeResolver.php
@@ -14,8 +14,10 @@ use Phpactor\WorseReflection\TypeUtil;
 
 class ParameterTypeResolver
 {
-    public function __construct(private ReflectionParameter $parameter, private GenericMapResolver $mapResolver)
-    {
+    public function __construct(
+        private ReflectionParameter $parameter,
+        private GenericMapResolver $mapResolver
+    ) {
     }
 
     public function resolve(): Type

--- a/lib/WorseReflection/Core/Reflector/CoreReflector.php
+++ b/lib/WorseReflection/Core/Reflector/CoreReflector.php
@@ -34,8 +34,10 @@ use Phpactor\WorseReflection\Core\Reflection\Collection\ReflectionFunctionCollec
 
 class CoreReflector implements ClassReflector, SourceCodeReflector, FunctionReflector, ConstantReflector
 {
-    public function __construct(private SourceCodeReflector $sourceReflector, private SourceCodeLocator $sourceLocator)
-    {
+    public function __construct(
+        private SourceCodeReflector $sourceReflector,
+        private SourceCodeLocator $sourceLocator
+    ) {
     }
 
     /**

--- a/lib/WorseReflection/Core/SourceCodeLocator/BruteForceSourceLocator.php
+++ b/lib/WorseReflection/Core/SourceCodeLocator/BruteForceSourceLocator.php
@@ -19,8 +19,10 @@ final class BruteForceSourceLocator implements SourceCodeLocator
      */
     private ?array $map = null;
 
-    public function __construct(private Reflector $reflector, private string $path)
-    {
+    public function __construct(
+        private Reflector $reflector,
+        private string $path
+    ) {
     }
 
     public function locate(Name $name): TextDocument

--- a/lib/WorseReflection/Core/Type/CallableType.php
+++ b/lib/WorseReflection/Core/Type/CallableType.php
@@ -12,8 +12,10 @@ class CallableType extends PrimitiveType implements InvokeableType
     /**
      * @param Type[] $args
      */
-    public function __construct(private array $args = [], private Type $returnType = new MissingType())
-    {
+    public function __construct(
+        private array $args = [],
+        private Type $returnType = new MissingType(),
+    ) {
     }
 
     public function __toString(): string

--- a/lib/WorseReflection/Core/Type/ClosureType.php
+++ b/lib/WorseReflection/Core/Type/ClosureType.php
@@ -14,8 +14,11 @@ class ClosureType extends ReflectedClassType implements ClassLikeType, Invokeabl
     /**
      * @param Type[] $args
      */
-    public function __construct(ClassReflector $reflector, private array $args = [], private Type $returnType = new MissingType())
-    {
+    public function __construct(
+        ClassReflector $reflector,
+        private array $args = [],
+        private Type $returnType = new MissingType(),
+    ) {
         parent::__construct($reflector, ClassName::fromString('Closure'));
     }
 

--- a/lib/WorseReflection/Core/Type/ConditionalType.php
+++ b/lib/WorseReflection/Core/Type/ConditionalType.php
@@ -13,8 +13,12 @@ use Phpactor\WorseReflection\Core\TypeFactory;
 
 class ConditionalType extends Type
 {
-    public function __construct(private string $variable, private Type $isType, private Type $left, private Type $right)
-    {
+    public function __construct(
+        private string $variable,
+        private Type $isType,
+        private Type $left,
+        private Type $right
+    ) {
     }
 
     public function __toString(): string

--- a/lib/WorseReflection/Core/Type/EnumBackedCaseType.php
+++ b/lib/WorseReflection/Core/Type/EnumBackedCaseType.php
@@ -11,8 +11,12 @@ use Phpactor\WorseReflection\Core\Type;
 
 class EnumBackedCaseType extends EnumCaseType implements ClassLikeType
 {
-    public function __construct(ClassReflector $reflector, ClassType $enumType, string $name, public Type $value)
-    {
+    public function __construct(
+        ClassReflector $reflector,
+        ClassType $enumType,
+        string $name,
+        public Type $value
+    ) {
         parent::__construct($reflector, $enumType, $name);
     }
 

--- a/lib/WorseReflection/Core/Type/EnumCaseType.php
+++ b/lib/WorseReflection/Core/Type/EnumCaseType.php
@@ -10,8 +10,11 @@ use Phpactor\WorseReflection\Core\Type;
 
 class EnumCaseType extends ReflectedClassType implements ClassLikeType
 {
-    public function __construct(ClassReflector $reflector, public ClassType $enumType, public string $caseName)
-    {
+    public function __construct(
+        ClassReflector $reflector,
+        public ClassType $enumType,
+        public string $caseName
+    ) {
         parent::__construct($reflector, ClassName::fromString('UnitEnumCase'));
     }
 

--- a/lib/WorseReflection/Core/Type/GlobbedConstantUnionType.php
+++ b/lib/WorseReflection/Core/Type/GlobbedConstantUnionType.php
@@ -9,8 +9,10 @@ use Phpactor\WorseReflection\Core\Type;
 
 class GlobbedConstantUnionType extends Type
 {
-    public function __construct(private Type $classType, private string $glob)
-    {
+    public function __construct(
+        private Type $classType,
+        private string $glob
+    ) {
     }
 
     public function __toString(): string

--- a/lib/WorseReflection/Core/Type/IntRangeType.php
+++ b/lib/WorseReflection/Core/Type/IntRangeType.php
@@ -6,8 +6,10 @@ use Phpactor\WorseReflection\Core\Type;
 
 final class IntRangeType extends IntType
 {
-    public function __construct(public ?Type $lower, public ?Type $upper)
-    {
+    public function __construct(
+        public ?Type $lower,
+        public ?Type $upper
+    ) {
     }
 
     public function __toString(): string

--- a/lib/WorseReflection/Core/Type/ReflectedClassType.php
+++ b/lib/WorseReflection/Core/Type/ReflectedClassType.php
@@ -18,8 +18,10 @@ use Phpactor\WorseReflection\Core\Type\Resolver\IterableTypeResolver;
 
 class ReflectedClassType extends ClassType
 {
-    public function __construct(protected ClassReflector $reflector, public ClassName $name)
-    {
+    public function __construct(
+        protected ClassReflector $reflector,
+        public ClassName $name
+    ) {
         $this->members = ClassLikeReflectionMemberCollection::empty();
     }
 


### PR DESCRIPTION
## Why

Promoted property constructors get noisy very quickly but breaking them into multiple lines helps seeing changes clearer.
Splitting this off from #2988 

# What

Added rule
```php
        'multiline_promoted_properties' => [
            'minimum_number_of_parameters' => 2
        ],
``` and run it.