### PR TITLE
Fix a few false positives from the analyzer

### DIFF
--- a/lib/DocblockParser/Ast/Token.php
+++ b/lib/DocblockParser/Ast/Token.php
@@ -10,6 +10,7 @@ final class Token implements Element
     public const T_PHPDOC_CLOSE = 'PHPDOC_CLOSE';
     public const T_VARIABLE = 'VARIABLE';
     public const T_UNKNOWN = 'UNKNOWN';
+    public const T_INLINE_CODE = 'INLINE_CODE';
     public const T_BANG = 'BANG';
     public const T_NULLABLE = 'NULLABLE';
     public const T_BAR = 'BAR';

--- a/lib/DocblockParser/Lexer.php
+++ b/lib/DocblockParser/Lexer.php
@@ -17,6 +17,7 @@ final class Lexer
         '/\*+', // start tag
         '\*/', // close tag
         ' {1}\* {1}',
+        '`[^`\r\n]*`', // inline code span - never a real tag, whatever it contains
         '\[\]', // list
         '\?', //tag
         '@[\w-]+', //tag
@@ -78,7 +79,9 @@ final class Lexer
             $this->pattern,
             $docblock,
             -1,
-            PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_OFFSET_CAPTURE
+            PREG_SPLIT_NO_EMPTY
+                | PREG_SPLIT_DELIM_CAPTURE
+                | PREG_SPLIT_OFFSET_CAPTURE
         );
 
         if (false === $chunks) {
@@ -103,6 +106,10 @@ final class Lexer
 
     private function resolveType(string $value): string
     {
+        if ($value[0] === '`') {
+            return Token::T_INLINE_CODE;
+        }
+
         if (str_contains($value, '/*')) {
             return Token::T_PHPDOC_OPEN;
         }

--- a/lib/DocblockParser/Tests/Unit/Ast/NodeTest.php
+++ b/lib/DocblockParser/Tests/Unit/Ast/NodeTest.php
@@ -84,6 +84,13 @@ class NodeTest extends NodeTestCase
         ];
 
         yield [ '/** This is docblock @deprecated Foo */'];
+
+        yield [
+            '/** `@deprecated` mentioned in prose is not a real tag */',
+            function (Docblock $block): void {
+                self::assertFalse($block->hasTag(DeprecatedTag::class));
+            }
+        ];
         yield [ '@mixin Foo\Bar'];
         yield [ '@param string $foo This is a parameter'];
         yield ['@param Baz\Bar $foobar This is a parameter'];

--- a/lib/DocblockParser/Tests/Unit/LexerTest.php
+++ b/lib/DocblockParser/Tests/Unit/LexerTest.php
@@ -138,5 +138,25 @@ class LexerTest extends TestCase
                 [Token::T_ASTERISK, '*'],
             ]
         ];
+
+        yield 'inline code span is a single token, not a tag' => [
+            '`@deprecated`',
+            [
+                [Token::T_INLINE_CODE, '`@deprecated`'],
+            ]
+        ];
+
+        yield 'inline code span with prose does not leak a tag' => [
+            'See `@template-covariant T` for details',
+            [
+                [Token::T_LABEL, 'See'],
+                [Token::T_WHITESPACE, ' '],
+                [Token::T_INLINE_CODE, '`@template-covariant T`'],
+                [Token::T_WHITESPACE, ' '],
+                [Token::T_LABEL, 'for'],
+                [Token::T_WHITESPACE, ' '],
+                [Token::T_LABEL, 'details'],
+            ]
+        ];
     }
 }

--- a/lib/DocblockParser/Tests/Unit/Printer/examples/inline_code_tag.test
+++ b/lib/DocblockParser/Tests/Unit/Printer/examples/inline_code_tag.test
@@ -1,0 +1,8 @@
+/**
+ * A producer annotated `@template-covariant T` may accept a child value.
+ */
+---
+Docblock: = 
+ ElementList: = /**
+ * A producer annotated `@template-covariant T` may accept a child value.
+ */

--- a/lib/Extension/WorseReflectionAnalyse/Model/Analyser.php
+++ b/lib/Extension/WorseReflectionAnalyse/Model/Analyser.php
@@ -3,9 +3,11 @@
 namespace Phpactor\Extension\WorseReflectionAnalyse\Model;
 
 use Generator;
+use Phpactor\Extension\WorseReflectionAnalyse\SourceLocator\AnalysedFilesIndex;
 use Phpactor\Filesystem\Domain\FileList;
 use Phpactor\Filesystem\Domain\FilePath;
 use Phpactor\Filesystem\Domain\FilesystemRegistry;
+use Phpactor\TextDocument\TextDocument;
 use Phpactor\TextDocument\TextDocumentBuilder;
 use Phpactor\WorseReflection\Core\Diagnostic;
 use Phpactor\WorseReflection\Core\Diagnostics;
@@ -19,7 +21,8 @@ class Analyser
 {
     public function __construct(
         private FilesystemRegistry $filesystem,
-        private SourceCodeReflector $reflector
+        private SourceCodeReflector $reflector,
+        private AnalysedFilesIndex $index,
     ) {
     }
 
@@ -35,16 +38,24 @@ class Analyser
             return;
         }
 
+        /** @var array<string,TextDocument> $documents */
+        $documents = [];
         foreach ($this->fileList($absPath) as $file) {
+            $document = TextDocumentBuilder::fromUri($file->path())->build();
+            $documents[$file->path()] = $document;
+            $this->index->index($document);
+        }
+
+        foreach ($documents as $filePath => $document) {
             try {
                 yield Path::makeRelative(
-                    $file->path(),
+                    $filePath,
                     $cwd
-                ) => wait($this->reflector->diagnostics(TextDocumentBuilder::fromUri($file->path())->build()));
+                ) => wait($this->reflector->diagnostics($document));
             } catch (Throwable $error) {
                 throw new RuntimeException(sprintf(
                     'Error while analysing file "%s": %s',
-                    $file,
+                    $filePath,
                     $error->getMessage()
                 ), 0, $error);
             }

