### PR TITLE
Add newline at end of .phpactor.json

### DIFF
--- a/lib/Configurator/Model/ConfigManipulator.php
+++ b/lib/Configurator/Model/ConfigManipulator.php
@@ -96,6 +96,6 @@ final class ConfigManipulator
      */
     private function writeConfig($value): void
     {
-        file_put_contents($this->configPath, json_encode($value, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES));
+        file_put_contents($this->configPath, json_encode($value, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES) . "\n");
     }
 }


### PR DESCRIPTION
This allows us to "cat .phpactor.json" without indenting/breaking the shell prompt.

Resolves: https://github.com/phpactor/phpactor/issues/3046