### PR TITLE
Gh 3042: No stacking code actions / code-action concurrency

### DIFF
--- a/doc/reference/configuration.rst
+++ b/doc/reference/configuration.rst
@@ -1328,6 +1328,19 @@ If applicable diagnostics should be "outsourced" to a different process
 **Default**: ``true``
 
 
+.. _param_language_server.code_action_outsource:
+
+
+``language_server.code_action_outsource``
+"""""""""""""""""""""""""""""""""""""""""
+
+
+Code actions will be "outsourced" to a different process
+
+
+**Default**: ``true``
+
+
 .. _param_language_server.diagnostic_exclude_paths:
 
 
@@ -1462,7 +1475,7 @@ Wait this amount of time (in milliseconds) after a shutdown request before self-
 """"""""""""""""""""""""""""""""""""""""""""""""
 
 
-Kill the diagnostics process if it outlives this timeout
+Kill the diagnostics or code action processes if they outlive this timeout
 
 
 **Default**: ``5``

--- a/lib/Extension/LanguageServer/CodeAction/OutsourcedCodeActionProvider.php
+++ b/lib/Extension/LanguageServer/CodeAction/OutsourcedCodeActionProvider.php
@@ -14,6 +14,7 @@ use Phpactor\LanguageServerProtocol\CodeActionParams;
 use Phpactor\LanguageServerProtocol\Range;
 use Phpactor\LanguageServerProtocol\TextDocumentItem;
 use Phpactor\LanguageServer\Core\CodeAction\CodeActionProvider;
+use Phpactor\LanguageServer\Core\Server\ClientApi;
 use Phpactor\LanguageServer\Test\ProtocolFactory;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
@@ -31,6 +32,7 @@ class OutsourcedCodeActionProvider implements CodeActionProvider
         private array $command,
         private string $cwd,
         private LoggerInterface $logger,
+        private ClientApi $client,
         private CodeActionProvider $providerInfo,
         private int $timeout = 5,
     ) {
@@ -71,7 +73,9 @@ class OutsourcedCodeActionProvider implements CodeActionProvider
             });
 
             yield $stdin->write($textDocument->text);
+
             $stdin->close();
+
             /** @var string $json */
             $json = yield buffer($process->getStdout());
 
@@ -79,7 +83,10 @@ class OutsourcedCodeActionProvider implements CodeActionProvider
                 /** @var int $exitCode */
                 $exitCode = yield $process->join();
             } catch (ProcessException $e) {
-                $this->logger->warning($e->getMessage());
+                $this->client->window()->showMessage()->warning(sprintf(
+                    'Code action took too long to analyse this file (timed-out after %s seconds)',
+                    $this->timeout,
+                ));
                 return [];
             }
             if ($exitCode !== 0) {
@@ -92,7 +99,9 @@ class OutsourcedCodeActionProvider implements CodeActionProvider
                     $stderr
                 ));
             }
+
             $array = json_decode($json, true);
+
             if (!is_array($array)) {
                 throw new RuntimeException(sprintf(
                     'Could not decode JSON: %s',

--- a/lib/Extension/LanguageServer/CodeAction/OutsourcedCodeActionProvider.php
+++ b/lib/Extension/LanguageServer/CodeAction/OutsourcedCodeActionProvider.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServer\CodeAction;
+
+use Amp\CancellationToken;
+use Amp\Process\Process;
+use Amp\Process\ProcessException;
+use Amp\Promise;
+use Phpactor\Amp\Process\ProcessUtil;
+use Phpactor\Extension\WorseReflection\WorseReflectionExtension;
+use Phpactor\LanguageServerProtocol\CodeAction;
+use Phpactor\LanguageServerProtocol\CodeActionContext;
+use Phpactor\LanguageServerProtocol\CodeActionParams;
+use Phpactor\LanguageServerProtocol\Range;
+use Phpactor\LanguageServerProtocol\TextDocumentItem;
+use Phpactor\LanguageServer\Core\CodeAction\CodeActionProvider;
+use Phpactor\LanguageServer\Test\ProtocolFactory;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use function Amp\ByteStream\buffer;
+use function Amp\asyncCall;
+use function Amp\call;
+use function Amp\async;
+use function Amp\delay;
+
+class OutsourcedCodeActionProvider implements CodeActionProvider
+{
+    /**
+     * @param list<string> $command
+     * @param list<CodeActionProvider> $providers
+     */
+    public function __construct(
+        private array $command,
+        private string $cwd,
+        private LoggerInterface $logger,
+        private int $timeout = 5,
+    ) {
+    }
+
+    public function provideActionsFor(TextDocumentItem $textDocument, Range $range, CancellationToken $cancel): Promise
+    {
+        return call(function () use ($textDocument, $range, $cancel) {
+            $process = new Process(array_merge([PHP_BINARY], $this->command, [
+                json_encode(new CodeActionParams(
+                    ProtocolFactory::textDocumentIdentifier($textDocument->uri),
+                    $range,
+                    new CodeActionContext([]),
+                )),
+                sprintf('--config-extra=%s', sprintf('{"%s": false}', WorseReflectionExtension::PARAM_ENABLE_CONTEXT_LOCATION))
+            ]), $this->cwd);
+            $pid = yield $process->start();
+
+            ProcessUtil::killAfter($this->logger, $process, $this->timeout);
+
+            $stdin = $process->getStdin();
+
+            asyncCall(function () use ($process, $cancel, $pid) {
+                while ($process->isRunning()) {
+                    if ($cancel->isRequested()) {
+                        $process->kill();
+                        $this->logger->info(sprintf(
+                            'Killing process code-action process "%s" as requested',
+                            $pid,
+                        ));
+                    }
+                    yield delay(0.5);
+                }
+            });
+
+            yield $stdin->write($textDocument->text);
+            $stdin->close();
+            $json = yield buffer($process->getStdout());
+
+            try {
+                $exitCode = yield $process->join();
+            } catch (ProcessException $e) {
+                $this->logger->warning($e->getMessage());
+                return [];
+            }
+            if ($exitCode !== 0) {
+                throw new RuntimeException(sprintf(
+                    'Phpactor code-action process exited with code "%s": %s',
+                    $exitCode,
+                    yield buffer($process->getStderr())
+                ));
+            }
+            $array = json_decode($json, true);
+            if (!is_array($array)) {
+                throw new RuntimeException(sprintf(
+                    'Could not decode JSON: %s',
+                    $json
+                ));
+            }
+
+            return array_map(fn (array $codeAction) => CodeAction::fromArray($codeAction), $array);
+        });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function kinds(): array
+    {
+        return [];
+    }
+
+    public function describe(): string
+    {
+        return sprintf('aggregate code action proivder with %s providers', count($this->providers));
+    }
+}
+

--- a/lib/Extension/LanguageServer/CodeAction/OutsourcedCodeActionProvider.php
+++ b/lib/Extension/LanguageServer/CodeAction/OutsourcedCodeActionProvider.php
@@ -20,19 +20,18 @@ use RuntimeException;
 use function Amp\ByteStream\buffer;
 use function Amp\asyncCall;
 use function Amp\call;
-use function Amp\async;
 use function Amp\delay;
 
 class OutsourcedCodeActionProvider implements CodeActionProvider
 {
     /**
      * @param list<string> $command
-     * @param list<CodeActionProvider> $providers
      */
     public function __construct(
         private array $command,
         private string $cwd,
         private LoggerInterface $logger,
+        private CodeActionProvider $providerInfo,
         private int $timeout = 5,
     ) {
     }
@@ -40,14 +39,18 @@ class OutsourcedCodeActionProvider implements CodeActionProvider
     public function provideActionsFor(TextDocumentItem $textDocument, Range $range, CancellationToken $cancel): Promise
     {
         return call(function () use ($textDocument, $range, $cancel) {
-            $process = new Process(array_merge([PHP_BINARY], $this->command, [
+            $process = new Process(array_merge([
+                PHP_BINARY
+            ], $this->command, [
                 json_encode(new CodeActionParams(
                     ProtocolFactory::textDocumentIdentifier($textDocument->uri),
                     $range,
                     new CodeActionContext([]),
-                )),
+                ), JSON_THROW_ON_ERROR),
                 sprintf('--config-extra=%s', sprintf('{"%s": false}', WorseReflectionExtension::PARAM_ENABLE_CONTEXT_LOCATION))
             ]), $this->cwd);
+
+            /** @var int $pid */
             $pid = yield $process->start();
 
             ProcessUtil::killAfter($this->logger, $process, $this->timeout);
@@ -63,25 +66,30 @@ class OutsourcedCodeActionProvider implements CodeActionProvider
                             $pid,
                         ));
                     }
-                    yield delay(0.5);
+                    yield delay(500);
                 }
             });
 
             yield $stdin->write($textDocument->text);
             $stdin->close();
+            /** @var string $json */
             $json = yield buffer($process->getStdout());
 
             try {
+                /** @var int $exitCode */
                 $exitCode = yield $process->join();
             } catch (ProcessException $e) {
                 $this->logger->warning($e->getMessage());
                 return [];
             }
             if ($exitCode !== 0) {
+                /** @var string $stderr */
+                $stderr = yield buffer($process->getStderr());
+
                 throw new RuntimeException(sprintf(
                     'Phpactor code-action process exited with code "%s": %s',
                     $exitCode,
-                    yield buffer($process->getStderr())
+                    $stderr
                 ));
             }
             $array = json_decode($json, true);
@@ -92,21 +100,18 @@ class OutsourcedCodeActionProvider implements CodeActionProvider
                 ));
             }
 
+            /** @phpstan-ignore-next-line */
             return array_map(fn (array $codeAction) => CodeAction::fromArray($codeAction), $array);
         });
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function kinds(): array
     {
-        return [];
+        return $this->providerInfo->kinds();
     }
 
     public function describe(): string
     {
-        return sprintf('aggregate code action proivder with %s providers', count($this->providers));
+        return sprintf('outsourced: %s', $this->providerInfo->describe());
     }
 }
-

--- a/lib/Extension/LanguageServer/CodeAction/ThereCanOnlyBeOneCodeActionProvider.php
+++ b/lib/Extension/LanguageServer/CodeAction/ThereCanOnlyBeOneCodeActionProvider.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServer\CodeAction;
+
+use Amp\CancellationToken;
+use Amp\CancellationTokenSource;
+use Amp\CombinedCancellationToken;
+use Amp\Promise;
+use Phpactor\LanguageServerProtocol\Range;
+use Phpactor\LanguageServerProtocol\TextDocumentItem;
+use Phpactor\LanguageServer\Core\CodeAction\CodeActionProvider;
+
+class ThereCanOnlyBeOneCodeActionProvider implements CodeActionProvider
+{
+    private ?CancellationTokenSource $cancel = null;
+
+    public function __construct(private CodeActionProvider $inner)
+    {
+    }
+
+    public function provideActionsFor(TextDocumentItem $textDocument, Range $range, CancellationToken $cancel): Promise
+    {
+        if ($this->cancel) {
+            $this->cancel->cancel();
+        }
+
+        $this->cancel = new CancellationTokenSource();
+
+        return $this->inner->provideActionsFor($textDocument, $range, new CombinedCancellationToken(
+            $cancel,
+            $this->cancel->getToken(),
+        ));
+    }
+
+    public function kinds(): array
+    {
+        return $this->inner->kinds();
+    }
+
+    public function describe(): string
+    {
+        return $this->inner->describe();
+    }
+}

--- a/lib/Extension/LanguageServer/CodeAction/TolerantCodeActionProvider.php
+++ b/lib/Extension/LanguageServer/CodeAction/TolerantCodeActionProvider.php
@@ -15,7 +15,7 @@ final class TolerantCodeActionProvider implements CodeActionProvider
 {
     public function __construct(
         private CodeActionProvider $provider,
-        private ClientApi $client
+        private ?ClientApi $client
     ) {
     }
 
@@ -25,12 +25,14 @@ final class TolerantCodeActionProvider implements CodeActionProvider
             try {
                 return yield $this->provider->provideActionsFor($textDocument, $range, $cancel);
             } catch (Throwable $error) {
-                $this->client->window()->showMessage()->error(sprintf(
-                    'Provider %s (%s) failed: %s',
-                    $this->provider::class,
-                    $this->provider->describe(),
-                    $error->getMessage(),
-                ));
+                if (null !== $this->client) {
+                    $this->client->window()->showMessage()->error(sprintf(
+                        'Provider %s (%s) failed: %s',
+                        $this->provider::class,
+                        $this->provider->describe(),
+                        $error->getMessage(),
+                    ));
+                }
                 return [];
             }
         });

--- a/lib/Extension/LanguageServer/CodeAction/TolerantCodeActionProvider.php
+++ b/lib/Extension/LanguageServer/CodeAction/TolerantCodeActionProvider.php
@@ -25,6 +25,7 @@ final class TolerantCodeActionProvider implements CodeActionProvider
             try {
                 return yield $this->provider->provideActionsFor($textDocument, $range, $cancel);
             } catch (Throwable $error) {
+                // if we are running in the main process the LS client API will be available
                 if (null !== $this->client) {
                     $this->client->window()->showMessage()->error(sprintf(
                         'Provider %s (%s) failed: %s',
@@ -32,8 +33,11 @@ final class TolerantCodeActionProvider implements CodeActionProvider
                         $this->provider->describe(),
                         $error->getMessage(),
                     ));
+                    return [];
                 }
-                return [];
+
+                // otherwise we're probably running in a dedicated process, just throw an error and let it die.
+                throw $error;
             }
         });
     }

--- a/lib/Extension/LanguageServer/Command/CodeActionsCommand.php
+++ b/lib/Extension/LanguageServer/Command/CodeActionsCommand.php
@@ -7,13 +7,11 @@ use Phpactor\Extension\LanguageServerBridge\Converter\TextDocumentConverter;
 use Phpactor\Extension\LanguageServerWorseReflection\Workspace\WorkspaceIndex;
 use Phpactor\LanguageServerProtocol\CodeActionParams;
 use Phpactor\LanguageServer\Core\CodeAction\CodeActionProvider;
-use Phpactor\LanguageServer\Core\Diagnostics\DiagnosticsProvider;
 use Phpactor\LanguageServer\Test\ProtocolFactory;
 use RuntimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use function Amp\Promise\wait;
 
@@ -21,8 +19,6 @@ class CodeActionsCommand extends Command
 {
     public const ARG_REQUEST = 'request';
     public const NAME = 'language-server:code-actions';
-    private const PARAM_URI = 'uri';
-
 
     public function __construct(
         private CodeActionProvider $provider,
@@ -34,7 +30,7 @@ class CodeActionsCommand extends Command
     protected function configure(): void
     {
         $this->setDescription('Internal: resolve code-actions asynchronously');
-        $this->addArgument(self::ARG_REQUEST, null, InputArgument::REQUIRED, 'Code action LSP request');
+        $this->addArgument(self::ARG_REQUEST, InputArgument::REQUIRED, 'Code action LSP request');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -42,7 +38,15 @@ class CodeActionsCommand extends Command
         /** @var string $request */
         $request = $input->getArgument(self::ARG_REQUEST);
 
-        $request = CodeActionParams::fromArray(json_decode($request, true, JSON_THROW_ON_ERROR));
+        $array = json_decode($request, true, JSON_THROW_ON_ERROR);
+        if (!is_array($array)) {
+            throw new RuntimeException(sprintf(
+                'Expected json to decode to an array, got "%s"',
+                get_debug_type($array)
+            ));
+        }
+        /** @phpstan-ignore argument.type */
+        $request = CodeActionParams::fromArray($array);
         $textDocumentItem = ProtocolFactory::textDocumentItem($request->textDocument->uri, $this->stdin());
 
         // update the in-memory worse reflection workspace index so that we

--- a/lib/Extension/LanguageServer/Command/CodeActionsCommand.php
+++ b/lib/Extension/LanguageServer/Command/CodeActionsCommand.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServer\Command;
+
+use Amp\CancellationTokenSource;
+use Phpactor\Extension\LanguageServerBridge\Converter\TextDocumentConverter;
+use Phpactor\Extension\LanguageServerWorseReflection\Workspace\WorkspaceIndex;
+use Phpactor\LanguageServerProtocol\CodeActionParams;
+use Phpactor\LanguageServer\Core\CodeAction\CodeActionProvider;
+use Phpactor\LanguageServer\Core\Diagnostics\DiagnosticsProvider;
+use Phpactor\LanguageServer\Test\ProtocolFactory;
+use RuntimeException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use function Amp\Promise\wait;
+
+class CodeActionsCommand extends Command
+{
+    public const ARG_REQUEST = 'request';
+    public const NAME = 'language-server:code-actions';
+    private const PARAM_URI = 'uri';
+
+
+    public function __construct(
+        private CodeActionProvider $provider,
+        private WorkspaceIndex $workspace,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription('Internal: resolve code-actions asynchronously');
+        $this->addArgument(self::ARG_REQUEST, null, InputArgument::REQUIRED, 'Code action LSP request');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        /** @var string $request */
+        $request = $input->getArgument(self::ARG_REQUEST);
+
+        $request = CodeActionParams::fromArray(json_decode($request, true, JSON_THROW_ON_ERROR));
+        $textDocumentItem = ProtocolFactory::textDocumentItem($request->textDocument->uri, $this->stdin());
+
+        // update the in-memory worse reflection workspace index so that we
+        // can locate the latest function and class definitions in this process.
+        $this->workspace->index(TextDocumentConverter::fromLspTextItem($textDocumentItem));
+
+        $diagnostics = wait(
+            $this->provider->provideActionsFor(
+                $textDocumentItem,
+                $request->range,
+                (new CancellationTokenSource())->getToken()
+            )
+        );
+        $decoded = json_encode($diagnostics);
+        if (false === $decoded) {
+            throw new RuntimeException(
+                'Could not encode diagnostics',
+            );
+        }
+        $output->write($decoded);
+        return 0;
+    }
+
+    private function stdin(): string
+    {
+        $in = '';
+
+        while (false !== $line = fgets(STDIN)) {
+            $in .= $line;
+        }
+
+        return $in;
+    }
+}

--- a/lib/Extension/LanguageServer/LanguageServerExtension.php
+++ b/lib/Extension/LanguageServer/LanguageServerExtension.php
@@ -12,6 +12,7 @@ use Phpactor\Extension\FilePathResolver\FilePathResolverExtension;
 use Phpactor\Extension\LanguageServerWorseReflection\Workspace\WorkspaceIndex;
 use Phpactor\Extension\LanguageServer\CodeAction\OutsourcedCodeActionProvider;
 use Phpactor\Extension\LanguageServer\CodeAction\ProfilingCodeActionProvider;
+use Phpactor\Extension\LanguageServer\CodeAction\ThereCanOnlyBeOneCodeActionProvider;
 use Phpactor\Extension\LanguageServer\CodeAction\TolerantCodeActionProvider;
 use Phpactor\Extension\LanguageServer\Command\CodeActionsCommand;
 use Phpactor\Extension\LanguageServer\Command\DiagnosticsCommand;
@@ -503,7 +504,7 @@ class LanguageServerExtension implements Extension
             }
 
             return new CodeActionHandler(
-                $provider,
+                new ThereCanOnlyBeOneCodeActionProvider($provider),
                 /** @phpstan-ignore-next-line */
                 $this->workspace($container),
                 $container->get(ProgressNotifier::class),

--- a/lib/Extension/LanguageServer/LanguageServerExtension.php
+++ b/lib/Extension/LanguageServer/LanguageServerExtension.php
@@ -10,8 +10,10 @@ use Phpactor\Container\Extension;
 use Phpactor\Extension\Core\CoreExtension as PhpactorCoreExtension;
 use Phpactor\Extension\FilePathResolver\FilePathResolverExtension;
 use Phpactor\Extension\LanguageServerWorseReflection\Workspace\WorkspaceIndex;
+use Phpactor\Extension\LanguageServer\CodeAction\OutsourcedCodeActionProvider;
 use Phpactor\Extension\LanguageServer\CodeAction\ProfilingCodeActionProvider;
 use Phpactor\Extension\LanguageServer\CodeAction\TolerantCodeActionProvider;
+use Phpactor\Extension\LanguageServer\Command\CodeActionsCommand;
 use Phpactor\Extension\LanguageServer\Command\DiagnosticsCommand;
 use Phpactor\Extension\LanguageServer\DiagnosticProvider\AggregateDiagnosticsProvider;
 use Phpactor\Extension\LanguageServer\DiagnosticProvider\CodeFilteringDiagnosticProvider;
@@ -117,6 +119,7 @@ class LanguageServerExtension implements Extension
     public const PARAM_DIAGNOSTIC_ON_OPEN = 'language_server.diagnostics_on_open';
     public const PARAM_DIAGNOSTIC_PROVIDERS = 'language_server.diagnostic_providers';
     public const PARAM_DIAGNOSTIC_OUTSOURCE = 'language_server.diagnostic_outsource';
+    public const PARAM_CODE_ACTION_OUTSOURCE = 'language_server.code_action_outsource';
     public const PARAM_FILE_EVENTS = 'language_server.file_events';
     public const PARAM_FILE_EVENT_GLOBS = 'language_server.file_event_globs';
     public const PARAM_PROFILE = 'language_server.profile';
@@ -143,6 +146,7 @@ class LanguageServerExtension implements Extension
             self::PARAM_DIAGNOSTIC_ON_OPEN => true,
             self::PARAM_DIAGNOSTIC_PROVIDERS => null,
             self::PARAM_DIAGNOSTIC_OUTSOURCE => true,
+            self::PARAM_CODE_ACTION_OUTSOURCE => true,
             self::PARAM_DIAGNOSTIC_EXCLUDE_PATHS => [],
             self::PARAM_DIAGNOSTIC_IGNORE_CODES => [],
             self::PARAM_ENABLE_TRUST_CHECK => true,
@@ -171,7 +175,8 @@ class LanguageServerExtension implements Extension
             self::PARAM_DIAGNOSTIC_ON_OPEN => 'Perform diagnostics when opening a text document',
             self::PARAM_DIAGNOSTIC_PROVIDERS => 'Specify which diagnostic providers should be active (default to all)',
             self::PARAM_DIAGNOSTIC_OUTSOURCE => 'If applicable diagnostics should be "outsourced" to a different process',
-            self::PARAM_DIAGNOSTIC_OUTSOURCE_TIMEOUT => 'Kill the diagnostics process if it outlives this timeout',
+            self::PARAM_CODE_ACTION_OUTSOURCE => 'Code actions will be "outsourced" to a different process',
+            self::PARAM_DIAGNOSTIC_OUTSOURCE_TIMEOUT => 'Kill the diagnostics or code action processes if they outlive this timeout',
             self::PARAM_DIAGNOSTIC_IGNORE_CODES => 'Ignore diagnostics that have the codes listed here, e.g. ["fix_namespace_class_name"]. The codes match those shown in the LSP client.',
             self::PARAM_FILE_EVENTS => 'Register to receive file events',
             self::PARAM_DIAGNOSTIC_EXCLUDE_PATHS => 'List of paths to exclude from diagnostics, e.g. `vendor/**/*`',
@@ -232,12 +237,22 @@ class LanguageServerExtension implements Extension
 
         $container->register(DiagnosticsCommand::class, function (Container $container) {
             /** @var AggregateDiagnosticsProvider $provider */
-            $provider = $container->get(AggregateDiagnosticsProvider::class . '.outsourced');
+            $diagnosticsProvider = $container->get(AggregateDiagnosticsProvider::class . '.outsourced');
+
             return new DiagnosticsCommand(
-                $provider,
+                $diagnosticsProvider,
                 $container->get(WorkspaceIndex::class),
             );
         }, [ ConsoleExtension::TAG_COMMAND => [ 'name' => DiagnosticsCommand::NAME ]]);
+
+        $container->register(CodeActionsCommand::class, function (Container $container) {
+            $provider = $container->get(AggregateCodeActionProvider::class);
+
+            return new CodeActionsCommand(
+                $provider,
+                $container->get(WorkspaceIndex::class),
+            );
+        }, [ ConsoleExtension::TAG_COMMAND => [ 'name' => CodeActionsCommand::NAME ]]);
     }
 
     private function registerSession(ContainerBuilder $container): void
@@ -481,12 +496,27 @@ class LanguageServerExtension implements Extension
         }, [ self::TAG_METHOD_HANDLER => []]);
 
         $container->register(CodeActionHandler::class, function (Container $container) {
+            if ($container->parameter(self::PARAM_CODE_ACTION_OUTSOURCE)->bool()) {
+                $provider = $container->get(OutsourcedCodeActionProvider::class);
+            } else {
+                $provider = $container->get(AggregateCodeActionProvider::class);
+            }
+
+            return new CodeActionHandler(
+                $provider,
+                /** @phpstan-ignore-next-line */
+                $this->workspace($container),
+                $container->get(ProgressNotifier::class),
+            );
+        }, [ self::TAG_METHOD_HANDLER => []]);
+
+        $container->register(AggregateCodeActionProvider::class, function (Container $container) {
             $services = new SplPriorityQueue();
             $profile = $container->parameter(self::PARAM_PROFILE)->bool();
             foreach ($container->getServiceIdsForTag(self::TAG_CODE_ACTION_PROVIDER) as $serviceId => $attributes) {
                 $provider = new TolerantCodeActionProvider(
                     $container->expect($serviceId, CodeActionProvider::class),
-                    $container->get(ClientApi::class),
+                    $container->has(ClientApi::class) ? $container->get(ClientApi::class) : null,
                 );
                 if ($profile) {
                     $provider = new ProfilingCodeActionProvider($provider, $this->logger($container));
@@ -495,13 +525,24 @@ class LanguageServerExtension implements Extension
                 $services->insert($provider, $attributes['priority'] ?? 0);
             }
 
-            return new CodeActionHandler(
-                /** @phpstan-ignore-next-line */
-                new AggregateCodeActionProvider(...$services),
-                $this->workspace($container),
-                $container->get(ProgressNotifier::class),
+            return new AggregateCodeActionProvider(...$services);
+        });
+        $container->register(OutsourcedCodeActionProvider::class, function (Container $container) {
+            /** @var PathResolver $resolver */
+            $resolver = $container->get(FilePathResolverExtension::SERVICE_FILE_PATH_RESOLVER);
+            $projectPath = $resolver->resolve('%project_root%');
+
+            return new OutsourcedCodeActionProvider(
+                [
+                    $container->parameter(self::PARAM_PHPACTOR_BIN)->string(),
+                    'language-server:code-action'
+                ],
+                $projectPath,
+                $this->logger($container),
+                $container->parameter(self::PARAM_DIAGNOSTIC_OUTSOURCE_TIMEOUT)->int()
             );
-        }, [ self::TAG_METHOD_HANDLER => []]);
+        }, [
+        ]);
 
         $container->register(FormattingHandler::class, function (Container $container) {
             $formatter = null;

--- a/lib/Extension/LanguageServer/LanguageServerExtension.php
+++ b/lib/Extension/LanguageServer/LanguageServerExtension.php
@@ -237,10 +237,10 @@ class LanguageServerExtension implements Extension
 
         $container->register(DiagnosticsCommand::class, function (Container $container) {
             /** @var AggregateDiagnosticsProvider $provider */
-            $diagnosticsProvider = $container->get(AggregateDiagnosticsProvider::class . '.outsourced');
+            $provider = $container->get(AggregateDiagnosticsProvider::class . '.outsourced');
 
             return new DiagnosticsCommand(
-                $diagnosticsProvider,
+                $provider,
                 $container->get(WorkspaceIndex::class),
             );
         }, [ ConsoleExtension::TAG_COMMAND => [ 'name' => DiagnosticsCommand::NAME ]]);
@@ -511,6 +511,7 @@ class LanguageServerExtension implements Extension
         }, [ self::TAG_METHOD_HANDLER => []]);
 
         $container->register(AggregateCodeActionProvider::class, function (Container $container) {
+            /** @var SplPriorityQueue<int,CodeActionProvider> $services */
             $services = new SplPriorityQueue();
             $profile = $container->parameter(self::PARAM_PROFILE)->bool();
             foreach ($container->getServiceIdsForTag(self::TAG_CODE_ACTION_PROVIDER) as $serviceId => $attributes) {
@@ -522,7 +523,9 @@ class LanguageServerExtension implements Extension
                     $provider = new ProfilingCodeActionProvider($provider, $this->logger($container));
                 }
 
-                $services->insert($provider, $attributes['priority'] ?? 0);
+                /** @var int $prio */
+                $prio = $attributes['priority'] ?? 0;
+                $services->insert($provider, $prio);
             }
 
             return new AggregateCodeActionProvider(...$services);
@@ -539,7 +542,8 @@ class LanguageServerExtension implements Extension
                 ],
                 $projectPath,
                 $this->logger($container),
-                $container->parameter(self::PARAM_DIAGNOSTIC_OUTSOURCE_TIMEOUT)->int()
+                $container->get(AggregateCodeActionProvider::class),
+                $container->parameter(self::PARAM_DIAGNOSTIC_OUTSOURCE_TIMEOUT)->int(),
             );
         }, [
         ]);

--- a/lib/Extension/LanguageServer/LanguageServerExtension.php
+++ b/lib/Extension/LanguageServer/LanguageServerExtension.php
@@ -543,6 +543,7 @@ class LanguageServerExtension implements Extension
                 ],
                 $projectPath,
                 $this->logger($container),
+                $container->get(ClientApi::class),
                 $container->get(AggregateCodeActionProvider::class),
                 $container->parameter(self::PARAM_DIAGNOSTIC_OUTSOURCE_TIMEOUT)->int(),
             );

--- a/lib/Extension/LanguageServer/Tests/Unit/Command/CodeActionsCommandTest.php
+++ b/lib/Extension/LanguageServer/Tests/Unit/Command/CodeActionsCommandTest.php
@@ -6,7 +6,6 @@ use Phpactor\Extension\LanguageServer\Tests\Unit\LanguageServerTestCase;
 use Phpactor\LanguageServerProtocol\CodeAction;
 use Phpactor\LanguageServerProtocol\CodeActionContext;
 use Phpactor\LanguageServerProtocol\CodeActionParams;
-use Phpactor\LanguageServerProtocol\Diagnostic;
 use Phpactor\LanguageServer\Test\ProtocolFactory;
 use RuntimeException;
 use Symfony\Component\Process\Process;
@@ -45,6 +44,7 @@ class CodeActionsCommandTest extends LanguageServerTestCase
             if (!is_array($array)) {
                 throw new RuntimeException('nope');
             }
+            /** @phpstan-ignore argument.type */
             return CodeAction::fromArray($array);
         }, (array)json_decode($process->getOutput(), true));
 

--- a/lib/Extension/LanguageServer/Tests/Unit/Command/CodeActionsCommandTest.php
+++ b/lib/Extension/LanguageServer/Tests/Unit/Command/CodeActionsCommandTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServer\Tests\Unit\Command;
+
+use Phpactor\Extension\LanguageServer\Tests\Unit\LanguageServerTestCase;
+use Phpactor\LanguageServerProtocol\CodeAction;
+use Phpactor\LanguageServerProtocol\CodeActionContext;
+use Phpactor\LanguageServerProtocol\CodeActionParams;
+use Phpactor\LanguageServerProtocol\Diagnostic;
+use Phpactor\LanguageServer\Test\ProtocolFactory;
+use RuntimeException;
+use Symfony\Component\Process\Process;
+
+class CodeActionsCommandTest extends LanguageServerTestCase
+{
+    protected function setUp(): void
+    {
+        $this->workspace()->reset();
+    }
+
+    public function testDiagnostics(): void
+    {
+        $actions = $this->codeActionsFor('<?php class Foobar { public function bar() { return "asd"; } }');
+        self::assertGreaterThanOrEqual(1, $actions);
+    }
+
+    /**
+     * @return CodeAction[]
+     */
+    private function codeActionsFor(string $sourceCode): array
+    {
+        $process = new Process([
+            PHP_BINARY,
+            __DIR__ . '/../../../../../../bin/phpactor',
+            'language-server:code-actions',
+            $payload= json_encode(new CodeActionParams(
+                ProtocolFactory::textDocumentIdentifier('file:///foobar'),
+                ProtocolFactory::range(0, 0, 100, 100),
+                new CodeActionContext([]),
+            )),
+        ], $this->workspace()->path(), [], $sourceCode);
+        $process->mustRun();
+
+        $actions = array_map(function (mixed $array): CodeAction {
+            if (!is_array($array)) {
+                throw new RuntimeException('nope');
+            }
+            return CodeAction::fromArray($array);
+        }, (array)json_decode($process->getOutput(), true));
+
+        return $actions;
+    }
+}

--- a/lib/Extension/LanguageServer/Tests/Unit/LanguageServerTestCase.php
+++ b/lib/Extension/LanguageServer/Tests/Unit/LanguageServerTestCase.php
@@ -48,6 +48,7 @@ class LanguageServerTestCase extends TestCase
     {
         $builder = $this->createContainer(array_merge([
             LanguageServerExtension::PARAM_DIAGNOSTIC_OUTSOURCE => false,
+            LanguageServerExtension::PARAM_CODE_ACTION_OUTSOURCE => false,
         ], $config))->get(
             LanguageServerBuilder::class
         );

--- a/lib/Extension/LanguageServerCodeTransform/Tests/Unit/CodeAction/ImportNameProviderTest.php
+++ b/lib/Extension/LanguageServerCodeTransform/Tests/Unit/CodeAction/ImportNameProviderTest.php
@@ -9,6 +9,7 @@ use Generator;
 use Phpactor\Extension\LanguageServerBridge\Converter\PositionConverter;
 use Phpactor\Extension\LanguageServerCodeTransform\LanguageServerCodeTransformExtension;
 use Phpactor\Extension\LanguageServerCodeTransform\Tests\IntegrationTestCase;
+use Phpactor\Extension\LanguageServer\LanguageServerExtension;
 use Phpactor\Extension\WorseReflection\WorseReflectionExtension;
 use Phpactor\LanguageServerProtocol\CodeActionContext;
 use Phpactor\LanguageServerProtocol\CodeActionParams;
@@ -32,7 +33,8 @@ class ImportNameProviderTest extends IntegrationTestCase
 
         $tester = $this->container([
             WorseReflectionExtension::PARAM_IMPORT_GLOBALS => $imprtGlobals,
-            LanguageServerCodeTransformExtension::PARAM_REPORT_NON_EXISTING_NAMES => true
+            LanguageServerCodeTransformExtension::PARAM_REPORT_NON_EXISTING_NAMES => true,
+            LanguageServerExtension::PARAM_CODE_ACTION_OUTSOURCE => false,
         ])->get(LanguageServerBuilder::class)->tester(
             ProtocolFactory::initializeParams($this->workspace()->path())
         );


### PR DESCRIPTION
This PR:

- Will provide an option to resolve code-actions in a separate process and that will be enabled by default.
- Ensures only one code action is running at a time (subsequent code actions will kill the previous code-action process).


TODO:

 - [x] Evaluate performance: **1.6x slower** - as no cache - and caching would require syncing text documents between processes.
 - [ ] Add test for the outsourced code-action provider.
 - [x] Allow the behavior to be disabled (so that code-actions run in-process again)
- [x] Concurrency doesn't work (needs changed upstream of overriding here)