### PR TITLE
(Added) Mago static analysis and lint diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,47 @@ jobs:
                   php -dphar.readonly=0 \
                     -dzend.assertions=1 \
                     vendor/bin/phpunit --log-junit phpunit-junit.xml
+    mago:
+        name: "Mago integration (${{ matrix.php-version }})"
+
+        runs-on: "ubuntu-latest"
+
+        permissions:
+            contents: read
+
+        strategy:
+            matrix:
+                php-version:
+                    - '8.2'
+
+        steps:
+            -
+                name: "Checkout code"
+                uses: "actions/checkout@v4"
+            -
+                name: "Install PHP"
+                uses: "shivammathur/setup-php@v2"
+                with:
+                    coverage: "none"
+                    extensions: "${{ env.REQUIRED_PHP_EXTENSIONS }}"
+                    php-version: "${{ matrix.php-version }}"
+                    tools: composer:v2
+
+            -
+                name: "Composer install"
+                uses: "ramsey/composer-install@v2"
+                with:
+                    composer-options: "--no-scripts"
+            -
+                name: "Install Mago"
+                env:
+                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                run: |
+                    composer require --dev --no-interaction "carthage-software/mago:^1.30"
+                    vendor/bin/mago --version
+            -
+                name: "Run Mago integration tests"
+                run: 'PATH="$PWD/vendor/bin:$PATH" vendor/bin/phpunit --group language-server-mago'
     phpstan:
         name: "PHPStan (${{ matrix.php-version }})"
 

--- a/doc/integrations/mago.rst
+++ b/doc/integrations/mago.rst
@@ -1,0 +1,27 @@
+Mago
+====
+
+`Mago <https://github.com/carthage-software/mago>`_ is a fast PHP linter, formatter and static analysis tool written in Rust.
+
+Phpactor can integrate with Mago and provide diagnostics in your IDE from two of its tools:
+
+- ``mago analyze`` (static analysis, the equivalent of PHPStan or Psalm), reported under the ``mago`` source.
+- ``mago lint`` (style and code smells), reported under the ``mago-lint`` source.
+
+To enable the integration set :ref:`param_language_server_mago.enabled`:
+
+.. code-block:: bash
+
+   $ phpactor config:set language_server_mago.enabled true
+
+Both tools are enabled by default once the extension is on. Toggle them independently with :ref:`param_language_server_mago.analyze.enabled` and :ref:`param_language_server_mago.lint.enabled`.
+
+- Specify the path to Mago if different to ``vendor/bin/mago`` via :ref:`param_language_server_mago.bin`. Mago is commonly installed globally, in which case set this to ``mago``.
+- Override the Mago configuration file with :ref:`param_language_server_mago.config`.
+- Adjust the run timeout (milliseconds) with :ref:`param_language_server_mago.timeout`.
+
+Phpactor sends the current buffer to Mago on standard input, so diagnostics update as you type without saving the file.
+
+.. note::
+
+   Pointing :ref:`param_language_server_mago.config` at a ``mago.toml`` outside the project root may change how Mago resolves the relative paths declared inside that file.

--- a/lib/Extension/LanguageServerMago/LanguageServerMagoExtension.php
+++ b/lib/Extension/LanguageServerMago/LanguageServerMagoExtension.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerMago;
+
+use Phpactor\Container\Container;
+use Phpactor\Container\ContainerBuilder;
+use Phpactor\Container\OptionalExtension;
+use Phpactor\Extension\FilePathResolver\FilePathResolverExtension;
+use Phpactor\Extension\LanguageServer\Container\DiagnosticProviderTag;
+use Phpactor\Extension\LanguageServer\LanguageServerExtension;
+use Phpactor\Extension\LanguageServerMago\Model\Linter\MagoLinter;
+use Phpactor\Extension\LanguageServerMago\Model\MagoConfig;
+use Phpactor\Extension\LanguageServerMago\Model\MagoProcess;
+use Phpactor\Extension\LanguageServerMago\Provider\MagoDiagnosticProvider;
+use Phpactor\Extension\Logger\LoggingExtension;
+use Phpactor\FilePathResolver\PathResolver;
+use Phpactor\MapResolver\Resolver;
+
+class LanguageServerMagoExtension implements OptionalExtension
+{
+    public const PARAM_BIN = 'language_server_mago.bin';
+    public const PARAM_CONFIG = 'language_server_mago.config';
+    public const PARAM_TIMEOUT = 'language_server_mago.timeout';
+    public const PARAM_ENABLED = 'language_server_mago.enabled';
+    public const PARAM_ANALYZE_ENABLED = 'language_server_mago.analyze.enabled';
+    public const PARAM_LINT_ENABLED = 'language_server_mago.lint.enabled';
+    private const SERVICE_ANALYZE_PROVIDER = 'language_server_mago.provider.analyze';
+    private const SERVICE_LINT_PROVIDER = 'language_server_mago.provider.lint';
+
+    public function load(ContainerBuilder $container): void
+    {
+        $container->register(MagoProcess::class, function (Container $container) {
+            $pathResolver = $container->expect(
+                FilePathResolverExtension::SERVICE_FILE_PATH_RESOLVER,
+                PathResolver::class
+            );
+
+            $bin = $pathResolver->resolve($container->parameter(self::PARAM_BIN)->string());
+            $root = $pathResolver->resolve('%project_root%');
+
+            $config = null;
+            if ($container->parameter(self::PARAM_CONFIG)->value()) {
+                $config = $pathResolver->resolve($container->parameter(self::PARAM_CONFIG)->string());
+            }
+
+            return new MagoProcess(
+                $root,
+                new MagoConfig($bin, $container->parameter(self::PARAM_TIMEOUT)->int(), $config),
+                LoggingExtension::channelLogger($container, 'mago'),
+            );
+        });
+
+        $this->registerProvider(
+            $container,
+            self::SERVICE_ANALYZE_PROVIDER,
+            'analyze',
+            'mago',
+            self::PARAM_ANALYZE_ENABLED,
+        );
+        $this->registerProvider(
+            $container,
+            self::SERVICE_LINT_PROVIDER,
+            'lint',
+            'mago-lint',
+            self::PARAM_LINT_ENABLED,
+        );
+    }
+
+    public function configure(Resolver $schema): void
+    {
+        $schema->setDefaults([
+            self::PARAM_BIN => '%project_root%/vendor/bin/mago',
+            self::PARAM_CONFIG => null,
+            self::PARAM_TIMEOUT => 10000,
+            self::PARAM_ANALYZE_ENABLED => true,
+            self::PARAM_LINT_ENABLED => true,
+        ]);
+        $schema->setDescriptions([
+            self::PARAM_BIN => 'Path to the Mago executable',
+            self::PARAM_CONFIG => 'Override the Mago configuration file (mago.toml)',
+            self::PARAM_TIMEOUT => 'Maximum time in milliseconds to wait for a Mago run',
+            self::PARAM_ANALYZE_ENABLED => 'Show diagnostics from `mago analyze` (static analysis)',
+            self::PARAM_LINT_ENABLED => 'Show diagnostics from `mago lint` (style and code smells)',
+        ]);
+    }
+
+    public function name(): string
+    {
+        return 'language_server_mago';
+    }
+
+    private function registerProvider(
+        ContainerBuilder $container,
+        string $serviceId,
+        string $subcommand,
+        string $source,
+        string $enabledParam,
+    ): void {
+        $container->register($serviceId, function (Container $container) use ($subcommand, $source, $enabledParam) {
+            $root = $container->expect(
+                FilePathResolverExtension::SERVICE_FILE_PATH_RESOLVER,
+                PathResolver::class
+            )->resolve('%project_root%');
+
+            return new MagoDiagnosticProvider(
+                new MagoLinter($container->get(MagoProcess::class), $root, $subcommand, $source),
+                $source,
+                $container->parameter($enabledParam)->bool(),
+            );
+        }, [
+            LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER => DiagnosticProviderTag::create($source),
+        ]);
+    }
+}

