### PR TITLE
Allow goto definition from first class callables

### DIFF
--- a/lib/WorseReferenceFinder/Tests/Unit/WorseReflectionDefinitionLocatorTest.php
+++ b/lib/WorseReferenceFinder/Tests/Unit/WorseReflectionDefinitionLocatorTest.php
@@ -83,6 +83,21 @@ class WorseReflectionDefinitionLocatorTest extends DefinitionLocatorTestCase
         $this->assertTypeLocation($location->first(), 'file1.php', 7, 28);
     }
 
+    public function testLocatesFunctionFromFirstClassCallable(): void
+    {
+        $location = $this->locate(<<<'EOT'
+            // File: file1.php
+            <?php
+
+            function foobar()
+            {
+            }
+            EOT
+            , '<?php $fb = foob<>ar(...);');
+
+        $this->assertTypeLocation($location->first(), 'file1.php', 7, 28);
+    }
+
     public function testExceptionForFunctionWithNoDefinition(): void
     {
         $this->expectException(CouldNotLocateDefinition::class);
@@ -123,6 +138,32 @@ class WorseReflectionDefinitionLocatorTest extends DefinitionLocatorTestCase
         $locationRange = $location->first()->location();
 
         $this->assertTypeLocation($location->first(), 'Foobar.php', 21, 45);
+    }
+
+    public function testLocatesToMethodFromFirstClassCallable(): void
+    {
+        $location = $this->locate(<<<'EOT'
+            // File: Foobar.php
+            <?php class Foobar { public function bar() {} }
+            EOT
+            , '<?php $foo = new Foobar(); $bar = $foo->b<>ar(...);');
+
+        $locationRange = $location->first()->location();
+
+        $this->assertTypeLocation($location->first(), 'Foobar.php', 21, 45);
+    }
+
+    public function testLocatesToStaticMethodFromFirstClassCallable(): void
+    {
+        $location = $this->locate(<<<'EOT'
+            // File: Foobar.php
+            <?php class Foobar { public static function bar() {} }
+            EOT
+            , '<?php $fb = Foobar::b<>ar(...)');
+
+        $locationRange = $location->first()->location();
+
+        $this->assertTypeLocation($location->first(), 'Foobar.php', 21, 52);
     }
 
     public function testLocatesToConstant(): void

--- a/lib/WorseReflection/Core/Inference/Resolver/MemberAccess/NodeContextFromMemberAccess.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/MemberAccess/NodeContextFromMemberAccess.php
@@ -124,15 +124,7 @@ class NodeContextFromMemberAccess
 
         if ($member instanceof ReflectionMember) {
             if ($member instanceof ReflectionMethod) {
-                if (NodeUtil::isFirstClassCallable($node->parent)) {
-                    return $context->withType(new ClosureType(
-                        $resolver->reflector(),
-                        $member->parameters()->types()->toArray(),
-                        $member->type(),
-                    ));
-                }
-
-                return new MethodCallContext(
+                $methodCallContext = new MethodCallContext(
                     $context->symbol(),
                     $memberType->reduce(),
                     $containerType,
@@ -140,6 +132,16 @@ class NodeContextFromMemberAccess
                     $member,
                     $arguments,
                 );
+
+                if (NodeUtil::isFirstClassCallable($node->parent)) {
+                    return $methodCallContext->withType(new ClosureType(
+                        $resolver->reflector(),
+                        $member->parameters()->types()->toArray(),
+                        $member->type(),
+                    ));
+                }
+
+                return $methodCallContext;
             }
             return new MemberAccessContext(
                 $context->symbol(),

--- a/lib/WorseReflection/Core/Inference/Resolver/QualifiedNameResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/QualifiedNameResolver.php
@@ -140,9 +140,10 @@ class QualifiedNameResolver implements Resolver
 
         if (NodeUtil::isFirstClassCallable($parent)) {
             $context = NodeContextFactory::create(
-                $parent->getText(),
-                $parent->getStartPosition(),
-                $parent->getEndPosition(),
+                $node->getText(),
+                $node->getStartPosition(),
+                $node->getEndPosition(),
+                ['symbol_type' => Symbol::FUNCTION],
             );
 
             return $context->withType(new ClosureType(


### PR DESCRIPTION
Fix: #2975 