--- a/lib/Extension/WorseReflectionAnalyse/SourceLocator/AnalysedFilesIndex.php
+++ b/lib/Extension/WorseReflectionAnalyse/SourceLocator/AnalysedFilesIndex.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Phpactor\Extension\WorseReflectionAnalyse\SourceLocator;
+
+use Phpactor\TextDocument\TextDocument;
+use Phpactor\WorseReflection\Core\Name;
+use Phpactor\WorseReflection\Core\Reflector\SourceCodeReflector;
+
+/**
+ * Maps class/function names declared in the set of files being analysed by
+ * `worse:analyse` back to the document that declares them, so that siblings
+ * within the analysed path can resolve each other without relying on
+ * Composer autoloading.
+ */
+final class AnalysedFilesIndex
+{
+    /**
+     * @var array<string, TextDocument>
+     */
+    private array $byName = [];
+
+    public function __construct(private SourceCodeReflector $reflector)
+    {
+    }
+
+    public function index(TextDocument $textDocument): void
+    {
+        foreach ($this->reflector->reflectClassesIn($textDocument) as $reflectionClass) {
+            $this->byName[$reflectionClass->name()->full()] = $textDocument;
+        }
+
+        foreach ($this->reflector->reflectFunctionsIn($textDocument) as $reflectionFunction) {
+            $this->byName[$reflectionFunction->name()->full()] = $textDocument;
+        }
+    }
+
+    public function documentForName(Name $name): ?TextDocument
+    {
+        return $this->byName[$name->full()] ?? null;
+    }
+}

--- a/lib/Extension/WorseReflectionAnalyse/SourceLocator/AnalysedFilesSourceLocator.php
+++ b/lib/Extension/WorseReflectionAnalyse/SourceLocator/AnalysedFilesSourceLocator.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Phpactor\Extension\WorseReflectionAnalyse\SourceLocator;
+
+use Phpactor\TextDocument\TextDocument;
+use Phpactor\WorseReflection\Core\Exception\SourceNotFound;
+use Phpactor\WorseReflection\Core\Name;
+use Phpactor\WorseReflection\Core\SourceCodeLocator;
+
+final class AnalysedFilesSourceLocator implements SourceCodeLocator
+{
+    public function __construct(private AnalysedFilesIndex $index)
+    {
+    }
+
+    public function locate(Name $name): TextDocument
+    {
+        if (null === $document = $this->index->documentForName($name)) {
+            throw new SourceNotFound(sprintf(
+                'Class "%s" not found in analysed files',
+                (string) $name
+            ));
+        }
+
+        return $document;
+    }
+}

--- a/lib/Extension/WorseReflectionAnalyse/WorseReflectionAnalyseExtension.php
+++ b/lib/Extension/WorseReflectionAnalyse/WorseReflectionAnalyseExtension.php
@@ -9,8 +9,11 @@ use Phpactor\Container\ContainerBuilder;
 use Phpactor\Container\Extension;
 use Phpactor\Extension\WorseReflectionAnalyse\Command\AnalyseCommand;
 use Phpactor\Extension\WorseReflectionAnalyse\Model\Analyser;
+use Phpactor\Extension\WorseReflectionAnalyse\SourceLocator\AnalysedFilesIndex;
+use Phpactor\Extension\WorseReflectionAnalyse\SourceLocator\AnalysedFilesSourceLocator;
 use Phpactor\Extension\WorseReflection\WorseReflectionExtension;
 use Phpactor\MapResolver\Resolver;
+use Phpactor\WorseReflection\ReflectorBuilder;
 
 class WorseReflectionAnalyseExtension implements Extension
 {
@@ -21,6 +24,7 @@ class WorseReflectionAnalyseExtension implements Extension
     public function load(ContainerBuilder $container): void
     {
         $this->registerCommands($container);
+        $this->registerSourceLocator($container);
     }
     private function registerCommands(ContainerBuilder $container): void
     {
@@ -28,11 +32,25 @@ class WorseReflectionAnalyseExtension implements Extension
             return new AnalyseCommand(
                 new Analyser(
                     $container->get(SourceCodeFilesystemExtension::SERVICE_REGISTRY),
-                    $container->get(WorseReflectionExtension::SERVICE_REFLECTOR)
+                    $container->get(WorseReflectionExtension::SERVICE_REFLECTOR),
+                    $container->get(AnalysedFilesIndex::class),
                 )
             );
         }, [ ConsoleExtension::TAG_COMMAND => [
             'name' => 'worse:analyse',
+        ]]);
+    }
+
+    private function registerSourceLocator(ContainerBuilder $container): void
+    {
+        $container->register(AnalysedFilesIndex::class, function (Container $container) {
+            return new AnalysedFilesIndex(ReflectorBuilder::create()->build());
+        });
+
+        $container->register(AnalysedFilesSourceLocator::class, function (Container $container) {
+            return new AnalysedFilesSourceLocator($container->get(AnalysedFilesIndex::class));
+        }, [ WorseReflectionExtension::TAG_SOURCE_LOCATOR => [
+            'priority' => 128,
         ]]);
     }
 }


### PR DESCRIPTION
The issues where found by running https://zonuexe.github.io/php-typing-conformance/ on the latest master branch. It was actually already the LSP (including qodana) with the least false positives with just 4 failing cases. If you could make a release after merging this I would like to submit a PR to the project so that it can be automatically checked going forward.