### PR TITLE
Enforce passing textdocument

### DIFF
--- a/lib/ClassMover/Adapter/TolerantParser/TolerantClassFinder.php
+++ b/lib/ClassMover/Adapter/TolerantParser/TolerantClassFinder.php
@@ -37,7 +37,7 @@ class TolerantClassFinder implements ClassFinder
 
     public function findIn(TextDocument $source): NamespacedClassReferences
     {
-        $ast = $this->parser->get($source->__toString());
+        $ast = $this->parser->get($source);
 
         $namespaceRef = $this->getNamespaceRef($ast);
         $sourceEnvironment = $this->getClassEnvironment($namespaceRef->namespace(), $ast);

--- a/lib/ClassMover/Adapter/WorseTolerant/WorseTolerantMemberFinder.php
+++ b/lib/ClassMover/Adapter/WorseTolerant/WorseTolerantMemberFinder.php
@@ -57,7 +57,7 @@ class WorseTolerantMemberFinder implements MemberFinder
 
     public function findMembers(SourceCode $source, ClassMemberQuery $query): MemberReferences
     {
-        $rootNode = $this->parser->get((string) $source);
+        $rootNode = $this->parser->get($source);
         $memberNodes = $this->collectMemberReferences($rootNode, $query);
 
         $queryClassReflection = null;

--- a/lib/CodeBuilder/Adapter/TolerantParser/TolerantUpdater.php
+++ b/lib/CodeBuilder/Adapter/TolerantParser/TolerantUpdater.php
@@ -51,7 +51,7 @@ class TolerantUpdater implements Updater
     public function textEditsFor(Prototype $prototype, Code $code): TextEdits
     {
         $edits = new Edits($this->textFormat);
-        $node = $this->parser->get((string) $code);
+        $node = $this->parser->get($code);
 
         $this->updateNamespace($edits, $prototype, $node);
         $this->useStatementUpdater->updateUseStatements($edits, $prototype, $node);

--- a/lib/CodeBuilder/Tests/Functional/Adapter/TolerantParser/Util/NodeHelperTest.php
+++ b/lib/CodeBuilder/Tests/Functional/Adapter/TolerantParser/Util/NodeHelperTest.php
@@ -7,11 +7,10 @@ use Phpactor\CodeBuilder\Adapter\TolerantParser\Util\NodeHelper;
 use Phpactor\TestUtils\ExtractOffset;
 use Microsoft\PhpParser\Node;
 use Phpactor\WorseReflection\Bridge\TolerantParser\AstProvider\TolerantAstProvider;
-use Phpactor\WorseReflection\Core\AstProvider;
 
 class NodeHelperTest extends TestCase
 {
-    private AstProvider $parser;
+    private TolerantAstProvider $parser;
 
     protected function setUp(): void
     {
@@ -31,7 +30,7 @@ class NodeHelperTest extends TestCase
     private function findSelfNode(): array
     {
         [$source, $methodOffset, $nameOffset] = ExtractOffset::fromSource('<?php class Foobar { public function f<>oo(): sel<>f() { return $this; }}');
-        $root = $this->parser->get($source);
+        $root = $this->parser->parseString($source);
         return [
             $root->getDescendantNodeAtPosition($methodOffset),
             $root->getDescendantNodeAtPosition($nameOffset),

--- a/lib/CodeTransform/Adapter/TolerantParser/ClassToFile/Transformer/ClassNameFixerTransformer.php
+++ b/lib/CodeTransform/Adapter/TolerantParser/ClassToFile/Transformer/ClassNameFixerTransformer.php
@@ -50,7 +50,7 @@ class ClassNameFixerTransformer implements Transformer
         $correctClassName = $classFqn->name();
         $correctNamespace = $classFqn->namespace();
 
-        $rootNode = $this->parser->get((string) $code);
+        $rootNode = $this->parser->get($code);
         $edits = [];
 
         if ($textEdit = $this->fixNamespace($rootNode, $correctNamespace)) {
@@ -73,7 +73,7 @@ class ClassNameFixerTransformer implements Transformer
         if ($code->uri()->scheme() !== 'file') {
             return new Success(Diagnostics::none());
         }
-        $rootNode = $this->parser->get((string) $code);
+        $rootNode = $this->parser->get($code);
         try {
             $classFqn = $this->determineClassFqn($code);
         } catch (RuntimeException) {

--- a/lib/CodeTransform/Adapter/TolerantParser/Refactor/TolerantChangeVisiblity.php
+++ b/lib/CodeTransform/Adapter/TolerantParser/Refactor/TolerantChangeVisiblity.php
@@ -23,7 +23,7 @@ class TolerantChangeVisiblity implements ChangeVisiblity
 
     public function changeVisiblity(SourceCode $source, int $offset): SourceCode
     {
-        $node = $this->parser->get((string) $source);
+        $node = $this->parser->get($source);
         $node = $node->getDescendantNodeAtPosition($offset);
 
         $node = $this->resolveMemberNode($node);

--- a/lib/CodeTransform/Adapter/TolerantParser/Refactor/TolerantExtractExpression.php
+++ b/lib/CodeTransform/Adapter/TolerantParser/Refactor/TolerantExtractExpression.php
@@ -55,7 +55,7 @@ class TolerantExtractExpression implements ExtractExpression
         if ($offsetStart === $offsetEnd) {
             return null;
         }
-        $rootNode = $this->parser->get((string) $source);
+        $rootNode = $this->parser->get($source);
         $startNode = $rootNode->getDescendantNodeAtPosition($offsetStart);
 
         if ($offsetEnd) {

--- a/lib/CodeTransform/Adapter/TolerantParser/Refactor/TolerantHereDoc.php
+++ b/lib/CodeTransform/Adapter/TolerantParser/Refactor/TolerantHereDoc.php
@@ -24,7 +24,7 @@ class TolerantHereDoc implements ByteOffsetRefactor
     public function refactor(TextDocument $document, ByteOffset $offset): TextEdits
     {
         $node = $this->parser
-            ->get($document->__toString())
+            ->get($document)
             ->getDescendantNodeAtPosition($offset->toInt())
         ;
 

--- a/lib/CodeTransform/Adapter/TolerantParser/Refactor/TolerantRenameVariable.php
+++ b/lib/CodeTransform/Adapter/TolerantParser/Refactor/TolerantRenameVariable.php
@@ -26,17 +26,12 @@ class TolerantRenameVariable implements RenameVariable
 
     public function renameVariable(SourceCode $sourceCode, int $offset, string $newName, string $scope = self::SCOPE_FILE): SourceCode
     {
-        $sourceNode = $this->sourceNode($sourceCode->__toString());
+        $sourceNode = $this->parser->get($sourceCode);
         $variable = $this->variableNodeFromSource($sourceNode, $offset);
         $scopeNode = $this->scopeNode($variable, $scope);
         $textEdits = $this->textEditsToRename($scopeNode, $variable, $newName);
 
         return $sourceCode->withSource(TextEdits::fromTextEdits($textEdits)->apply($sourceCode->__toString()));
-    }
-
-    private function sourceNode(string $source): SourceFileNode
-    {
-        return $this->parser->get($source);
     }
 
     private function variableNodeFromSource(SourceFileNode $sourceNode, int $offset): Node

--- a/lib/CodeTransform/Adapter/WorseReflection/Helper/WorseInterestingOffsetFinder.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Helper/WorseInterestingOffsetFinder.php
@@ -24,7 +24,7 @@ class WorseInterestingOffsetFinder implements InterestingOffsetFinder
             return $interestingOffset;
         }
 
-        $node = $this->parser->get($source->__toString())->getDescendantNodeAtPosition($offset->toInt());
+        $node = $this->parser->get($source)->getDescendantNodeAtPosition($offset->toInt());
 
         do {
             $offset = ByteOffset::fromInt($node->getStartPosition());

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseExtractConstant.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseExtractConstant.php
@@ -44,7 +44,7 @@ class WorseExtractConstant implements ExtractConstant
 
     public function canExtractConstant(SourceCode $source, int $offset): bool
     {
-        $node = $this->parser->get($source->__toString());
+        $node = $this->parser->get($source);
         $targetNode = $node->getDescendantNodeAtPosition($offset);
         try {
             $this->getComparableValue($targetNode);
@@ -86,7 +86,7 @@ class WorseExtractConstant implements ExtractConstant
 
     private function replaceValues(SourceCode $sourceCode, int $offset, string $constantName): TextEdits
     {
-        $node = $this->parser->get($sourceCode->__toString());
+        $node = $this->parser->get($sourceCode);
         $targetNode = $node->getDescendantNodeAtPosition($offset);
         $targetValue = $this->getComparableValue($targetNode);
         $classNode = $targetNode->getFirstAncestor(ClassLike::class);

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseExtractMethod.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseExtractMethod.php
@@ -2,6 +2,7 @@
 
 namespace Phpactor\CodeTransform\Adapter\WorseReflection\Refactor;
 
+use Phpactor\TextDocument\TextDocumentBuilder;
 use Phpactor\WorseReflection\Bridge\TolerantParser\AstProvider\TolerantAstProvider;
 use Microsoft\PhpParser\FunctionLike;
 use Microsoft\PhpParser\Node;
@@ -46,7 +47,7 @@ class WorseExtractMethod implements ExtractMethod
         if ($offsetEnd == $offsetStart || $offsetEnd - $offsetStart === strlen($source->__toString())) {
             return false;
         }
-        $node = $this->parser->get($source->__toString());
+        $node = $this->parser->get($source);
         $endNode = $node->getDescendantNodeAtPosition($offsetEnd);
         $startNode = $node->getDescendantNodeAtPosition($offsetStart);
 
@@ -424,7 +425,7 @@ class WorseExtractMethod implements ExtractMethod
 
     private function isSelectionAnExpression(SourceCode $source, int $offsetStart, int $offsetEnd): bool
     {
-        $node = $this->parser->get($source->__toString());
+        $node = $this->parser->get($source);
         $endNode = $node->getDescendantNodeAtPosition($offsetEnd);
 
         // end node is in the statement body, get last child node
@@ -462,7 +463,7 @@ class WorseExtractMethod implements ExtractMethod
     private function parseSelection(string $source): SourceFileNode
     {
         $source = '<?php ' . $source;
-        $node = $this->parser->get($source);
+        $node = $this->parser->get(TextDocumentBuilder::create($source)->build());
         return $node;
     }
 }

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseFillMatchArms.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseFillMatchArms.php
@@ -30,7 +30,7 @@ final class WorseFillMatchArms implements ByteOffsetRefactor
 
     public function refactor(TextDocument $document, ByteOffset $offset): TextEdits
     {
-        $node = $this->parser->get($document->__toString())->getDescendantNodeAtPosition($offset->toInt());
+        $node = $this->parser->get($document)->getDescendantNodeAtPosition($offset->toInt());
         $node = $node instanceof MatchExpression ? $node : $node->getFirstAncestor(MatchExpression::class);
         if (!$node instanceof MatchExpression) {
             return TextEdits::none();

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseFillObject.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseFillObject.php
@@ -40,7 +40,7 @@ class WorseFillObject implements ByteOffsetRefactor
     {
         /** @var ObjectCreationExpression|Attribute|null $node */
         $node = $this->parser
-            ->get($document->__toString())
+            ->get($document)
             ->getDescendantNodeAtPosition($offset->toInt())
             ->getFirstAncestor(ObjectCreationExpression::class, Attribute::class)
         ;

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseGenerateConstructor.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseGenerateConstructor.php
@@ -116,7 +116,7 @@ class WorseGenerateConstructor implements GenerateConstructor
 
     private function node(TextDocument $document, ByteOffset $offset): ?Node
     {
-        $node = $this->parser->get($document->__toString())->getDescendantNodeAtPosition($offset->toInt());
+        $node = $this->parser->get($document)->getDescendantNodeAtPosition($offset->toInt());
 
         if ($node->parent instanceof Attribute) {
             return $node->parent;

--- a/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseReplaceQualifierWithImport.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Refactor/WorseReplaceQualifierWithImport.php
@@ -56,7 +56,7 @@ class WorseReplaceQualifierWithImport implements ReplaceQualifierWithImport
 
     public function canReplaceWithImport(SourceCode $source, int $offset): bool
     {
-        $node = $this->parser->get($source->__toString());
+        $node = $this->parser->get($source);
         $targetNode = $node->getDescendantNodeAtPosition($offset);
 
         if ($targetNode instanceof QualifiedName) {

--- a/lib/CodeTransform/Adapter/WorseReflection/Transformer/AddMissingProperties.php
+++ b/lib/CodeTransform/Adapter/WorseReflection/Transformer/AddMissingProperties.php
@@ -39,7 +39,7 @@ class AddMissingProperties implements Transformer
     public function transform(SourceCode $code): Promise
     {
         return call(function () use ($code) {
-            $rootNode = $this->parser->get($code->__toString());
+            $rootNode = $this->parser->get($code);
             $wrDiagnostics = yield $this->reflector->diagnostics($code);
             $sourceBuilder = SourceCodeBuilder::create();
 

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/DocblockCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/DocblockCompletor.php
@@ -48,7 +48,7 @@ class DocblockCompletor implements TolerantCompletor
 
     public function __construct(
         private TypeSuggestionProvider $typeSuggestionProvider,
-        private AstProvider $parser
+        private AstProvider $provider
     ) {
     }
 
@@ -57,10 +57,7 @@ class DocblockCompletor implements TolerantCompletor
      */
     public function complete(Node $node, TextDocument $source, ByteOffset $byteOffset): Generator
     {
-        // we re-parse the document because the above node is for the truncated
-        // doc, which will often (if not always) result in a SourceFileNode
-        // with no namespace context
-        $node = $this->parser->get($source->__toString());
+        $node = $this->provider->get($source);
         $node = NodeUtil::firstDescendantNodeAfterOffset($node, $byteOffset->toInt());
 
         [$tag, $type, $var] = $this->extractTag($source, $byteOffset);

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/DoctrineAnnotationCompletor.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/DoctrineAnnotationCompletor.php
@@ -2,6 +2,7 @@
 
 namespace Phpactor\Completion\Bridge\TolerantParser\WorseReflection;
 
+use Phpactor\TextDocument\TextDocumentBuilder;
 use Phpactor\WorseReflection\Bridge\TolerantParser\AstProvider\TolerantAstProvider;
 use Generator;
 use Microsoft\PhpParser\Node;
@@ -34,7 +35,9 @@ class DoctrineAnnotationCompletor extends NameSearcherCompletor implements Compl
     public function complete(TextDocument $source, ByteOffset $byteOffset): Generator
     {
         $truncatedSource = $this->truncateSource((string) $source, $byteOffset->toInt());
-        $sourceNodeFile = $this->parser->get((string) $source);
+
+        // gh-3001: this is potentially very inefficient
+        $sourceNodeFile = $this->parser->get(TextDocumentBuilder::create($source)->build());
 
         $node = $this->findNodeForPhpdocAtPosition(
             $sourceNodeFile,

--- a/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseSignatureHelper.php
+++ b/lib/Completion/Bridge/TolerantParser/WorseReflection/WorseSignatureHelper.php
@@ -52,7 +52,7 @@ class WorseSignatureHelper implements SignatureHelper
 
     private function doSignatureHelp(TextDocument $textDocument, ByteOffset $offset): SignatureHelp // NOSONAR
     {
-        $rootNode = $this->parser->get($textDocument->__toString());
+        $rootNode = $this->parser->get($textDocument);
         $nodeAtPosition = $rootNode->getDescendantNodeAtPosition($offset->toInt());
 
         [$argsNode, $callNode] = $this->resolveArgsAndCallNode($nodeAtPosition, $offset);

--- a/lib/Completion/Tests/Integration/Bridge/TolerantParser/Qualifier/TolerantQualifierTestCase.php
+++ b/lib/Completion/Tests/Integration/Bridge/TolerantParser/Qualifier/TolerantQualifierTestCase.php
@@ -2,6 +2,7 @@
 
 namespace Phpactor\Completion\Tests\Integration\Bridge\TolerantParser\Qualifier;
 
+use Phpactor\TextDocument\TextDocumentBuilder;
 use Phpactor\WorseReflection\Bridge\TolerantParser\AstProvider\TolerantAstProvider;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Closure;
@@ -17,7 +18,7 @@ abstract class TolerantQualifierTestCase extends TestCase
         [$source, $offset] = ExtractOffset::fromSource($source);
 
         $parser = new TolerantAstProvider();
-        $root = $parser->get($source);
+        $root = $parser->get(TextDocumentBuilder::create($source)->build());
         $node = $root->getDescendantNodeAtPosition($offset);
 
         $assertion($this->createQualifier()->couldComplete($node));

--- a/lib/Completion/Tests/Integration/Bridge/TolerantParser/ReferenceFinder/ExpressionNameCompletorTest.php
+++ b/lib/Completion/Tests/Integration/Bridge/TolerantParser/ReferenceFinder/ExpressionNameCompletorTest.php
@@ -36,12 +36,13 @@ class ExpressionNameCompletorTest extends IntegrationTestCase
         );
 
         [$source, $offset] = ExtractOffset::fromSource($source);
-        $node = (new TolerantAstProvider())->get($source)->getDescendantNodeAtPosition($offset);
+        $document = TextDocumentBuilder::fromPathAndString(__DIR__, $source);
+        $node = (new TolerantAstProvider())->get($document)->getDescendantNodeAtPosition($offset);
         $results = new Suggestions(
             ...iterator_to_array(
                 $completor->complete(
                     $node,
-                    TextDocumentBuilder::fromUnknown($source),
+                    $document,
                     ByteOffset::fromInt($offset)
                 ),
                 false

--- a/lib/Completion/Tests/Integration/Bridge/TolerantParser/TypeSuggestionProviderTest.php
+++ b/lib/Completion/Tests/Integration/Bridge/TolerantParser/TypeSuggestionProviderTest.php
@@ -30,7 +30,7 @@ class TypeSuggestionProviderTest extends TestCase
             ),
         ]);
         [$source, $offset] = ExtractOffset::fromSource($source);
-        $node = (new TolerantAstProvider())->get($source)->getDescendantNodeAtPosition((int)$offset);
+        $node = (new TolerantAstProvider())->parseString($source)->getDescendantNodeAtPosition((int)$offset);
         $suggestions = iterator_to_array((new TypeSuggestionProvider($searcher))->provide($node, $search));
         self::assertArraySubset(
             $expected,

--- a/lib/Completion/Tests/Integration/Bridge/TolerantParser/WorseReflection/DocblockCompletorTest.php
+++ b/lib/Completion/Tests/Integration/Bridge/TolerantParser/WorseReflection/DocblockCompletorTest.php
@@ -35,7 +35,7 @@ class DocblockCompletorTest extends TestCase
         ];
 
         [$source, $offset] = ExtractOffset::fromSource($source);
-        $node = (new TolerantAstProvider())->get($source)->getDescendantNodeAtPosition((int)$offset);
+        $node = (new TolerantAstProvider())->parseString($source)->getDescendantNodeAtPosition((int)$offset);
         $suggestions = iterator_to_array((new DocblockCompletor(
             new TypeSuggestionProvider(new PredefinedNameSearcher($results)),
             new TolerantAstProvider(),

--- a/lib/Completion/Tests/Unit/Bridge/TolerantParser/CompletionContextTest.php
+++ b/lib/Completion/Tests/Unit/Bridge/TolerantParser/CompletionContextTest.php
@@ -16,7 +16,7 @@ class CompletionContextTest extends TestCase
     public function testExpression(string $source, bool $expected): void
     {
         [$source, $offset] = ExtractOffset::fromSource($source);
-        $node = (new TolerantAstProvider())->get($source)->getDescendantNodeAtPosition((int)$offset);
+        $node = (new TolerantAstProvider())->parseString($source)->getDescendantNodeAtPosition((int)$offset);
         self::assertEquals($expected, CompletionContext::expression($node));
     }
 
@@ -88,7 +88,7 @@ class CompletionContextTest extends TestCase
     public function testClassMemberBody(string $source, bool $expected): void
     {
         [$source, $offset] = ExtractOffset::fromSource($source);
-        $node = (new TolerantAstProvider())->get($source)->getDescendantNodeAtPosition((int)$offset);
+        $node = (new TolerantAstProvider())->parseString($source)->getDescendantNodeAtPosition((int)$offset);
         self::assertEquals($expected, CompletionContext::classMembersBody($node));
     }
 
@@ -145,7 +145,7 @@ class CompletionContextTest extends TestCase
     public function testClassClause(string $source, bool $expected): void
     {
         [$source, $offset] = ExtractOffset::fromSource($source);
-        $node = (new TolerantAstProvider())->get($source)->getDescendantNodeAtPosition((int)$offset);
+        $node = (new TolerantAstProvider())->parseString($source)->getDescendantNodeAtPosition((int)$offset);
         self::assertEquals($expected, CompletionContext::classClause($node, ByteOffset::fromInt((int)$offset)));
     }
 
@@ -181,7 +181,7 @@ class CompletionContextTest extends TestCase
     public function testAttribute(string $source, bool $expected): void
     {
         [$source, $offset] = ExtractOffset::fromSource($source);
-        $node = (new TolerantAstProvider())->get($source)->getDescendantNodeAtPosition((int)$offset);
+        $node = (new TolerantAstProvider())->parseString($source)->getDescendantNodeAtPosition((int)$offset);
         self::assertEquals($expected, CompletionContext::attribute($node));
     }
 
@@ -220,7 +220,7 @@ class CompletionContextTest extends TestCase
     public function testAnonymousUse(string $source, bool $expected): void
     {
         [$source, $offset] = ExtractOffset::fromSource($source);
-        $node = (new TolerantAstProvider())->get($source)->getDescendantNodeAtPosition((int)$offset);
+        $node = (new TolerantAstProvider())->parseString($source)->getDescendantNodeAtPosition((int)$offset);
         self::assertEquals($expected, CompletionContext::anonymousUse($node));
     }
 
@@ -259,7 +259,7 @@ class CompletionContextTest extends TestCase
     public function testPromotedProperty(string $source, bool $expected): void
     {
         [$source, $offset] = ExtractOffset::fromSource($source);
-        $node = (new TolerantAstProvider())->get($source)->getDescendantNodeAtPosition((int)$offset);
+        $node = (new TolerantAstProvider())->parseString($source)->getDescendantNodeAtPosition((int)$offset);
         self::assertEquals($expected, CompletionContext::promotedPropertyVisibility($node));
     }
 
@@ -295,7 +295,7 @@ class CompletionContextTest extends TestCase
     public function testMethodName(string $source, bool $expected): void
     {
         [$source, $offset] = ExtractOffset::fromSource($source);
-        $node = (new TolerantAstProvider())->get($source)->getDescendantNodeAtPosition((int)$offset);
+        $node = (new TolerantAstProvider())->parseString($source)->getDescendantNodeAtPosition((int)$offset);
         self::assertEquals($expected, CompletionContext::methodName($node));
     }
 

--- a/lib/Completion/Tests/Unit/Bridge/TolerantParser/Helper/NodeQueryTest.php
+++ b/lib/Completion/Tests/Unit/Bridge/TolerantParser/Helper/NodeQueryTest.php
@@ -10,14 +10,13 @@ use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\DelimitedList\ArgumentExpressionList;
 use Microsoft\PhpParser\Node\Expression\ArgumentExpression;
 use Microsoft\PhpParser\Node\Expression\ObjectCreationExpression;
-use Phpactor\WorseReflection\Core\AstProvider;
 use PHPUnit\Framework\TestCase;
 use Phpactor\Completion\Bridge\TolerantParser\Helper\NodeQuery;
 use Phpactor\TestUtils\ExtractOffset;
 
 class NodeQueryTest extends TestCase
 {
-    private AstProvider $parser;
+    private TolerantAstProvider $parser;
 
     protected function setUp(): void
     {
@@ -64,6 +63,6 @@ class NodeQueryTest extends TestCase
     private function nodeFromSource(string $source): Node
     {
         [$source, $offset] = ExtractOffset::fromSource($source);
-        return $this->parser->get($source)->getDescendantNodeAtPosition($offset);
+        return $this->parser->parseString($source)->getDescendantNodeAtPosition($offset);
     }
 }

--- a/lib/Completion/Tests/Unit/Bridge/WorseReflection/Completor/ContextSensitiveCompletorTest.php
+++ b/lib/Completion/Tests/Unit/Bridge/WorseReflection/Completor/ContextSensitiveCompletorTest.php
@@ -24,7 +24,7 @@ class ContextSensitiveCompletorTest extends TestCase
     public function testComplete(array $suggestions, string $source, array $expected): void
     {
         [$source, $offset] = ExtractOffset::fromSource($source);
-        $node = (new TolerantAstProvider())->get($source);
+        $node = (new TolerantAstProvider())->parseString($source);
         $node = $node->getDescendantNodeAtPosition($offset);
         $reflector = ReflectorBuilder::create()->addSource($source)->build();
         $inner = new TolerantArrayCompletor(array_map(

--- a/lib/Extension/CodeTransform/CodeTransformExtension.php
+++ b/lib/Extension/CodeTransform/CodeTransformExtension.php
@@ -272,7 +272,8 @@ class CodeTransformExtension implements Extension
             return new WorseExtractMethod(
                 $container->expect(WorseReflectionExtension::SERVICE_REFLECTOR, Reflector::class),
                 $container->get(BuilderFactory::class),
-                $container->get(Updater::class)
+                $container->get(Updater::class),
+                $container->get(AstProvider::class),
             );
         });
 

--- a/lib/Extension/LanguageServerEvaluatableExpression/Handler/EvaluatableExpressionHandler.php
+++ b/lib/Extension/LanguageServerEvaluatableExpression/Handler/EvaluatableExpressionHandler.php
@@ -58,7 +58,7 @@ class EvaluatableExpressionHandler implements Handler, CanRegisterCapabilities
             return new Success(null);
         }
 
-        $rootNode = $this->parser->get((string) $document, $document->uri()?->__toString());
+        $rootNode = $this->parser->get($document);
         $node = $rootNode->getDescendantNodeAtPosition($offset->toInt());
         return new Success($this->nodeToEvaluatable($node));
     }

--- a/lib/Extension/LanguageServerInlineValue/Handler/InlineValueHandler.php
+++ b/lib/Extension/LanguageServerInlineValue/Handler/InlineValueHandler.php
@@ -53,7 +53,7 @@ class InlineValueHandler implements Handler, CanRegisterCapabilities
         $start = PositionConverter::positionToByteOffset($range->start, $document)->toInt();
         $end = PositionConverter::positionToByteOffset($range->end, $document)->toInt();
 
-        $root = $this->parser->get((string) $document, $document->uri()?->__toString());
+        $root = $this->parser->get($document);
 
         $i = $root->getDescendantNodes(fn ($child) => $child->getStartPosition() <= $end && $child->getEndPosition() >= $start);
         $i = new CallbackFilterIterator($i, fn ($node) =>

--- a/lib/Extension/LanguageServerReferenceFinder/Model/Highlighter.php
+++ b/lib/Extension/LanguageServerReferenceFinder/Model/Highlighter.php
@@ -88,7 +88,7 @@ class Highlighter
      */
     private function generate(TextDocument $source, ByteOffset $offset): Generator
     {
-        $rootNode = $this->parser->get($source->__toString(), $source->uri()?->__toString());
+        $rootNode = $this->parser->get($source);
         $node = $rootNode->getDescendantNodeAtPosition($offset->toInt());
 
         if ($node instanceof Variable && $node->getFirstAncestor(PropertyDeclaration::class)) {

--- a/lib/Extension/LanguageServerSelectionRange/Handler/SelectionRangeHandler.php
+++ b/lib/Extension/LanguageServerSelectionRange/Handler/SelectionRangeHandler.php
@@ -5,6 +5,7 @@ namespace Phpactor\Extension\LanguageServerSelectionRange\Handler;
 use Amp\Promise;
 use Amp\Success;
 use Phpactor\Extension\LanguageServerBridge\Converter\PositionConverter;
+use Phpactor\Extension\LanguageServerBridge\Converter\TextDocumentConverter;
 use Phpactor\Extension\LanguageServerSelectionRange\Model\RangeProvider;
 use Phpactor\LanguageServerProtocol\Position;
 use Phpactor\LanguageServerProtocol\SelectionRange;
@@ -41,7 +42,10 @@ class SelectionRangeHandler implements Handler, CanRegisterCapabilities
             return PositionConverter::positionToByteOffset($position, $textDocument->text);
         }, $params->positions);
 
-        return new Success($this->provider->provide($textDocument->text, $offsets));
+        return new Success($this->provider->provide(
+            TextDocumentConverter::fromLspTextItem($textDocument),
+            $offsets
+        ));
     }
 
     public function registerCapabiltiies(ServerCapabilities $capabilities): void

--- a/lib/Extension/LanguageServerSelectionRange/Model/RangeProvider.php
+++ b/lib/Extension/LanguageServerSelectionRange/Model/RangeProvider.php
@@ -3,6 +3,7 @@
 namespace Phpactor\Extension\LanguageServerSelectionRange\Model;
 
 use Microsoft\PhpParser\Node;
+use Phpactor\TextDocument\TextDocument;
 use Phpactor\WorseReflection\Core\AstProvider;
 use Phpactor\Extension\LanguageServerBridge\Converter\PositionConverter;
 use Phpactor\LanguageServerProtocol\Range;
@@ -20,7 +21,7 @@ class RangeProvider
      *
      * @return array<SelectionRange>
      */
-    public function provide(string $source, array $offsets): array
+    public function provide(TextDocument $source, array $offsets): array
     {
         $rootNode = $this->parser->get($source);
 

--- a/lib/Extension/LanguageServerSymbolProvider/Adapter/TolerantDocumentSymbolProvider.php
+++ b/lib/Extension/LanguageServerSymbolProvider/Adapter/TolerantDocumentSymbolProvider.php
@@ -24,6 +24,7 @@ use Microsoft\PhpParser\Node\Statement\FunctionDeclaration;
 use Microsoft\PhpParser\Node\Statement\InterfaceDeclaration;
 use Microsoft\PhpParser\Node\Statement\TraitDeclaration;
 use Microsoft\PhpParser\Node\TraitMembers;
+use Phpactor\TextDocument\TextDocument;
 use Phpactor\WorseReflection\Core\AstProvider;
 use Phpactor\Extension\LanguageServerBridge\Converter\PositionConverter;
 use Phpactor\Extension\LanguageServerSymbolProvider\Model\DocumentSymbolProvider;
@@ -37,11 +38,11 @@ class TolerantDocumentSymbolProvider implements DocumentSymbolProvider
     {
     }
 
-    public function provideFor(string $source): array
+    public function provideFor(TextDocument $document): array
     {
-        $rootNode = $this->parser->get($source);
+        $rootNode = $this->parser->get($document);
 
-        return $this->buildNodes($rootNode->getChildNodes(), $source);
+        return $this->buildNodes($rootNode->getChildNodes(), $document->__toString());
     }
 
     /**

--- a/lib/Extension/LanguageServerSymbolProvider/Handler/DocumentSymbolProviderHandler.php
+++ b/lib/Extension/LanguageServerSymbolProvider/Handler/DocumentSymbolProviderHandler.php
@@ -4,6 +4,7 @@ namespace Phpactor\Extension\LanguageServerSymbolProvider\Handler;
 
 use Amp\Promise;
 use Amp\Success;
+use Phpactor\Extension\LanguageServerBridge\Converter\TextDocumentConverter;
 use Phpactor\Extension\LanguageServerSymbolProvider\Model\DocumentSymbolProvider;
 use Phpactor\LanguageServerProtocol\DocumentSymbolParams;
 use Phpactor\LanguageServerProtocol\DocumentSymbolRequest;
@@ -35,7 +36,7 @@ class DocumentSymbolProviderHandler implements Handler, CanRegisterCapabilities
     {
         $textDocument = $this->workspace->get($params->textDocument->uri);
 
-        return new Success($this->provider->provideFor($textDocument->text));
+        return new Success($this->provider->provideFor(TextDocumentConverter::fromLspTextItem($textDocument)));
     }
 
     public function registerCapabiltiies(ServerCapabilities $capabilities): void

--- a/lib/Extension/LanguageServerSymbolProvider/Model/DocumentSymbolProvider.php
+++ b/lib/Extension/LanguageServerSymbolProvider/Model/DocumentSymbolProvider.php
@@ -3,11 +3,12 @@
 namespace Phpactor\Extension\LanguageServerSymbolProvider\Model;
 
 use Phpactor\LanguageServerProtocol\DocumentSymbol;
+use Phpactor\TextDocument\TextDocument;
 
 interface DocumentSymbolProvider
 {
     /**
      * @return array<DocumentSymbol>
      */
-    public function provideFor(string $source): array;
+    public function provideFor(TextDocument $document): array;
 }

--- a/lib/Extension/LanguageServerSymbolProvider/Tests/Unit/Adapter/TolerantDocumentSymbolProviderTest.php
+++ b/lib/Extension/LanguageServerSymbolProvider/Tests/Unit/Adapter/TolerantDocumentSymbolProviderTest.php
@@ -2,6 +2,7 @@
 
 namespace Phpactor\Extension\LanguageServerSymbolProvider\Tests\Unit\Adapter;
 
+use Phpactor\TextDocument\TextDocumentBuilder;
 use Phpactor\WorseReflection\Bridge\TolerantParser\AstProvider\TolerantAstProvider;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Exception;
@@ -35,7 +36,9 @@ class TolerantDocumentSymbolProviderTest extends TestCase
     #[DataProvider('provideEnums')]
     public function testBuildDocumentSymbol(string $source, array $expected): void
     {
-        $actual = (new TolerantDocumentSymbolProvider(new TolerantAstProvider()))->provideFor($source);
+        $actual = (new TolerantDocumentSymbolProvider(new TolerantAstProvider()))->provideFor(
+            TextDocumentBuilder::create($source)->build()
+        );
         $this->assertTree($actual, $expected);
     }
 

--- a/lib/Extension/WorseReflection/Command/DumpAstCommand.php
+++ b/lib/Extension/WorseReflection/Command/DumpAstCommand.php
@@ -3,9 +3,9 @@
 namespace Phpactor\Extension\WorseReflection\Command;
 
 use Microsoft\PhpParser\Node;
+use Phpactor\TextDocument\TextDocumentBuilder;
 use Phpactor\WorseReflection\Core\AstProvider;
 use Microsoft\PhpParser\Token;
-use RuntimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
@@ -30,15 +30,9 @@ class DumpAstCommand extends Command
     {
         /** @var string $path */
         $path = $input->getArgument(self::ARG_PATH);
-        $contents = file_get_contents($path);
-        if (false === $contents) {
-            throw new RuntimeException(sprintf(
-                'Could not read file %s',
-                $path
-            ));
-        }
+
         $parseStart = microtime(true);
-        $rootNode = $this->parser->get($contents);
+        $rootNode = $this->parser->get(TextDocumentBuilder::fromUri($path)->build());
         $parseEnd = microtime(true);
 
         $traveralStart = microtime(true);

--- a/lib/Indexer/Adapter/Tolerant/TolerantIndexBuilder.php
+++ b/lib/Indexer/Adapter/Tolerant/TolerantIndexBuilder.php
@@ -63,10 +63,7 @@ final class TolerantIndexBuilder implements IndexBuilder
             $indexer->beforeParse($this->index, $document);
         }
 
-        $node = $this->parser->get(
-            $document->__toString(),
-            $document->uri()?->__toString()
-        );
+        $node = $this->parser->get($document);
         $this->indexNode($document, $node);
     }
 

--- a/lib/Rename/Adapter/ReferenceFinder/AbstractReferenceRenamer.php
+++ b/lib/Rename/Adapter/ReferenceFinder/AbstractReferenceRenamer.php
@@ -29,7 +29,7 @@ abstract class AbstractReferenceRenamer implements Renamer
 
     public function getRenameRange(TextDocument $textDocument, ByteOffset $offset): ?ByteOffsetRange
     {
-        $node = $this->parser->get($textDocument->__toString())->getDescendantNodeAtPosition($offset->toInt());
+        $node = $this->parser->get($textDocument)->getDescendantNodeAtPosition($offset->toInt());
         return $this->getRenameRangeForNode($node);
     }
 

--- a/lib/Rename/Adapter/ReferenceFinder/ClassMover/ClassRenamer.php
+++ b/lib/Rename/Adapter/ReferenceFinder/ClassMover/ClassRenamer.php
@@ -43,7 +43,7 @@ final class ClassRenamer implements Renamer
 
     public function getRenameRange(TextDocument $textDocument, ByteOffset $offset): ?ByteOffsetRange
     {
-        $node = $this->parser->get($textDocument->__toString())->getDescendantNodeAtPosition($offset->toInt());
+        $node = $this->parser->get($textDocument)->getDescendantNodeAtPosition($offset->toInt());
 
         if ($node instanceof ClassDeclaration) {
             return TokenUtil::offsetRangeFromToken($node->name, false);
@@ -70,7 +70,7 @@ final class ClassRenamer implements Renamer
 
     public function rename(TextDocument $textDocument, ByteOffset $offset, string $newName): Generator
     {
-        $node = $this->parser->get($textDocument->__toString())->getDescendantNodeAtPosition($offset->toInt());
+        $node = $this->parser->get($textDocument)->getDescendantNodeAtPosition($offset->toInt());
 
         $originalName = $this->getFullName($node);
         $newName = $this->createNewName($originalName, $newName);

--- a/lib/WorseReferenceFinder/TolerantVariableReferenceFinder.php
+++ b/lib/WorseReferenceFinder/TolerantVariableReferenceFinder.php
@@ -39,7 +39,7 @@ class TolerantVariableReferenceFinder implements ReferenceFinder
      */
     public function findReferences(TextDocument $document, ByteOffset $byteOffset): Generator
     {
-        $sourceNode = $this->sourceNode($document->__toString());
+        $sourceNode = $this->parser->get($document);
         $variable = $this->variableNodeFromSource($sourceNode, $byteOffset->toInt());
         if ($variable === null) {
             return false;
@@ -57,11 +57,6 @@ class TolerantVariableReferenceFinder implements ReferenceFinder
         }
 
         return true;
-    }
-
-    private function sourceNode(string $source): SourceFileNode
-    {
-        return $this->parser->get($source);
     }
 
     private function variableNodeFromSource(SourceFileNode $sourceNode, int $offset): ?Node

--- a/lib/WorseReferenceFinder/WorsePlainTextClassDefinitionLocator.php
+++ b/lib/WorseReferenceFinder/WorsePlainTextClassDefinitionLocator.php
@@ -80,7 +80,7 @@ class WorsePlainTextClassDefinitionLocator implements DefinitionLocator
             return $word;
         }
 
-        $node = $this->parser->get($document->__toString());
+        $node = $this->parser->get($document);
         $node = NodeUtil::firstDescendantNodeAfterOffset($node, $byteOffset->toInt());
 
         if ($node instanceof SourceFileNode) {

--- a/lib/WorseReflection/Bridge/TolerantParser/AstProvider/CachedAstProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/AstProvider/CachedAstProvider.php
@@ -3,9 +3,7 @@
 namespace Phpactor\WorseReflection\Bridge\TolerantParser\AstProvider;
 
 use Microsoft\PhpParser\Node\SourceFileNode;
-use Microsoft\PhpParser\Parser;
 use Phpactor\TextDocument\TextDocument;
-use Phpactor\TextDocument\TextDocumentUri;
 use Phpactor\WorseReflection\Core\AstProvider;
 use Phpactor\WorseReflection\Core\Cache;
 use Phpactor\WorseReflection\Core\CacheForDocument;
@@ -15,35 +13,30 @@ class CachedAstProvider implements AstProvider
 {
     private CacheForDocument $cacheForDocument;
 
-    private Parser $parser;
-
     public function __construct(
+        private AstProvider $astProvider,
         private Cache $cache = new TtlCache(),
         ?CacheForDocument $cacheForDocument = null
     ) {
         $this->cacheForDocument = $cacheForDocument ?? CacheForDocument::none();
-        $this->parser = new Parser();
     }
 
-    public function get(string|TextDocument $document, ?string $uri = null): SourceFileNode
+    public function get(TextDocument $document): SourceFileNode
     {
-
-        $uri = ($document instanceof TextDocument ? $document->uri()?->__toString() : null) ?? $uri;
-
-        if (null === $uri) {
+        if ($document->uri() === null) {
             return $this->cache->getOrSet(
-                '__parser__' . md5($document),
+                'astanon:' . md5($document),
                 function () use ($document) {
-                    return $this->parser->parseSourceFile((string)$document);
+                    return $this->astProvider->get($document);
                 }
             );
         }
 
         return $this->cacheForDocument->getOrSet(
-            TextDocumentUri::fromString($uri),
+            $document->uri(),
             'ast',
-            function () use ($document, $uri) {
-                return $this->parser->parseSourceFile((string)$document, $uri);
+            function () use ($document) {
+                return $this->astProvider->get($document);
             }
         );
     }

--- a/lib/WorseReflection/Bridge/TolerantParser/AstProvider/TolerantAstProvider.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/AstProvider/TolerantAstProvider.php
@@ -6,22 +6,36 @@ use Microsoft\PhpParser\Node\SourceFileNode;
 use Microsoft\PhpParser\Parser;
 use Phpactor\WorseReflection\Core\AstProvider;
 use Phpactor\TextDocument\TextDocument;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 final class TolerantAstProvider implements AstProvider
 {
-    public function __construct(private Parser $parser = new Parser())
-    {
+    public function __construct(
+        private Parser $parser = new Parser(),
+        private LoggerInterface $logger = new NullLogger(
+        )
+    ) {
     }
 
-    public function get(string|TextDocument $document, ?string $uri = null): SourceFileNode
+    public function get(TextDocument $document): SourceFileNode
     {
-        if (is_string($document)) {
-            return $this->parser->parseSourceFile($document, $uri);
-        }
-
-        return $this->parser->parseSourceFile(
+        $start = microtime(true);
+        $node = $this->parser->parseSourceFile(
             $document->__toString(),
             $document->uri()?->__toString(),
         );
+        $this->logger->info(sprintf(
+            'parse %s (%s)',
+            microtime(true) - $start,
+            $document->uri()?->__toString() ?? '<anonymous>',
+        ));
+
+        return $node;
+    }
+
+    public function parseString(string $string): SourceFileNode
+    {
+        return $this->parser->parseSourceFile($string);
     }
 }

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflector/TolerantFactory.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflector/TolerantFactory.php
@@ -2,15 +2,15 @@
 
 namespace Phpactor\WorseReflection\Bridge\TolerantParser\Reflector;
 
+use Phpactor\WorseReflection\Bridge\TolerantParser\AstProvider\TolerantAstProvider;
 use Phpactor\WorseReflection\Core\AstProvider;
-use Phpactor\WorseReflection\Bridge\TolerantParser\AstProvider\CachedAstProvider;
 use Phpactor\WorseReflection\Core\Reflector\SourceCodeReflectorFactory;
 use Phpactor\WorseReflection\Core\Reflector\SourceCodeReflector;
 use Phpactor\WorseReflection\Core\ServiceLocator;
 
 class TolerantFactory implements SourceCodeReflectorFactory
 {
-    public function __construct(private AstProvider $parser = new CachedAstProvider())
+    public function __construct(private AstProvider $parser = new TolerantAstProvider())
     {
     }
 

--- a/lib/WorseReflection/Bridge/TolerantParser/Reflector/TolerantSourceCodeReflector.php
+++ b/lib/WorseReflection/Bridge/TolerantParser/Reflector/TolerantSourceCodeReflector.php
@@ -161,6 +161,6 @@ class TolerantSourceCodeReflector implements SourceCodeReflector
 
     private function parseSourceCode(TextDocument $sourceCode): SourceFileNode
     {
-        return $this->parser->get((string) $sourceCode, $sourceCode->uri()?->__toString());
+        return $this->parser->get($sourceCode);
     }
 }

--- a/lib/WorseReflection/Core/AstProvider.php
+++ b/lib/WorseReflection/Core/AstProvider.php
@@ -7,5 +7,5 @@ use Phpactor\TextDocument\TextDocument;
 
 interface AstProvider
 {
-    public function get(string|TextDocument $document, ?string $uri = null): SourceFileNode;
+    public function get(TextDocument $document): SourceFileNode;
 }

--- a/lib/WorseReflection/Core/Inference/Walker/IncludeWalker.php
+++ b/lib/WorseReflection/Core/Inference/Walker/IncludeWalker.php
@@ -2,6 +2,7 @@
 
 namespace Phpactor\WorseReflection\Core\Inference\Walker;
 
+use Phpactor\TextDocument\TextDocumentBuilder;
 use Phpactor\WorseReflection\Bridge\TolerantParser\AstProvider\TolerantAstProvider;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\Expression\AssignmentExpression;
@@ -69,8 +70,7 @@ class IncludeWalker implements Walker
             return $frame;
         }
 
-        $sourceCode = (string)file_get_contents($includeUri);
-        $sourceNode = $this->parser->get($sourceCode);
+        $sourceNode = $this->parser->get(TextDocumentBuilder::fromUri($uri)->build());
         $includedFrame = $this->resolver->build($sourceNode);
         $frame->locals()->merge($includedFrame->locals());
 

--- a/lib/WorseReflection/Tests/Integration/Core/Inference/FrameResolverTest.php
+++ b/lib/WorseReflection/Tests/Integration/Core/Inference/FrameResolverTest.php
@@ -90,7 +90,8 @@ class FrameResolverTest extends IntegrationTestCase
         $docblockFactory = $this->createMock(DocBlockFactory::class);
         $cache = new StaticCache();
 
-        $ast = (new TolerantAstProvider())->get($source, 'file:///test.php');
+        $ast = (new TolerantAstProvider())->parseString($source);
+        $ast->uri = 'file:///test.php';
 
         foreach ($offsets as $offset) {
             $nodeResolver = new NodeContextResolver(

--- a/lib/WorseReflection/Tests/Integration/IntegrationTestCase.php
+++ b/lib/WorseReflection/Tests/Integration/IntegrationTestCase.php
@@ -58,10 +58,10 @@ class IntegrationTestCase extends TestCase
         return new Workspace(__DIR__ . '/../Workspace');
     }
 
-    protected function parseSource(string $source, ?string $uri = null): SourceFileNode
+    protected function parseSource(string $source): SourceFileNode
     {
         $parser = new TolerantAstProvider();
 
-        return $parser->get($source, $uri);
+        return $parser->parseString($source);
     }
 }

--- a/lib/WorseReflection/Tests/Unit/Bridge/TolerantParser/Parser/CachedParserTest.php
+++ b/lib/WorseReflection/Tests/Unit/Bridge/TolerantParser/Parser/CachedParserTest.php
@@ -3,35 +3,45 @@
 namespace Phpactor\WorseReflection\Tests\Unit\Bridge\TolerantParser\Parser;
 
 use PHPUnit\Framework\TestCase;
+use Phpactor\TextDocument\TextDocumentBuilder;
 use Phpactor\WorseReflection\Bridge\TolerantParser\AstProvider\CachedAstProvider;
+use Phpactor\WorseReflection\Bridge\TolerantParser\AstProvider\TolerantAstProvider;
 use Phpactor\WorseReflection\Core\Cache\TtlCache;
 
 class CachedParserTest extends TestCase
 {
     public function testCachesResults(): void
     {
-        $parser = new CachedAstProvider(new TtlCache());
-        $node1 = $parser->get(file_get_contents(__FILE__));
-        $node2 = $parser->get(file_get_contents(__FILE__));
+        $parser = $this->createParser();
+        $node1 = $parser->get(TextDocumentBuilder::create(file_get_contents(__FILE__))->build());
+        $node2 = $parser->get(TextDocumentBuilder::create(file_get_contents(__FILE__))->build());
 
         $this->assertSame($node1, $node2);
     }
 
     public function testUsesUriInKey(): void
     {
-        $parser = new CachedAstProvider(new TtlCache());
-        $node1 = $parser->get(file_get_contents(__FILE__));
-        $node2 = $parser->get(file_get_contents(__FILE__), 'file:///test.php');
+        $parser = $this->createParser();
+        $node1 = $parser->get(TextDocumentBuilder::create(file_get_contents(__FILE__))->build());
+        $node2 = $parser->get(TextDocumentBuilder::fromUri(__FILE__)->build());
 
         $this->assertNotSame($node1, $node2);
     }
 
     public function testReturnsDifferentResultsForDifferentSourceCodes(): void
     {
-        $parser = new CachedAstProvider(new TtlCache());
-        $node1 = $parser->get(file_get_contents(__FILE__));
-        $node2 = $parser->get('Foobar' . file_get_contents(__FILE__));
+        $parser = $this->createParser();
+        $node1 = $parser->get(TextDocumentBuilder::create(file_get_contents(__FILE__))->build());
+        $node2 = $parser->get(TextDocumentBuilder::create('Foobar' . file_get_contents(__FILE__))->build());
 
         $this->assertNotSame($node1, $node2);
+    }
+
+    private function createParser(): CachedAstProvider
+    {
+        return new CachedAstProvider(
+            new TolerantAstProvider(),
+            new TtlCache()
+        );
     }
 }


### PR DESCRIPTION
Refactor to always pass a TextDocument to the AST provider.

Note that this highlights the fact that we parse the document multiple times during completion due to the "need" to truncate it.