--- a/lib/Extension/LanguageServerMago/LanguageServerMagoSuggestExtension.php
+++ b/lib/Extension/LanguageServerMago/LanguageServerMagoSuggestExtension.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerMago;
+
+use Phpactor\ComposerInspector\ComposerInspector;
+use Phpactor\Configurator\Adapter\Phpactor\PhpactorConfigChange;
+use Phpactor\Configurator\Model\Changes;
+use Phpactor\Configurator\Model\JsonConfig;
+use Phpactor\Container\Container;
+use Phpactor\Container\ContainerBuilder;
+use Phpactor\Container\Extension;
+use Phpactor\Extension\Configuration\ChangeSuggestor\PhpactorComposerSuggestor;
+use Phpactor\Extension\Configuration\ConfigurationExtension;
+use Phpactor\MapResolver\Resolver;
+
+class LanguageServerMagoSuggestExtension implements Extension
+{
+    public function load(ContainerBuilder $container): void
+    {
+        $container->register('language_server_mago.suggest', function (Container $container) {
+            return new PhpactorComposerSuggestor(
+                $container->expect(ConfigurationExtension::SERVICE_PHPACTOR_CONFIG_LOCAL, JsonConfig::class),
+                $container->get(ComposerInspector::class),
+                function (JsonConfig $config, ComposerInspector $inspector) {
+                    if ($config->has(LanguageServerMagoExtension::PARAM_ENABLED)) {
+                        return Changes::none();
+                    }
+
+                    if (!$inspector->package('carthage-software/mago')) {
+                        return Changes::none();
+                    }
+
+                    return Changes::from([
+                        new PhpactorConfigChange('Mago detected, enable Mago extension?', function (bool $enable) {
+                            return [
+                                LanguageServerMagoExtension::PARAM_ENABLED => $enable,
+                            ];
+                        })
+                    ]);
+                }
+            );
+        }, [
+            ConfigurationExtension::TAG_SUGGESTOR => [],
+        ]);
+    }
+
+    public function configure(Resolver $schema): void
+    {
+    }
+}

