### PR TITLE
fix(BinaryExpressionResolver): null coalesce on undefined variable

### DIFF
--- a/lib/WorseReflection/Core/Inference/Resolver/BinaryExpressionResolver.php
+++ b/lib/WorseReflection/Core/Inference/Resolver/BinaryExpressionResolver.php
@@ -284,6 +284,10 @@ class BinaryExpressionResolver implements Resolver
 
     private function nullCoalesce(Type $left, Type $right): Type
     {
+        if ($left instanceof MissingType) {
+            return $right;
+        }
+
         if ($left->isNullable()) {
             return TypeFactory::union($left->stripNullable(), $right);
         }

--- a/lib/WorseReflection/Tests/Inference/null-coalesce/null-coalesce_undefined.test
+++ b/lib/WorseReflection/Tests/Inference/null-coalesce/null-coalesce_undefined.test
@@ -1,0 +1,5 @@
+<?php
+
+$baz = $foo ?? 123;
+
+wrAssertType('123', $baz, 'assumes right if left is undefined');


### PR DESCRIPTION
Fix: #3030

In practice: 

- it fixes hover info on `$baz` from the test case
- diagnostic provider still complains about undefined variable (apparently it's a separate issue).