### PR TITLE
Add .readthedocs.yaml and rector.php to export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,7 @@
 /*.neon                 export-ignore
 /.github                export-ignore
 /.php-cs-fixer.dist.php export-ignore
+/.readthedocs.yaml      export-ignore
 /Makefile               export-ignore
 /box.json               export-ignore
 /doc/                   export-ignore
@@ -20,3 +21,4 @@
 /phpunit.xml.dist       export-ignore
 /test.php               export-ignore
 /tests/                 export-ignore
+/rector.php             export-ignore


### PR DESCRIPTION
With this PR, The archive targets other than `templates/` and ` lib/`, will be as follows:


```
gh api repos/sasezaki/phpactor/tarball/patch-1 | tar -tzf - | cut -d/ -f2- | sed '/^$/d' | grep -v templates/ | grep -v lib/
CHANGELOG.md
LICENSE
README.md
autoload/
autoload/health/
autoload/health/phpactor.vim
autoload/phpactor.vim
autoload/phpactor/
autoload/phpactor/completion.vim
autoload/phpactor/input.vim
autoload/phpactor/input/
autoload/phpactor/input/list.vim
autoload/phpactor/quickfix.vim
bin/
bin/phpactor
composer.json
composer.lock
ftplugin/
ftplugin/php.vim
ftplugin/php/
ftplugin/php/commands.vim
ftplugin/php/mappings.vim
plugin/
plugin/phpactor.vim
requirements.txt
```