### PR TITLE
Require posix extension and fail early when required extensions are missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+## Unreleased
+
+- Require the posix extension and fail early with a descriptive error when a
+  required extension is missing (instead of crashing mid-session) @fain182 #3053
+
 ## 2026.06.25.0
 
 - Mago diagnostics and lint extension @marjovanlier #3052

--- a/bin/phpactor
+++ b/bin/phpactor
@@ -35,6 +35,19 @@ if (version_compare(PHP_VERSION, $minVersion) < 0) {
     exit(255);
 }
 
+$missingExtensions = array_filter(['mbstring', 'posix', 'tokenizer'], function (string $extension) {
+    return !extension_loaded($extension);
+});
+
+if ($missingExtensions) {
+    fwrite(STDERR, sprintf(
+        'Phpactor requires the following PHP extension(s) which are not loaded: %s. ' .
+        'Install or enable them and try again (e.g. on Fedora the posix extension is provided by the php-process package).',
+        implode(', ', $missingExtensions)
+    ) . "\n");
+    exit(255);
+}
+
 require_once $autoloadFile;
 
 $phpactorBin = $argv[0];

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "require": {
         "php": "^8.2",
         "ext-mbstring": "*",
+        "ext-posix": "*",
         "ext-tokenizer": "*",
         "composer/xdebug-handler": "^3.0",
         "symfony/yaml": "^5.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c6f110fc3aa8a2fcbf396d994ec3778f",
+    "content-hash": "ce37ef692b689fcf157fc2e665060a14",
     "packages": [
         {
             "name": "amphp/amp",
@@ -9506,6 +9506,7 @@
     "platform": {
         "php": "^8.2",
         "ext-mbstring": "*",
+        "ext-posix": "*",
         "ext-tokenizer": "*"
     },
     "platform-dev": {},


### PR DESCRIPTION
Related to #3053

The language server crashed mid-session with `Call to undefined function posix_kill()` on systems without the posix extension (e.g. Fedora, where it ships separately in the `php-process` package). `ext-posix` was not declared in `composer.json`, and PHAR distributions bypass Composer's platform checks entirely, so the missing extension only surfaced as a fatal error when amphp/process tried to kill a subprocess during an LSP session.

This PR implements both fixes suggested in the issue:

- Declare `ext-posix` in `composer.json` `require` (and update `composer.lock`), so Composer-based installations fail early at install time.
- Check required extensions (`mbstring`, `posix`, `tokenizer`) at startup in `bin/phpactor`, exiting with a descriptive error message instead of crashing mid-session — this covers PHAR distributions, with a hint pointing Fedora users to the `php-process` package.

Example output when an extension is missing:

```
Phpactor requires the following PHP extension(s) which are not loaded: posix. Install or enable them and try again (e.g. on Fedora the posix extension is provided by the php-process package).
```