--- a/lib/Extension/LanguageServerMago/Model/DiagnosticsParser.php
+++ b/lib/Extension/LanguageServerMago/Model/DiagnosticsParser.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerMago\Model;
+
+use Phpactor\Extension\LanguageServerBridge\Converter\PositionConverter;
+use Phpactor\LanguageServerProtocol\Diagnostic;
+use Phpactor\LanguageServerProtocol\DiagnosticRelatedInformation;
+use Phpactor\LanguageServerProtocol\DiagnosticSeverity;
+use Phpactor\LanguageServerProtocol\Location;
+use Phpactor\LanguageServerProtocol\Range;
+use RuntimeException;
+
+/**
+ * Converts the JSON produced by `mago analyze|lint --reporting-format=json`
+ * into LSP diagnostics.
+ *
+ * Mago reports byte offsets (not columns) and 0-indexed lines, so positions are
+ * derived from the byte offsets against the analysed document text. Only issues
+ * anchored to the current document are emitted: a single Mago run may report
+ * issues for other files, but a provider call publishes for one document.
+ */
+class DiagnosticsParser
+{
+    /**
+     * @return array<Diagnostic>
+     */
+    public function parse(
+        string $jsonString,
+        string $documentText,
+        string $source,
+        string $relativePath,
+        string $documentUri
+    ): array {
+        $decoded = $this->decodeJson($jsonString);
+        $issues = is_array($decoded['issues'] ?? null) ? $decoded['issues'] : [];
+
+        $diagnostics = [];
+        foreach ($issues as $issue) {
+            if (!is_array($issue)) {
+                continue;
+            }
+            $diagnostic = $this->parseIssue($issue, $documentText, $source, $relativePath, $documentUri);
+            if (null !== $diagnostic) {
+                $diagnostics[] = $diagnostic;
+            }
+        }
+
+        return $diagnostics;
+    }
+
+    /**
+     * @param array<mixed> $issue
+     */
+    private function parseIssue(
+        array $issue,
+        string $documentText,
+        string $source,
+        string $relativePath,
+        string $documentUri
+    ): ?Diagnostic {
+        $annotations = is_array($issue['annotations'] ?? null) ? $issue['annotations'] : [];
+
+        $primary = $this->primaryAnnotation($annotations);
+        if (null === $primary) {
+            return null;
+        }
+
+        // Drop issues whose primary location is in another file: the provider
+        // publishes diagnostics for the current document only.
+        if ($this->annotationName($primary) !== $relativePath) {
+            return null;
+        }
+
+        return new Diagnostic(
+            range: $this->annotationRange($primary, $documentText),
+            message: $this->composeMessage($issue),
+            severity: $this->severity(is_string($issue['level'] ?? null) ? $issue['level'] : ''),
+            code: is_string($issue['code'] ?? null) ? $issue['code'] : null,
+            source: $source,
+            relatedInformation: $this->relatedInformation($annotations, $documentText, $relativePath, $documentUri),
+        );
+    }
+
+    /**
+     * @param array<mixed> $annotations
+     * @return array<mixed>|null
+     */
+    private function primaryAnnotation(array $annotations): ?array
+    {
+        foreach ($annotations as $annotation) {
+            if (is_array($annotation) && ($annotation['kind'] ?? null) === 'Primary') {
+                return $annotation;
+            }
+        }
+
+        $first = $annotations[0] ?? null;
+
+        return is_array($first) ? $first : null;
+    }
+
+    /**
+     * Secondary annotations that point inside the current document become
+     * related information. Cross-file secondaries are skipped: their byte
+     * offsets index a file whose text is not available here.
+     *
+     * @param array<mixed> $annotations
+     * @return array<DiagnosticRelatedInformation>|null
+     */
+    private function relatedInformation(
+        array $annotations,
+        string $documentText,
+        string $relativePath,
+        string $documentUri
+    ): ?array {
+        $related = [];
+        foreach ($annotations as $annotation) {
+            if (!is_array($annotation) || ($annotation['kind'] ?? null) !== 'Secondary') {
+                continue;
+            }
+            if ($this->annotationName($annotation) !== $relativePath) {
+                continue;
+            }
+            $message = is_string($annotation['message'] ?? null) ? $annotation['message'] : 'related';
+            $related[] = new DiagnosticRelatedInformation(
+                new Location($documentUri, $this->annotationRange($annotation, $documentText)),
+                $message,
+            );
+        }
+
+        return $related === [] ? null : $related;
+    }
+
+    /**
+     * @param array<mixed> $annotation
+     */
+    private function annotationRange(array $annotation, string $documentText): Range
+    {
+        $span = is_array($annotation['span'] ?? null) ? $annotation['span'] : [];
+        $start = $this->offset($span['start'] ?? null, 0);
+        $end = $this->offset($span['end'] ?? null, $start);
+
+        return new Range(
+            PositionConverter::intByteOffsetToPosition($start, $documentText),
+            PositionConverter::intByteOffsetToPosition($end, $documentText),
+        );
+    }
+
+    private function offset(mixed $position, int $default): int
+    {
+        if (is_array($position) && is_int($position['offset'] ?? null)) {
+            return $position['offset'];
+        }
+
+        return $default;
+    }
+
+    /**
+     * @param array<mixed> $annotation
+     */
+    private function annotationName(array $annotation): ?string
+    {
+        $span = is_array($annotation['span'] ?? null) ? $annotation['span'] : [];
+        $fileId = is_array($span['file_id'] ?? null) ? $span['file_id'] : [];
+        $name = $fileId['name'] ?? null;
+
+        return is_string($name) ? $name : null;
+    }
+
+    /**
+     * Mago levels have no LSP columns, so notes and help (which carry no
+     * location) are folded into the message rather than dropped.
+     *
+     * @param array<mixed> $issue
+     */
+    private function composeMessage(array $issue): string
+    {
+        $message = is_string($issue['message'] ?? null) ? $issue['message'] : '';
+
+        foreach (is_array($issue['notes'] ?? null) ? $issue['notes'] : [] as $note) {
+            if (is_string($note) && $note !== '') {
+                $message .= "\n" . $note;
+            }
+        }
+
+        if (is_string($issue['help'] ?? null) && $issue['help'] !== '') {
+            $message .= "\n\n" . $issue['help'];
+        }
+
+        return $message;
+    }
+
+    /**
+     * @return DiagnosticSeverity::*
+     */
+    private function severity(string $level): int
+    {
+        return match (strtolower($level)) {
+            'warning' => DiagnosticSeverity::WARNING,
+            'note' => DiagnosticSeverity::INFORMATION,
+            'help' => DiagnosticSeverity::HINT,
+            default => DiagnosticSeverity::ERROR,
+        };
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    private function decodeJson(string $jsonString): array
+    {
+        $decoded = json_decode($jsonString, true);
+
+        if (!is_array($decoded)) {
+            throw new RuntimeException(sprintf(
+                'Could not decode expected Mago JSON string "%s"',
+                $jsonString
+            ));
+        }
+
+        return $decoded;
+    }
+}

--- a/lib/Extension/LanguageServerMago/Model/Linter.php
+++ b/lib/Extension/LanguageServerMago/Model/Linter.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerMago\Model;
+
+use Amp\CancellationToken;
+use Amp\Promise;
+use Phpactor\LanguageServerProtocol\Diagnostic;
+
+interface Linter
+{
+    /**
+     * @return Promise<array<Diagnostic>>
+     */
+    public function lint(string $url, string $text, CancellationToken $cancel): Promise;
+}

--- a/lib/Extension/LanguageServerMago/Model/Linter/MagoLinter.php
+++ b/lib/Extension/LanguageServerMago/Model/Linter/MagoLinter.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerMago\Model\Linter;
+
+use Amp\CancellationToken;
+use Amp\Promise;
+use Phpactor\Extension\LanguageServerMago\Model\Linter;
+use Phpactor\Extension\LanguageServerMago\Model\MagoProcess;
+use Phpactor\TextDocument\TextDocumentUri;
+use Symfony\Component\Filesystem\Path;
+use function Amp\call;
+
+/**
+ * Lints a single document with one Mago subcommand (analyze or lint), reporting
+ * diagnostics under one source name.
+ */
+class MagoLinter implements Linter
+{
+    public function __construct(
+        private MagoProcess $process,
+        private string $projectRoot,
+        private string $subcommand,
+        private string $source,
+    ) {
+    }
+
+    public function lint(string $url, string $text, CancellationToken $cancel): Promise
+    {
+        return call(function () use ($url, $text, $cancel) {
+            // Only on-disk documents within the project can be expressed as a
+            // workspace-relative path for Mago. Untitled buffers and files
+            // outside the project root are skipped.
+            if (!str_starts_with($url, 'file:')) {
+                return [];
+            }
+
+            $path = TextDocumentUri::fromString($url)->path();
+
+            // Skip anything not contained in the project root (the root itself
+            // yields an empty relative path).
+            if (!Path::isBasePath($this->projectRoot, $path)) {
+                return [];
+            }
+
+            $relativePath = Path::makeRelative($path, $this->projectRoot);
+
+            if ($relativePath === '') {
+                return [];
+            }
+
+            return yield $this->process->analyse(
+                $this->subcommand,
+                $this->source,
+                $relativePath,
+                $url,
+                $text,
+                $cancel,
+            );
+        });
+    }
+}

--- a/lib/Extension/LanguageServerMago/Model/Linter/TestLinter.php
+++ b/lib/Extension/LanguageServerMago/Model/Linter/TestLinter.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerMago\Model\Linter;
+
+use Amp\CancellationToken;
+use Amp\Promise;
+use Amp\Success;
+use Phpactor\Extension\LanguageServerMago\Model\Linter;
+use Phpactor\LanguageServerProtocol\Diagnostic;
+
+class TestLinter implements Linter
+{
+    /**
+     * @param array<Diagnostic> $diagnostics
+     */
+    public function __construct(private array $diagnostics = [])
+    {
+    }
+
+    public function lint(string $url, string $text, CancellationToken $cancel): Promise
+    {
+        return new Success($this->diagnostics);
+    }
+}

--- a/lib/Extension/LanguageServerMago/Model/MagoConfig.php
+++ b/lib/Extension/LanguageServerMago/Model/MagoConfig.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerMago\Model;
+
+final class MagoConfig
+{
+    public function __construct(
+        private string $bin,
+        private int $timeout,
+        private ?string $config = null,
+    ) {
+    }
+
+    public function bin(): string
+    {
+        return $this->bin;
+    }
+
+    /**
+     * Maximum time in milliseconds to wait for a Mago run before giving up.
+     */
+    public function timeout(): int
+    {
+        return $this->timeout;
+    }
+
+    public function config(): ?string
+    {
+        return $this->config;
+    }
+}

--- a/lib/Extension/LanguageServerMago/Model/MagoProcess.php
+++ b/lib/Extension/LanguageServerMago/Model/MagoProcess.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerMago\Model;
+
+use Amp\ByteStream\StreamException;
+use Amp\CancellationToken;
+use Amp\Process\ProcessException;
+use Amp\Promise;
+use Amp\TimeoutException;
+use Phpactor\Amp\Process\ProcessBuilder;
+use Phpactor\LanguageServerProtocol\Diagnostic;
+use Psr\Log\LoggerInterface;
+use Throwable;
+use function Amp\ByteStream\buffer;
+use function Amp\call;
+use function Amp\Promise\timeout;
+
+/**
+ * Runs `mago <subcommand> --reporting-format=json --stdin-input <relative path>`
+ * with the document text piped on stdin, and parses the result.
+ *
+ * Mago is a native (Rust) binary, so the command is run directly without a PHP
+ * interpreter prefix. Global options such as --config must precede the
+ * subcommand.
+ */
+class MagoProcess
+{
+    public function __construct(
+        private string $cwd,
+        private MagoConfig $config,
+        private LoggerInterface $logger,
+        private DiagnosticsParser $parser = new DiagnosticsParser(),
+    ) {
+    }
+
+    /**
+     * @return Promise<array<Diagnostic>>
+     */
+    public function analyse(
+        string $subcommand,
+        string $source,
+        string $relativePath,
+        string $documentUri,
+        string $documentText,
+        CancellationToken $cancel,
+    ): Promise {
+        return call(function () use ($subcommand, $source, $relativePath, $documentUri, $documentText, $cancel) {
+            $process = ProcessBuilder::create($this->buildArgs($subcommand, $relativePath))
+                ->cwd($this->cwd)
+                ->mergeParentEnv()
+                ->build();
+
+            $start = microtime(true);
+            yield $process->start();
+
+            // Honour client cancellation by killing the process.
+            $cancelId = $cancel->subscribe(function () use ($process): void {
+                if ($process->isRunning()) {
+                    $process->kill();
+                }
+            });
+
+            try {
+                // Buffer both streams before writing stdin and joining, so the
+                // child can drain its stdout while we feed it (avoiding a pipe
+                // deadlock) and large output cannot stall the process.
+                $stdoutPromise = buffer($process->getStdout());
+                $stderrPromise = buffer($process->getStderr());
+
+                try {
+                    $stdin = $process->getStdin();
+                    yield $stdin->write($documentText);
+                    yield $stdin->end();
+
+                    /** @var int $exitCode */
+                    $exitCode = yield timeout($process->join(), $this->config->timeout());
+                } catch (TimeoutException) {
+                    if ($process->isRunning()) {
+                        $process->kill();
+                    }
+                    $this->logger->error(sprintf(
+                        'Mago timed out after %dms: %s',
+                        $this->config->timeout(),
+                        $process->getCommand(),
+                    ));
+
+                    return [];
+                } catch (ProcessException | StreamException) {
+                    // join() rejects, or stdin closes, when the process is
+                    // killed, which happens when the client cancels the request.
+                    $this->logger->debug(sprintf(
+                        'Mago run cancelled: %s',
+                        $process->getCommand(),
+                    ));
+
+                    return [];
+                }
+
+                $stdout = yield $stdoutPromise;
+
+                // A clean file produces empty output (issues are reported via
+                // JSON only when present), so empty stdout is not an error.
+                if (!is_string($stdout) || trim($stdout) === '') {
+                    $this->logger->debug(sprintf(
+                        'Mago produced no diagnostics in %ss (exit %s): %s',
+                        number_format(microtime(true) - $start, 4),
+                        $exitCode,
+                        $process->getCommand(),
+                    ));
+
+                    return [];
+                }
+
+                try {
+                    return $this->parser->parse($stdout, $documentText, $source, $relativePath, $documentUri);
+                } catch (Throwable $error) {
+                    $stderr = yield $stderrPromise;
+                    $this->logger->error(sprintf(
+                        'Mago output could not be parsed (exit %s): %s; error: %s; stderr: %s',
+                        $exitCode,
+                        $process->getCommand(),
+                        $error->getMessage(),
+                        is_string($stderr) ? trim($stderr) : '',
+                    ));
+
+                    return [];
+                }
+            } finally {
+                $cancel->unsubscribe($cancelId);
+            }
+        });
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function buildArgs(string $subcommand, string $relativePath): array
+    {
+        $args = [$this->config->bin()];
+
+        // Global options precede the subcommand.
+        if (null !== $this->config->config()) {
+            $args[] = '--config';
+            $args[] = $this->config->config();
+        }
+
+        $args[] = $subcommand;
+        $args[] = '--reporting-format=json';
+        $args[] = '--stdin-input';
+        $args[] = $relativePath;
+
+        return $args;
+    }
+}

--- a/lib/Extension/LanguageServerMago/Provider/MagoDiagnosticProvider.php
+++ b/lib/Extension/LanguageServerMago/Provider/MagoDiagnosticProvider.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerMago\Provider;
+
+use Amp\CancellationToken;
+use Amp\Promise;
+use Amp\Success;
+use Phpactor\Extension\LanguageServerMago\Model\Linter;
+use Phpactor\LanguageServerProtocol\TextDocumentItem;
+use Phpactor\LanguageServer\Core\Diagnostics\DiagnosticsProvider;
+
+/**
+ * Publishes Mago diagnostics for a document. One instance is registered per Mago
+ * subcommand (analyze -> "mago", lint -> "mago-lint"); each can be toggled
+ * independently.
+ */
+class MagoDiagnosticProvider implements DiagnosticsProvider
+{
+    public function __construct(
+        private Linter $linter,
+        private string $name,
+        private bool $enabled = true,
+    ) {
+    }
+
+    public function provideDiagnostics(TextDocumentItem $textDocument, CancellationToken $cancel): Promise
+    {
+        if (!$this->enabled) {
+            return new Success([]);
+        }
+
+        return $this->linter->lint($textDocument->uri, $textDocument->text, $cancel);
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+}

--- a/lib/Extension/LanguageServerMago/Tests/Fixtures/analyze.json
+++ b/lib/Extension/LanguageServerMago/Tests/Fixtures/analyze.json
@@ -1,0 +1,106 @@
+{
+  "issues": [
+    {
+      "level": "Error",
+      "code": "invalid-argument",
+      "message": "Invalid argument type for argument #1 of `add`: expected `int`, but found `string('x')`.",
+      "notes": [
+        "The provided type `string('x')` is not compatible with the expected type `int`."
+      ],
+      "help": "Change the argument value to match `int`, or update the parameter's type declaration.",
+      "annotations": [
+        {
+          "message": "This has type `string('x')`",
+          "kind": "Primary",
+          "span": {
+            "file_id": {
+              "name": "src/Example.php",
+              "path": "/private/var/folders/p6/c8nqdy2s1vg1ps052xyq7zdw0000gn/T/tmp.egyt9o1cqA/src/Example.php",
+              "size": 81,
+              "file_type": "Host"
+            },
+            "start": {
+              "offset": 70,
+              "line": 7
+            },
+            "end": {
+              "offset": 73,
+              "line": 7
+            }
+          }
+        },
+        {
+          "message": "Arguments to this function are incorrect",
+          "kind": "Secondary",
+          "span": {
+            "file_id": {
+              "name": "src/Example.php",
+              "path": "/private/var/folders/p6/c8nqdy2s1vg1ps052xyq7zdw0000gn/T/tmp.egyt9o1cqA/src/Example.php",
+              "size": 81,
+              "file_type": "Host"
+            },
+            "start": {
+              "offset": 66,
+              "line": 7
+            },
+            "end": {
+              "offset": 69,
+              "line": 7
+            }
+          }
+        }
+      ]
+    },
+    {
+      "level": "Error",
+      "code": "invalid-argument",
+      "message": "Invalid argument type for argument #2 of `add`: expected `int`, but found `string('y')`.",
+      "notes": [
+        "The provided type `string('y')` is not compatible with the expected type `int`."
+      ],
+      "help": "Change the argument value to match `int`, or update the parameter's type declaration.",
+      "annotations": [
+        {
+          "message": "This has type `string('y')`",
+          "kind": "Primary",
+          "span": {
+            "file_id": {
+              "name": "src/Example.php",
+              "path": "/private/var/folders/p6/c8nqdy2s1vg1ps052xyq7zdw0000gn/T/tmp.egyt9o1cqA/src/Example.php",
+              "size": 81,
+              "file_type": "Host"
+            },
+            "start": {
+              "offset": 75,
+              "line": 7
+            },
+            "end": {
+              "offset": 78,
+              "line": 7
+            }
+          }
+        },
+        {
+          "message": "Arguments to this function are incorrect",
+          "kind": "Secondary",
+          "span": {
+            "file_id": {
+              "name": "src/Example.php",
+              "path": "/private/var/folders/p6/c8nqdy2s1vg1ps052xyq7zdw0000gn/T/tmp.egyt9o1cqA/src/Example.php",
+              "size": 81,
+              "file_type": "Host"
+            },
+            "start": {
+              "offset": 66,
+              "line": 7
+            },
+            "end": {
+              "offset": 69,
+              "line": 7
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/lib/Extension/LanguageServerMago/Tests/Fixtures/lint.json
+++ b/lib/Extension/LanguageServerMago/Tests/Fixtures/lint.json
@@ -1,0 +1,113 @@
+{
+  "issues": [
+    {
+      "level": "Warning",
+      "code": "strict-types",
+      "message": "Missing `declare(strict_types=1);` statement at the beginning of the file.",
+      "notes": [
+        "The `strict_types` directive enforces strict type checking, which can prevent subtle bugs."
+      ],
+      "help": "Add `declare(strict_types=1);` at the top of your file.",
+      "annotations": [
+        {
+          "kind": "Primary",
+          "span": {
+            "file_id": {
+              "name": "src/Example.php",
+              "path": "/private/var/folders/p6/c8nqdy2s1vg1ps052xyq7zdw0000gn/T/tmp.egyt9o1cqA/src/Example.php",
+              "size": 81,
+              "file_type": "Host"
+            },
+            "start": {
+              "offset": 0,
+              "line": 0
+            },
+            "end": {
+              "offset": 5,
+              "line": 0
+            }
+          }
+        }
+      ],
+      "edits": [
+        [
+          {
+            "name": "src/Example.php",
+            "path": "/private/var/folders/p6/c8nqdy2s1vg1ps052xyq7zdw0000gn/T/tmp.egyt9o1cqA/src/Example.php",
+            "size": 81,
+            "file_type": "Host"
+          },
+          [
+            {
+              "range": {
+                "start": 5,
+                "end": 5
+              },
+              "new_text": [
+                10,
+                10,
+                100,
+                101,
+                99,
+                108,
+                97,
+                114,
+                101,
+                40,
+                115,
+                116,
+                114,
+                105,
+                99,
+                116,
+                95,
+                116,
+                121,
+                112,
+                101,
+                115,
+                61,
+                49,
+                41,
+                59,
+                10
+              ],
+              "safety": "potentiallyunsafe"
+            }
+          ]
+        ]
+      ]
+    },
+    {
+      "level": "Warning",
+      "code": "literal-named-argument",
+      "message": "Literal argument `'y'` should be passed as a named argument for clarity.",
+      "notes": [
+        "Passing literals positionally can make code less clear, especially with booleans, numbers, or `null`."
+      ],
+      "help": "Consider using a named argument instead: `function_name(param: 'y')`.",
+      "annotations": [
+        {
+          "message": "This literal is being passed positionally.",
+          "kind": "Primary",
+          "span": {
+            "file_id": {
+              "name": "src/Example.php",
+              "path": "/private/var/folders/p6/c8nqdy2s1vg1ps052xyq7zdw0000gn/T/tmp.egyt9o1cqA/src/Example.php",
+              "size": 81,
+              "file_type": "Host"
+            },
+            "start": {
+              "offset": 75,
+              "line": 7
+            },
+            "end": {
+              "offset": 78,
+              "line": 7
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/lib/Extension/LanguageServerMago/Tests/IntegrationTestCase.php
+++ b/lib/Extension/LanguageServerMago/Tests/IntegrationTestCase.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerMago\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Phpactor\TestUtils\Workspace;
+
+abstract class IntegrationTestCase extends TestCase
+{
+    public function workspace(): Workspace
+    {
+        return Workspace::create(__DIR__ . '/Workspace');
+    }
+}

--- a/lib/Extension/LanguageServerMago/Tests/LanguageServerMagoExtensionTest.php
+++ b/lib/Extension/LanguageServerMago/Tests/LanguageServerMagoExtensionTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerMago\Tests;
+
+use Phpactor\Container\Container;
+use Phpactor\Container\PhpactorContainer;
+use Phpactor\Extension\FilePathResolver\FilePathResolverExtension;
+use Phpactor\Extension\LanguageServer\LanguageServerExtension;
+use Phpactor\Extension\LanguageServerMago\LanguageServerMagoExtension;
+use Phpactor\Extension\LanguageServerMago\Provider\MagoDiagnosticProvider;
+use Phpactor\Extension\Logger\LoggingExtension;
+use PHPUnit\Framework\TestCase;
+
+class LanguageServerMagoExtensionTest extends TestCase
+{
+    public function testRegistersBothDiagnosticProviders(): void
+    {
+        $container = $this->getContainer();
+
+        $names = [];
+        foreach (array_keys($container->getServiceIdsForTag(LanguageServerExtension::TAG_DIAGNOSTICS_PROVIDER)) as $id) {
+            $provider = $container->get($id);
+            self::assertInstanceOf(MagoDiagnosticProvider::class, $provider);
+            $names[] = $provider->name();
+        }
+
+        self::assertContains('mago', $names);
+        self::assertContains('mago-lint', $names);
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function getContainer(array $params = []): Container
+    {
+        return PhpactorContainer::fromExtensions(
+            [
+                FilePathResolverExtension::class,
+                LoggingExtension::class,
+                LanguageServerMagoExtension::class,
+            ],
+            $params,
+        );
+    }
+}

--- a/lib/Extension/LanguageServerMago/Tests/LanguageServerMagoSuggestExtensionTest.php
+++ b/lib/Extension/LanguageServerMago/Tests/LanguageServerMagoSuggestExtensionTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerMago\Tests;
+
+use Phpactor\Container\PhpactorContainer;
+use Phpactor\Extension\Configuration\ConfigurationExtension;
+use Phpactor\Extension\LanguageServerMago\LanguageServerMagoSuggestExtension;
+use PHPUnit\Framework\TestCase;
+
+class LanguageServerMagoSuggestExtensionTest extends TestCase
+{
+    public function testRegistersSuggestor(): void
+    {
+        $container = PhpactorContainer::fromExtensions([LanguageServerMagoSuggestExtension::class]);
+
+        self::assertArrayHasKey(
+            'language_server_mago.suggest',
+            $container->getServiceIdsForTag(ConfigurationExtension::TAG_SUGGESTOR),
+        );
+    }
+}

--- a/lib/Extension/LanguageServerMago/Tests/Model/DiagnosticsParserTest.php
+++ b/lib/Extension/LanguageServerMago/Tests/Model/DiagnosticsParserTest.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerMago\Tests\Model;
+
+use PHPUnit\Framework\TestCase;
+use Phpactor\Extension\LanguageServerMago\Model\DiagnosticsParser;
+use Phpactor\LanguageServerProtocol\DiagnosticSeverity;
+use Phpactor\LanguageServerProtocol\Position;
+use Phpactor\LanguageServerProtocol\Range;
+use RuntimeException;
+
+class DiagnosticsParserTest extends TestCase
+{
+    private const URI = 'file:///src/A.php';
+    private const REL = 'src/A.php';
+
+    // The source the analyze.json/lint.json fixtures were captured against, so
+    // the recorded byte offsets line up.
+    private const EXAMPLE_SOURCE = <<<'PHP'
+        <?php
+
+        function add(int $a, int $b): int
+        {
+            return $a + $b;
+        }
+
+        add('x', 'y');
+        PHP;
+
+    public function testParsesIssueWithRangeSeverityCodeAndRelatedInformation(): void
+    {
+        $text = "<?php\n\$x = foo();\n";
+        $json = json_encode([
+            'issues' => [
+                [
+                    'level' => 'Error',
+                    'code' => 'undefined-function',
+                    'message' => 'Function foo not found',
+                    'notes' => ['It is not defined anywhere'],
+                    'help' => 'Did you mean bar?',
+                    'annotations' => [
+                        [
+                            'message' => 'called here',
+                            'kind' => 'Primary',
+                            'span' => $this->span(self::REL, 11, 16),
+                        ],
+                        [
+                            'message' => 'assigned here',
+                            'kind' => 'Secondary',
+                            'span' => $this->span(self::REL, 6, 8),
+                        ],
+                    ],
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR);
+
+        $diagnostics = (new DiagnosticsParser())->parse($json, $text, 'mago', self::REL, self::URI);
+
+        self::assertCount(1, $diagnostics);
+        $diagnostic = $diagnostics[0];
+        self::assertEquals(new Range(new Position(1, 5), new Position(1, 10)), $diagnostic->range);
+        self::assertSame(DiagnosticSeverity::ERROR, $diagnostic->severity);
+        self::assertSame('undefined-function', $diagnostic->code);
+        self::assertSame('mago', $diagnostic->source);
+        self::assertStringContainsString('Function foo not found', $diagnostic->message);
+        self::assertStringContainsString('It is not defined anywhere', $diagnostic->message);
+        self::assertStringContainsString('Did you mean bar?', $diagnostic->message);
+
+        self::assertNotNull($diagnostic->relatedInformation);
+        self::assertCount(1, $diagnostic->relatedInformation);
+        $related = $diagnostic->relatedInformation[0];
+        self::assertSame('assigned here', $related->message);
+        self::assertSame(self::URI, $related->location->uri);
+        self::assertEquals(new Range(new Position(1, 0), new Position(1, 2)), $related->location->range);
+    }
+
+    public function testDropsIssueWhosePrimaryAnnotationIsInAnotherFile(): void
+    {
+        $json = json_encode([
+            'issues' => [
+                [
+                    'level' => 'Error',
+                    'code' => 'x',
+                    'message' => 'in another file',
+                    'annotations' => [
+                        ['kind' => 'Primary', 'span' => $this->span('other/B.php', 0, 1)],
+                    ],
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR);
+
+        $diagnostics = (new DiagnosticsParser())->parse($json, "<?php\n", 'mago', self::REL, self::URI);
+
+        self::assertCount(0, $diagnostics);
+    }
+
+    public function testByteOffsetMapsToUtf16Column(): void
+    {
+        // The closing quote sits at byte offset 17 but UTF-16 column 10, because
+        // "é" is two UTF-8 bytes but one UTF-16 code unit.
+        $text = "<?php\n\$x = 'café';\n";
+        $json = json_encode([
+            'issues' => [
+                [
+                    'level' => 'Warning',
+                    'code' => 'x',
+                    'message' => 'm',
+                    'annotations' => [
+                        ['kind' => 'Primary', 'span' => $this->span(self::REL, 17, 18)],
+                    ],
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR);
+
+        $diagnostics = (new DiagnosticsParser())->parse($json, $text, 'mago-lint', self::REL, self::URI);
+
+        self::assertCount(1, $diagnostics);
+        self::assertSame(DiagnosticSeverity::WARNING, $diagnostics[0]->severity);
+        self::assertSame(1, $diagnostics[0]->range->start->line);
+        self::assertSame(10, $diagnostics[0]->range->start->character);
+    }
+
+    public function testThrowsOnInvalidJson(): void
+    {
+        $this->expectException(RuntimeException::class);
+        (new DiagnosticsParser())->parse('not json', '', 'mago', self::REL, self::URI);
+    }
+
+    public function testParsesRealAnalyzeFixture(): void
+    {
+        $diagnostics = (new DiagnosticsParser())->parse(
+            $this->fixture('analyze.json'),
+            self::EXAMPLE_SOURCE,
+            'mago',
+            'src/Example.php',
+            'file:///src/Example.php',
+        );
+
+        self::assertCount(2, $diagnostics);
+        foreach ($diagnostics as $diagnostic) {
+            self::assertSame(DiagnosticSeverity::ERROR, $diagnostic->severity);
+            self::assertSame('invalid-argument', $diagnostic->code);
+            self::assertSame('mago', $diagnostic->source);
+        }
+    }
+
+    public function testParsesRealLintFixture(): void
+    {
+        $diagnostics = (new DiagnosticsParser())->parse(
+            $this->fixture('lint.json'),
+            self::EXAMPLE_SOURCE,
+            'mago-lint',
+            'src/Example.php',
+            'file:///src/Example.php',
+        );
+
+        self::assertCount(2, $diagnostics);
+        foreach ($diagnostics as $diagnostic) {
+            self::assertSame(DiagnosticSeverity::WARNING, $diagnostic->severity);
+            self::assertSame('mago-lint', $diagnostic->source);
+        }
+    }
+
+    /**
+     * @return array{file_id: array{name: string}, start: array{offset: int, line: int}, end: array{offset: int, line: int}}
+     */
+    private function span(string $name, int $start, int $end): array
+    {
+        return [
+            'file_id' => ['name' => $name],
+            'start' => ['offset' => $start, 'line' => 0],
+            'end' => ['offset' => $end, 'line' => 0],
+        ];
+    }
+
+    private function fixture(string $name): string
+    {
+        return (string)file_get_contents(__DIR__ . '/../Fixtures/' . $name);
+    }
+}

--- a/lib/Extension/LanguageServerMago/Tests/Model/Linter/MagoLinterTest.php
+++ b/lib/Extension/LanguageServerMago/Tests/Model/Linter/MagoLinterTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerMago\Tests\Model\Linter;
+
+use Amp\NullCancellationToken;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Phpactor\Extension\LanguageServerMago\Model\Linter\MagoLinter;
+use Phpactor\Extension\LanguageServerMago\Model\MagoConfig;
+use Phpactor\Extension\LanguageServerMago\Model\MagoProcess;
+use Psr\Log\NullLogger;
+use function Amp\Promise\wait;
+
+class MagoLinterTest extends TestCase
+{
+    private const ROOT = '/home/project';
+
+    #[DataProvider('provideUncontainedDocuments')]
+    public function testReturnsNoDiagnosticsForUncontainedDocuments(string $url): void
+    {
+        // The process binary does not exist; these cases must return before it
+        // is ever invoked.
+        $linter = new MagoLinter(
+            new MagoProcess(self::ROOT, new MagoConfig('/does/not/exist/mago', 1000, null), new NullLogger()),
+            self::ROOT,
+            'analyze',
+            'mago',
+        );
+
+        self::assertSame([], wait($linter->lint($url, '<?php', new NullCancellationToken())));
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function provideUncontainedDocuments(): iterable
+    {
+        yield 'non-file scheme' => ['untitled:Untitled-1'];
+        yield 'outside the root' => ['file:///home/other/file.php'];
+        yield 'sibling whose name prefixes the root' => ['file:///home/project2/file.php'];
+        yield 'the root itself' => ['file://' . self::ROOT];
+        yield 'parent escape' => ['file:///home/project/../escape.php'];
+    }
+}

--- a/lib/Extension/LanguageServerMago/Tests/Model/MagoProcessTest.php
+++ b/lib/Extension/LanguageServerMago/Tests/Model/MagoProcessTest.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerMago\Tests\Model;
+
+use Amp\CancellationTokenSource;
+use Amp\Loop;
+use Amp\NullCancellationToken;
+use Phpactor\Extension\LanguageServerMago\Model\MagoConfig;
+use Phpactor\Extension\LanguageServerMago\Model\MagoProcess;
+use Phpactor\Extension\LanguageServerMago\Tests\IntegrationTestCase;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Psr\Log\Test\TestLogger;
+use function Amp\Promise\wait;
+
+class MagoProcessTest extends IntegrationTestCase
+{
+    private const DOCUMENT_TEXT = "<?php\n\$x = 1;\n";
+    private const RELATIVE_PATH = 'src/A.php';
+
+    protected function setUp(): void
+    {
+        $this->workspace()->reset();
+        $this->workspace()->mkdir('capture');
+    }
+
+    public function testRunsBinaryDirectlyAndParsesOutput(): void
+    {
+        $this->fakeMago($this->issuesJson());
+
+        $diagnostics = wait($this->process()->analyse(
+            'analyze',
+            'mago',
+            self::RELATIVE_PATH,
+            'file:///workspace/src/A.php',
+            self::DOCUMENT_TEXT,
+            new NullCancellationToken(),
+        ));
+
+        self::assertCount(1, $diagnostics);
+        self::assertSame('invalid-argument', $diagnostics[0]->code);
+        self::assertSame('mago', $diagnostics[0]->source);
+
+        // The subcommand precedes its flags, the reporting format is JSON, and
+        // the workspace-relative path is passed to --stdin-input.
+        self::assertSame(
+            'analyze --reporting-format=json --stdin-input src/A.php',
+            trim($this->workspace()->getContents('capture/args')),
+        );
+        // The document buffer is piped on stdin.
+        self::assertSame(self::DOCUMENT_TEXT, $this->workspace()->getContents('capture/stdin'));
+        // The process runs in the project root.
+        self::assertSame(
+            realpath($this->workspace()->path()),
+            realpath(trim($this->workspace()->getContents('capture/cwd'))),
+        );
+    }
+
+    public function testPassesGlobalConfigBeforeSubcommand(): void
+    {
+        $this->fakeMago('');
+
+        wait($this->process('/etc/mago.toml')->analyse(
+            'lint',
+            'mago-lint',
+            self::RELATIVE_PATH,
+            'file:///workspace/src/A.php',
+            self::DOCUMENT_TEXT,
+            new NullCancellationToken(),
+        ));
+
+        self::assertSame(
+            '--config /etc/mago.toml lint --reporting-format=json --stdin-input src/A.php',
+            trim($this->workspace()->getContents('capture/args')),
+        );
+    }
+
+    public function testEmptyOutputYieldsNoDiagnostics(): void
+    {
+        $this->fakeMago('');
+
+        $diagnostics = wait($this->process()->analyse(
+            'analyze',
+            'mago',
+            self::RELATIVE_PATH,
+            'file:///workspace/src/A.php',
+            self::DOCUMENT_TEXT,
+            new NullCancellationToken(),
+        ));
+
+        self::assertSame([], $diagnostics);
+    }
+
+    public function testInvalidOutputIsLoggedAndYieldsNoDiagnostics(): void
+    {
+        $this->fakeMago('this is not json');
+        $logger = new TestLogger();
+
+        $diagnostics = wait($this->process(null, $logger)->analyse(
+            'analyze',
+            'mago',
+            self::RELATIVE_PATH,
+            'file:///workspace/src/A.php',
+            self::DOCUMENT_TEXT,
+            new NullCancellationToken(),
+        ));
+
+        self::assertSame([], $diagnostics);
+        self::assertTrue($logger->hasErrorRecords());
+    }
+
+    public function testTimeoutKillsProcessAndYieldsNoDiagnostics(): void
+    {
+        $this->fakeMago($this->issuesJson(), sleepSeconds: 5);
+        $logger = new TestLogger();
+
+        $diagnostics = wait($this->process(null, $logger, timeout: 200)->analyse(
+            'analyze',
+            'mago',
+            self::RELATIVE_PATH,
+            'file:///workspace/src/A.php',
+            self::DOCUMENT_TEXT,
+            new NullCancellationToken(),
+        ));
+
+        self::assertSame([], $diagnostics);
+        self::assertTrue($logger->hasErrorRecords());
+    }
+
+    public function testCancellationKillsProcessAndYieldsNoDiagnostics(): void
+    {
+        $this->fakeMago($this->issuesJson(), sleepSeconds: 5);
+        $source = new CancellationTokenSource();
+
+        $promise = $this->process(null, null, timeout: 10000)->analyse(
+            'analyze',
+            'mago',
+            self::RELATIVE_PATH,
+            'file:///workspace/src/A.php',
+            self::DOCUMENT_TEXT,
+            $source->getToken(),
+        );
+        Loop::delay(100, function () use ($source): void {
+            $source->cancel();
+        });
+
+        self::assertSame([], wait($promise));
+    }
+
+    private function process(?string $config = null, ?LoggerInterface $logger = null, int $timeout = 5000): MagoProcess
+    {
+        return new MagoProcess(
+            $this->workspace()->path(),
+            new MagoConfig($this->workspace()->path('mago'), $timeout, $config),
+            $logger ?? new NullLogger(),
+        );
+    }
+
+    private function fakeMago(string $output, int $sleepSeconds = 0): void
+    {
+        $capture = $this->workspace()->path('capture');
+        $this->workspace()->put('capture/output', $output);
+        $sleep = $sleepSeconds > 0 ? "sleep $sleepSeconds\n" : '';
+        $script = <<<BASH
+            #!/usr/bin/env bash
+            printf '%s' "\$*" > "$capture/args"
+            pwd > "$capture/cwd"
+            cat > "$capture/stdin"
+            $sleep
+            cat "$capture/output"
+            BASH;
+        $this->workspace()->put('mago', $script);
+        chmod($this->workspace()->path('mago'), 0755);
+    }
+
+    private function issuesJson(): string
+    {
+        return (string)json_encode([
+            'issues' => [
+                [
+                    'level' => 'Error',
+                    'code' => 'invalid-argument',
+                    'message' => 'bad',
+                    'annotations' => [
+                        [
+                            'kind' => 'Primary',
+                            'span' => [
+                                'file_id' => ['name' => self::RELATIVE_PATH],
+                                'start' => ['offset' => 6, 'line' => 1],
+                                'end' => ['offset' => 8, 'line' => 1],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+}

--- a/lib/Extension/LanguageServerMago/Tests/Model/MagoRealBinaryTest.php
+++ b/lib/Extension/LanguageServerMago/Tests/Model/MagoRealBinaryTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerMago\Tests\Model;
+
+use Amp\NullCancellationToken;
+use PHPUnit\Framework\Attributes\Group;
+use Phpactor\Extension\LanguageServerMago\Model\MagoConfig;
+use Phpactor\Extension\LanguageServerMago\Model\MagoProcess;
+use Phpactor\Extension\LanguageServerMago\Tests\IntegrationTestCase;
+use Psr\Log\NullLogger;
+use function Amp\Promise\wait;
+
+/**
+ * Smoke test against the real Mago binary. It self-skips when `mago` is not on
+ * the PATH, so it is a no-op in the default suite. The `language-server-mago`
+ * group lets CI run it deliberately (`phpunit --group language-server-mago`)
+ * after installing the binary, e.g. composer require carthage-software/mago.
+ */
+#[Group('language-server-mago')]
+class MagoRealBinaryTest extends IntegrationTestCase
+{
+    private string $mago = '';
+
+    protected function setUp(): void
+    {
+        $mago = trim((string)shell_exec('command -v mago'));
+        if ($mago === '' || !is_executable($mago)) {
+            $this->markTestSkipped('mago binary is not available on PATH');
+        }
+        $this->mago = $mago;
+        $this->workspace()->reset();
+        $this->workspace()->put('mago.toml', "[source]\npaths = [\"src\"]\n");
+    }
+
+    public function testAnalyzeReportsTypeErrorsFromTheRealBinary(): void
+    {
+        $text = <<<'PHP'
+            <?php
+
+            function add(int $a): int
+            {
+                return $a;
+            }
+
+            add('not an int');
+            PHP;
+        $this->workspace()->put('src/A.php', $text);
+
+        $process = new MagoProcess(
+            $this->workspace()->path(),
+            new MagoConfig($this->mago, 20000, null),
+            new NullLogger(),
+        );
+
+        $diagnostics = wait($process->analyse(
+            'analyze',
+            'mago',
+            'src/A.php',
+            'file://' . $this->workspace()->path('src/A.php'),
+            $text,
+            new NullCancellationToken(),
+        ));
+
+        self::assertNotEmpty($diagnostics);
+        self::assertSame('mago', $diagnostics[0]->source);
+    }
+}

--- a/lib/Extension/LanguageServerMago/Tests/Provider/MagoDiagnosticProviderTest.php
+++ b/lib/Extension/LanguageServerMago/Tests/Provider/MagoDiagnosticProviderTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Phpactor\Extension\LanguageServerMago\Tests\Provider;
+
+use Amp\NullCancellationToken;
+use PHPUnit\Framework\TestCase;
+use Phpactor\Extension\LanguageServerMago\Model\Linter\TestLinter;
+use Phpactor\Extension\LanguageServerMago\Provider\MagoDiagnosticProvider;
+use Phpactor\LanguageServerProtocol\Diagnostic;
+use Phpactor\LanguageServerProtocol\Position;
+use Phpactor\LanguageServerProtocol\Range;
+use Phpactor\LanguageServerProtocol\TextDocumentItem;
+use function Amp\Promise\wait;
+
+class MagoDiagnosticProviderTest extends TestCase
+{
+    public function testDelegatesToLinterWhenEnabled(): void
+    {
+        $diagnostic = $this->diagnostic();
+        $provider = new MagoDiagnosticProvider(new TestLinter([$diagnostic]), 'mago', true);
+
+        $result = wait($provider->provideDiagnostics($this->document(), new NullCancellationToken()));
+
+        self::assertSame([$diagnostic], $result);
+        self::assertSame('mago', $provider->name());
+    }
+
+    public function testReturnsNothingWhenDisabled(): void
+    {
+        $provider = new MagoDiagnosticProvider(new TestLinter([$this->diagnostic()]), 'mago-lint', false);
+
+        $result = wait($provider->provideDiagnostics($this->document(), new NullCancellationToken()));
+
+        self::assertSame([], $result);
+        self::assertSame('mago-lint', $provider->name());
+    }
+
+    private function diagnostic(): Diagnostic
+    {
+        return new Diagnostic(
+            range: new Range(new Position(0, 0), new Position(0, 1)),
+            message: 'something',
+            source: 'mago',
+        );
+    }
+
+    private function document(): TextDocumentItem
+    {
+        return new TextDocumentItem('file:///src/A.php', 'php', 1, '<?php');
+    }
+}

--- a/lib/Phpactor.php
+++ b/lib/Phpactor.php
@@ -17,6 +17,8 @@ use Phpactor\Extension\LanguageServerConfiguration\LanguageServerConfigurationEx
 use Phpactor\Extension\LanguageServerHighlight\LanguageServerHighlightExtension;
 use Phpactor\Extension\LanguageServerPhpCsFixer\LanguageServerPhpCsFixerExtension;
 use Phpactor\Extension\LanguageServerPhpCsFixer\LanguageServerPhpCsFixerSuggestExtension;
+use Phpactor\Extension\LanguageServerMago\LanguageServerMagoExtension;
+use Phpactor\Extension\LanguageServerMago\LanguageServerMagoSuggestExtension;
 use Phpactor\Extension\LanguageServerPhpstan\LanguageServerPhpstanExtension;
 use Phpactor\Extension\LanguageServerBridge\LanguageServerBridgeExtension;
 use Phpactor\Extension\LanguageServerCodeTransform\LanguageServerCodeTransformExtension;
@@ -191,6 +193,7 @@ class Phpactor
         }
 
 
+        /** @var list<class-string> $extensionNames */
         $extensionNames = [
             CoreExtension::class,
             ClassToFileExtraExtension::class,
@@ -244,6 +247,8 @@ class Phpactor
             LanguageServerPhpstanSuggestExtension::class,
             LanguageServerPsalmExtension::class,
             LanguageServerPsalmSuggestExtension::class,
+            LanguageServerMagoExtension::class,
+            LanguageServerMagoSuggestExtension::class,
             LanguageServerPhpCsFixerExtension::class,
             LanguageServerPhpCsFixerSuggestExtension::class,
             LanguageServerHighlightExtension::class,


### PR DESCRIPTION
Phpactor already surfaces static analysis in the editor through PHPStan and Psalm, but offered no way to use Mago, the Rust PHP toolchain that runs considerably faster and understands the same PHPStan and Psalm annotations. A new optional LanguageServerMago extension closes that gap by registering two language server diagnostics providers that mirror the existing integrations: the mago provider runs `mago analyze` for static analysis, and the mago-lint provider runs `mago lint` for style and code smells. The current buffer is streamed to Mago over standard input so results update as you type, and its JSON report is mapped to LSP diagnostics with precise byte-offset ranges and related information for secondary spans. The extension is disabled by default; once enabled, analysis is active immediately while the linter remains an explicit opt-in, and a configuration suggestor offers to switch it on when the carthage-software/mago Composer package is detected. Developers who enable it gain live Mago diagnostics in their editor alongside the existing PHPStan and Psalm output, with no change in behaviour for anyone who leaves it off.