### PR TITLE
gh-3039: Resolve additive stub paths consistently

### DIFF
--- a/lib/Extension/LanguageServerWorseReflection/LanguageServerWorseReflectionExtension.php
+++ b/lib/Extension/LanguageServerWorseReflection/LanguageServerWorseReflectionExtension.php
@@ -40,7 +40,7 @@ class LanguageServerWorseReflectionExtension implements Extension
         $container->register(StubValidationListener::class, function (Container $container) {
             return new StubValidationListener(
                 $container->get(ClientApi::class),
-                $container->parameter(WorseReflectionExtension::PARAM_ADDITIVE_STUBS)->listOfString(),
+                WorseReflectionExtension::additiveStubPaths($container)
             );
         }, [ LanguageServerExtension::TAG_LISTENER_PROVIDER => [] ]);
     }

--- a/lib/Extension/WorseReflection/WorseReflectionExtension.php
+++ b/lib/Extension/WorseReflection/WorseReflectionExtension.php
@@ -105,6 +105,20 @@ class WorseReflectionExtension implements Extension
         $this->registerTelemetry($container);
     }
 
+    /**
+     * @return list<string>
+     */
+    public static function additiveStubPaths(Container $container): array
+    {
+        $resolver = $container->expect(FilePathResolverExtension::SERVICE_FILE_PATH_RESOLVER, PathResolver::class);
+        $stubPaths = array_map(function (string $path) use ($resolver) {
+            $projectRoot = $resolver->resolve('%project_root%');
+            return Path::join($projectRoot, $resolver->resolve($path));
+
+        }, $container->parameter(self::PARAM_ADDITIVE_STUBS)->listOfString());
+        return $stubPaths;
+    }
+
     private function registerReflection(ContainerBuilder $container): void
     {
         $container->register(self::SERVICE_REFLECTOR, function (Container $container) {
@@ -206,11 +220,8 @@ class WorseReflectionExtension implements Extension
             return new DocblockMemberProvider();
         }, [ self::TAG_MEMBER_PROVIDER => []]);
         $container->register('worse_reflection.member_provider.stubs', function (Container $container) {
-            $resolver = $container->expect(FilePathResolverExtension::SERVICE_FILE_PATH_RESOLVER, PathResolver::class);
-            return new StubFileMemberProvider(array_map(function (string $path) use ($resolver) {
-                $projectRoot = $resolver->resolve('%project_root%');
-                return Path::join($projectRoot, $resolver->resolve($path));
-            }, $container->parameter(self::PARAM_ADDITIVE_STUBS)->listOfString()));
+            $stubPaths = self::additiveStubPaths($container);
+            return new StubFileMemberProvider($stubPaths);
         }, [ self::TAG_MEMBER_PROVIDER => []]);
     }
 


### PR DESCRIPTION
Use the same, fully qualified, paths in both the validation listener and the member provider. Fixes #3039 