### PR TITLE
Index optimiser

### DIFF
--- a/doc/lsp/vim-lsp.rst
+++ b/doc/lsp/vim-lsp.rst
@@ -45,6 +45,7 @@ If you want to profile Phpactor for debugging purposes:
           autocmd Filetype php command! -nargs=0 LspPhpactorStatus lua LspPhpactorStatus()
           autocmd Filetype php command! -nargs=0 LspPhpactorBlackfireStart lua LspPhpactorBlackfireStart()
           autocmd Filetype php command! -nargs=0 LspPhpactorBlackfireFinish lua LspPhpactorBlackfireFinish()
+          autocmd Filetype php command! -nargs=0 LspPhpactorIndexOptimise lua vim.lsp.buf_notify(0, "phpactor/indexer/optimise",{})
         augroup END
     ]])
 

--- a/doc/reference/configuration.rst
+++ b/doc/reference/configuration.rst
@@ -1623,6 +1623,22 @@ Unconditionally reindex modified files every N seconds
 **Default**: ``300``
 
 
+.. _param_language_server_indexer.optimiser_timeout:
+
+
+``language_server_indexer.optimiser_timeout``
+"""""""""""""""""""""""""""""""""""""""""""""
+
+
+Type: integer
+
+
+Optimise the index every N seconds
+
+
+**Default**: ``3600``
+
+
 .. _LanguageServerCodeTransformExtension:
 
 

--- a/lib/Extension/LanguageServerIndexer/Handler/IndexerHandler.php
+++ b/lib/Extension/LanguageServerIndexer/Handler/IndexerHandler.php
@@ -28,7 +28,8 @@ use function Amp\delay;
 
 class IndexerHandler implements Handler, ServiceProvider
 {
-    const SERVICE_INDEXER = 'indexer';
+    public const SERVICE_INDEXER = 'indexer';
+    public const SERVICE_OPTIMISER = 'optimiser';
 
     public function __construct(
         private Indexer $indexer,
@@ -38,6 +39,7 @@ class IndexerHandler implements Handler, ServiceProvider
         private EventDispatcherInterface $eventDispatcher,
         private ProgressNotifier $progressNotifier,
         private ?int $reindexTimeout = null,
+        private int $optimiserTimeout = 3600,
     ) {
     }
 
@@ -48,6 +50,7 @@ class IndexerHandler implements Handler, ServiceProvider
     {
         return [
             'phpactor/indexer/reindex' => 'reindex',
+            'phpactor/indexer/optimise' => 'optimise',
         ];
     }
 
@@ -57,7 +60,8 @@ class IndexerHandler implements Handler, ServiceProvider
     public function services(): array
     {
         return [
-            self::SERVICE_INDEXER
+            self::SERVICE_INDEXER,
+            self::SERVICE_OPTIMISER,
         ];
     }
 
@@ -142,6 +146,53 @@ class IndexerHandler implements Handler, ServiceProvider
             }
 
             $this->eventDispatcher->dispatch(new IndexReset());
+        });
+    }
+
+    /**
+     * @return Promise<mixed>
+     */
+    public function optimiser(CancellationToken $cancel): Promise
+    {
+        return call(function () use ($cancel) {
+            while (true) {
+                yield delay($this->optimiserTimeout);
+
+                if ($cancel->isRequested()) {
+                    break;
+                }
+
+                yield $this->optimise($cancel);
+            }
+        });
+    }
+
+    /**
+     * @return Promise<void>
+     */
+    public function optimise(?CancellationToken $cancel = null): Promise
+    {
+        return call(function () use ($cancel) {
+            $token = WorkDoneToken::generate();
+            $this->clientApi->workDoneProgress()->create($token);
+            $this->clientApi->workDoneProgress()->begin(
+                $token,
+                'optimising index',
+            );
+            $optimised = 0;
+            foreach ($this->indexer->optimise(false) as $tick) {
+                if ($tick !== null) {
+                    $optimised++;
+                }
+                if ($cancel && $cancel->isRequested()) {
+                    break;
+                }
+                yield new Delayed(0);
+            }
+            $this->clientApi->workDoneProgress()->end($token, sprintf(
+                '%d files optimised',
+                $optimised
+            ));
         });
     }
 

--- a/lib/Extension/LanguageServerIndexer/LanguageServerIndexerExtension.php
+++ b/lib/Extension/LanguageServerIndexer/LanguageServerIndexerExtension.php
@@ -30,6 +30,7 @@ class LanguageServerIndexerExtension implements Extension
 {
     public const WORKSPACE_SYMBOL_SEARCH_LIMIT = 'language_server_indexer.workspace_symbol_search_limit';
     public const PARAM_REINDEX_TIMEOUT = 'language_server_indexer.reindex_timeout';
+    public const PARAM_OPTIMISER_TIMEOUT = 'language_server_indexer.optimiser_timeout';
 
     public function load(ContainerBuilder $container): void
     {
@@ -68,9 +69,14 @@ class LanguageServerIndexerExtension implements Extension
         $schema->setDefaults([
             self::WORKSPACE_SYMBOL_SEARCH_LIMIT => 250,
             self::PARAM_REINDEX_TIMEOUT => 300,
+            self::PARAM_OPTIMISER_TIMEOUT => 3600,
+        ]);
+        $schema->setTypes([
+            self::PARAM_OPTIMISER_TIMEOUT => 'integer',
         ]);
         $schema->setDescriptions([
             self::PARAM_REINDEX_TIMEOUT => 'Unconditionally reindex modified files every N seconds',
+            self::PARAM_OPTIMISER_TIMEOUT => 'Optimise the index every N seconds',
         ]);
     }
 
@@ -86,7 +92,8 @@ class LanguageServerIndexerExtension implements Extension
                 $container->get(ProgressNotifier::class),
                 (fn (mixed $timeout) => is_int($timeout) ? $timeout * 1000 : null)(
                     $container->parameter(self::PARAM_REINDEX_TIMEOUT)->value()
-                )
+                ),
+                $container->parameter(self::PARAM_OPTIMISER_TIMEOUT)->int() * 1000
             );
         }, [
             LanguageServerExtension::TAG_METHOD_HANDLER => [],

--- a/lib/Extension/LanguageServerIndexer/Tests/Unit/IndexerHandlerTest.php
+++ b/lib/Extension/LanguageServerIndexer/Tests/Unit/IndexerHandlerTest.php
@@ -6,6 +6,7 @@ use Phpactor\Extension\LanguageServer\LanguageServerExtension;
 use Phpactor\LanguageServerProtocol\ClientCapabilities;
 use Phpactor\LanguageServerProtocol\InitializeParams;
 use Phpactor\LanguageServerProtocol\WindowClientCapabilities;
+use Phpactor\LanguageServer\Core\Rpc\NotificationMessage;
 use Phpactor\LanguageServer\LanguageServerBuilder;
 use Phpactor\LanguageServer\Test\LanguageServerTester;
 use Phpactor\Extension\LanguageServerIndexer\Tests\IntegrationTestCase;
@@ -71,6 +72,22 @@ class IndexerHandlerTest extends IntegrationTestCase
         ]);
 
         self::assertContains('indexer', $this->tester->services()->listRunning());
+    }
+
+    public function testOptimiseCommand(): void
+    {
+        $this->tester->notifyAndWait('phpactor/indexer/optimise', [
+        ]);
+
+        // shift off progress create
+        $this->tester->transmitter()->shift();
+
+        // test we started optimising the index
+        $message = $this->tester->transmitter()->shift();
+        self::assertInstanceOf(NotificationMessage::class, $message);
+        self::assertIsArray($message->params);
+        self::assertIsArray($message->params['value']);
+        self::assertEquals('optimising index', $message->params['value']['title'] ?? null);
     }
 
     public function testShowsMessageOnWatcherDied(): void

--- a/lib/Indexer/Adapter/Php/InMemory/InMemoryIndex.php
+++ b/lib/Indexer/Adapter/Php/InMemory/InMemoryIndex.php
@@ -72,6 +72,11 @@ class InMemoryIndex implements Index
         return isset($this->index[$this->recordKey($record)]);
     }
 
+    public function optimise(bool $dryRun): iterable
+    {
+        return [];
+    }
+
     private function recordKey(Record $record): string
     {
         return $record->recordType().$record->identifier();

--- a/lib/Indexer/Adapter/Php/Serialized/FileRepository.php
+++ b/lib/Indexer/Adapter/Php/Serialized/FileRepository.php
@@ -2,11 +2,16 @@
 
 namespace Phpactor\Indexer\Adapter\Php\Serialized;
 
+use FilesystemIterator;
+use Generator;
 use Phpactor\Indexer\Model\RecordSerializer;
 use Phpactor\Indexer\Util\Filesystem;
 use Phpactor\Indexer\Model\Record;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
 use Throwable;
 
 class FileRepository
@@ -142,6 +147,55 @@ class FileRepository
             file_put_contents($path, $this->serializer->serialize($record));
         }
         $this->buffer = [];
+    }
+    /**
+     * @return Generator<string,Record>
+     */
+    public function iterator(): Generator
+    {
+        $flags =
+            FilesystemIterator::KEY_AS_PATHNAME |
+            FilesystemIterator::CURRENT_AS_FILEINFO |
+            FilesystemIterator::SKIP_DOTS;
+
+        if (!file_exists($this->path)) {
+            return;
+        }
+
+        if (!is_dir($this->path)) {
+            return;
+        }
+
+        $files = new RecursiveDirectoryIterator($this->path, $flags);
+        $files = new RecursiveIteratorIterator(
+            $files,
+            RecursiveIteratorIterator::LEAVES_ONLY,
+            RecursiveIteratorIterator::CATCH_GET_CHILD
+        );
+
+        foreach ($files as $file) {
+            assert($file instanceof SplFileInfo);
+
+            if ($file->getExtension() !== 'cache') {
+                continue;
+            }
+
+            $contents = file_get_contents($file->getPathname());
+
+            if (false === $contents) {
+                continue;
+            }
+
+            $record = $this->serializer->deserialize(
+                $contents
+            );
+
+            if (null === $record) {
+                continue;
+            }
+
+            yield $file->getPathname() => $record;
+        }
     }
 
     private function ensureDirectoryExists(string $path): void

--- a/lib/Indexer/Adapter/Php/Serialized/SerializedIndex.php
+++ b/lib/Indexer/Adapter/Php/Serialized/SerializedIndex.php
@@ -4,18 +4,92 @@ namespace Phpactor\Indexer\Adapter\Php\Serialized;
 
 use Phpactor\Indexer\Model\Index;
 use Phpactor\Indexer\Model\Record;
+use Phpactor\Indexer\Model\Record\HasFileReferences;
+use Phpactor\Indexer\Model\Record\HasPath;
+use Phpactor\TextDocument\Exception\TextDocumentNotFound;
+use Phpactor\TextDocument\TextDocumentLocator;
+use Phpactor\TextDocument\TextDocumentUri;
 use RuntimeException;
 use SplFileInfo;
 
 class SerializedIndex implements Index
 {
-    public function __construct(private FileRepository $repository)
-    {
+    public function __construct(
+        private FileRepository $repository,
+        private TextDocumentLocator $locator
+    ) {
     }
 
     public function lastUpdate(): int
     {
         return $this->repository->lastUpdate();
+    }
+
+    public function optimise(bool $dryRun): iterable
+    {
+        $count = 0;
+        clearstatcache(true);
+        foreach ($this->repository->iterator() as $cachePath => $record) {
+            if ($record instanceof HasPath) {
+                if (!$record->filePath()) {
+                    yield sprintf(
+                        'Record %s in %s has no file path: %s',
+                        $record::class,
+                        (string)$cachePath,
+                        sprintf('%s:%s', $record->recordType(), $record->identifier())
+                    );
+                    if ($dryRun === false) {
+                        $this->repository->remove($record);
+                    }
+                    continue;
+                }
+
+                try {
+                    $doc = $this->locator->get(TextDocumentUri::fromString($record->filePath()));
+                } catch (TextDocumentNotFound) {
+                    if ($dryRun === false) {
+                        $this->repository->remove($record);
+                    }
+                    yield sprintf(
+                        'File does not exist so removed %s:%s',
+                        $record->recordType(),
+                        $record->identifier()
+                    );
+                    continue;
+                }
+            }
+            if ($record instanceof HasFileReferences) {
+                $removed = 0;
+                foreach ($record->references() as $reference) {
+                    try {
+                        $doc = $this->locator->get(TextDocumentUri::fromString($reference));
+                    } catch (TextDocumentNotFound) {
+                        $removed++;
+                        $record->removeReference($reference);
+                    }
+                }
+                if ($removed > 0) {
+                    $this->write($record);
+                    yield sprintf(
+                        'removed %d dead refernces from %s:%s',
+                        $removed,
+                        $record->recordType(),
+                        $record->identifier(),
+                    );
+                }
+            }
+
+            $count++;
+
+            // arbitrarily flush to disk after every N records
+            if ($count % 500 === 0) {
+                $this->repository->flush();
+            }
+
+            yield null;
+        }
+
+        $this->repository->flush();
     }
 
     public function get(Record $record): Record

--- a/lib/Indexer/Extension/Command/IndexOptimiseCommand.php
+++ b/lib/Indexer/Extension/Command/IndexOptimiseCommand.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Phpactor\Indexer\Extension\Command;
+
+use Phpactor\Indexer\Model\Indexer;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class IndexOptimiseCommand extends Command
+{
+    private const OPT_DRY_RUN = 'dry-run';
+
+    public function __construct(
+        private Indexer $indexer,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription('Optimise the index');
+        $this->addOption(self::OPT_DRY_RUN, null, InputOption::VALUE_NONE, 'Do not make any changes');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $start = microtime(true);
+        $dryRun = $input->getOption(self::OPT_DRY_RUN);
+        $optimisations = 0;
+
+        $output->writeln('<info>Optimising index</info>...');
+
+        if ($output->isVerbose()) {
+            $progress = new ProgressBar(new NullOutput());
+        } else {
+            $progress = new ProgressBar($output);
+        }
+        $progress->setFormat('%current% [%bar%] %optimisations% optimisations');
+        $progress->setPlaceholderFormatterDefinition('optimisations', function () use (&$optimisations): string {
+            return (string)$optimisations;
+        });
+
+        foreach ($this->indexer->optimise((bool)$dryRun) as $tick) {
+            if ($tick !== null) {
+                $optimisations++;
+                if ($output->isVerbose()) {
+                    $output->writeln($tick);
+                }
+            }
+            $progress->advance();
+        }
+
+        $progress->finish();
+
+        $output->write("\n");
+        $output->write("\n");
+
+        if ($dryRun) {
+            $output->writeln(sprintf(
+                '<bg=yellow;fg=black;option>%d optimisations would have been done in %s seconds using %sb of memory</>',
+                $optimisations,
+                number_format(microtime(true) - $start, 2),
+                number_format(memory_get_usage(true))
+            ));
+
+            return 0;
+        }
+
+        $output->writeln(sprintf(
+            '<bg=green;fg=black;option>%d optimisations done in %s seconds using %sb of memory</>',
+            $optimisations,
+            number_format(microtime(true) - $start, 2),
+            number_format(memory_get_usage(true))
+        ));
+
+        return 0;
+    }
+}

--- a/lib/Indexer/Extension/IndexerExtension.php
+++ b/lib/Indexer/Extension/IndexerExtension.php
@@ -31,6 +31,7 @@ use Phpactor\Indexer\Adapter\Worse\IndexerConstantSourceLocator;
 use Phpactor\Indexer\Adapter\Worse\IndexerFunctionSourceLocator;
 use Phpactor\Indexer\Adapter\ReferenceFinder\IndexedReferenceFinder;
 use Phpactor\Indexer\Adapter\Worse\WorseRecordReferenceEnhancer;
+use Phpactor\Indexer\Extension\Command\IndexOptimiseCommand;
 use Phpactor\Indexer\Extension\Command\IndexSearchCommand;
 use Phpactor\Indexer\IndexAgent;
 use Phpactor\Indexer\IndexAgentBuilder;
@@ -181,6 +182,12 @@ class IndexerExtension implements Extension
                 $container->get(Watcher::class)
             );
         }, [ ConsoleExtension::TAG_COMMAND => ['name' => 'index:build']]);
+
+        $container->register(IndexOptimiseCommand::class, function (Container $container) {
+            return new IndexOptimiseCommand(
+                $container->get(Indexer::class),
+            );
+        }, [ ConsoleExtension::TAG_COMMAND => ['name' => 'index:optimise']]);
 
         $container->register(IndexCleanCommand::class, function (Container $container) {
             $indexPath = $container->get(

--- a/lib/Indexer/IndexAgentBuilder.php
+++ b/lib/Indexer/IndexAgentBuilder.php
@@ -34,6 +34,8 @@ use Phpactor\Indexer\Model\SearchIndex\FilteredSearchIndex;
 use Phpactor\Indexer\Model\SearchIndex\SearchIncludeIndex;
 use Phpactor\Indexer\Model\SearchIndex\ValidatingSearchIndex;
 use Phpactor\Indexer\Model\TestIndexAgent;
+use Phpactor\TextDocument\FilesystemTextDocumentLocator;
+use Phpactor\TextDocument\TextDocumentLocator;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
@@ -84,12 +86,21 @@ final class IndexAgentBuilder
 
     private LoggerInterface $logger;
 
+    private ?TextDocumentLocator $documentLocator = null;
+
     private function __construct(
         private string $indexRoot,
         private string $projectRoot,
     ) {
         $this->enhancer = new NullRecordReferenceEnhancer();
         $this->logger = new NullLogger();
+    }
+
+    public function setDocumentLocator(TextDocumentLocator $locator): self
+    {
+        $this->documentLocator = $locator;
+
+        return $this;
     }
 
     public static function create(string $indexRootPath, string $projectRoot): self
@@ -218,7 +229,10 @@ final class IndexAgentBuilder
             $this->logger
         );
 
-        return new SerializedIndex($repository);
+        return new SerializedIndex(
+            $repository,
+            $this->documentLocator ?? new FilesystemTextDocumentLocator(),
+        );
     }
 
     private function buildQuery(Index $index): QueryClient

--- a/lib/Indexer/Model/Index.php
+++ b/lib/Indexer/Model/Index.php
@@ -17,4 +17,15 @@ interface Index extends IndexAccess
     public function exists(): bool;
 
     public function done(): void;
+
+    /**
+     * Remove records referencing non-existing files etc.
+     *
+     * Returns NULL as a "tick" event to avoid blocking or an _informational_
+     * string describing an optimization operation.
+     *
+     * @return iterable<string|null>
+     */
+    public function optimise(bool $dryRun): iterable;
+
 }

--- a/lib/Indexer/Model/Index/SearchAwareIndex.php
+++ b/lib/Indexer/Model/Index/SearchAwareIndex.php
@@ -2,6 +2,7 @@
 
 namespace Phpactor\Indexer\Model\Index;
 
+use Generator;
 use Phpactor\Indexer\Model\Index;
 use Phpactor\Indexer\Model\Record;
 use Phpactor\Indexer\Model\SearchIndex;
@@ -56,5 +57,10 @@ class SearchAwareIndex implements Index
     public function has(Record $record): bool
     {
         return $this->innerIndex->has($record);
+    }
+
+    public function optimise(bool $dryRun): Generator
+    {
+        yield from $this->innerIndex->optimise($dryRun);
     }
 }

--- a/lib/Indexer/Model/Indexer.php
+++ b/lib/Indexer/Model/Indexer.php
@@ -2,6 +2,7 @@
 
 namespace Phpactor\Indexer\Model;
 
+use Generator;
 use Phpactor\Indexer\Model\DirtyDocumentTracker\NullDirtyDocumentTracker;
 use Phpactor\TextDocument\TextDocument;
 
@@ -23,6 +24,13 @@ class Indexer
             $this->provider->provideFileList($this->index, $subPath),
             $this->maxFileSizeToIndex,
         );
+    }
+    /**
+     * @return Generator<string|null>
+     */
+    public function optimise(bool $dryRun): Generator
+    {
+        yield from $this->index->optimise($dryRun);
     }
 
     public function index(TextDocument $textDocument): void

--- a/lib/Indexer/Model/RecordSerializer/PhpSerializer.php
+++ b/lib/Indexer/Model/RecordSerializer/PhpSerializer.php
@@ -14,6 +14,10 @@ class PhpSerializer implements RecordSerializer
 
     public function deserialize(string $data): ?Record
     {
-        return unserialize($data);
+        $unserialized = unserialize($data);
+        if (false === $unserialized) {
+            return null;
+        }
+        return $unserialized;
     }
 }

--- a/lib/Indexer/Tests/Adapter/Php/SerializedIndexTest.php
+++ b/lib/Indexer/Tests/Adapter/Php/SerializedIndexTest.php
@@ -7,6 +7,7 @@ use Phpactor\Indexer\Adapter\Php\Serialized\SerializedIndex;
 use Phpactor\Indexer\Model\Index;
 use Phpactor\Indexer\Model\RecordSerializer\PhpSerializer;
 use Phpactor\Indexer\Tests\Adapter\IndexTestCase;
+use Phpactor\TextDocument\FilesystemTextDocumentLocator;
 
 class SerializedIndexTest extends IndexTestCase
 {
@@ -14,7 +15,7 @@ class SerializedIndexTest extends IndexTestCase
     {
         return new SerializedIndex(new FileRepository(
             $this->workspace()->path('cache'),
-            new PhpSerializer()
-        ));
+            new PhpSerializer(),
+        ), new FilesystemTextDocumentLocator());
     }
 }

--- a/lib/Indexer/Tests/Extension/Command/IndexOptimiseCommandTest.php
+++ b/lib/Indexer/Tests/Extension/Command/IndexOptimiseCommandTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Phpactor\Indexer\Tests\Extension\Command;
+
+use Phpactor\Indexer\Tests\IntegrationTestCase;
+use Symfony\Component\Process\Process;
+
+class IndexOptimiseCommandTest extends IntegrationTestCase
+{
+    public function tearDown():void
+    {
+        $this->workspace()->reset();
+    }
+
+    public function testRefreshIndex(): void
+    {
+        $this->initProject();
+
+        // create an index
+        $process = new Process([
+            PHP_BINARY,
+            __DIR__ . '/../../bin/console',
+            'index:build',
+        ], $this->workspace()->path());
+        $process->mustRun();
+
+        // optimise the index
+        $process = new Process([
+            PHP_BINARY,
+            __DIR__ . '/../../bin/console',
+            'index:optimise',
+        ], $this->workspace()->path());
+        $process->mustRun();
+
+        self::assertEquals(0, $process->getExitCode());
+        self::assertStringContainsString('optimisations done', $process->getOutput());
+    }
+}

--- a/lib/Indexer/Tests/Unit/Adapter/Php/Serialized/FileRepositoryTest.php
+++ b/lib/Indexer/Tests/Unit/Adapter/Php/Serialized/FileRepositoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Phpactor\Indexer\Tests\Unit\Adapter\Php\Serialized;
 
+use Phpactor\Indexer\Model\Record;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Phpactor\Indexer\Adapter\Php\Serialized\FileRepository;
 use Phpactor\Indexer\Model\Exception\CorruptedRecord;
@@ -15,6 +16,19 @@ use Psr\Log\LoggerInterface;
 class FileRepositoryTest extends IntegrationTestCase
 {
     use ProphecyTrait;
+
+    public function testIterate(): void
+    {
+        $repo = $this->createFileRepository();
+        $repo->put(ClassRecord::fromName('Foobar'));
+        $repo->put(ClassRecord::fromName('Barfoo'));
+        $repo->flush();
+
+        /** @var list<Record> */
+        $records = iterator_to_array($repo->iterator());
+        self::assertCount(2, $records);
+        self::assertEquals('class', $records[array_key_first($records)]->recordType());
+    }
 
     public function testResetRemovesTheIndex(): void
     {

--- a/lib/Indexer/Tests/Unit/Adapter/Php/Serialized/SerializedIndexTest.php
+++ b/lib/Indexer/Tests/Unit/Adapter/Php/Serialized/SerializedIndexTest.php
@@ -6,16 +6,96 @@ use PHPUnit\Framework\Assert;
 use Phpactor\Indexer\Adapter\Php\Serialized\FileRepository;
 use Phpactor\Indexer\Adapter\Php\Serialized\SerializedIndex;
 use Phpactor\Indexer\Model\RecordSerializer\PhpSerializer;
+use Phpactor\Indexer\Model\Record\ClassRecord;
 use Phpactor\Indexer\Tests\IntegrationTestCase;
+use Phpactor\TextDocument\FilesystemTextDocumentLocator;
+use Phpactor\TextDocument\TextDocumentUri;
 use SplFileInfo;
 
 class SerializedIndexTest extends IntegrationTestCase
 {
     public function testIsFreshWithNonExistingFile(): void
     {
-        $repo = new FileRepository($this->workspace()->path(), new PhpSerializer());
-        $index = new SerializedIndex($repo);
+        $repo = new FileRepository(
+            $this->workspace()->path(),
+            new PhpSerializer()
+        );
+        $index = new SerializedIndex(
+            $repo,
+            new FilesystemTextDocumentLocator(),
+        );
         $info = new SplFileInfo($this->workspace()->path('no'));
         Assert::assertFalse($index->isFresh($info), 'File doesn\'t exist, so its not fresh');
+    }
+
+    public function testOptimizeWillRemoveRecordsWithNonExistingFiles(): void
+    {
+        $this->workspace()->reset();
+        $this->workspace()->put('hello.php', '<?php echo "hello";');
+        $this->workspace()->put('ref1.php', '<?php echo "hello";');
+        $this->workspace()->put('ref2.php', '<?php echo "hello";');
+
+        $repo = $this->createRepo();
+        $index = $this->createIndex($repo);
+        $index->write(
+            ClassRecord::fromName('Foobar')->setFilePath(
+                TextDocumentUri::fromString($this->workspace()->path('hello.php'))
+            ),
+        );
+        $index->write(
+            ClassRecord::fromName('Barfoo')->setFilePath(
+                TextDocumentUri::fromString($this->workspace()->path('goodbye.php'))
+            ),
+        );
+        $repo->flush();
+
+        iterator_to_array($index->optimise(false));
+
+        self::assertTrue($index->has(ClassRecord::fromName('Foobar')));
+        self::assertFalse($index->has(ClassRecord::fromName('Barfoo')));
+    }
+
+    public function testOptimizeWillRemoveReferencesToNonExistingFiles(): void
+    {
+        $this->workspace()->reset();
+        $this->workspace()->put('hello.php', '<?php echo "hello";');
+        $this->workspace()->put('ref1.php', '<?php echo "hello";');
+        $this->workspace()->put('ref2.php', '<?php echo "hello";');
+
+        $repo = $this->createRepo();
+        $index = $this->createIndex($repo);
+        $index->write(
+            ClassRecord::fromName('Foobar')->setFilePath(
+                TextDocumentUri::fromString($this->workspace()->path('hello.php'))
+            )->addReference(
+                $this->workspace()->path('ref1.php'),
+            )->addReference(
+                $this->workspace()->path('ref2.php'),
+            )->addReference(
+                $this->workspace()->path('ref3.php'),
+            ),
+        );
+        $repo->flush();
+
+        iterator_to_array($index->optimise(false));
+
+        $record = $index->get(ClassRecord::fromName('Foobar'));
+        self::assertEquals([
+            $this->workspace()->path('ref1.php'),
+            $this->workspace()->path('ref2.php'),
+        ], $record->references());
+    }
+
+    private function createRepo(): FileRepository
+    {
+        return new FileRepository($this->workspace()->path(), new PhpSerializer());
+    }
+
+    private function createIndex(FileRepository $repo): SerializedIndex
+    {
+        return new SerializedIndex(
+            $repo,
+            new FilesystemTextDocumentLocator(),
+        );
     }
 }


### PR DESCRIPTION
This PR introduces an index optimiser:

- Remove references records that were defined in now-non-existing files.
- Remove references to non-existing files.

> [!NOTE]
> This is mostly because I'm fed up of seeing entries in the index for non-existing files.
> In theory they should be removed from the index by the file watcher. But the file-watcher service is the LSP client now by default, and Neovim (for example) [doesn't watch files](https://github.com/neovim/neovim/pull/22405) on Linux at least.

In anycase, having a way to periodically clean up is a missing feature and I've observed this operation saving 5-10% on index size on some long-standing projects.

TODO:

- [x] Provide an `index:optimise` command.
- [x] Provide an LSP service that runs periodically.
- [ ] Consider skipping when there's no activity.
- [ ] Add test for the IndexerHandler or split out the Optmiser to a new class.